### PR TITLE
Trim whitespace from tool and add it manually between sections

### DIFF
--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -44,14 +44,17 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
     if (content && countryCode && showBanner) {
         const cleanHighlightedText =
             content.highlightedText &&
-            replaceNonArticleCountPlaceholders(content.highlightedText, countryCode);
+            replaceNonArticleCountPlaceholders(content.highlightedText, countryCode).trim();
 
         const cleanMessageText = replaceNonArticleCountPlaceholders(
             content.messageText,
             countryCode,
-        );
+        ).trim();
 
-        const cleanHeading = replaceNonArticleCountPlaceholders(content.heading, countryCode);
+        const cleanHeading = replaceNonArticleCountPlaceholders(
+            content.heading,
+            countryCode,
+        ).trim();
 
         const copyHasPlaceholder =
             containsNonArticleCountPlaceholder(cleanMessageText) ||
@@ -72,13 +75,15 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
                                 <div css={styles.copyAndCta}>
                                     <div css={styles.copy}>
                                         {cleanHeading && (
-                                            <span css={styles.heading}>
-                                                {replaceArticleCount(
-                                                    cleanHeading,
-                                                    numArticles,
-                                                    'banner',
-                                                )}
-                                            </span>
+                                            <>
+                                                <span css={styles.heading}>
+                                                    {replaceArticleCount(
+                                                        cleanHeading,
+                                                        numArticles,
+                                                        'banner',
+                                                    )}
+                                                </span>{' '}
+                                            </>
                                         )}
                                         <span css={styles.messageText}>
                                             {replaceArticleCount(
@@ -88,13 +93,16 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
                                             )}
                                         </span>
                                         {cleanHighlightedText && (
-                                            <span css={styles.highlightedText}>
-                                                {replaceArticleCount(
-                                                    cleanHighlightedText,
-                                                    numArticles,
-                                                    'banner',
-                                                )}
-                                            </span>
+                                            <>
+                                                {' '}
+                                                <span css={styles.highlightedText}>
+                                                    {replaceArticleCount(
+                                                        cleanHighlightedText,
+                                                        numArticles,
+                                                        'banner',
+                                                    )}
+                                                </span>
+                                            </>
                                         )}
                                     </div>
                                     {content.cta && (


### PR DESCRIPTION
## What does this change?
Fix some issues with whitespace in the contributions banner. This is coming from [this card](https://trello.com/c/muzZ8j5M/2281-epic-banner-manager-parent-card-of-bugs-and-fixes). It was reported as a bug with the banner manager, but I think it makes sense to fix it here. A user could easily leave some trailing whitespace in the tool without realising it. 

## Images
<img width="1460" alt="Screenshot 2020-09-29 at 14 11 11" src="https://user-images.githubusercontent.com/17720442/94563231-50c1ed80-025e-11eb-8579-4547d91375f7.png">

