### PR TITLE
Enable banner for frontend

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,16 +27,6 @@ const globals = {
 const config = [
     ['epic', 'src/components/modules/epics/ContributionsEpic.tsx', 'dist/modules/epics/Epic.js'],
     [
-        'aus-banner',
-        'src/components/modules/banners/ausMomentContributionsBanner/AusMomentContributionsBanner.tsx',
-        'dist/modules/banners/ausMomentContributionsBanner/AusMomentContributionsBanner.js',
-    ],
-    [
-        'aus-thank-you-banner',
-        'src/components/modules/banners/ausMomentThankYouBanner/AusMomentThankYouBanner.tsx',
-        'dist/modules/banners/ausMomentThankYouBanner/AusMomentThankYouBanner.js',
-    ],
-    [
         'contributions-banner',
         'src/components/modules/banners/contributions/ContributionsBanner.tsx',
         'dist/modules/banners/contributions/ContributionsBanner.js',

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -102,7 +102,6 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
                                             <div css={styles.cta}>
                                                 <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
                                                     <LinkButton
-                                                        target="_blank"
                                                         data-link-name={ctaComponentId}
                                                         css={styles.ctaButton}
                                                         priority="primary"

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -102,6 +102,7 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
                                             <div css={styles.cta}>
                                                 <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
                                                     <LinkButton
+                                                        target="_blank"
                                                         data-link-name={ctaComponentId}
                                                         css={styles.ctaButton}
                                                         priority="primary"

--- a/src/components/modules/banners/contributions/ContributionsBannerStyles.ts
+++ b/src/components/modules/banners/contributions/ContributionsBannerStyles.ts
@@ -14,6 +14,7 @@ export const styles = {
     banner: css`
         padding: 0.5rem 0.625rem 0 0.625rem;
         margin: auto;
+        box-sizing: border-box;
 
         ${from.tablet} {
             padding: 0.5rem 20px 1.125rem 20px;

--- a/src/components/modules/epics/ArticleCountOptOut.tsx
+++ b/src/components/modules/epics/ArticleCountOptOut.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/core';
 import {
     brand,
@@ -127,27 +127,6 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
     const [isOpen, setIsOpen] = useState(false);
     const [hasOptedOut, setHasOptedOut] = useState(false);
 
-    const optOutRef = useRef<HTMLDivElement>(null);
-
-    const clickWasOutsideOptOut = (event: MouseEvent): boolean => {
-        if (optOutRef.current) {
-            return !optOutRef.current.contains(event.target as Node);
-        } else {
-            return true;
-        }
-    };
-
-    const handleClick = (event: MouseEvent): void => {
-        if (clickWasOutsideOptOut(event)) {
-            setIsOpen(false);
-        }
-    };
-
-    useEffect(() => {
-        document.addEventListener('mousedown', handleClick);
-        return (): void => document.removeEventListener('mousedown', handleClick);
-    }, []);
-
     const addArticleCountOptOutCookie = (): void =>
         addCookie(
             ARTICLE_COUNT_OPT_OUT_COOKIE.name,
@@ -167,7 +146,7 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
     };
 
     return (
-        <div css={optOutContainer} ref={optOutRef}>
+        <div css={optOutContainer} >
             <button css={articleCountButton} onClick={(): void => setIsOpen(!isOpen)}>
                 {`${numArticles}${nextWord ? nextWord : ''}`}
             </button>

--- a/src/components/modules/epics/ArticleCountOptOut.tsx
+++ b/src/components/modules/epics/ArticleCountOptOut.tsx
@@ -146,7 +146,7 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
     };
 
     return (
-        <div css={optOutContainer} >
+        <div css={optOutContainer}>
             <button css={articleCountButton} onClick={(): void => setIsOpen(!isOpen)}>
                 {`${numArticles}${nextWord ? nextWord : ''}`}
             </button>

--- a/src/tests/banners/ContributionsBannerTests.ts
+++ b/src/tests/banners/ContributionsBannerTests.ts
@@ -23,7 +23,7 @@ const ContributionsBannerTest = (testParams: RawTestParams): BannerTest => {
         testAudience: testParams.userCohort,
         locations: testParams.locations,
         canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking): boolean =>
-            testParams.isOn && pageTracking.clientName === 'dcr', // Do not serve to frontend for now
+            testParams.isOn,
         minPageViews: testParams.minArticlesBeforeShowingBanner,
         variants: testParams.variants.map(
             (variant: RawVariantParams): BannerVariant => ({

--- a/src/tests/banners/ContributionsBannerTests.ts
+++ b/src/tests/banners/ContributionsBannerTests.ts
@@ -22,8 +22,7 @@ const ContributionsBannerTest = (testParams: RawTestParams): BannerTest => {
         bannerType: 'contributions',
         testAudience: testParams.userCohort,
         locations: testParams.locations,
-        canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking): boolean =>
-            testParams.isOn,
+        canRun: (): boolean => testParams.isOn,
         minPageViews: testParams.minArticlesBeforeShowingBanner,
         variants: testParams.variants.map(
             (variant: RawVariantParams): BannerVariant => ({

--- a/src/tests/banners/ContributionsBannerTests.ts
+++ b/src/tests/banners/ContributionsBannerTests.ts
@@ -2,8 +2,6 @@ import fetch from 'node-fetch';
 import {
     BannerTestGenerator,
     BannerTest,
-    BannerTargeting,
-    BannerPageTracking,
     RawTestParams,
     RawVariantParams,
     BannerVariant,


### PR DESCRIPTION
The css change ensures that the text aligns with the article body in frontend (it wasn't required for DCR).

https://github.com/guardian/frontend/pull/22993

![Screen Shot 2020-09-10 at 08 52 42](https://user-images.githubusercontent.com/1513454/92708700-3d51ef80-f34e-11ea-85c1-8766e99da8f5.png)

Edit: I've removed the feature that allows the user to close the popup if they click elsewhere on the page. It doesn't work with frontend because of shadow dom, and the fix is fiddly and will not work on all browsers.
