### PR TITLE
Subscriptions banner: Make space for packshot to avoid reflow on image load

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -125,6 +125,8 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                 <img
                                     src="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&quality=85&s=24cb49b459c52c9d25868ca20979defb"
                                     alt=""
+                                    width="500"
+                                    height="297"
                                 />
                             </div>
                             <div css={iconPanel}>

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -125,8 +125,6 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                 <img
                                     src="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&quality=85&s=24cb49b459c52c9d25868ca20979defb"
                                     alt=""
-                                    width="500"
-                                    height="297"
                                 />
                             </div>
                             <div css={iconPanel}>

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -220,6 +220,7 @@ export const packShot = css`
     margin-top: -20px;
 
     img {
+        height: auto;
         width: 90%;
     }
 

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -212,6 +212,8 @@ export const bottomRightComponent = css`
     }
 `;
 
+const packShotWidth = 500;
+const packShotHeight = 297;
 export const packShot = css`
     max-width: 100%;
     display: flex;
@@ -219,9 +221,14 @@ export const packShot = css`
     align-items: flex-end;
     margin-top: -20px;
 
+    position: relative;
+    width: 90%;
+    padding-bottom: ${(packShotHeight / packShotWidth) * 100}%;
+
     img {
-        height: auto;
-        width: 90%;
+        width: 100%;
+        position: absolute;
+        bottom: 0;
     }
 
     ${from.mobileMedium} {


### PR DESCRIPTION
## What does this change?

This PR is about improving [cumulative layout shift](https://web.dev/cls/) (CLS) on the Digital Subs Banner. We can see in the filmstrip of the page loading that the text of the banner moves up when the packshot eventually loads.

<img width="522" alt="Rhys_Mills_-_Chat" src="https://user-images.githubusercontent.com/1672034/93621945-32ddc880-f9d4-11ea-9431-8764b1be6973.png">

<img width="525" alt="Untitled_document_-_Google_Docs" src="https://user-images.githubusercontent.com/1672034/93622828-b3e98f80-f9d5-11ea-9e67-b26a19f2fd76.png">

This type of "layout shift" is pretty standard behaviour, and only this year did browsers roll out a new CSS feature to address it. This is explained [on web.dev](https://web.dev/optimize-cls/#modern-best-practice), and this PR is basically an implementation of their recommended solution.

### How did you notice this?

Google scores pages based on CLS and 2 other metrics and uses that score to rank search results. Google calls this set of metrics "Core Web Vitals".

On July 29th, dotcom rendering started rendering reader revenue banners for the first time. And our Core Web Vitals for mobile web took a nose dive!

<img width="736" alt="Core_web_vitals" src="https://user-images.githubusercontent.com/1672034/93620644-3d975e00-f9d2-11ea-8f15-d68ee887ab3c.png">

Our pages are no longer considered good, which means google are less likely to surface them in search results : -(

Upon investigation this turns out to be driven by an increase in CLS. Given the coincidence of the dates, I measured CLS for different banners and I found this one to have the highest!

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I've only tested this in storybook so far. Ideally, I'd like to run dotcom locally and have the banner fetched from the server and rendered, so as to redo the filmstrip/performance analysis using chrome devtools. Is that possible?

## How can we measure success?

I'm hoping the number of pages that google thinks are "good" will rise!

## Have we considered potential risks?

The big risk I see is this patch making the banner not render properly and we lose acquisition. I wonder if there's a campaign code associated with the banner that could be used to monitor for any negative impact?

## Images

The banner should look exactly the same as before on all viewports.

<img width="635" alt="Storybook" src="https://user-images.githubusercontent.com/1672034/93622529-3756b100-f9d5-11ea-9629-8f96ecae13be.png">

<img width="1004" alt="Storybook" src="https://user-images.githubusercontent.com/1672034/93622570-463d6380-f9d5-11ea-84c1-eeb0c2a90d9b.png">