### PR TITLE
Select variant using MVT cookie

### DIFF
--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -90,7 +90,7 @@ export const selectBannerTest = async (
             test.canRun(targeting, pageTracking) &&
             (await redeployedSinceLastClosed(targeting, test.bannerType, bannerDeployCaches))
         ) {
-            const variant = test.variants[0]; // TODO - use mvt
+            const variant = test.variants[targeting.mvtId % test.variants.length];
             const bannerTestSelection = {
                 test,
                 variant,


### PR DESCRIPTION
Currently we put the user into the first variant.
Now that we're going to be running actual A/B tests we need to assign a variant based on the MVT cookie value

As with https://github.com/guardian/ab-testing/blob/d908567fa95d113a01f915c319ed27268e394eb1/packages/ab-core/src/core.ts#L62