### PR TITLE
Add liveblog epics

### DIFF
--- a/src/api/contributionsApi.ts
+++ b/src/api/contributionsApi.ts
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 import { EpicTests, Variant } from '../lib/variants';
 import { isProd } from '../lib/env';
 import { fetchS3Data } from '../utils/S3';
+import { EpicType } from '../components/modules/epics/ContributionsEpicTypes';
 
 const defaultEpicUrl =
     'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
@@ -49,9 +50,9 @@ export const fetchDefaultEpicContent = async (): Promise<Variant> => {
     return transformedData;
 };
 
-export const fetchConfiguredEpicTests = async (): Promise<EpicTests> => {
-    return fetchS3Data(
-        'gu-contributions-public',
-        `epic/${isProd ? 'PROD' : 'CODE'}/epic-tests.json`,
-    ).then(JSON.parse);
+export const fetchConfiguredEpicTests = async (type: EpicType): Promise<EpicTests> => {
+    const file = type === 'ARTICLE' ? 'epic-tests.json' : 'liveblog-epic-tests.json';
+    const key = `epic/${isProd ? 'PROD' : 'CODE'}/${file}`;
+
+    return fetchS3Data('gu-contributions-public', key).then(JSON.parse);
 };

--- a/src/components/modules/epics/ContributionsEpicTypes.ts
+++ b/src/components/modules/epics/ContributionsEpicTypes.ts
@@ -65,3 +65,5 @@ export type EpicPayload = {
     tracking: EpicPageTracking;
     targeting: EpicTargeting;
 };
+
+export type EpicType = 'ARTICLE' | 'LIVEBLOG';

--- a/src/components/modules/epics/ContributionsLiveblogEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.stories.tsx
@@ -1,0 +1,64 @@
+import React, { ReactElement } from 'react';
+import { ContributionsLiveblogEpic } from './ContributionsLiveblogEpic';
+import { withKnobs, text, object } from '@storybook/addon-knobs';
+import { StorybookWrapper } from '../../../utils/StorybookWrapper';
+import testData from './ContributionsLiveblogEpic.testData';
+import { Variant } from '../../../lib/variants';
+import { getArticleViewCountForWeeks } from '../../../lib/history';
+import { EpicTracking } from './ContributionsEpicTypes';
+
+export default {
+    component: ContributionsLiveblogEpic,
+    title: 'Components/ContributionsLiveblogEpic',
+    decorators: [withKnobs],
+};
+
+// Number of articles viewed
+// Used to replace the template placeholder
+const periodInWeeks = 52;
+const numArticles = getArticleViewCountForWeeks(
+    testData.targeting.weeklyArticleHistory,
+    periodInWeeks,
+);
+
+export const defaultStory = (): ReactElement => {
+    // Epic content props
+    const variant: Variant = {
+        name: 'Test Epic',
+        paragraphs: object('paragraphs', testData.content.paragraphs),
+        cta: {
+            text: text('primaryCta.text', testData.content.cta.text),
+            baseUrl: text('primaryCta.baseUrl', testData.content.cta.baseUrl),
+        },
+    };
+
+    // Epic metadata props
+    const epicTracking: EpicTracking = {
+        ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
+        componentType: testData.tracking.componentType,
+        products: testData.tracking.products,
+        platformId: text('platformId', testData.tracking.platformId),
+        clientName: testData.tracking.clientName,
+        campaignCode: text('campaignCode', testData.tracking.campaignCode),
+        campaignId: text('campaignId', testData.tracking.campaignId),
+        abTestName: text('abTestName', testData.tracking.abTestName),
+        abTestVariant: text('abTestVariant', testData.tracking.abTestVariant),
+        referrerUrl: text('referrerUrl', testData.tracking.referrerUrl),
+    };
+
+    // Epic countryCode prop
+    const countryCode = text('countryCode', testData.targeting.countryCode || 'GB');
+
+    return (
+        <StorybookWrapper>
+            <ContributionsLiveblogEpic
+                variant={variant}
+                tracking={epicTracking}
+                countryCode={countryCode}
+                numArticles={numArticles}
+            />
+        </StorybookWrapper>
+    );
+};
+
+defaultStory.story = { name: 'Default Epic' };

--- a/src/components/modules/epics/ContributionsLiveblogEpic.testData.ts
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.testData.ts
@@ -1,0 +1,72 @@
+import {
+    EpicTestTracking,
+    EpicPageTracking,
+    EpicTracking,
+    EpicTargeting,
+} from './ContributionsEpicTypes';
+
+const content = {
+    paragraphs: [
+        'In these extraordinary times, the Guardian’s editorial independence has never been more important. Because no one sets our agenda, or edits our editor, we can keep delivering quality, trustworthy, fact-checked journalism each and every day. Free from commercial or political bias, we can report fearlessly on world events and challenge those in power.',
+        'Your support protects the Guardian’s independence. We believe every one of us deserves equal access to accurate news and calm explanation. No matter how unpredictable the future feels, we will remain with you, delivering high quality news so we can all make critical decisions about our lives, health and security – based on fact, not fiction.',
+        'Support the Guardian from as little as £1 – and it only takes a minute. Thank you.',
+    ],
+    cta: {
+        text: 'Make a contribution',
+        baseUrl: 'https://support.theguardian.com/contribute',
+    },
+};
+
+const pageTracking: EpicPageTracking = {
+    ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
+    platformId: 'GUARDIAN_WEB',
+    clientName: 'dcr',
+    referrerUrl:
+        'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
+};
+
+const testTracking: EpicTestTracking = {
+    campaignCode: 'gdnwb_copts_memco_remote_epic_test_api',
+    campaignId: 'remote_epic_test',
+    abTestName: 'remote_epic_test',
+    abTestVariant: 'api',
+    componentType: 'ACQUISITIONS_EPIC',
+    products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+};
+
+const tracking: EpicTracking = {
+    ...pageTracking,
+    ...testTracking,
+};
+
+const targeting: EpicTargeting = {
+    contentType: 'Article',
+    sectionName: 'environment',
+    shouldHideReaderRevenue: false,
+    isMinuteArticle: false,
+    isPaidContent: false,
+    tags: [
+        {
+            id: 'environment/drought',
+            type: 'Keyword',
+        },
+        {
+            id: 'environment/climate-change',
+            type: 'Keyword',
+        },
+    ],
+    showSupportMessaging: true,
+    isRecurringContributor: false,
+    lastOneOffContributionDate: 1548979200000, // 2019-02-01
+    mvtId: 2,
+    weeklyArticleHistory: [
+        { week: 18337, count: 10 },
+        { week: 18330, count: 5 },
+    ],
+    hasOptedOutOfArticleCount: false,
+    countryCode: 'GB',
+};
+
+const testData = { content, tracking, testTracking, pageTracking, targeting };
+
+export default testData;

--- a/src/components/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/core';
 import { body } from '@guardian/src-foundations/typography';
+import { from } from '@guardian/src-foundations/mq';
 import { palette } from '@guardian/src-foundations';
 import { news, neutral } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
@@ -15,6 +16,10 @@ import { replaceArticleCount } from '../../../lib/replaceArticleCount';
 import { addTrackingParams } from '../../../lib/tracking';
 
 const container = css`
+    padding: 6px 10px 28px 10px;
+    border-top: 1px solid ${news[300]};
+    border-bottom: 1px solid ${neutral[93]};
+
     * {
         ::selection {
             background: ${palette.brandAlt[400]};
@@ -22,7 +27,16 @@ const container = css`
     }
 
     & > * + * {
-        margin-top: ${space[4]}px;
+        margin-top: ${space[3]}px;
+    }
+
+    ${from.tablet} {
+        padding-left: 80px;
+        padding-right: 20px;
+
+        & > * + * {
+            margin-top: ${space[4]}px;
+        }
     }
 `;
 
@@ -35,7 +49,13 @@ const textContainer = css`
     }
 
     & > * + p {
-        margin-top: ${space[4]}px;
+        margin-top: ${space[3]}px;
+    }
+
+    ${from.tablet} {
+        & > * + p {
+            margin-top: ${space[4]}px;
+        }
     }
 `;
 
@@ -128,7 +148,7 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
     );
 
     if (cleanParagraphs.some(containsNonArticleCountPlaceholder)) {
-        return null; // quick exit if something goes wrong. Ideally we'd throw and caller would catch/log but TODO that separately
+        return null;
     }
 
     return (

--- a/src/components/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import { body } from '@guardian/src-foundations/typography';
+import { palette } from '@guardian/src-foundations';
+import { news, neutral } from '@guardian/src-foundations/palette';
+import { space } from '@guardian/src-foundations';
+import { LinkButton } from '@guardian/src-button';
+import {
+    replaceNonArticleCountPlaceholders,
+    containsNonArticleCountPlaceholder,
+} from '../../../lib/placeholders';
+import { EpicTracking } from './ContributionsEpicTypes';
+import { Variant } from '../../../lib/variants';
+import { replaceArticleCount } from '../../../lib/replaceArticleCount';
+
+const container = css`
+    * {
+        ::selection {
+            background: ${palette.brandAlt[400]};
+        }
+    }
+
+    & > * + * {
+        margin-top: ${space[4]}px;
+    }
+`;
+
+const textContainer = css`
+    ${body.medium()};
+
+    p {
+        margin: 0;
+    }
+
+    & > * + p {
+        margin-top: ${space[4]}px;
+    }
+`;
+
+const cta = css`
+    color: ${news[400]};
+    border-color: ${neutral[86]};
+
+    &:hover {
+        background-color: ${neutral[97]};
+    }
+`;
+
+interface LiveblogEpicBodyParagraphProps {
+    paragraph: string;
+    numArticles: number;
+}
+
+const LiveblogEpicBodyParagraph: React.FC<LiveblogEpicBodyParagraphProps> = ({
+    paragraph,
+    numArticles,
+}: LiveblogEpicBodyParagraphProps) => {
+    const elements = replaceArticleCount(paragraph, numArticles, 'epic');
+
+    return (
+        <p>
+            <em>{elements}</em>
+        </p>
+    );
+};
+
+interface LiveblogEpicBodyProps {
+    paragraphs: string[];
+    numArticles: number;
+}
+
+const LiveblogEpicBody: React.FC<LiveblogEpicBodyProps> = ({
+    numArticles,
+    paragraphs,
+}: LiveblogEpicBodyProps) => {
+    return (
+        <div css={textContainer}>
+            {paragraphs.map(paragraph => (
+                <LiveblogEpicBodyParagraph
+                    key={paragraph}
+                    paragraph={paragraph}
+                    numArticles={numArticles}
+                />
+            ))}
+        </div>
+    );
+};
+
+interface LiveblogEpicCtaProps {
+    text?: string;
+    baseUrl?: string;
+}
+
+const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
+    text,
+    baseUrl,
+}: LiveblogEpicCtaProps) => (
+    <LinkButton css={cta} priority="tertiary" href={baseUrl}>
+        {text}
+    </LinkButton>
+);
+
+interface LiveblogEpicProps {
+    variant: Variant;
+    tracking: EpicTracking;
+    countryCode?: string;
+    numArticles: number;
+}
+
+export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
+    variant,
+    countryCode,
+    numArticles,
+}: LiveblogEpicProps) => {
+    const cleanParagraphs = variant.paragraphs.map(paragraph =>
+        replaceNonArticleCountPlaceholders(paragraph, countryCode),
+    );
+
+    if (cleanParagraphs.some(containsNonArticleCountPlaceholder)) {
+        return null; // quick exit if something goes wrong. Ideally we'd throw and caller would catch/log but TODO that separately
+    }
+
+    return (
+        <section css={container}>
+            <LiveblogEpicBody paragraphs={cleanParagraphs} numArticles={numArticles} />
+            <LiveblogEpicCta text={variant.cta?.text} baseUrl={variant.cta?.baseUrl} />
+        </section>
+    );
+};

--- a/src/components/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.tsx
@@ -12,6 +12,7 @@ import {
 import { EpicTracking } from './ContributionsEpicTypes';
 import { Variant } from '../../../lib/variants';
 import { replaceArticleCount } from '../../../lib/replaceArticleCount';
+import { addTrackingParams } from '../../../lib/tracking';
 
 const container = css`
     * {
@@ -27,6 +28,7 @@ const container = css`
 
 const textContainer = css`
     ${body.medium()};
+    font-size: 16px;
 
     p {
         margin: 0;
@@ -86,20 +88,28 @@ const LiveblogEpicBody: React.FC<LiveblogEpicBodyProps> = ({
     );
 };
 
+const DEFAULT_CTA_TEXT = 'Make a contribution';
+const DEFAULT_CTA_BASE_URL = 'https://support.theguardian.com/uk/contribute';
+
 interface LiveblogEpicCtaProps {
     text?: string;
     baseUrl?: string;
+    tracking: EpicTracking;
 }
 
 const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
     text,
     baseUrl,
-}: LiveblogEpicCtaProps) => (
-    <LinkButton css={cta} priority="tertiary" href={baseUrl}>
-        {text}
-    </LinkButton>
-);
-
+    tracking,
+}: LiveblogEpicCtaProps) => {
+    // TODO: use addRegionIdAndTrackingToSupportUrl
+    const url = addTrackingParams(baseUrl || DEFAULT_CTA_BASE_URL, tracking);
+    return (
+        <LinkButton css={cta} priority="tertiary" href={url}>
+            {text || DEFAULT_CTA_TEXT}
+        </LinkButton>
+    );
+};
 interface LiveblogEpicProps {
     variant: Variant;
     tracking: EpicTracking;
@@ -111,6 +121,7 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
     variant,
     countryCode,
     numArticles,
+    tracking,
 }: LiveblogEpicProps) => {
     const cleanParagraphs = variant.paragraphs.map(paragraph =>
         replaceNonArticleCountPlaceholders(paragraph, countryCode),
@@ -123,7 +134,11 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
     return (
         <section css={container}>
             <LiveblogEpicBody paragraphs={cleanParagraphs} numArticles={numArticles} />
-            <LiveblogEpicCta text={variant.cta?.text} baseUrl={variant.cta?.baseUrl} />
+            <LiveblogEpicCta
+                text={variant.cta?.text}
+                baseUrl={variant.cta?.baseUrl}
+                tracking={tracking}
+            />
         </section>
     );
 };

--- a/src/components/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/core';
 import { body } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { palette } from '@guardian/src-foundations';
-import { news, neutral } from '@guardian/src-foundations/palette';
+import { neutral, brandAlt } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { LinkButton } from '@guardian/src-button';
 import {
@@ -13,12 +13,13 @@ import {
 import { EpicTracking } from './ContributionsEpicTypes';
 import { Variant } from '../../../lib/variants';
 import { replaceArticleCount } from '../../../lib/replaceArticleCount';
-import { addTrackingParams } from '../../../lib/tracking';
+import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
 
 const container = css`
     padding: 6px 10px 28px 10px;
-    border-top: 1px solid ${news[300]};
-    border-bottom: 1px solid ${neutral[93]};
+    border-top: 1px solid ${brandAlt[200]};
+    border-bottom: 1px solid ${neutral[86]};
+    background: ${neutral[93]};
 
     * {
         ::selection {
@@ -60,11 +61,12 @@ const textContainer = css`
 `;
 
 const cta = css`
-    color: ${news[400]};
-    border-color: ${neutral[86]};
+    color: ${neutral[7]};
+    border: 1px solid ${neutral[0]};
+    background-color: ${brandAlt[400]};
 
     &:hover {
-        background-color: ${neutral[97]};
+        background-color: ${brandAlt[200]};
     }
 `;
 
@@ -79,11 +81,7 @@ const LiveblogEpicBodyParagraph: React.FC<LiveblogEpicBodyParagraphProps> = ({
 }: LiveblogEpicBodyParagraphProps) => {
     const elements = replaceArticleCount(paragraph, numArticles, 'epic');
 
-    return (
-        <p>
-            <em>{elements}</em>
-        </p>
-    );
+    return <p>{elements}</p>;
 };
 
 interface LiveblogEpicBodyProps {
@@ -114,6 +112,7 @@ const DEFAULT_CTA_BASE_URL = 'https://support.theguardian.com/uk/contribute';
 interface LiveblogEpicCtaProps {
     text?: string;
     baseUrl?: string;
+    countryCode?: string;
     tracking: EpicTracking;
 }
 
@@ -121,15 +120,20 @@ const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
     text,
     baseUrl,
     tracking,
+    countryCode,
 }: LiveblogEpicCtaProps) => {
-    // TODO: use addRegionIdAndTrackingToSupportUrl
-    const url = addTrackingParams(baseUrl || DEFAULT_CTA_BASE_URL, tracking);
+    const url = addRegionIdAndTrackingParamsToSupportUrl(
+        baseUrl || DEFAULT_CTA_BASE_URL,
+        tracking,
+        countryCode,
+    );
     return (
-        <LinkButton css={cta} priority="tertiary" href={url}>
+        <LinkButton css={cta} priority="primary" href={url}>
             {text || DEFAULT_CTA_TEXT}
         </LinkButton>
     );
 };
+
 interface LiveblogEpicProps {
     variant: Variant;
     tracking: EpicTracking;

--- a/src/lib/targeting.test.ts
+++ b/src/lib/targeting.test.ts
@@ -2,21 +2,27 @@ import { shouldNotRenderEpic, shouldThrottle } from './targeting';
 import { factories } from '../factories';
 
 describe('shouldNotRenderEpic', () => {
-    it('returns true for non-article', () => {
+    it('returns true for non-articles when epic type is ARTICLE', () => {
         const data = factories.targeting.build({ contentType: 'Liveblog' });
-        const got = shouldNotRenderEpic(data);
+        const got = shouldNotRenderEpic(data, 'ARTICLE');
+        expect(got).toBe(true);
+    });
+
+    it('returns true for non-liveblogs when epic type is LIVEBLOG', () => {
+        const data = factories.targeting.build({ contentType: 'Article' });
+        const got = shouldNotRenderEpic(data, 'LIVEBLOG');
         expect(got).toBe(true);
     });
 
     it('returns true for blacklisted section', () => {
         const data = factories.targeting.build({ sectionName: 'careers' });
-        const got = shouldNotRenderEpic(data);
+        const got = shouldNotRenderEpic(data, 'ARTICLE');
         expect(got).toBe(true);
     });
 
     it('returns false for valid data', () => {
         const data = factories.targeting.build();
-        const got = shouldNotRenderEpic(data);
+        const got = shouldNotRenderEpic(data, 'ARTICLE');
         expect(got).toBe(false);
     });
 });

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -1,4 +1,8 @@
-import { EpicTargeting, ViewLog } from '../components/modules/epics/ContributionsEpicTypes';
+import {
+    EpicTargeting,
+    EpicType,
+    ViewLog,
+} from '../components/modules/epics/ContributionsEpicTypes';
 import { daysSince } from '../lib/dates';
 
 const lowValueSections = ['football', 'money', 'education', 'games', 'teacher-network', 'careers'];
@@ -38,7 +42,7 @@ export const shouldThrottle = (
     return hasReachedViewsLimitInWindow || withinMinDaysSinceLastView;
 };
 
-export const shouldNotRenderEpic = (meta: EpicTargeting): boolean => {
+export const shouldNotRenderEpic = (meta: EpicTargeting, epicType: EpicType): boolean => {
     const isLowValueSection = lowValueSections.some(id => id === meta.sectionName);
     const isLowValueTag = lowValueTags.some(id => meta.tags.some(pageTag => pageTag.id === id));
 
@@ -46,7 +50,7 @@ export const shouldNotRenderEpic = (meta: EpicTargeting): boolean => {
         meta.shouldHideReaderRevenue ||
         isLowValueSection ||
         isLowValueTag ||
-        meta.contentType !== 'Article' ||
+        meta.contentType.toUpperCase() !== epicType ||
         meta.isMinuteArticle ||
         meta.isPaidContent
     );

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -51,7 +51,6 @@ export const shouldNotRenderEpic = (meta: EpicTargeting, epicType: EpicType): bo
         isLowValueSection ||
         isLowValueTag ||
         meta.contentType.toUpperCase() !== epicType ||
-        meta.isMinuteArticle ||
         meta.isPaidContent
     );
 };

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -9,7 +9,6 @@ import {
     inCorrectCohort,
     excludeTags,
     withinMaxViews,
-    isContentType,
     withinArticleViewedSettings,
     userInTest,
     hasNoZeroArticleCount,
@@ -630,39 +629,6 @@ describe('withinMaxViews filter', () => {
         const got = filter.test(test, targetingDefault);
 
         expect(got).toBe(true);
-    });
-});
-
-describe('isContentType filter', () => {
-    it('should pass when is correct content type', () => {
-        const test = {
-            ...testDefault,
-            isLiveBlog: true,
-        };
-        const targeting = {
-            ...targetingDefault,
-            contentType: 'LiveBlog',
-        };
-
-        const got = isContentType.test(test, targeting);
-
-        expect(got).toBe(true);
-    });
-
-    it('should fail when incorrect content type', () => {
-        const test = {
-            ...testDefault,
-            isLiveBlog: true,
-        };
-
-        const targeting = {
-            ...targetingDefault,
-            contentType: 'Article',
-        };
-
-        const got = isContentType.test(test, targeting);
-
-        expect(got).toBe(false);
     });
 });
 

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -90,8 +90,9 @@ describe('findTestAndVariant', () => {
             ...targetingDefault,
             weeklyArticleHistory: [{ week: 18330, count: 45 }],
         };
+        const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting);
+        const got = findTestAndVariant(tests, targeting, epicType);
 
         expect(got?.result?.test.name).toBe('example-1');
         expect(got?.result?.variant.name).toBe('control-example-1');
@@ -104,8 +105,9 @@ describe('findTestAndVariant', () => {
             weeklyArticleHistory: [{ week: 18330, count: 45 }],
             hasOptedOutOfArticleCount: true,
         };
+        const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting);
+        const got = findTestAndVariant(tests, targeting, epicType);
 
         expect(got.result).toBe(undefined);
     });
@@ -114,8 +116,9 @@ describe('findTestAndVariant', () => {
         const test = { ...testDefault, excludedSections: ['news'] };
         const tests = [test];
         const targeting = { ...targetingDefault, sectionName: 'news' };
+        const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting);
+        const got = findTestAndVariant(tests, targeting, epicType);
 
         expect(got.result).toBe(undefined);
     });

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -10,6 +10,7 @@ import { isRecentOneOffContributor } from '../lib/dates';
 import { ArticlesViewedSettings, WeeklyArticleHistory } from '../types/shared';
 import { getReminderFields, ReminderFields } from './reminderFields';
 import { selectVariant } from './ab';
+import { EpicType } from '../components/modules/epics/ContributionsEpicTypes';
 
 export enum TickerEndType {
     unlimited = 'unlimited',
@@ -260,10 +261,10 @@ export const hasNoZeroArticleCount = (now: Date = new Date(), templateWeeks = 52
     },
 });
 
-export const shouldNotRender: Filter = {
+export const shouldNotRender = (epicType: EpicType): Filter => ({
     id: 'shouldNotRender',
-    test: (_, targeting) => !shouldNotRenderEpic(targeting),
-};
+    test: (_, targeting): boolean => !shouldNotRenderEpic(targeting, epicType),
+});
 
 export const isNotExpired = (now: Date = new Date()): Filter => ({
     id: 'isNotExpired',
@@ -305,6 +306,7 @@ export interface Result {
 export const findTestAndVariant = (
     tests: Test[],
     targeting: EpicTargeting,
+    epicType: EpicType,
     includeDebug: boolean = false,
 ): Result => {
     const debug: Debug = {};
@@ -313,7 +315,7 @@ export const findTestAndVariant = (
     // manually configured tests).
     // https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L378
     const filters: Filter[] = [
-        shouldNotRender,
+        shouldNotRender(epicType),
         isOn,
         isNotExpired(),
         hasSectionOrTags,

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -184,11 +184,6 @@ export const isOn: Filter = {
     test: (test): boolean => test.isOn,
 };
 
-export const isContentType: Filter = {
-    id: 'isContentType',
-    test: (test, targeting) => (test.isLiveBlog ? targeting.contentType === 'LiveBlog' : true),
-};
-
 export const userInTest = (mvtId: number): Filter => ({
     id: 'userInTest',
     test: (test: Test): boolean => userIsInTest(test, mvtId),
@@ -327,7 +322,6 @@ export const findTestAndVariant = (
         matchesCountryGroups,
         withinMaxViews(targeting.epicViewLog || []),
         withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
-        isContentType,
         hasNoZeroArticleCount(),
         respectArticleCountOptOut,
     ];

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -26,6 +26,11 @@ export const epicACInline: ModuleInfo = getDefaultModuleInfo(
     'epics/ContributionsEpicWithArticleCountInline',
 );
 
+export const liveblogEpic: ModuleInfo = getDefaultModuleInfo(
+    'liveblog-epic',
+    'epics/ContributionsLiveblogEpic',
+);
+
 export const contributionsBanner: ModuleInfo = getDefaultModuleInfo(
     'contributions-banner',
     'banners/contributions/ContributionsBanner',
@@ -50,6 +55,7 @@ export const moduleInfos: ModuleInfo[] = [
     epic,
     epicACAbove,
     epicACInline,
+    liveblogEpic,
     contributionsBanner,
     digiSubs,
     guardianWeekly,

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -104,7 +104,7 @@ const buildEpicData = async (
         const variant = test?.variants.find(v => v.name === params.force?.variantName);
         result = test && variant ? { result: { test, variant } } : {};
     } else {
-        result = findTestAndVariant(tests, targeting, params.debug);
+        result = findTestAndVariant(tests, targeting, type, params.debug);
     }
 
     logTargeting(


### PR DESCRIPTION
## What does this change?
Allows dotcom-components to serve liveblog epics. Adds data and module endpoints to the server as well as adding the new `ContributionsLiveblogEpic` component.

## Images

### desktop
![desktop](https://user-images.githubusercontent.com/17720442/99975652-71a84a00-2d9a-11eb-917d-9cd0da7db542.png)

### tablet
![tablet](https://user-images.githubusercontent.com/17720442/99975679-78cf5800-2d9a-11eb-92dd-317a9bc4adde.png)

### mobile
![mobile](https://user-images.githubusercontent.com/17720442/99975711-7f5dcf80-2d9a-11eb-9f42-ef740a189b01.png)

