### PR TITLE
Fix links in banners/epics

### DIFF
--- a/src/components/modules/banners/ausMomentThankYouBanner/AusMomentThankYouBanner.stories.tsx
+++ b/src/components/modules/banners/ausMomentThankYouBanner/AusMomentThankYouBanner.stories.tsx
@@ -49,6 +49,7 @@ export const defaultStory = (): ReactElement => {
                 isSupporter={isSupporter}
                 tickerSettings={tickerSettings}
                 tracking={tracking}
+                countryCode="AU"
             />
         </StorybookWrapper>
     );

--- a/src/components/modules/banners/ausMomentThankYouBanner/AusMomentThankYouBanner.tsx
+++ b/src/components/modules/banners/ausMomentThankYouBanner/AusMomentThankYouBanner.tsx
@@ -12,7 +12,7 @@ import {
 } from '@guardian/src-icons';
 import { from } from '@guardian/src-foundations/mq';
 import { BannerProps } from '../../../../types/BannerTypes';
-import { addTrackingParams } from '../../../../lib/tracking';
+import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../../lib/tracking';
 import { setContributionsBannerClosedTimestamp } from '../localStorage';
 
 const banner = css`
@@ -739,6 +739,7 @@ export const AusMomentThankYouBanner: React.FC<BannerProps> = ({
     tracking,
     isSupporter,
     tickerSettings,
+    countryCode,
 }: BannerProps) => {
     if (!(tickerSettings && tickerSettings.tickerData)) {
         return null;
@@ -907,9 +908,10 @@ export const AusMomentThankYouBanner: React.FC<BannerProps> = ({
                                 <div css={nonSupporterCtaContainer}>
                                     <a
                                         css={supportTheGuardianLink}
-                                        href={addTrackingParams(
+                                        href={addRegionIdAndTrackingParamsToSupportUrl(
                                             'https://support.theguardian.com/contribute',
                                             tracking,
+                                            countryCode,
                                         )}
                                     >
                                         Support the Guardian

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -1,6 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
-import { addTrackingParams, createClickEventFromTracking } from '../../../../lib/tracking';
+import {
+    addRegionIdAndTrackingParamsToSupportUrl,
+    createClickEventFromTracking,
+} from '../../../../lib/tracking';
 import { setChannelClosedTimestamp } from '../localStorage';
 import React, { useState } from 'react';
 import { BannerProps } from '../../../../types/BannerTypes';
@@ -119,9 +122,10 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
                                                     onClick={onContributeClick}
                                                     hideLabel={false}
                                                     aria-label="Contribute"
-                                                    href={addTrackingParams(
+                                                    href={addRegionIdAndTrackingParamsToSupportUrl(
                                                         content.cta.baseUrl,
                                                         props.tracking,
+                                                        props.countryCode,
                                                     )}
                                                 >
                                                     {content.cta.text}

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
@@ -40,6 +40,7 @@ export const defaultStory = (): ReactElement => {
         content,
         isSupporter: false,
         tracking,
+        countryCode: 'GB',
     };
 
     return (

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -1,6 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
-import { addTrackingParams, createClickEventFromTracking } from '../../../../lib/tracking';
+import {
+    addRegionIdAndTrackingParamsToSupportUrl,
+    createClickEventFromTracking,
+} from '../../../../lib/tracking';
 import React, { useState } from 'react';
 import { SvgGuardianLogo } from '@guardian/src-brand';
 import { SvgClose } from '@guardian/src-icons';
@@ -42,12 +45,17 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     content,
     tracking,
     submitComponentEvent,
+    countryCode,
 }: BannerProps) => {
     const [showBanner, setShowBanner] = useState(true);
 
     const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
         evt.preventDefault();
-        const subscriptionUrlWithTracking = addTrackingParams(subscriptionUrl, tracking);
+        const subscriptionUrlWithTracking = addRegionIdAndTrackingParamsToSupportUrl(
+            subscriptionUrl,
+            tracking,
+            countryCode,
+        );
         const componentClickEvent = createClickEventFromTracking(tracking, ctaComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerCtas.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerCtas.tsx
@@ -6,7 +6,7 @@ import { neutral } from '@guardian/src-foundations/palette';
 import { LinkButton, buttonReaderRevenueBrandAlt } from '@guardian/src-button';
 import styles from '../helpers/styles';
 import { BannerTracking } from '../../../../../types/BannerTypes';
-import { addTrackingParams } from '../../../../../lib/tracking';
+import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../../../lib/tracking';
 
 const container = css`
     display: flex;
@@ -63,7 +63,11 @@ const EnvironmentMomentBannerCtas: React.FC<EnvironmentMomentBannerCtasProps> = 
         </ThemeProvider>
     );
 
-    let landingPageUrl = addTrackingParams(BASE_LANDING_PAGE_URL, tracking);
+    let landingPageUrl = addRegionIdAndTrackingParamsToSupportUrl(
+        BASE_LANDING_PAGE_URL,
+        tracking,
+        countryCode,
+    );
     if (isSupporter) {
         landingPageUrl += '&selected-contribution-type=ONE_OFF';
     }

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentSimpleBannerCtas.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentSimpleBannerCtas.tsx
@@ -7,7 +7,7 @@ import { neutral } from '@guardian/src-foundations/palette';
 import { LinkButton, buttonReaderRevenueBrandAlt } from '@guardian/src-button';
 import styles from '../helpers/styles';
 import { BannerTracking } from '../../../../../types/BannerTypes';
-import { addTrackingParams } from '../../../../../lib/tracking';
+import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../../../lib/tracking';
 
 const container = css`
     display: flex;
@@ -55,7 +55,11 @@ const EnvironmentMomentSimpleBannerCtas: React.FC<EnvironmentMomentSimpleBannerC
     onHearFromOurEditorClick,
     tracking,
 }: EnvironmentMomentSimpleBannerCtasProps) => {
-    let landingPageUrl = addTrackingParams(BASE_LANDING_PAGE_URL, tracking);
+    let landingPageUrl = addRegionIdAndTrackingParamsToSupportUrl(
+        BASE_LANDING_PAGE_URL,
+        tracking,
+        countryCode,
+    );
     if (isSupporter) {
         landingPageUrl += '&selected-contribution-type=ONE_OFF';
     }

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -22,7 +22,10 @@ import {
 } from './guardianWeeklyBannerStyles';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setChannelClosedTimestamp } from '../localStorage';
-import { addTrackingParams, createClickEventFromTracking } from '../../../../lib/tracking';
+import {
+    addRegionIdAndTrackingParamsToSupportUrl,
+    createClickEventFromTracking,
+} from '../../../../lib/tracking';
 
 const subscriptionUrl = 'https://support.theguardian.com/subscribe/weekly';
 const signInUrl =
@@ -38,12 +41,17 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
     content,
     tracking,
     submitComponentEvent,
+    countryCode,
 }: BannerProps) => {
     const [showBanner, setShowBanner] = useState(true);
 
     const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
         evt.preventDefault();
-        const subscriptionUrlWithTracking = addTrackingParams(subscriptionUrl, tracking);
+        const subscriptionUrlWithTracking = addRegionIdAndTrackingParamsToSupportUrl(
+            subscriptionUrl,
+            tracking,
+            countryCode,
+        );
         const componentClickEvent = createClickEventFromTracking(tracking, ctaComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);

--- a/src/components/modules/epics/ContributionsEpicButtons.tsx
+++ b/src/components/modules/epics/ContributionsEpicButtons.tsx
@@ -67,12 +67,7 @@ const SecondaryCtaButton = ({
     tracking: EpicTracking;
     countryCode?: string;
 }): JSX.Element | null => {
-    const isSupportUrl =
-        cta.baseUrl.search(/(support.theguardian.com)\/(contribute|subscribe)/) >= 0;
-
-    const url = isSupportUrl
-        ? addRegionIdAndTrackingParamsToSupportUrl(cta.baseUrl, tracking, countryCode)
-        : cta.baseUrl;
+    const url = addRegionIdAndTrackingParamsToSupportUrl(cta.baseUrl, tracking, countryCode);
 
     return (
         <div css={buttonMargins}>

--- a/src/components/modules/epics/ContributionsEpicButtons.tsx
+++ b/src/components/modules/epics/ContributionsEpicButtons.tsx
@@ -4,8 +4,7 @@ import { space } from '@guardian/src-foundations';
 import { Button } from './Button';
 import { EpicTracking } from './ContributionsEpicTypes';
 import { Cta, Variant } from '../../../lib/variants';
-import { addTrackingParams } from '../../../lib/tracking';
-import { addRegionIdToSupportUrl } from '../../../lib/geolocation';
+import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
 
 const buttonWrapperStyles = css`
     margin: ${space[6]}px ${space[2]}px ${space[1]}px 0;
@@ -29,15 +28,6 @@ const buttonMargins = css`
     margin: ${space[1]}px ${space[2]}px ${space[1]}px 0;
 `;
 
-const augmentSupportUrl = (
-    baseUrl: string,
-    tracking: EpicTracking,
-    countryCode?: string,
-): string => {
-    const urlWithRegion = addRegionIdToSupportUrl(baseUrl, countryCode);
-    return addTrackingParams(urlWithRegion, tracking);
-};
-
 const PrimaryCtaButton = ({
     cta,
     tracking,
@@ -53,7 +43,11 @@ const PrimaryCtaButton = ({
 
     const buttonText = cta.text || 'Support The Guardian';
     const baseUrl = cta.baseUrl || 'https://support.theguardian.com/contribute';
-    const urlWithRegionAndTracking = augmentSupportUrl(baseUrl, tracking, countryCode);
+    const urlWithRegionAndTracking = addRegionIdAndTrackingParamsToSupportUrl(
+        baseUrl,
+        tracking,
+        countryCode,
+    );
 
     return (
         <div css={buttonMargins}>
@@ -76,7 +70,9 @@ const SecondaryCtaButton = ({
     const isSupportUrl =
         cta.baseUrl.search(/(support.theguardian.com)\/(contribute|subscribe)/) >= 0;
 
-    const url = isSupportUrl ? augmentSupportUrl(cta.baseUrl, tracking, countryCode) : cta.baseUrl;
+    const url = isSupportUrl
+        ? addRegionIdAndTrackingParamsToSupportUrl(cta.baseUrl, tracking, countryCode)
+        : cta.baseUrl;
 
     return (
         <div css={buttonMargins}>

--- a/src/lib/tracking.test.ts
+++ b/src/lib/tracking.test.ts
@@ -1,4 +1,8 @@
-import { buildCampaignCode, addTrackingParams } from './tracking';
+import {
+    buildCampaignCode,
+    addTrackingParams,
+    addRegionIdAndTrackingParamsToSupportUrl,
+} from './tracking';
 import { factories } from '../factories/';
 
 describe('addTrackingParams', () => {
@@ -19,6 +23,71 @@ describe('addTrackingParams', () => {
 
         const want =
             'https://support.theguardian.com/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D';
+        expect(got).toEqual(want);
+    });
+    it('should return a correctly formatted URL when the base URL already has a query string', () => {
+        const trackingData = factories.tracking.build({
+            ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
+            campaignCode:
+                'gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet',
+            campaignId: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestName: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestVariant: 'v2_stay_quiet',
+            referrerUrl:
+                'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
+        });
+        const buttonBaseUrl =
+            'https://support.theguardian.com/contribute/climate-pledge-2019?foo=bar';
+
+        const got = addTrackingParams(buttonBaseUrl, trackingData);
+
+        const want =
+            'https://support.theguardian.com/contribute/climate-pledge-2019?foo=bar&REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D';
+        expect(got).toEqual(want);
+    });
+});
+
+describe('addRegionIdAndTrackingParamsToSupportUrl', () => {
+    it('should return the base URL for non support URLs', () => {
+        const trackingData = factories.tracking.build({
+            ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
+            campaignCode:
+                'gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet',
+            campaignId: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestName: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestVariant: 'v2_stay_quiet',
+            referrerUrl:
+                'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
+        });
+        const buttonBaseUrl = 'https://theguardian.com/contribute/climate-pledge-2019';
+
+        const got = addRegionIdAndTrackingParamsToSupportUrl(buttonBaseUrl, trackingData);
+
+        const want = 'https://theguardian.com/contribute/climate-pledge-2019';
+        expect(got).toEqual(want);
+    });
+    it('should return a correctly formatted URL for a support URL', () => {
+        const trackingData = factories.tracking.build({
+            ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
+            campaignCode:
+                'gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet',
+            campaignId: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestName: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestVariant: 'v2_stay_quiet',
+            referrerUrl:
+                'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
+        });
+        const buttonBaseUrl = 'https://support.theguardian.com/contribute/climate-pledge-2019';
+        const countryCode = 'GB';
+
+        const got = addRegionIdAndTrackingParamsToSupportUrl(
+            buttonBaseUrl,
+            trackingData,
+            countryCode,
+        );
+
+        const want =
+            'https://support.theguardian.com/uk/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D';
         expect(got).toEqual(want);
     });
 });

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -48,7 +48,7 @@ export const addRegionIdAndTrackingParamsToSupportUrl = (
     tracking: EpicTracking | BannerTracking,
     countryCode?: string,
 ): string => {
-    const isSupportUrl = baseUrl.search(/(support.theguardian.com)\/(contribute|subscribe)/) >= 0;
+    const isSupportUrl = /\bsupport\./.test(baseUrl);
 
     return isSupportUrl
         ? addTrackingParams(addRegionIdToSupportUrl(baseUrl, countryCode), tracking)

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -2,6 +2,7 @@ import { EpicTracking } from '../components/modules/epics/ContributionsEpicTypes
 import { Test, Variant } from '../lib/variants';
 import { BannerTest, BannerVariant, BannerTracking } from '../types/BannerTypes';
 import { OphanComponentEvent } from '../types/OphanTypes';
+import { addRegionIdToSupportUrl } from './geolocation';
 
 type LinkParams = {
     REFPVID: string;
@@ -39,6 +40,14 @@ export const addTrackingParams = (
     const queryString = Object.entries(trackingLinkParams).map(([key, value]) => `${key}=${value}`);
 
     return `${baseUrl}?${queryString.join('&')}`;
+};
+
+export const addRegionIdAndTrackingParamsToSupportUrl = (
+    baseUrl: string,
+    tracking: EpicTracking | BannerTracking,
+    countryCode?: string,
+): string => {
+    return addTrackingParams(addRegionIdToSupportUrl(baseUrl, countryCode), tracking);
 };
 
 const campaignPrefix = 'gdnwb_copts_memco';

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -38,8 +38,9 @@ export const addTrackingParams = (
     };
 
     const queryString = Object.entries(trackingLinkParams).map(([key, value]) => `${key}=${value}`);
+    const alreadyHasQueryString = baseUrl.includes('?');
 
-    return `${baseUrl}?${queryString.join('&')}`;
+    return `${baseUrl}${alreadyHasQueryString ? '&' : '?'}${queryString.join('&')}`;
 };
 
 export const addRegionIdAndTrackingParamsToSupportUrl = (
@@ -47,7 +48,11 @@ export const addRegionIdAndTrackingParamsToSupportUrl = (
     tracking: EpicTracking | BannerTracking,
     countryCode?: string,
 ): string => {
-    return addTrackingParams(addRegionIdToSupportUrl(baseUrl, countryCode), tracking);
+    const isSupportUrl = baseUrl.search(/(support.theguardian.com)\/(contribute|subscribe)/) >= 0;
+
+    return isSupportUrl
+        ? addTrackingParams(addRegionIdToSupportUrl(baseUrl, countryCode), tracking)
+        : baseUrl;
 };
 
 const campaignPrefix = 'gdnwb_copts_memco';


### PR DESCRIPTION
## What does this change?
Make a couple of fixes to links in epics/banners:

- update all banner links to the landing page to add region id if it's present - it saves a redirect!
- only add tracking params and region if the url is to the lp
- handle the case where the url in the tool already has a query string


