### PR TITLE
Allow client to force banner variant

### DIFF
--- a/src/lib/params.ts
+++ b/src/lib/params.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 
-interface TestVariant {
+export interface TestVariant {
     testName: string;
     variantName: string;
 }

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -157,6 +157,7 @@ const buildBannerData = async (
         baseUrl(req),
         getCachedTests,
         bannerDeployCaches,
+        params.force,
     );
 
     if (selectedTest) {

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -231,6 +231,7 @@ describe('selectBannerTest', () => {
                 '',
                 () => Promise.resolve([test]),
                 cache,
+                undefined,
                 now,
             ).then(result => {
                 expect(result && result.test.name).toBe('test');
@@ -246,6 +247,7 @@ describe('selectBannerTest', () => {
                 '',
                 () => Promise.resolve([test]),
                 cache,
+                undefined,
                 now,
             ).then(result => {
                 expect(result).toBe(null);
@@ -267,6 +269,7 @@ describe('selectBannerTest', () => {
                         },
                     ]),
                 cache,
+                undefined,
                 now,
             ).then(result => {
                 expect(result && result.test.name).toBe('test');

--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -9,7 +9,7 @@ import {
 import { countryCodeToCountryGroupId, inCountryGroups } from '../../lib/geolocation';
 import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
 import { historyWithinArticlesViewedSettings } from '../../lib/history';
-import {TestVariant} from "../../lib/params";
+import { TestVariant } from '../../lib/params';
 
 export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
     switch (true) {
@@ -74,9 +74,17 @@ const audienceMatches = (showSupportMessaging: boolean, testAudience: BannerAudi
     }
 };
 
-const getForcedVariant = (forceTestVariant: TestVariant, tests: BannerTest[], baseUrl: string): BannerTestSelection | null => {
-    const test = tests.find(test => test.name.toLowerCase() === forceTestVariant.testName.toLowerCase());
-    const variant = test?.variants.find(v => v.name.toLowerCase() === forceTestVariant.variantName.toLowerCase());
+const getForcedVariant = (
+    forceTestVariant: TestVariant,
+    tests: BannerTest[],
+    baseUrl: string,
+): BannerTestSelection | null => {
+    const test = tests.find(
+        test => test.name.toLowerCase() === forceTestVariant.testName.toLowerCase(),
+    );
+    const variant = test?.variants.find(
+        v => v.name.toLowerCase() === forceTestVariant.variantName.toLowerCase(),
+    );
 
     if (test && variant) {
         return {

--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -75,15 +75,15 @@ const audienceMatches = (showSupportMessaging: boolean, testAudience: BannerAudi
 };
 
 const getForcedVariant = (
-    forceTestVariant: TestVariant,
+    forcedTestVariant: TestVariant,
     tests: BannerTest[],
     baseUrl: string,
 ): BannerTestSelection | null => {
     const test = tests.find(
-        test => test.name.toLowerCase() === forceTestVariant.testName.toLowerCase(),
+        test => test.name.toLowerCase() === forcedTestVariant.testName.toLowerCase(),
     );
     const variant = test?.variants.find(
-        v => v.name.toLowerCase() === forceTestVariant.variantName.toLowerCase(),
+        v => v.name.toLowerCase() === forcedTestVariant.variantName.toLowerCase(),
     );
 
     if (test && variant) {
@@ -103,13 +103,13 @@ export const selectBannerTest = async (
     baseUrl: string,
     getTests: () => Promise<BannerTest[]>,
     bannerDeployCaches: BannerDeployCaches,
-    forceTestVariant?: TestVariant,
+    forcedTestVariant?: TestVariant,
     now: Date = new Date(),
 ): Promise<BannerTestSelection | null> => {
     const tests = await getTests();
 
-    if (forceTestVariant) {
-        return Promise.resolve(getForcedVariant(forceTestVariant, tests, baseUrl));
+    if (forcedTestVariant) {
+        return Promise.resolve(getForcedVariant(forcedTestVariant, tests, baseUrl));
     }
 
     for (const test of tests) {


### PR DESCRIPTION
We already have this for epics.
The client can add this to the url: `?force=test-name:variant-name`.