### PR TITLE
handle failure of initial fetch in cache

### DIFF
--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -49,7 +49,6 @@ describe('cache', () => {
         let counter = 0;
         const err = new Error('ERROR');
         const fn = jest.fn().mockImplementation(() => {
-            console.log("RUN",counter)
             counter++;
             if (counter === 1) {
                 return Promise.reject(err);

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -45,7 +45,7 @@ describe('cache', () => {
     });
 
     it('retries if initial request fails', async () => {
-        // Use counter to ensure it fails on the 2nd invocation only
+        // Use counter to ensure it fails on the 1st invocation only
         let counter = 0;
         const err = new Error('ERROR');
         const fn = jest.fn().mockImplementation(() => {

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -44,6 +44,33 @@ describe('cache', () => {
         reset();
     });
 
+    it('retries if initial request fails', async () => {
+        // Use counter to ensure it fails on the 2nd invocation only
+        let counter = 0;
+        const err = new Error('ERROR');
+        const fn = jest.fn().mockImplementation(() => {
+            console.log("RUN",counter)
+            counter++;
+            if (counter === 1) {
+                return Promise.reject(err);
+            } else {
+                return Promise.resolve(true);
+            }
+        });
+
+        const [reset, fetchData] = cacheAsync(fn, 60, 'test4');
+
+        await expect(fetchData()).rejects;
+
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        jest.runOnlyPendingTimers(); // fast-forward to retry
+
+        expect(fn).toHaveBeenCalledTimes(2);
+
+        await expect(fetchData()).resolves.toEqual(true);
+    });
+
     it('retries if a refresh fails', async () => {
         // Use counter to ensure it fails on the 2nd invocation only
         let counter = 0;
@@ -55,7 +82,7 @@ describe('cache', () => {
                 return Promise.resolve(true);
             }
         });
-        const [reset, fetchData] = cacheAsync(fn, 60, 'test4');
+        const [reset, fetchData] = cacheAsync(fn, 60, 'test5');
 
         await fetchData();
 

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -68,6 +68,8 @@ describe('cache', () => {
         expect(fn).toHaveBeenCalledTimes(2);
 
         await expect(fetchData()).resolves.toEqual(true);
+
+        reset();
     });
 
     it('retries if a refresh fails', async () => {

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -32,9 +32,11 @@ export const cacheAsync = <T>(
                 const result: T = await fn();
                 cache[key] = result;
                 return Promise.resolve(result);
-            } catch(err) {
+            } catch (err) {
                 console.log(`Failed to make initial request for ${key}: ${err}`);
-                return Promise.reject(new Error(`Failed to make initial request for ${key}: ${err}`));
+                return Promise.reject(
+                    new Error(`Failed to make initial request for ${key}: ${err}`),
+                );
             } finally {
                 const scheduleRefresh = (ms: number): void => {
                     setTimeout(async () => {


### PR DESCRIPTION
The cache has retry logic if an attempt fails.
But this does not apply to the initial request. This PR ensures it retries if the initial request fails as well.
Also increased the retry period to 20 seconds to avoid making things worse.

It's possible this is the cause of the problems we're having with the banner deploy timestamps in PROD.
(If so, then we still need to establish why it's failing on the initial request)