### PR TITLE
Tweak close button position

### DIFF
--- a/src/components/modules/banners/environmentMomentBanner/EnvironmentMomentBanner.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/EnvironmentMomentBanner.tsx
@@ -59,7 +59,6 @@ const closeButtonAndRoundelContainer = css`
     }
 
     ${from.wide} {
-        top: ${space[12]}px;
         right: ${space[9]}px;
     }
 `;


### PR DESCRIPTION
## What does this change?

Nothing slips by Hyuna! Now the close button is just 20px from the top from tablet onwards

## images

<img width="982" alt="Screenshot 2020-10-02 at 09 14 18" src="https://user-images.githubusercontent.com/17720442/94902569-4dae4380-0490-11eb-8b7b-84252962b61f.png">
