### PR TITLE
Change breakpoint to mobileLandscape

### DIFF
--- a/src/components/modules/banners/contributions/ContributionsBannerStyles.ts
+++ b/src/components/modules/banners/contributions/ContributionsBannerStyles.ts
@@ -113,7 +113,7 @@ export const styles = {
         align-items: flex-start;
         justify-content: flex-start;
         flex-direction: column;
-        ${from.mobileMedium} {
+        ${from.mobileLandscape} {
             flex-direction: row;
             align-items: center;
             justify-content: center;


### PR DESCRIPTION
## What does this change?
Fix banner overflow bug at 375-437px as per [this card](https://trello.com/c/87i425hX/2240-fix-dcr-banner-on-mobile)

## Images
original:
![banner](https://user-images.githubusercontent.com/1513454/90871550-28a7ba80-e393-11ea-9a7d-8f4767708433.png)


fix:
<img width="379" alt="Screenshot 2020-08-21 at 09 43 22" src="https://user-images.githubusercontent.com/17720442/90871463-09109200-e393-11ea-86a3-bec98982505e.png">

