### PR TITLE
Use articlesViewedSettings in banner tests

### DIFF
--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -8,7 +8,6 @@ import { Lines } from '../../Lines';
 import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';
 import { SvgArrowRightStraight, SvgClose } from '@guardian/src-svgs';
-import { isProd } from '../../../lib/env';
 
 const rootStyles = css`
     position: relative;
@@ -120,9 +119,7 @@ type ReminderPayload = {
     reminderDate: string;
 };
 
-const contributionsReminderUrl = isProd
-    ? 'https://contribution-reminders.support.guardianapis.com/remind-me'
-    : 'https://contribution-reminders-code.support.guardianapis.com/remind-me';
+const contributionsReminderUrl = 'https://contribution-reminders.support.guardianapis.com/remind-me';
 
 const submitForm = ({ email, reminderDate }: ReminderPayload): Promise<Response> => {
     return fetch(contributionsReminderUrl, {

--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -119,7 +119,8 @@ type ReminderPayload = {
     reminderDate: string;
 };
 
-const contributionsReminderUrl = 'https://contribution-reminders.support.guardianapis.com/remind-me';
+const contributionsReminderUrl =
+    'https://contribution-reminders.support.guardianapis.com/remind-me';
 
 const submitForm = ({ email, reminderDate }: ReminderPayload): Promise<Response> => {
     return fetch(contributionsReminderUrl, {

--- a/src/components/modules/epics/ContributionsEpicTypes.ts
+++ b/src/components/modules/epics/ContributionsEpicTypes.ts
@@ -1,5 +1,5 @@
 import { OphanComponentType, OphanProduct } from '../../../types/OphanTypes';
-import { WeeklyArticleHistory } from "../../../types/shared";
+import { WeeklyArticleHistory } from '../../../types/shared';
 
 export type EpicPageTracking = {
     ophanPageId: string;

--- a/src/components/modules/epics/ContributionsEpicTypes.ts
+++ b/src/components/modules/epics/ContributionsEpicTypes.ts
@@ -1,4 +1,5 @@
 import { OphanComponentType, OphanProduct } from '../../../types/OphanTypes';
+import { WeeklyArticleHistory } from "../../../types/shared";
 
 export type EpicPageTracking = {
     ophanPageId: string;
@@ -34,13 +35,6 @@ interface View {
     testId: string;
 }
 export type ViewLog = View[];
-
-export type WeeklyArticleLog = {
-    week: number;
-    count: number;
-};
-
-export type WeeklyArticleHistory = WeeklyArticleLog[];
 
 export type EpicTargeting = {
     contentType: string;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 
-export const isProd = process.env.stage === 'production';
+export const isProd = process.env.stage === 'PROD';
 
 export const isDev = process.env.NODE_ENV === 'development';
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 
-export const isProd = process.env.NODE_ENV === 'production';
+export const isProd = process.env.stage === 'production';
 
 export const isDev = process.env.NODE_ENV === 'development';
 

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,4 +1,4 @@
-import {ArticlesViewedSettings, WeeklyArticleHistory, WeeklyArticleLog} from "../types/shared";
+import { ArticlesViewedSettings, WeeklyArticleHistory, WeeklyArticleLog } from '../types/shared';
 
 export const getMondayFromDate = (date: Date): number => {
     const day = date.getDay() || 7;

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,7 +1,4 @@
-import {
-    WeeklyArticleLog,
-    WeeklyArticleHistory,
-} from '../components/modules/epics/ContributionsEpicTypes';
+import {ArticlesViewedSettings, WeeklyArticleHistory, WeeklyArticleLog} from "../types/shared";
 
 export const getMondayFromDate = (date: Date): number => {
     const day = date.getDay() || 7;
@@ -28,4 +25,23 @@ export const getArticleViewCountForWeeks = (
         (accumulator: number, currentValue: WeeklyArticleLog) => currentValue.count + accumulator,
         0,
     );
+};
+
+export const historyWithinArticlesViewedSettings = (
+    articlesViewedSettings?: ArticlesViewedSettings,
+    history: WeeklyArticleHistory = [],
+    now: Date = new Date(),
+) => {
+    // Allow test to pass if no articles viewed settings have been set
+    if (!articlesViewedSettings || !articlesViewedSettings.periodInWeeks) {
+        return true;
+    }
+
+    const { minViews, maxViews, periodInWeeks } = articlesViewedSettings;
+
+    const viewCountForWeeks = getArticleViewCountForWeeks(history, periodInWeeks, now);
+    const minViewsOk = minViews ? viewCountForWeeks >= minViews : true;
+    const maxViewsOk = maxViews ? viewCountForWeeks <= maxViews : true;
+
+    return minViewsOk && maxViewsOk;
 };

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -1,13 +1,13 @@
 import {
     EpicTargeting,
     ViewLog,
-    WeeklyArticleHistory,
     UserCohort,
 } from '../components/modules/epics/ContributionsEpicTypes';
 import { shouldThrottle, shouldNotRenderEpic } from '../lib/targeting';
-import { getArticleViewCountForWeeks } from '../lib/history';
 import { getCountryName, inCountryGroups, CountryGroupId } from '../lib/geolocation';
+import {getArticleViewCountForWeeks, historyWithinArticlesViewedSettings} from '../lib/history';
 import { isRecentOneOffContributor } from '../lib/dates';
+import {ArticlesViewedSettings, WeeklyArticleHistory} from "../types/shared";
 
 export enum TickerEndType {
     unlimited = 'unlimited',
@@ -34,12 +34,6 @@ export interface TickerSettings {
     currencySymbol: string;
     copy: TickerCopy;
     tickerData?: TickerData;
-}
-
-interface ArticlesViewedSettings {
-    minViews: number;
-    periodInWeeks: number;
-    maxViews?: number;
 }
 
 interface MaxViews {
@@ -241,20 +235,7 @@ export const withinArticleViewedSettings = (
     now: Date = new Date(),
 ): Filter => ({
     id: 'withinArticleViewedSettings',
-    test: (test): boolean => {
-        // Allow test to pass if no articles viewed settings have been set
-        if (!test.articlesViewedSettings || !test.articlesViewedSettings.periodInWeeks) {
-            return true;
-        }
-
-        const { minViews, maxViews, periodInWeeks } = test.articlesViewedSettings;
-
-        const viewCountForWeeks = getArticleViewCountForWeeks(history, periodInWeeks, now);
-        const minViewsOk = minViews ? viewCountForWeeks >= minViews : true;
-        const maxViewsOk = maxViews ? viewCountForWeeks <= maxViews : true;
-
-        return minViewsOk && maxViewsOk;
-    },
+    test: (test): boolean => historyWithinArticlesViewedSettings(test.articlesViewedSettings, history, now),
 });
 
 export const inCorrectCohort = (userCohorts: UserCohort[]): Filter => ({

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -5,9 +5,9 @@ import {
 } from '../components/modules/epics/ContributionsEpicTypes';
 import { shouldThrottle, shouldNotRenderEpic } from '../lib/targeting';
 import { getCountryName, inCountryGroups, CountryGroupId } from '../lib/geolocation';
-import {getArticleViewCountForWeeks, historyWithinArticlesViewedSettings} from '../lib/history';
+import { getArticleViewCountForWeeks, historyWithinArticlesViewedSettings } from '../lib/history';
 import { isRecentOneOffContributor } from '../lib/dates';
-import {ArticlesViewedSettings, WeeklyArticleHistory} from "../types/shared";
+import { ArticlesViewedSettings, WeeklyArticleHistory } from '../types/shared';
 
 export enum TickerEndType {
     unlimited = 'unlimited',
@@ -235,7 +235,8 @@ export const withinArticleViewedSettings = (
     now: Date = new Date(),
 ): Filter => ({
     id: 'withinArticleViewedSettings',
-    test: (test): boolean => historyWithinArticlesViewedSettings(test.articlesViewedSettings, history, now),
+    test: (test): boolean =>
+        historyWithinArticlesViewedSettings(test.articlesViewedSettings, history, now),
 });
 
 export const inCorrectCohort = (userCohorts: UserCohort[]): Filter => ({

--- a/src/schemas/bannerPayload.schema.json
+++ b/src/schemas/bannerPayload.schema.json
@@ -47,6 +47,24 @@
                 },
                 "engagementBannerLastClosedAt": {
                     "type": "string"
+                },
+                "weeklyArticleHistory": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "week": {
+                                "type": "number"
+                            },
+                            "count": {
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "count",
+                            "week"
+                        ]
+                    }
                 }
             },
             "required": [

--- a/src/tests/banners/ContributionsBannerTests.ts
+++ b/src/tests/banners/ContributionsBannerTests.ts
@@ -39,6 +39,7 @@ const ContributionsBannerTest = (testParams: RawTestParams): BannerTest => {
             }),
         ),
         componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+        articlesViewedSettings: testParams.articlesViewedSettings,
     };
 };
 

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -259,12 +259,13 @@ describe('selectBannerTest', () => {
                 }),
                 tracking,
                 '',
-                () => Promise.resolve([
-                    {
-                        ...test,
-                        articlesViewedSettings: undefined,
-                    }
-                ]),
+                () =>
+                    Promise.resolve([
+                        {
+                            ...test,
+                            articlesViewedSettings: undefined,
+                        },
+                    ]),
                 cache,
                 now,
             ).then(result => {

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -172,6 +172,8 @@ describe('selectBannerTest', () => {
     describe('Contributions banner rules', () => {
         const now = new Date('2020-03-31T12:30:00');
 
+        const cache = getBannerDeployCache(secondDate, 'australia');
+
         const targeting: BannerTargeting = {
             alreadyVisitedCount: 3,
             shouldHideReaderRevenue: false,
@@ -221,8 +223,6 @@ describe('selectBannerTest', () => {
         };
 
         it('returns test if enough article views', () => {
-            const cache = getBannerDeployCache(secondDate, 'australia');
-
             return selectBannerTest(
                 Object.assign(targeting, {
                     weeklyArticleHistory: [{ week: 18330, count: 6 }],
@@ -238,8 +238,6 @@ describe('selectBannerTest', () => {
         });
 
         it('returns null if not enough article views', () => {
-            const cache = getBannerDeployCache(secondDate, 'australia');
-
             return selectBannerTest(
                 Object.assign(targeting, {
                     weeklyArticleHistory: [{ week: 18330, count: 1 }],
@@ -251,6 +249,26 @@ describe('selectBannerTest', () => {
                 now,
             ).then(result => {
                 expect(result).toBe(null);
+            });
+        });
+
+        it('returns test if no articlesViewedSettings', () => {
+            return selectBannerTest(
+                Object.assign(targeting, {
+                    weeklyArticleHistory: [{ week: 18330, count: 1 }],
+                }),
+                tracking,
+                '',
+                () => Promise.resolve([
+                    {
+                        ...test,
+                        articlesViewedSettings: undefined,
+                    }
+                ]),
+                cache,
+                now,
+            ).then(result => {
+                expect(result && result.test.name).toBe('test');
             });
         });
     });

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -1,6 +1,14 @@
 import { selectBannerTest } from './bannerSelection';
 import { getTests } from './bannerTests';
 import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
+import {
+    BannerPageTracking,
+    BannerTargeting,
+    BannerTest,
+    BannerVariant,
+    RawVariantParams
+} from "../../types/BannerTypes";
+import {ContributionsBannerPath} from "./ContributionsBannerTests";
 
 const getBannerDeployCache = (date: string, region: ReaderRevenueRegion): BannerDeployCaches =>
     ({
@@ -161,6 +169,92 @@ describe('selectBannerTest', () => {
                 '',
                 getTests,
                 cache,
+            ).then(result => {
+                expect(result).toBe(null);
+            });
+        });
+    });
+
+    describe('Contributions banner rules', () => {
+        const now = new Date('2020-03-31T12:30:00');
+
+        const targeting: BannerTargeting = {
+            alreadyVisitedCount: 3,
+            shouldHideReaderRevenue: false,
+            isPaidContent: false,
+            showSupportMessaging: true,
+            mvtId: 3,
+            countryCode: 'AU',
+            engagementBannerLastClosedAt: firstDate,
+            switches: {
+                remoteSubscriptionsBanner: true,
+            },
+        };
+
+        const tracking = {
+            ophanPageId: '',
+            platformId: '',
+            referrerUrl: '',
+            clientName: '',
+        };
+
+        const test: BannerTest = {
+            name: 'test',
+            bannerType: 'contributions',
+            testAudience: 'Everyone',
+            canRun: () => true,
+            minPageViews: 2,
+            variants: [
+                {
+                    name: 'variant',
+                    modulePath: ContributionsBannerPath,
+                    moduleName: 'ContributionsBanner',
+                    bannerContent: {
+                        messageText: 'body',
+                        highlightedText: 'highlighted text',
+                        cta: {
+                            text: 'cta',
+                            baseUrl: 'https://support.theguardian.com',
+                        }
+                    },
+                }
+            ],
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            articlesViewedSettings: {
+                minViews: 5,
+                periodInWeeks: 52
+            },
+        };
+
+        it('returns test if enough article views', () => {
+            const cache = getBannerDeployCache(secondDate, 'australia');
+
+            return selectBannerTest(
+                Object.assign(targeting, {
+                    weeklyArticleHistory: [{ week: 18330, count: 6 }]
+                }),
+                tracking,
+                '',
+                () => Promise.resolve([test]),
+                cache,
+                now,
+            ).then(result => {
+                expect(result && result.test.name).toBe('test');
+            });
+        });
+
+        it('returns null if not enough article views', () => {
+            const cache = getBannerDeployCache(secondDate, 'australia');
+
+            return selectBannerTest(
+                Object.assign(targeting, {
+                    weeklyArticleHistory: [{ week: 18330, count: 1 }]
+                }),
+                tracking,
+                '',
+                () => Promise.resolve([test]),
+                cache,
+                now,
             ).then(result => {
                 expect(result).toBe(null);
             });

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -1,14 +1,8 @@
 import { selectBannerTest } from './bannerSelection';
 import { getTests } from './bannerTests';
 import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
-import {
-    BannerPageTracking,
-    BannerTargeting,
-    BannerTest,
-    BannerVariant,
-    RawVariantParams
-} from "../../types/BannerTypes";
-import {ContributionsBannerPath} from "./ContributionsBannerTests";
+import { BannerTargeting, BannerTest } from '../../types/BannerTypes';
+import { ContributionsBannerPath } from './ContributionsBannerTests';
 
 const getBannerDeployCache = (date: string, region: ReaderRevenueRegion): BannerDeployCaches =>
     ({
@@ -215,14 +209,14 @@ describe('selectBannerTest', () => {
                         cta: {
                             text: 'cta',
                             baseUrl: 'https://support.theguardian.com',
-                        }
+                        },
                     },
-                }
+                },
             ],
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             articlesViewedSettings: {
                 minViews: 5,
-                periodInWeeks: 52
+                periodInWeeks: 52,
             },
         };
 
@@ -231,7 +225,7 @@ describe('selectBannerTest', () => {
 
             return selectBannerTest(
                 Object.assign(targeting, {
-                    weeklyArticleHistory: [{ week: 18330, count: 6 }]
+                    weeklyArticleHistory: [{ week: 18330, count: 6 }],
                 }),
                 tracking,
                 '',
@@ -248,7 +242,7 @@ describe('selectBannerTest', () => {
 
             return selectBannerTest(
                 Object.assign(targeting, {
-                    weeklyArticleHistory: [{ week: 18330, count: 1 }]
+                    weeklyArticleHistory: [{ week: 18330, count: 1 }],
                 }),
                 tracking,
                 '',

--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -8,6 +8,8 @@ import {
 } from '../../types/BannerTypes';
 import { countryCodeToCountryGroupId, inCountryGroups } from '../../lib/geolocation';
 import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
+import {WeeklyArticleHistory} from "../../types/shared";
+import {getArticleViewCountForWeeks, historyWithinArticlesViewedSettings} from "../../lib/history";
 
 export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
     switch (true) {
@@ -78,6 +80,7 @@ export const selectBannerTest = async (
     baseUrl: string,
     getTests: () => Promise<BannerTest[]>,
     bannerDeployCaches: BannerDeployCaches,
+    now: Date = new Date(),
 ): Promise<BannerTestSelection | null> => {
     const tests = await getTests();
 
@@ -89,6 +92,7 @@ export const selectBannerTest = async (
             inCountryGroups(targeting.countryCode, test.locations) &&
             targeting.alreadyVisitedCount >= test.minPageViews &&
             test.canRun(targeting, pageTracking) &&
+            historyWithinArticlesViewedSettings(test.articlesViewedSettings, targeting.weeklyArticleHistory, now) &&
             (await redeployedSinceLastClosed(targeting, test.bannerType, bannerDeployCaches))
         ) {
             const variant = test.variants[targeting.mvtId % test.variants.length];

--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -8,8 +8,7 @@ import {
 } from '../../types/BannerTypes';
 import { countryCodeToCountryGroupId, inCountryGroups } from '../../lib/geolocation';
 import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
-import {WeeklyArticleHistory} from "../../types/shared";
-import {getArticleViewCountForWeeks, historyWithinArticlesViewedSettings} from "../../lib/history";
+import { historyWithinArticlesViewedSettings } from '../../lib/history';
 
 export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
     switch (true) {
@@ -92,7 +91,11 @@ export const selectBannerTest = async (
             inCountryGroups(targeting.countryCode, test.locations) &&
             targeting.alreadyVisitedCount >= test.minPageViews &&
             test.canRun(targeting, pageTracking) &&
-            historyWithinArticlesViewedSettings(test.articlesViewedSettings, targeting.weeklyArticleHistory, now) &&
+            historyWithinArticlesViewedSettings(
+                test.articlesViewedSettings,
+                targeting.weeklyArticleHistory,
+                now,
+            ) &&
             (await redeployedSinceLastClosed(targeting, test.bannerType, bannerDeployCaches))
         ) {
             const variant = test.variants[targeting.mvtId % test.variants.length];

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -1,7 +1,7 @@
 import { TickerSettings } from '../lib/variants';
 import { OphanProduct, OphanComponentType, OphanComponentEvent } from './OphanTypes';
 import { CountryGroupId } from '../lib/geolocation';
-import {ArticlesViewedSettings, WeeklyArticleHistory} from "./shared";
+import { ArticlesViewedSettings, WeeklyArticleHistory } from './shared';
 
 // TODO - it may be worth sharing some types with Epic tests
 

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -1,6 +1,7 @@
 import { TickerSettings } from '../lib/variants';
 import { OphanProduct, OphanComponentType, OphanComponentEvent } from './OphanTypes';
 import { CountryGroupId } from '../lib/geolocation';
+import {ArticlesViewedSettings, WeeklyArticleHistory} from "./shared";
 
 // TODO - it may be worth sharing some types with Epic tests
 
@@ -16,6 +17,7 @@ export type BannerTargeting = {
     switches: {
         remoteSubscriptionsBanner: boolean;
     };
+    weeklyArticleHistory?: WeeklyArticleHistory;
 };
 
 export type BannerTestTracking = {
@@ -81,6 +83,7 @@ export interface BannerTest {
     componentType: OphanComponentType;
     products?: OphanProduct[];
     locations?: CountryGroupId[];
+    articlesViewedSettings?: ArticlesViewedSettings;
 }
 
 // The result of selecting a test+variant for a user
@@ -100,12 +103,6 @@ export interface BannerProps {
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
 }
 
-export interface ArticlesViewedSettings {
-    minViews: number;
-    maxViews: number;
-    periodInWeeks: number;
-}
-
 export interface RawVariantParams {
     name: string;
     body: string;
@@ -122,5 +119,5 @@ export interface RawTestParams {
     userCohort: BannerAudience;
     locations: CountryGroupId[];
     variants: RawVariantParams[];
-    articlesViewedSettings: ArticlesViewedSettings;
+    articlesViewedSettings?: ArticlesViewedSettings;
 }

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1,0 +1,12 @@
+export type WeeklyArticleLog = {
+    week: number;
+    count: number;
+};
+
+export type WeeklyArticleHistory = WeeklyArticleLog[];
+
+export interface ArticlesViewedSettings {
+    minViews: number;
+    maxViews?: number;
+    periodInWeeks: number;
+}


### PR DESCRIPTION
The banner tool sends an `articlesViewedSettings` field for restricting who is put in a test based on how many articles they have viewed.
This PR ensures the user's `weeklyArticleHistory` is correct if a test has the `articlesViewedSettings` field.

Moved `ArticlesViewedSettings` and `WeeklyArticleHistory` into a `shared.ts` file as they are used by epic + banner.

TODO: 
- [ ] update the client to send `weeklyArticleHistory`
- [ ] handle the %%ARTICLE_COUNT%% placeholder in the banner component