### PR TITLE
Allow subs banners to accept content via props

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,18 @@
     "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
     "[json]": {
         "editor.formatOnSave": false
-    }
+    },
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#53c876",
+        "activityBar.activeBorder": "#7856c9",
+        "activityBar.background": "#53c876",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#7856c9",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "statusBar.background": "#38b05c",
+        "statusBar.foreground": "#15202b",
+        "statusBarItem.hoverBackground": "#2c8948"
+    },
+    "peacock.color": "#38b05c"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,18 +5,5 @@
     "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
     "[json]": {
         "editor.formatOnSave": false
-    },
-    "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#53c876",
-        "activityBar.activeBorder": "#7856c9",
-        "activityBar.background": "#53c876",
-        "activityBar.foreground": "#15202b",
-        "activityBar.inactiveForeground": "#15202b99",
-        "activityBarBadge.background": "#7856c9",
-        "activityBarBadge.foreground": "#e7e7e7",
-        "statusBar.background": "#38b05c",
-        "statusBar.foreground": "#15202b",
-        "statusBarItem.hoverBackground": "#2c8948"
-    },
-    "peacock.color": "#38b05c"
+    }
 }

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
@@ -7,7 +7,11 @@ import { BannerContent, BannerProps, BannerTracking } from '../../../../types/Ba
 export default {
     component: DigitalSubscriptionsBanner,
     title: 'Components/DigitalSubscriptionsBanner',
-    decorators: [withKnobs],
+    decorators: [
+        withKnobs({
+            escapeHTML: false,
+        }),
+    ],
 };
 
 const tracking: BannerTracking = {

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from 'react';
 import { DigitalSubscriptionsBanner } from './DigitalSubscriptionsBanner';
-import { withKnobs } from '@storybook/addon-knobs';
+import { withKnobs, text } from '@storybook/addon-knobs';
 import { StorybookWrapper } from '../../../../utils/StorybookWrapper';
-import { BannerTracking } from '../../../../types/BannerTypes';
+import { BannerContent, BannerProps, BannerTracking } from '../../../../types/BannerTypes';
 
 export default {
     component: DigitalSubscriptionsBanner,
@@ -23,13 +23,24 @@ const tracking: BannerTracking = {
 };
 
 export const defaultStory = (): ReactElement => {
+    const content: BannerContent = {
+        heading: text('heading', 'Enjoy ad-free reading and the best of our apps'),
+        messageText: text(
+            'messageText',
+            'Support the Guardian with a Digital Subscription, enjoy our reporting without ads and get premium access to our Live app and The Daily.',
+        ),
+    };
+
+    const props: BannerProps = {
+        bannerChannel: 'subscriptions',
+        content,
+        isSupporter: false,
+        tracking,
+    };
+
     return (
         <StorybookWrapper>
-            <DigitalSubscriptionsBanner
-                bannerChannel="subscriptions"
-                tracking={tracking}
-                isSupporter={false}
-            />
+            <DigitalSubscriptionsBanner {...props} />
         </StorybookWrapper>
     );
 };

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -38,6 +38,7 @@ const signInComponentId = `${bannerId} : sign in`;
 
 export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     bannerChannel,
+    content,
     tracking,
     submitComponentEvent,
 }: BannerProps) => {
@@ -88,12 +89,8 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                 <section css={banner} data-target={bannerId}>
                     <div css={contentContainer}>
                         <div css={topLeftComponent}>
-                            <h3 css={heading}>Enjoy ad-free reading and the best of our apps</h3>
-                            <p css={paragraph}>
-                                Support the Guardian with a Digital Subscription, enjoy our
-                                reporting without ads and get premium access to our Live app and The
-                                Daily.
-                            </p>
+                            <h3 css={heading}>{content?.heading}</h3>
+                            <p css={paragraph}>{content?.messageText}</p>
                             <a css={linkStyle} onClick={onSubscribeClick}>
                                 <div data-link-name={ctaComponentId} css={becomeASubscriberButton}>
                                     <span css={buttonTextDesktop}>Become a digital subscriber</span>

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -35,6 +35,7 @@ const signInComponentId = `${bannerId} : sign in`;
 
 export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
     bannerChannel,
+    content,
     tracking,
     submitComponentEvent,
 }: BannerProps) => {
@@ -85,12 +86,8 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                 <section css={banner} data-target={bannerId}>
                     <div css={contentContainer}>
                         <div css={topLeftComponent}>
-                            <h3 css={heading}>Read The Guardian in print</h3>
-                            <p css={paragraph}>
-                                Support The Guardian&apos;s independent journalism by subscribing to
-                                The Guardian Weekly, our essential world news magazine. Home
-                                delivery available wherever you are.
-                            </p>
+                            <h3 css={heading}>{content?.heading}</h3>
+                            <p css={paragraph}>{content?.messageText}</p>
                             <a
                                 data-link-name={ctaComponentId}
                                 css={linkStyle}

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
@@ -1,11 +1,17 @@
 import React, { ReactElement } from 'react';
 import { GuardianWeeklyBanner } from './GuardianWeeklyBanner';
+import { withKnobs, text } from '@storybook/addon-knobs';
 import { StorybookWrapper } from '../../../../utils/StorybookWrapper';
-import { BannerTracking } from '../../../../types/BannerTypes';
+import { BannerContent, BannerProps, BannerTracking } from '../../../../types/BannerTypes';
 
 export default {
     component: GuardianWeeklyBanner,
     title: 'Components/GuardianWeeklyBanner',
+    decorators: [
+        withKnobs({
+            escapeHTML: false,
+        }),
+    ],
 };
 
 const tracking: BannerTracking = {
@@ -21,13 +27,23 @@ const tracking: BannerTracking = {
 };
 
 export const defaultStory = (): ReactElement => {
+    const content: BannerContent = {
+        heading: text('heading', 'Read The Guardian in print'),
+        messageText: text(
+            'messageText',
+            "Support The Guardian's independent journalism by subscribing to The Guardian Weekly, our essential world news magazine. Home delivery available wherever you are.",
+        ),
+    };
+
+    const props: BannerProps = {
+        bannerChannel: 'subscriptions',
+        content,
+        isSupporter: false,
+        tracking,
+    };
     return (
         <StorybookWrapper>
-            <GuardianWeeklyBanner
-                bannerChannel="subscriptions"
-                tracking={tracking}
-                isSupporter={false}
-            />
+            <GuardianWeeklyBanner {...props} />
         </StorybookWrapper>
     );
 };

--- a/src/tests/banners/DigitalSubscriptionsBannerTest.ts
+++ b/src/tests/banners/DigitalSubscriptionsBannerTest.ts
@@ -22,6 +22,11 @@ export const DigitalSubscriptionsBanner: BannerTest = {
             name: 'control',
             modulePath: DigitalSubscriptionsBannerPath,
             moduleName: name,
+            bannerContent: {
+                messageText:
+                    'Support the Guardian with a Digital Subscription, enjoy our reporting without ads and get premium access to our Live app and The Daily',
+                heading: 'Enjoy ad-free reading and the best of our apps',
+            },
             componentType: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
             products: ['DIGITAL_SUBSCRIPTION'],
         },

--- a/src/tests/banners/GuardianWeeklyBannerTest.ts
+++ b/src/tests/banners/GuardianWeeklyBannerTest.ts
@@ -22,6 +22,11 @@ export const GuardianWeeklyBanner: BannerTest = {
             name: 'control',
             modulePath: GuardianWeeklyBannerPath,
             moduleName: name,
+            bannerContent: {
+                messageText:
+                    "Support The Guardian's independent journalism by subscribing to The Guardian Weekly, our essential world news magazine. Home delivery available wherever you are.",
+                heading: 'Read The Guardian in print',
+            },
             componentType: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
             products: ['PRINT_SUBSCRIPTION'],
         },


### PR DESCRIPTION
## What does this change?
This adds the ability to pass heading and message copy as props to the Digital Subscriptions and Guardian Weekly banners, so their content can be managed via support-admin-console.

The CTA text remains hard-coded as it needs to be different at different breakpoints- we'll look at adding this to support-admin-console in future.

## How to test
In CODE, changes made to the copy of any test variant which is using the Digital Subscriptions or Guardian Weekly template [here](https://support.code.dev-gutools.co.uk/) should be visible in the correct template on dotcom CODE.

## Have we considered potential risks?
Currently the second banner channel only gets retrieved on CODE. I've updated the existing hard-coded tests in src/tests/banners for the Digital Subs and Weekly banners to include the current heading and message copy to be passed as props when the banners are rendered, and tested that this works in CODE with the second banner channel retrieval completely turned off, so this shouldn't cause any regressions if merged to production now.