### PR TITLE
Display article count in contributions banner

### DIFF
--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -5,8 +5,11 @@ import { setContributionsBannerClosedTimestamp } from '../localStorage';
 import React, { useState } from 'react';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { styles } from './ContributionsBannerStyles';
-import { getLocalCurrencySymbol } from '../../../../lib/geolocation';
-import { containsPlaceholder } from '../../../../lib/placeholders';
+import {
+    containsNonArticleCountPlaceholder,
+    replaceArticleCount,
+    replaceNonArticleCountPlaceholders,
+} from '../../../../lib/placeholders';
 import { SvgRoundel } from '@guardian/src-brand';
 import { SvgCross, SvgArrowRightStraight } from '@guardian/src-icons';
 import { ThemeProvider } from 'emotion-theming';
@@ -19,9 +22,7 @@ const ctaComponentId = `${bannerId} : cta`;
 export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) => {
     const [showBanner, setShowBanner] = useState(true);
     const { content, countryCode } = props;
-    const replaceCurrencyPlaceholder = (text: string, currencySymbol: string): string => {
-        return text.replace('%%CURRENCY_SYMBOL%%', currencySymbol);
-    };
+    const numArticles = props.numArticles || 0;
 
     const onContributeClick = (): void => {
         const componentClickEvent = createClickEventFromTracking(props.tracking, ctaComponentId);
@@ -41,16 +42,22 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
     };
 
     if (content && countryCode && showBanner) {
-        const currencySymbol = getLocalCurrencySymbol(countryCode);
 
-        const highlightedText =
+        const cleanHighlightedText =
             content.highlightedText &&
-            replaceCurrencyPlaceholder(content.highlightedText, currencySymbol);
+            replaceNonArticleCountPlaceholders(content.highlightedText, countryCode);
+
+        const cleanMessageText = replaceNonArticleCountPlaceholders(
+            content.messageText,
+            countryCode,
+        );
+
+        const cleanHeading = replaceNonArticleCountPlaceholders(content.heading, countryCode);
 
         const copyHasPlaceholder =
-            containsPlaceholder(content.messageText) ||
-            (!!highlightedText && containsPlaceholder(highlightedText)) ||
-            (!!content.header && containsPlaceholder(content.header));
+            containsNonArticleCountPlaceholder(cleanMessageText) ||
+            (!!cleanHighlightedText && containsNonArticleCountPlaceholder(cleanHighlightedText)) ||
+            (!!cleanHeading && containsNonArticleCountPlaceholder(cleanHeading));
 
         if (!copyHasPlaceholder) {
             return (
@@ -65,16 +72,22 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
                                 </div>
                                 <div css={styles.copyAndCta}>
                                     <div css={styles.copy}>
-                                        {content.header && (
-                                            <span css={styles.header}>{content.header}</span>
+                                        {cleanHeading && (
+                                            <span css={styles.heading}>
+                                                {replaceArticleCount(cleanHeading, numArticles)}
+                                            </span>
                                         )}
-                                        <span
-                                            css={styles.messageText}
-                                            dangerouslySetInnerHTML={{
-                                                __html: content.messageText,
-                                            }}
-                                        />
-                                        <span css={styles.highlightedText}>{highlightedText}</span>
+                                        <span css={styles.messageText}>
+                                            {replaceArticleCount(cleanMessageText, numArticles)}
+                                        </span>
+                                        {cleanHighlightedText && (
+                                            <span css={styles.highlightedText}>
+                                                {replaceArticleCount(
+                                                    cleanHighlightedText,
+                                                    numArticles,
+                                                )}
+                                            </span>
+                                        )}
                                     </div>
                                     {content.cta && (
                                         <div css={styles.ctaContainer}>

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -42,7 +42,6 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
     };
 
     if (content && countryCode && showBanner) {
-
         const cleanHighlightedText =
             content.highlightedText &&
             replaceNonArticleCountPlaceholders(content.highlightedText, countryCode);

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -73,17 +73,26 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
                                     <div css={styles.copy}>
                                         {cleanHeading && (
                                             <span css={styles.heading}>
-                                                {replaceArticleCount(cleanHeading, numArticles)}
+                                                {replaceArticleCount(
+                                                    cleanHeading,
+                                                    numArticles,
+                                                    'banner',
+                                                )}
                                             </span>
                                         )}
                                         <span css={styles.messageText}>
-                                            {replaceArticleCount(cleanMessageText, numArticles)}
+                                            {replaceArticleCount(
+                                                cleanMessageText,
+                                                numArticles,
+                                                'banner',
+                                            )}
                                         </span>
                                         {cleanHighlightedText && (
                                             <span css={styles.highlightedText}>
                                                 {replaceArticleCount(
                                                     cleanHighlightedText,
                                                     numArticles,
+                                                    'banner',
                                                 )}
                                             </span>
                                         )}

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -7,13 +7,13 @@ import { BannerProps } from '../../../../types/BannerTypes';
 import { styles } from './ContributionsBannerStyles';
 import {
     containsNonArticleCountPlaceholder,
-    replaceArticleCount,
     replaceNonArticleCountPlaceholders,
 } from '../../../../lib/placeholders';
 import { SvgRoundel } from '@guardian/src-brand';
 import { SvgCross, SvgArrowRightStraight } from '@guardian/src-icons';
 import { ThemeProvider } from 'emotion-theming';
 import { Button, LinkButton, buttonReaderRevenueBrandAlt } from '@guardian/src-button';
+import { replaceArticleCount } from '../../../../lib/replaceArticleCount';
 
 const bannerId = 'contributions-banner';
 const closeComponentId = `${bannerId} : close`;
@@ -147,6 +147,8 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
                     </div>
                 </>
             );
+        } else {
+            console.log('Banner copy contains placeholders, abandoning.');
         }
     }
 

--- a/src/components/modules/banners/contributions/ContributionsBannerStyles.ts
+++ b/src/components/modules/banners/contributions/ContributionsBannerStyles.ts
@@ -63,7 +63,7 @@ export const styles = {
         }
     `,
 
-    header: css`
+    heading: css`
         ${body.medium({ fontWeight: 'bold' })};
         &::selection {
             background-color: ${brandAlt[400]};

--- a/src/components/modules/epics/ArticleCountOptOut.tsx
+++ b/src/components/modules/epics/ArticleCountOptOut.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from 'emotion-theming';
 import { brand as brandTheme } from '@guardian/src-foundations/themes';
 import { from } from '@guardian/src-foundations/mq';
 import { addCookie } from '../../../lib/cookies';
+import { ComponentType } from '../../../types/shared';
 
 const ARTICLE_COUNT_OPT_OUT_COOKIE = {
     name: 'gu_article_count_opt_out',
@@ -37,7 +38,7 @@ const articleCountButton = css`
     font-weight: inherit;
 `;
 
-const overlayContainer = css`
+const overlayContainer = (componentType: ComponentType) => css`
     position: absolute;
     z-index: 100;
     left: ${space[4]}px;
@@ -46,6 +47,7 @@ const overlayContainer = css`
     background: ${brand[400]};
     ${textSans.medium()}
     padding: ${space[3]}px;
+    ${componentType === 'banner' ? 'bottom: 21px;' : ''}
 
 
     ${from.tablet} {
@@ -106,11 +108,13 @@ const overlayNote = css`
 export interface ArticleCountOptOutProps {
     numArticles: number;
     nextWord: string | null;
+    componentType: ComponentType;
 }
 
 export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
     numArticles,
     nextWord,
+    componentType,
 }: ArticleCountOptOutProps) => {
     const [isOpen, setIsOpen] = useState(false);
     const [hasOptedOut, setHasOptedOut] = useState(false);
@@ -160,7 +164,7 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
                 {`${numArticles}${nextWord ? nextWord : ''}`}
             </button>
             {isOpen && (
-                <div css={overlayContainer}>
+                <div css={overlayContainer(componentType)}>
                     <div css={overlayHeader}>
                         <div css={overlayHeaderText}>
                             {hasOptedOut ? "You've opted out" : "What's this?"}

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -111,7 +111,7 @@ interface EpicHeaderProps {
 }
 
 const EpicHeader: React.FC<EpicHeaderProps> = ({ text, numArticles }: EpicHeaderProps) => {
-    const elements = replaceArticleCount(text, numArticles);
+    const elements = replaceArticleCount(text, numArticles, 'epic');
     return <h2 css={headingStyles}>{elements}</h2>;
 };
 
@@ -119,7 +119,7 @@ const Highlighted: React.FC<HighlightedProps> = ({
     highlightedText,
     numArticles,
 }: HighlightedProps) => {
-    const elements = replaceArticleCount(highlightedText, numArticles);
+    const elements = replaceArticleCount(highlightedText, numArticles, 'epic');
 
     return (
         <strong css={highlightWrapperStyles}>
@@ -140,7 +140,7 @@ const EpicBodyParagraph: React.FC<EpicBodyParagraphProps> = ({
     numArticles,
     highlighted,
 }: EpicBodyParagraphProps) => {
-    const elements = replaceArticleCount(paragraph, numArticles);
+    const elements = replaceArticleCount(paragraph, numArticles, 'epic');
 
     return (
         <p css={bodyStyles}>

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -7,13 +7,13 @@ import { from } from '@guardian/src-foundations/mq';
 import {
     replaceNonArticleCountPlaceholders,
     containsNonArticleCountPlaceholder,
-    replaceArticleCount,
 } from '../../../lib/placeholders';
 import { EpicTracking } from './ContributionsEpicTypes';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { Variant } from '../../../lib/variants';
 import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { ContributionsEpicTicker } from './ContributionsEpicTicker';
+import { replaceArticleCount } from '../../../lib/replaceArticleCount';
 
 // Spacing values below are multiples of 4.
 // See https://www.theguardian.design/2a1e5182b/p/449bd5

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -7,13 +7,13 @@ import { from } from '@guardian/src-foundations/mq';
 import {
     replaceNonArticleCountPlaceholders,
     containsNonArticleCountPlaceholder,
+    replaceArticleCount,
 } from '../../../lib/placeholders';
 import { EpicTracking } from './ContributionsEpicTypes';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { Variant } from '../../../lib/variants';
 import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { ContributionsEpicTicker } from './ContributionsEpicTicker';
-import { ArticleCountOptOut } from './ArticleCountOptOut';
 
 // Spacing values below are multiples of 4.
 // See https://www.theguardian.design/2a1e5182b/p/449bd5
@@ -104,24 +104,6 @@ type BodyProps = {
 interface OnReminderOpen {
     buttonCopyAsString: string;
 }
-
-const replaceArticleCount = (text: string, numArticles: number): Array<JSX.Element> => {
-    const nextWords: Array<string | null> = [];
-    const subbedText = text.replace(/%%ARTICLE_COUNT%%( \w+)?/g, (_, nextWord) => {
-        nextWords.push(nextWord);
-        return '%%ARTICLE_COUNT_AND_NEXT_WORD%%';
-    });
-
-    const parts = subbedText.split(/%%ARTICLE_COUNT_AND_NEXT_WORD%%/);
-    const elements = [];
-    for (let i = 0; i < parts.length - 1; i += 1) {
-        elements.push(<span dangerouslySetInnerHTML={{ __html: parts[i] }} />);
-        elements.push(<ArticleCountOptOut numArticles={numArticles} nextWord={nextWords[i]} />);
-    }
-    elements.push(<span dangerouslySetInnerHTML={{ __html: parts[parts.length - 1] }} />);
-
-    return elements;
-};
 
 interface EpicHeaderProps {
     text: string;

--- a/src/lib/placeholders.test.ts
+++ b/src/lib/placeholders.test.ts
@@ -6,6 +6,13 @@ describe('containsNonArticleCountPlaceholder', () => {
         expect(got).toBe(true);
     });
 
+    it('returns true if string contains two placeholders (that is not %%ARTICLE_COUNT%%)', () => {
+        const got = containsNonArticleCountPlaceholder(
+            "You've read %%ARTICLE_COUNT%%. Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.",
+        );
+        expect(got).toBe(true);
+    });
+
     it('returns false if string contains an article count placeholder', () => {
         const got = containsNonArticleCountPlaceholder('apple %%ARTICLE_COUNT%%SDF%%');
         expect(got).toBe(false);

--- a/src/lib/placeholders.ts
+++ b/src/lib/placeholders.ts
@@ -1,6 +1,4 @@
 import { getCountryName, getLocalCurrencySymbol } from './geolocation';
-import { ArticleCountOptOut } from '../components/modules/epics/ArticleCountOptOut';
-import React from 'react';
 
 // we have to treat %%ARTICLE_COUNT%% placeholders specially as they are replaced
 // with react components, not a simple text substitution
@@ -21,26 +19,8 @@ export const replaceNonArticleCountPlaceholders = (
 };
 
 // Nb. don't attempt to use lookbehind (?<!) here, as IE 11 will break alas
-const PLACEHOLDER_RE = /%%.*?%%/;
+const PLACEHOLDER_RE = /%%.*?%%/g;
 export const containsNonArticleCountPlaceholder = (text: string): boolean => {
     const matches = text.match(PLACEHOLDER_RE)?.filter(str => str !== '%%ARTICLE_COUNT%%');
     return !!matches && matches.length > 0;
-};
-
-export const replaceArticleCount = (text: string, numArticles: number): Array<JSX.Element> => {
-    const nextWords: Array<string | null> = [];
-    const subbedText = text.replace(/%%ARTICLE_COUNT%%( \w+)?/g, (_, nextWord) => {
-        nextWords.push(nextWord);
-        return '%%ARTICLE_COUNT_AND_NEXT_WORD%%';
-    });
-
-    const parts = subbedText.split(/%%ARTICLE_COUNT_AND_NEXT_WORD%%/);
-    const elements = [];
-    for (let i = 0; i < parts.length - 1; i += 1) {
-        elements.push(<span dangerouslySetInnerHTML={{ __html: parts[i] }} />);
-        elements.push(<ArticleCountOptOut numArticles={numArticles} nextWord={nextWords[i]} />);
-    }
-    elements.push(<span dangerouslySetInnerHTML={{ __html: parts[parts.length - 1] }} />);
-
-    return elements;
 };

--- a/src/lib/placeholders.tsx
+++ b/src/lib/placeholders.tsx
@@ -1,4 +1,6 @@
 import { getCountryName, getLocalCurrencySymbol } from './geolocation';
+import { ArticleCountOptOut } from '../components/modules/epics/ArticleCountOptOut';
+import React from 'react';
 
 // we have to treat %%ARTICLE_COUNT%% placeholders specially as they are replaced
 // with react components, not a simple text substitution
@@ -25,4 +27,20 @@ export const containsNonArticleCountPlaceholder = (text: string): boolean => {
     return !!matches && matches.length > 0;
 };
 
-export const containsPlaceholder = (text: string): boolean => text.includes('%%');
+export const replaceArticleCount = (text: string, numArticles: number): Array<JSX.Element> => {
+    const nextWords: Array<string | null> = [];
+    const subbedText = text.replace(/%%ARTICLE_COUNT%%( \w+)?/g, (_, nextWord) => {
+        nextWords.push(nextWord);
+        return '%%ARTICLE_COUNT_AND_NEXT_WORD%%';
+    });
+
+    const parts = subbedText.split(/%%ARTICLE_COUNT_AND_NEXT_WORD%%/);
+    const elements = [];
+    for (let i = 0; i < parts.length - 1; i += 1) {
+        elements.push(<span dangerouslySetInnerHTML={{ __html: parts[i] }} />);
+        elements.push(<ArticleCountOptOut numArticles={numArticles} nextWord={nextWords[i]} />);
+    }
+    elements.push(<span dangerouslySetInnerHTML={{ __html: parts[parts.length - 1] }} />);
+
+    return elements;
+};

--- a/src/lib/replaceArticleCount.tsx
+++ b/src/lib/replaceArticleCount.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { ArticleCountOptOut } from '../components/modules/epics/ArticleCountOptOut';
+import { ComponentType } from '../types/shared';
 
-export const replaceArticleCount = (text: string, numArticles: number): Array<JSX.Element> => {
+export const replaceArticleCount = (
+    text: string,
+    numArticles: number,
+    componentType: ComponentType,
+): Array<JSX.Element> => {
     const nextWords: Array<string | null> = [];
     const subbedText = text.replace(/%%ARTICLE_COUNT%%( \w+)?/g, (_, nextWord) => {
         nextWords.push(nextWord);
@@ -12,7 +17,13 @@ export const replaceArticleCount = (text: string, numArticles: number): Array<JS
     const elements = [];
     for (let i = 0; i < parts.length - 1; i += 1) {
         elements.push(<span dangerouslySetInnerHTML={{ __html: parts[i] }} />);
-        elements.push(<ArticleCountOptOut numArticles={numArticles} nextWord={nextWords[i]} />);
+        elements.push(
+            <ArticleCountOptOut
+                numArticles={numArticles}
+                nextWord={nextWords[i]}
+                componentType={componentType}
+            />,
+        );
     }
     elements.push(<span dangerouslySetInnerHTML={{ __html: parts[parts.length - 1] }} />);
 

--- a/src/lib/replaceArticleCount.tsx
+++ b/src/lib/replaceArticleCount.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ArticleCountOptOut } from '../components/modules/epics/ArticleCountOptOut';
+
+export const replaceArticleCount = (text: string, numArticles: number): Array<JSX.Element> => {
+    const nextWords: Array<string | null> = [];
+    const subbedText = text.replace(/%%ARTICLE_COUNT%%( \w+)?/g, (_, nextWord) => {
+        nextWords.push(nextWord);
+        return '%%ARTICLE_COUNT_AND_NEXT_WORD%%';
+    });
+
+    const parts = subbedText.split(/%%ARTICLE_COUNT_AND_NEXT_WORD%%/);
+    const elements = [];
+    for (let i = 0; i < parts.length - 1; i += 1) {
+        elements.push(<span dangerouslySetInnerHTML={{ __html: parts[i] }} />);
+        elements.push(<ArticleCountOptOut numArticles={numArticles} nextWord={nextWords[i]} />);
+    }
+    elements.push(<span dangerouslySetInnerHTML={{ __html: parts[parts.length - 1] }} />);
+
+    return elements;
+};

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -126,7 +126,10 @@ const buildEpicData = async (
     const props: EpicProps = {
         variant: variantWithTickerData,
         tracking: { ...pageTracking, ...testTracking },
-        numArticles: getArticleViewCountForWeeks(targeting.weeklyArticleHistory),
+        numArticles: getArticleViewCountForWeeks(
+            targeting.weeklyArticleHistory,
+            test.articlesViewedSettings?.periodInWeeks,
+        ),
         countryCode: targeting.countryCode,
     };
 
@@ -180,6 +183,10 @@ const buildBannerData = async (
             isSupporter: !targeting.showSupportMessaging,
             countryCode: targeting.countryCode,
             content: variant.bannerContent,
+            numArticles: getArticleViewCountForWeeks(
+                targeting.weeklyArticleHistory,
+                test.articlesViewedSettings?.periodInWeeks,
+            ),
             tickerSettings,
         };
 

--- a/src/tests/banners/ContributionsBannerTests.ts
+++ b/src/tests/banners/ContributionsBannerTests.ts
@@ -32,6 +32,7 @@ const ContributionsBannerTest = (testParams: RawTestParams): BannerTest => {
                 moduleName: 'ContributionsBanner',
                 bannerContent: {
                     messageText: variant.body,
+                    heading: variant.heading,
                     highlightedText: variant.highlightedText,
                     cta: variant.cta,
                     secondaryCta: variant.secondaryCta,

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -48,7 +48,7 @@ export interface Cta {
 }
 
 export interface BannerContent {
-    header?: string;
+    heading?: string;
     messageText: string;
     highlightedText?: string;
     cta?: Cta;
@@ -101,11 +101,13 @@ export interface BannerProps {
     isSupporter?: boolean;
     tickerSettings?: TickerSettings;
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
+    numArticles?: number;
 }
 
 export interface RawVariantParams {
     name: string;
     body: string;
+    heading?: string;
     highlightedText?: string;
     cta?: Cta;
     secondaryCta?: Cta;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -10,3 +10,5 @@ export interface ArticlesViewedSettings {
     maxViews?: number;
     periodInWeeks: number;
 }
+
+export type ComponentType = 'epic' | 'banner';


### PR DESCRIPTION
We already exclude clients from tests based on their article view count.
This PR replaces the %%ARTICLE_COUNT%% template with the user's article count.
It re-uses the `replaceArticleCount` function from the epic's implementation of the same feature.

Also, renamed `header` -> `heading` for consistency with the banner tool (and the epic).

The following screenshot shows the count in the heading, body, and highlighted text parts of the banner:
![Screen Shot 2020-08-28 at 09 01 31](https://user-images.githubusercontent.com/1513454/91538147-43d47600-e90f-11ea-9078-3ba668ec331d.png)

Also, moved the popup above the link for banner:
![Screen Shot 2020-08-28 at 10 34 16](https://user-images.githubusercontent.com/1513454/91546725-d0386600-e91a-11ea-8cf6-1f17cde1fc2e.png)

But not for epic:
![Screen Shot 2020-08-28 at 10 34 23](https://user-images.githubusercontent.com/1513454/91546727-d0d0fc80-e91a-11ea-9489-226af939a7f4.png)