### PR TITLE
Re-implement cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "express": "^4.17.1",
     "jsonschema": "^1.2.5",
     "lodash.debounce": "^4.0.8",
-    "node-cache": "^5.1.0",
     "node-fetch": "^2.6.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -1,0 +1,92 @@
+import {cacheAsync} from "./cache";
+
+jest.useFakeTimers();
+
+describe('cache', () => {
+
+    it('sets new cache value', async () => {
+        const fn = jest.fn().mockImplementation(() => Promise.resolve(true));
+        const [reset, fetchData] = cacheAsync(
+            fn,
+            60,
+            'test1',
+        );
+
+        await fetchData();
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        reset();
+    });
+
+    it('sets new cache value and uses cached value', async () => {
+        const fn = jest.fn().mockImplementation(() => Promise.resolve(true));
+        const [reset, fetchData] = cacheAsync(
+            fn,
+            60,
+            'test1',
+        );
+
+        await fetchData();
+
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        await fetchData();
+
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        reset();
+    });
+
+    it('sets new cache value and refresh', async () => {
+        const fn = jest.fn().mockImplementation(() => Promise.resolve(true));
+        const [reset, fetchData] = cacheAsync(
+            fn,
+            60,
+            'test1',
+        );
+
+        await fetchData();
+
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        jest.runOnlyPendingTimers();    // fast-forward to first refresh
+
+        expect(fn).toHaveBeenCalledTimes(2);
+
+        reset();
+    });
+
+    // TODO - test it doesn't call fn twice within ttl
+
+    it('retries if a refresh fails', async () => {
+        // Use counter to ensure it fails on the 2nd invocation only
+        var counter = 0;
+        const fn = jest.fn().mockImplementation(() => {
+            counter++;
+            if (counter === 2) return Promise.reject("ERROR!");
+            else return Promise.resolve(true);
+            // return Promise.resolve(true);
+        });
+        const [reset, fetchData] = cacheAsync(
+            fn,
+            60,
+            'test2',
+        );
+
+        await fetchData();
+
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        await fetchData();
+        jest.runOnlyPendingTimers();    // fast-forward to first refresh
+
+        expect(fn).toHaveBeenCalledTimes(2);
+
+        await fetchData();
+        jest.runOnlyPendingTimers();    // fast-forward to second refresh
+
+        expect(fn).toHaveBeenCalledTimes(3);
+
+        reset();
+    });
+});

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -7,8 +7,9 @@ describe('cache', () => {
         const fn = jest.fn().mockImplementation(() => Promise.resolve(true));
         const [reset, fetchData] = cacheAsync(fn, 60, 'test1');
 
-        await fetchData();
+        const value = await fetchData();
 
+        expect(value).toEqual(true);
         expect(fn).toHaveBeenCalledTimes(1);
         reset();
     });
@@ -28,7 +29,7 @@ describe('cache', () => {
         reset();
     });
 
-    it('sets new cache value and refresh', async () => {
+    it('sets new cache value and refreshes', async () => {
         const fn = jest.fn().mockImplementation(() => Promise.resolve(true));
         const [reset, fetchData] = cacheAsync(fn, 60, 'test1');
 
@@ -42,8 +43,6 @@ describe('cache', () => {
 
         reset();
     });
-
-    // TODO - test it doesn't call fn twice within ttl
 
     it('retries if a refresh fails', async () => {
         // Use counter to ensure it fails on the 2nd invocation only

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -16,7 +16,7 @@ describe('cache', () => {
 
     it('sets new cache value and uses cached value', async () => {
         const fn = jest.fn().mockImplementation(() => Promise.resolve(true));
-        const [reset, fetchData] = cacheAsync(fn, 60, 'test1');
+        const [reset, fetchData] = cacheAsync(fn, 60, 'test2');
 
         await fetchData();
 
@@ -31,7 +31,7 @@ describe('cache', () => {
 
     it('sets new cache value and refreshes', async () => {
         const fn = jest.fn().mockImplementation(() => Promise.resolve(true));
-        const [reset, fetchData] = cacheAsync(fn, 60, 'test1');
+        const [reset, fetchData] = cacheAsync(fn, 60, 'test3');
 
         await fetchData();
 
@@ -55,7 +55,7 @@ describe('cache', () => {
                 return Promise.resolve(true);
             }
         });
-        const [reset, fetchData] = cacheAsync(fn, 60, 'test2');
+        const [reset, fetchData] = cacheAsync(fn, 60, 'test4');
 
         await fetchData();
 

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -54,7 +54,6 @@ describe('cache', () => {
             } else {
                 return Promise.resolve(true);
             }
-            // return Promise.resolve(true);
         });
         const [reset, fetchData] = cacheAsync(fn, 60, 'test2');
 

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -1,16 +1,11 @@
-import {cacheAsync} from "./cache";
+import { cacheAsync } from './cache';
 
 jest.useFakeTimers();
 
 describe('cache', () => {
-
     it('sets new cache value', async () => {
         const fn = jest.fn().mockImplementation(() => Promise.resolve(true));
-        const [reset, fetchData] = cacheAsync(
-            fn,
-            60,
-            'test1',
-        );
+        const [reset, fetchData] = cacheAsync(fn, 60, 'test1');
 
         await fetchData();
 
@@ -20,11 +15,7 @@ describe('cache', () => {
 
     it('sets new cache value and uses cached value', async () => {
         const fn = jest.fn().mockImplementation(() => Promise.resolve(true));
-        const [reset, fetchData] = cacheAsync(
-            fn,
-            60,
-            'test1',
-        );
+        const [reset, fetchData] = cacheAsync(fn, 60, 'test1');
 
         await fetchData();
 
@@ -39,17 +30,13 @@ describe('cache', () => {
 
     it('sets new cache value and refresh', async () => {
         const fn = jest.fn().mockImplementation(() => Promise.resolve(true));
-        const [reset, fetchData] = cacheAsync(
-            fn,
-            60,
-            'test1',
-        );
+        const [reset, fetchData] = cacheAsync(fn, 60, 'test1');
 
         await fetchData();
 
         expect(fn).toHaveBeenCalledTimes(1);
 
-        jest.runOnlyPendingTimers();    // fast-forward to first refresh
+        jest.runOnlyPendingTimers(); // fast-forward to first refresh
 
         expect(fn).toHaveBeenCalledTimes(2);
 
@@ -60,30 +47,29 @@ describe('cache', () => {
 
     it('retries if a refresh fails', async () => {
         // Use counter to ensure it fails on the 2nd invocation only
-        var counter = 0;
+        let counter = 0;
         const fn = jest.fn().mockImplementation(() => {
             counter++;
-            if (counter === 2) return Promise.reject("ERROR!");
-            else return Promise.resolve(true);
+            if (counter === 2) {
+                return Promise.reject('ERROR!');
+            } else {
+                return Promise.resolve(true);
+            }
             // return Promise.resolve(true);
         });
-        const [reset, fetchData] = cacheAsync(
-            fn,
-            60,
-            'test2',
-        );
+        const [reset, fetchData] = cacheAsync(fn, 60, 'test2');
 
         await fetchData();
 
         expect(fn).toHaveBeenCalledTimes(1);
 
         await fetchData();
-        jest.runOnlyPendingTimers();    // fast-forward to first refresh
+        jest.runOnlyPendingTimers(); // fast-forward to first refresh
 
         expect(fn).toHaveBeenCalledTimes(2);
 
         await fetchData();
-        jest.runOnlyPendingTimers();    // fast-forward to second refresh
+        jest.runOnlyPendingTimers(); // fast-forward to second refresh
 
         expect(fn).toHaveBeenCalledTimes(3);
 

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -6,6 +6,18 @@ const cache: Cache = {};
 
 const retryIntervalMs = 5000;
 
+/**
+ * A cache that refreshes after ttlSec seconds.
+ * If there are cache reads after ttlSecs have expired but before the value has been refreshed then
+ * the stale data will be returned.
+ *
+ * If a refresh attempt fails then it will be retried after retryIntervalMs, and stale data will be returned until this
+ * completes.
+ *
+ * @param fn        the async function for generating the data to be cached
+ * @param ttlSec    time to live in seconds
+ * @param key       unique cache key
+ */
 export const cacheAsync = <T>(
     fn: () => Promise<T>,
     ttlSec: number,

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -8,7 +8,7 @@ const retryIntervalMs = 5000;
 
 /**
  * A cache that refreshes after ttlSec seconds.
- * If there are cache reads after ttlSecs have expired but before the value has been refreshed then
+ * If there are cache reads after a value has expired but before the value has been refreshed then
  * the stale data will be returned.
  *
  * If a refresh attempt fails then it will be retried after retryIntervalMs, and stale data will be returned until this

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,5 +1,6 @@
 interface Cache {
-    [key: string]: any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
 }
 const cache: Cache = {};
 
@@ -10,7 +11,7 @@ export const cacheAsync = <T>(
     ttlSec: number,
     key: string,
 ): [() => void, () => Promise<T>] => {
-    const getValue = async () => {
+    const getValue = async (): Promise<T> => {
         if (cache[key] !== undefined) {
             return Promise.resolve(cache[key] as T);
         } else {
@@ -18,19 +19,16 @@ export const cacheAsync = <T>(
             const result: T = await fn();
             cache[key] = result;
 
-            const scheduleRefresh = (ms: number) => {
-                setTimeout(
-                    async () => {
-                        try {
-                            cache[key] = await fn();
-                            scheduleRefresh(ms);
-                        } catch(err) {
-                            console.log(`Error refreshing cached value for key ${key}: ${err}`);
-                            scheduleRefresh(retryIntervalMs);
-                        }
-                    },
-                    ms,
-                );
+            const scheduleRefresh = (ms: number): void => {
+                setTimeout(async () => {
+                    try {
+                        cache[key] = await fn();
+                        scheduleRefresh(ms);
+                    } catch (err) {
+                        console.log(`Error refreshing cached value for key ${key}: ${err}`);
+                        scheduleRefresh(retryIntervalMs);
+                    }
+                }, ms);
             };
 
             scheduleRefresh(ttlSec * 1000);
@@ -39,7 +37,9 @@ export const cacheAsync = <T>(
         }
     };
 
-    const reset = () => { cache[key] = undefined };
+    const reset = (): void => {
+        cache[key] = undefined;
+    };
 
     return [reset, getValue];
 };

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,24 +1,45 @@
-import NodeCache from 'node-cache';
+interface Cache {
+    [key: string]: any
+}
+const cache: Cache = {};
 
-const cache = new NodeCache();
+const retryIntervalMs = 5000;
 
 export const cacheAsync = <T>(
     fn: () => Promise<T>,
     ttlSec: number,
     key: string,
 ): [() => void, () => Promise<T>] => {
-    const retFn = async (): Promise<T> => {
-        const got = cache.get(key);
-        if (got !== undefined) {
-            return got as T;
-        }
+    const getValue = async () => {
+        if (cache[key] !== undefined) {
+            return Promise.resolve(cache[key] as T);
+        } else {
+            // First read attempt on this key. Fetch an initial value and setup the refresh scheduler
+            const result: T = await fn();
+            cache[key] = result;
 
-        const res = await fn();
-        cache.set(key, res, ttlSec);
-        return res;
+            const scheduleRefresh = (ms: number) => {
+                setTimeout(
+                    async () => {
+                        try {
+                            cache[key] = await fn();
+                            scheduleRefresh(ms);
+                        } catch(err) {
+                            console.log(`Error refreshing cached value for key ${key}: ${err}`);
+                            scheduleRefresh(retryIntervalMs);
+                        }
+                    },
+                    ms,
+                );
+            };
+
+            scheduleRefresh(ttlSec * 1000);
+
+            return Promise.resolve(result);
+        }
     };
 
-    const resetFn = (): number => cache.del(key);
+    const reset = () => { cache[key] = undefined };
 
-    return [resetFn, retFn];
+    return [reset, getValue];
 };


### PR DESCRIPTION
We cache some data in memory, e.g. the epic and banner test data from the tools.

Currently we use `node-cache`. When a cached value expires it becomes `undefined`. Any reads will then re-trigger the loading function.
This is not appropriate for this server because we receive thousands of client requests per minute, and so if there is a delay in refreshing the cache then the server will attempt to make a request for the data for each incoming client request.

I suspect this is the cause of the intermittent problems we've been having, where a server becomes unable to make new http requests for a time (possibly because it reaches the open files limit), e.g.:
![Screen Shot 2020-09-25 at 12 16 18](https://user-images.githubusercontent.com/1513454/94260971-ff95bf00-ff28-11ea-9ff5-08224a4e7eaf.png)

I've instead written a custom cache which periodically refreshes the value, but will continue to serve a stale value until it can be refreshed. If a refresh attempt fails then it logs and retries after 5 seconds.