### PR TITLE
Update the Digital Subscriptions Banner's copy

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -89,13 +89,10 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                     <div css={contentContainer}>
                         <div css={topLeftComponent}>
                             <h3 css={heading}>
-                                Our reporting. <br css={headLineBreak} />
-                                Your pace.
+                                Enjoy ad-free reading and the best of our apps
                             </h3>
                             <p css={paragraph}>
-                                Tired of being always on? Our Daily edition comes to you just once a
-                                day. If a story breaks, you can still catch it with Premium access
-                                to our Live app. All with no ads. It&apos;s up to you.
+                                Support the Guardian with a Digital Subscription, enjoy our reporting without ads and get premium access to our Live app and The Daily.
                             </p>
                             <a css={linkStyle} onClick={onSubscribeClick}>
                                 <div data-link-name={ctaComponentId} css={becomeASubscriberButton}>

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -9,7 +9,6 @@ import {
     contentContainer,
     topLeftComponent,
     heading,
-    headLineBreak,
     paragraph,
     buttonTextDesktop,
     buttonTextTablet,
@@ -88,11 +87,11 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                 <section css={banner} data-target={bannerId}>
                     <div css={contentContainer}>
                         <div css={topLeftComponent}>
-                            <h3 css={heading}>
-                                Enjoy ad-free reading and the best of our apps
-                            </h3>
+                            <h3 css={heading}>Enjoy ad-free reading and the best of our apps</h3>
                             <p css={paragraph}>
-                                Support the Guardian with a Digital Subscription, enjoy our reporting without ads and get premium access to our Live app and The Daily.
+                                Support the Guardian with a Digital Subscription, enjoy our
+                                reporting without ads and get premium access to our Live app and The
+                                Daily.
                             </p>
                             <a css={linkStyle} onClick={onSubscribeClick}>
                                 <div data-link-name={ctaComponentId} css={becomeASubscriberButton}>

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -4,6 +4,8 @@ import { neutral, brandAlt, text } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
+const closeButtonWidthHeight = '35px';
+
 export const banner = css`
     html {
         box-sizing: border-box;
@@ -65,6 +67,7 @@ export const heading = css`
     ${headline.xsmall({ fontWeight: 'bold' })};
     margin: 0;
     max-width: 100%;
+    padding-right: ${closeButtonWidthHeight};
 
     @media (min-width: 740px) {
         max-width: 90%;
@@ -290,8 +293,8 @@ export const closeButton = css`
     outline: none;
     background: transparent;
     cursor: pointer;
-    width: 35px;
-    height: 35px;
+    width: ${closeButtonWidthHeight};
+    height: ${closeButtonWidthHeight};
     svg {
         width: 25px;
         height: 25px;


### PR DESCRIPTION
## What does this change?

This PR update the Digital Subscriptions Banner's copy. It's pretty straightforward, I had to add some `padding-right` of `35px` to the `heading` styles, this prevents the heading copy running into the close button (which is `position: absolute`), `35px` is the width/height of this button.

Trello: https://trello.com/c/diKaVILO/3278-ds-banner-copy-update

## Images

<img width="316" alt="Screenshot 2020-08-27 at 12 42 29" src="https://user-images.githubusercontent.com/1590704/91439202-7d03dc00-e864-11ea-92de-842352035f83.png">

<img width="734" alt="Screenshot 2020-08-27 at 12 42 50" src="https://user-images.githubusercontent.com/1590704/91439130-62316780-e864-11ea-9c7a-9dd61afda47c.png">

<img width="1409" alt="Screenshot 2020-08-27 at 12 43 17" src="https://user-images.githubusercontent.com/1590704/91439120-5f367700-e864-11ea-8e2a-1999c5046334.png">