### PR TITLE
DS Editions banner mobile styling fix

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -218,14 +218,17 @@ export const packShotContainer = css`
     }
 `;
 
+const imageWidthPercentage = 100;
+const mobileImageWidthPercentage = 80;
+
 export const packShot = css`
-    width: 100%;
+    width: ${imageWidthPercentage}%;
     position: relative;
-    padding-bottom: ${(packShotHeight / packShotWidth) * 100}%;
+    padding-bottom: ${(packShotHeight / packShotWidth) * imageWidthPercentage}%;
 
     ${until.tablet} {
-        padding-bottom: ${(packShotHeight / packShotWidth) * 90}%;
-        width: 90%;
+        padding-bottom: ${(packShotHeight / packShotWidth) * mobileImageWidthPercentage}%;
+        width: ${mobileImageWidthPercentage}%;
         margin: 0 auto;
     }
 

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -86,12 +86,13 @@ export const headLineBreak = css`
 `;
 
 export const paragraph = css`
-    ${body.medium()}
+    ${body.small()}
     line-height: 135%;
     margin: ${space[2]}px 0 ${space[6]}px;
     max-width: 100%;
 
-    ${from.phablet} {
+    ${from.tablet} {
+        ${body.medium()}
         max-width: 80%;
     }
 
@@ -221,6 +222,12 @@ export const packShot = css`
     width: 100%;
     position: relative;
     padding-bottom: ${(packShotHeight / packShotWidth) * 100}%;
+
+    ${until.tablet} {
+        padding-bottom: ${(packShotHeight / packShotWidth) * 90}%;
+        width: 90%;
+        margin: 0 auto;
+    }
 
     img {
         position: absolute;


### PR DESCRIPTION
## What does this change?
This fixes the height of the new digital subscriptions banner at the mobile breakpoint; it was previously taking up most of or the entirety of a user's screen.

## Images

**Before**

![Screenshot 2020-10-06 at 13 29 35](https://user-images.githubusercontent.com/29146931/95206291-6e530200-07de-11eb-9fc0-2f4737fdb787.png)
![Screenshot 2020-10-06 at 14 27 48](https://user-images.githubusercontent.com/29146931/95207837-38168200-07e0-11eb-818b-f76100f87efd.png)

**After**

![Screenshot 2020-10-06 at 13 33 52](https://user-images.githubusercontent.com/29146931/95206422-980c2900-07de-11eb-949d-c3e89f894322.png)
![Screenshot 2020-10-06 at 14 22 29](https://user-images.githubusercontent.com/29146931/95207671-03a2c600-07e0-11eb-9f62-311be55780ed.png)
