### PR TITLE
Realign roundel and close and tweak heading size

### DIFF
--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -66,98 +66,96 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
                 <>
                     <div css={styles.bannerContainer}>
                         <div css={styles.banner}>
-                            <div css={styles.bannerFlexBox}>
-                                <div css={styles.leftRoundel}>
+                            <div css={styles.leftRoundel}>
+                                <div css={styles.roundelContainer}>
+                                    <SvgRoundel />
+                                </div>
+                            </div>
+                            <div css={styles.copyAndCta}>
+                                <div css={styles.copy}>
+                                    {cleanHeading && (
+                                        <>
+                                            <span css={styles.heading}>
+                                                {replaceArticleCount(
+                                                    cleanHeading,
+                                                    numArticles,
+                                                    'banner',
+                                                )}
+                                            </span>{' '}
+                                        </>
+                                    )}
+                                    <span css={styles.messageText}>
+                                        {replaceArticleCount(
+                                            cleanMessageText,
+                                            numArticles,
+                                            'banner',
+                                        )}
+                                    </span>
+                                    {cleanHighlightedText && (
+                                        <>
+                                            {' '}
+                                            <span css={styles.highlightedText}>
+                                                {replaceArticleCount(
+                                                    cleanHighlightedText,
+                                                    numArticles,
+                                                    'banner',
+                                                )}
+                                            </span>
+                                        </>
+                                    )}
+                                </div>
+                                {content.cta && (
+                                    <div css={styles.ctaContainer}>
+                                        <div css={styles.cta}>
+                                            <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
+                                                <LinkButton
+                                                    data-link-name={ctaComponentId}
+                                                    css={styles.ctaButton}
+                                                    priority="primary"
+                                                    size="small"
+                                                    icon={<SvgArrowRightStraight />}
+                                                    iconSide="right"
+                                                    nudgeIcon={true}
+                                                    onClick={onContributeClick}
+                                                    hideLabel={false}
+                                                    aria-label="Contribute"
+                                                    href={addTrackingParams(
+                                                        content.cta.baseUrl,
+                                                        props.tracking,
+                                                    )}
+                                                >
+                                                    {content.cta.text}
+                                                </LinkButton>
+                                            </ThemeProvider>
+                                            <img
+                                                src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+                                                alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                                                css={styles.paymentMethods}
+                                            />
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                            <div css={styles.rightButtons}>
+                                <div css={styles.rightRoundel}>
                                     <div css={styles.roundelContainer}>
                                         <SvgRoundel />
                                     </div>
                                 </div>
-                                <div css={styles.copyAndCta}>
-                                    <div css={styles.copy}>
-                                        {cleanHeading && (
-                                            <>
-                                                <span css={styles.heading}>
-                                                    {replaceArticleCount(
-                                                        cleanHeading,
-                                                        numArticles,
-                                                        'banner',
-                                                    )}
-                                                </span>{' '}
-                                            </>
-                                        )}
-                                        <span css={styles.messageText}>
-                                            {replaceArticleCount(
-                                                cleanMessageText,
-                                                numArticles,
-                                                'banner',
-                                            )}
-                                        </span>
-                                        {cleanHighlightedText && (
-                                            <>
-                                                {' '}
-                                                <span css={styles.highlightedText}>
-                                                    {replaceArticleCount(
-                                                        cleanHighlightedText,
-                                                        numArticles,
-                                                        'banner',
-                                                    )}
-                                                </span>
-                                            </>
-                                        )}
-                                    </div>
-                                    {content.cta && (
-                                        <div css={styles.ctaContainer}>
-                                            <div css={styles.cta}>
-                                                <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
-                                                    <LinkButton
-                                                        data-link-name={ctaComponentId}
-                                                        css={styles.ctaButton}
-                                                        priority="primary"
-                                                        size="small"
-                                                        icon={<SvgArrowRightStraight />}
-                                                        iconSide="right"
-                                                        nudgeIcon={true}
-                                                        onClick={onContributeClick}
-                                                        hideLabel={false}
-                                                        aria-label="Contribute"
-                                                        href={addTrackingParams(
-                                                            content.cta.baseUrl,
-                                                            props.tracking,
-                                                        )}
-                                                    >
-                                                        {content.cta.text}
-                                                    </LinkButton>
-                                                </ThemeProvider>
-                                                <img
-                                                    src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
-                                                    alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-                                                    css={styles.paymentMethods}
-                                                />
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                                <div css={styles.rightButtons}>
-                                    <div css={styles.rightRoundel}>
-                                        <div css={styles.roundelContainer}>
-                                            <SvgRoundel />
-                                        </div>
-                                    </div>
-                                    <div css={styles.closeButtonContainer}>
-                                        <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
-                                            <Button
-                                                aria-label="Close"
-                                                data-link-name={closeComponentId}
-                                                priority="tertiary"
-                                                size="small"
-                                                icon={<SvgCross />}
-                                                nudgeIcon={false}
-                                                onClick={onCloseClick}
-                                                hideLabel={true}
-                                                iconSide="left"
-                                            />
-                                        </ThemeProvider>
-                                    </div>
+                                <div css={styles.closeButtonContainer}>
+                                    <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
+                                        <Button
+                                            aria-label="Close"
+                                            data-link-name={closeComponentId}
+                                            priority="tertiary"
+                                            size="small"
+                                            icon={<SvgCross />}
+                                            nudgeIcon={false}
+                                            onClick={onCloseClick}
+                                            hideLabel={true}
+                                            iconSide="left"
+                                        />
+                                    </ThemeProvider>
                                 </div>
                             </div>
                         </div>

--- a/src/components/modules/banners/contributions/ContributionsBannerStyles.ts
+++ b/src/components/modules/banners/contributions/ContributionsBannerStyles.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 import { body } from '@guardian/src-foundations/typography';
-import { until, from } from '@guardian/src-foundations/mq';
+import { until, from, breakpoints } from '@guardian/src-foundations/mq';
 
 export const styles = {
     // We need bannerContainer/banner/bannerFlexBox in order to track DCR's article grid.
@@ -15,31 +15,35 @@ export const styles = {
         padding: 0.5rem 0.625rem 0 0.625rem;
         margin: auto;
         box-sizing: border-box;
-
-        ${from.tablet} {
-            padding: 0.5rem 20px 1.125rem 20px;
-            max-width: 740px;
-        }
-
-        ${from.desktop} {
-            max-width: 980px;
-        }
-        ${from.leftCol} {
-            max-width: 1140px;
-        }
-    `,
-    bannerFlexBox: css`
         color: ${neutral[7]};
         width: 100%;
         display: flex;
-        justify-content: space-between;
         flex-direction: row;
-    `,
 
+        ${from.mobileLandscape} {
+            padding: 0.5rem 20px 1.125rem 20px;
+        }
+
+        ${from.tablet} {
+            max-width: ${breakpoints.tablet}px;
+        }
+
+        ${from.desktop} {
+            padding-right: 29px;
+            max-width: ${breakpoints.desktop}px;
+        }
+        ${from.leftCol} {
+            padding-right: 27px;
+            max-width: ${breakpoints.leftCol - 2}px;
+        }
+        ${from.wide} {
+            padding-right: 40px;
+            max-width: ${breakpoints.wide - 2}px;
+        }
+    `,
     copy: css`
         max-width: 40rem;
         display: block;
-        margin-right: 3rem;
         padding-bottom: 0;
         ${body.medium()};
         ${until.tablet} {
@@ -62,10 +66,13 @@ export const styles = {
         ${until.tablet} {
             margin-right: 0;
         }
+        ${from.desktop} {
+            width: 620px;
+        }
     `,
 
     heading: css`
-        ${body.medium({ fontWeight: 'bold' })};
+        font-weight: bold;
         &::selection {
             background-color: ${brandAlt[400]};
             color: ${neutral[7]};
@@ -107,6 +114,9 @@ export const styles = {
     ctaButton: css`
         margin-bottom: 0.5rem;
         margin-right: 0.5rem;
+        ${from.desktop} {
+            margin-right: 0;
+        }
     `,
 
     cta: css`
@@ -133,6 +143,13 @@ export const styles = {
         ${until.desktop} {
             padding: 0.5rem 0 0 0;
         }
+        ${from.desktop} {
+            margin-left: 10px;
+        }
+        ${from.wide} {
+            width: 264px;
+            margin-left: auto;
+        }
     `,
 
     closeButtonContainer: css`
@@ -143,9 +160,12 @@ export const styles = {
 
     leftRoundel: css`
         display: none;
-        width: 168px;
         ${from.leftCol} {
             display: block;
+            width: 161px;
+        }
+        ${from.wide} {
+            width: 240px;
         }
     `,
 
@@ -160,12 +180,14 @@ export const styles = {
     `,
 
     rightButtons: css`
+        margin-left: auto;
         display: flex;
         flex-direction: row;
         white-space: nowrap;
     `,
 
     copyAndCta: css`
+        flex-grow: 1;
         display: flex;
         flex-direction: column;
         ${from.desktop} {


### PR DESCRIPTION
## What does this change?
Fix the aligment of the roundel and close button on the contributions banner as per [this card](https://trello.com/c/sjHX5sK7/2274-banner-design-bug-the-g-and-x-buttons-are-too-close-together). Also make some general tweaks to get everthing aligned better to the Guardian's grid. Also, fix the heading size on mobile (was slightly larger than the rest of the text).

TODO
- test in frontend

## Images
mobile
<img width="381" alt="Screenshot 2020-10-01 at 11 51 32" src="https://user-images.githubusercontent.com/17720442/94801003-509c2c00-03dd-11eb-80f7-7d6ea8eadc2a.png">

mobile landscape
<img width="526" alt="Screenshot 2020-10-01 at 11 51 51" src="https://user-images.githubusercontent.com/17720442/94801009-52fe8600-03dd-11eb-9390-07bf56bf6c80.png">

tablet
<img width="886" alt="Screenshot 2020-10-01 at 11 52 09" src="https://user-images.githubusercontent.com/17720442/94801015-55f97680-03dd-11eb-893c-c34dd30fc30d.png">

desktop
<img width="1131" alt="Screenshot 2020-10-01 at 11 52 29" src="https://user-images.githubusercontent.com/17720442/94801068-690c4680-03dd-11eb-9adf-fa5a73b5e0f9.png">

leftcol
<img width="1279" alt="Screenshot 2020-10-01 at 11 52 52" src="https://user-images.githubusercontent.com/17720442/94801077-6c9fcd80-03dd-11eb-9879-c18e2a3a2f92.png">

wide
<img width="1430" alt="Screenshot 2020-10-01 at 11 53 09" src="https://user-images.githubusercontent.com/17720442/94801087-6f022780-03dd-11eb-9fd2-b068e846673d.png">

