### PR TITLE
Fix DigitalSubscriptionsBanner packshot issues

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
+import { css } from '@emotion/core';
 import { addTrackingParams, createClickEventFromTracking } from '../../../../lib/tracking';
 import React, { useState } from 'react';
 import { SvgGuardianLogo } from '@guardian/src-brand';
@@ -23,6 +24,7 @@ import {
     becomeASubscriberButton,
     linkStyle,
     signInLink,
+    packShotContainer
 } from './digitalSubscriptionsBannerStyles';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setChannelClosedTimestamp } from '../localStorage';
@@ -118,11 +120,13 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                             </div>
                         </div>
                         <div css={bottomRightComponent}>
-                            <div css={packShot}>
-                                <img
-                                    src="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&quality=85&s=24cb49b459c52c9d25868ca20979defb"
-                                    alt=""
-                                />
+                            <div css={packShotContainer}>
+                                <div css={packShot}>
+                                    <img
+                                        src="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&quality=85&s=24cb49b459c52c9d25868ca20979defb"
+                                        alt=""
+                                    />
+                                </div>
                             </div>
                             <div css={iconPanel}>
                                 <button

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
-import { css } from '@emotion/core';
 import { addTrackingParams, createClickEventFromTracking } from '../../../../lib/tracking';
 import React, { useState } from 'react';
 import { SvgGuardianLogo } from '@guardian/src-brand';
@@ -24,7 +23,7 @@ import {
     becomeASubscriberButton,
     linkStyle,
     signInLink,
-    packShotContainer
+    packShotContainer,
 } from './digitalSubscriptionsBannerStyles';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setChannelClosedTimestamp } from '../localStorage';

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -214,7 +214,7 @@ export const bottomRightComponent = css`
     }
 `;
 
-export const c = css`
+export const packShotContainer = css`
     flex: 1;
     display: flex;
     flex-direction: column;

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -4,7 +4,9 @@ import { neutral, brandAlt, text } from '@guardian/src-foundations/palette';
 import { from, until, between } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
-const closeButtonWidthHeight = '35px';
+const closeButtonWidthHeight = 35;
+const packShotWidth = 500;
+const packShotHeight = 297;
 
 export const banner = css`
     html {
@@ -67,7 +69,7 @@ export const heading = css`
     ${headline.xsmall({ fontWeight: 'bold' })};
     margin: 0;
     max-width: 100%;
-    padding-right: ${closeButtonWidthHeight};
+    padding-right: ${closeButtonWidthHeight}px;
 
     @media (min-width: 740px) {
         max-width: 90%;
@@ -218,18 +220,12 @@ export const packShotContainer = css`
     flex-direction: column;
     justify-content: flex-end;
     margin: 0 ${space[4]}px;
-
-    ${between.phablet.and.tablet} {
-        max-width: 75%;
-    }
+    max-width: ${packShotWidth}px;
 
     ${from.wide} {
         margin-top: ${space[4]}px;
     }
 `;
-
-const packShotWidth = 500;
-const packShotHeight = 297;
 
 export const packShot = css`
     width: 100%;

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 import { body, headline, textSans } from '@guardian/src-foundations/typography/cjs';
 import { neutral, brandAlt, text } from '@guardian/src-foundations/palette';
-import { from, until, between } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
 const closeButtonWidthHeight = 35;
@@ -214,7 +214,7 @@ export const bottomRightComponent = css`
     }
 `;
 
-export const packShotContainer = css`
+export const c = css`
     flex: 1;
     display: flex;
     flex-direction: column;

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 import { body, headline, textSans } from '@guardian/src-foundations/typography/cjs';
 import { neutral, brandAlt, text } from '@guardian/src-foundations/palette';
-import { from, until } from '@guardian/src-foundations/mq';
+import { from, until, between } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
 const closeButtonWidthHeight = '35px';
@@ -212,55 +212,34 @@ export const bottomRightComponent = css`
     }
 `;
 
+export const packShotContainer = css`
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    margin: 0 ${space[4]}px;
+
+    ${between.phablet.and.tablet} {
+        max-width: 75%;
+    }
+
+    ${from.wide} {
+        margin-top: ${space[4]}px;
+    }
+`;
+
 const packShotWidth = 500;
 const packShotHeight = 297;
-export const packShot = css`
-    max-width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: flex-end;
-    margin-top: -20px;
 
+export const packShot = css`
+    width: 100%;
     position: relative;
-    width: 90%;
     padding-bottom: ${(packShotHeight / packShotWidth) * 100}%;
 
     img {
         width: 100%;
         position: absolute;
         bottom: 0;
-    }
-
-    ${from.mobileMedium} {
-        margin-top: -10px;
-    }
-
-    ${from.phablet} {
-        max-width: 100%;
-    }
-
-    ${from.tablet} {
-        img {
-            max-width: 125%;
-        }
-    }
-
-    ${from.tablet} {
-        img {
-            width: 100%;
-        }
-    }
-
-    ${from.leftCol} {
-        max-width: 80%;
-        img {
-            width: 90%;
-        }
-    }
-
-    ${from.wide} {
-        max-width: 100%;
-        width: 75%;
     }
 `;
 


### PR DESCRIPTION
## What does this change?

In this PR https://github.com/guardian/support-dotcom-components/pull/231 we made a change to reserve space for the packshot image on the DigitalSubscriptionsBanner to avoid reflow on image load. We did this by adding a `padding-bottom` to the `packShot` element which wrapped the `<img>`. 

After releasing this issue an was raised by @jfsoul who had seen the `packshot` elements padding was unnecessarily high. This is because The `padding-bottom` on the `packShot` element is calculated relative to the width of it's containing element. In this case the containing element `bottomRightComponent` was wider than the image area. To resolve this we need an additional containing element around the `packshot` element, this new `packShotContainer` is the width of the image, so the `padding-bottom` will be calculated relative to this width.

**Rotating through different screen widths in Storybook following change...**

![DS_BANNER_SB](https://user-images.githubusercontent.com/1590704/94559772-a051ea80-0259-11eb-9e91-9d0c76ecbf99.gif)




