### PR TITLE
get banner deploy times from s3

### DIFF
--- a/src/tests/banners/bannerDeployCache.ts
+++ b/src/tests/banners/bannerDeployCache.ts
@@ -15,7 +15,7 @@ const fetchBannerDeployTime = (
 ) => (): Promise<Date> => {
     const channel = bannerChannel === 'contributions' ? 'channel1' : 'channel2';
     return fetch(
-        `https://gu-contributions-public.s3-eu-west-1.amazonaws.com/banner-deploy/${channel}/${region}.json`
+        `https://gu-contributions-public.s3-eu-west-1.amazonaws.com/banner-deploy/${channel}/${region}.json`,
     )
         .then(response => response.json())
         .then(data => {

--- a/src/tests/banners/bannerDeployCache.ts
+++ b/src/tests/banners/bannerDeployCache.ts
@@ -13,11 +13,13 @@ const fetchBannerDeployTime = (
     region: ReaderRevenueRegion,
     bannerChannel: BannerChannel,
 ) => (): Promise<Date> => {
+    const channel = bannerChannel === 'contributions' ? 'channel1' : 'channel2';
     return fetch(
-        `https://www.theguardian.com/reader-revenue/${bannerChannel}-banner-deploy-log/${region}`,
+        `https://gu-contributions-public.s3-eu-west-1.amazonaws.com/banner-deploy/${channel}/${region}.json`
     )
         .then(response => response.json())
         .then(data => {
+            console.log(`Got banner deploy time for ${channel}/${region}`, data.time);
             return new Date(data.time);
         });
 };
@@ -31,42 +33,34 @@ export interface BannerDeployCaches {
         [key in ReaderRevenueRegion]: () => Promise<Date>;
     };
 }
-const ContributionsDeployDate = new Date(Date.parse('2020-10-06 06:00:00'));
 export const bannerDeployCaches: BannerDeployCaches = {
     contributions: {
-        'united-kingdom': () => Promise.resolve(ContributionsDeployDate),
-        'united-states': () => Promise.resolve(ContributionsDeployDate),
-        australia: () => Promise.resolve(ContributionsDeployDate),
-        'rest-of-world': () => Promise.resolve(ContributionsDeployDate),
+        'united-kingdom': cacheAsync(
+            fetchBannerDeployTime('united-kingdom', 'contributions'),
+            fiveMinutes,
+            'fetchEngagementBannerDeployTime_united-kingdom',
+        )[1],
+        'united-states': cacheAsync(
+            fetchBannerDeployTime('united-states', 'contributions'),
+            fiveMinutes,
+            'fetchEngagementBannerDeployTime_united-states',
+        )[1],
+        australia: cacheAsync(
+            fetchBannerDeployTime('australia', 'contributions'),
+            fiveMinutes,
+            'fetchEngagementBannerDeployTime_australia',
+        )[1],
+        'rest-of-world': cacheAsync(
+            fetchBannerDeployTime('rest-of-world', 'contributions'),
+            fiveMinutes,
+            'fetchEngagementBannerDeployTime_rest-of-world',
+        )[1],
         // Contributions doesn't separate europe from row
-        'european-union': () => Promise.resolve(ContributionsDeployDate),
-        // TODO - fix timestamp fetching
-        // 'united-kingdom': cacheAsync(
-        //     fetchBannerDeployTime('united-kingdom', 'contributions'),
-        //     fiveMinutes,
-        //     'fetchEngagementBannerDeployTime_united-kingdom',
-        // )[1],
-        // 'united-states': cacheAsync(
-        //     fetchBannerDeployTime('united-states', 'contributions'),
-        //     fiveMinutes,
-        //     'fetchEngagementBannerDeployTime_united-states',
-        // )[1],
-        // australia: cacheAsync(
-        //     fetchBannerDeployTime('australia', 'contributions'),
-        //     fiveMinutes,
-        //     'fetchEngagementBannerDeployTime_australia',
-        // )[1],
-        // 'rest-of-world': cacheAsync(
-        //     fetchBannerDeployTime('rest-of-world', 'contributions'),
-        //     fiveMinutes,
-        //     'fetchEngagementBannerDeployTime_rest-of-world',
-        // )[1],
-        // // Contributions doesn't separate europe from row
-        // 'european-union': cacheAsync(
-        //     fetchBannerDeployTime('rest-of-world', 'contributions'),
-        //     fiveMinutes,
-        //     'fetchEngagementBannerDeployTime_rest-of-world',
-        // )[1],
+        'european-union': cacheAsync(
+            fetchBannerDeployTime('rest-of-world', 'contributions'),
+            fiveMinutes,
+            'fetchEngagementBannerDeployTime_rest-of-world',
+        )[1],
     },
     subscriptions: {
         'united-kingdom': cacheAsync(


### PR DESCRIPTION
The endpoint we're currently using is behind some complicated caching.
This means the existing redeploy tool isn't working reliably.

Instead, I've moved the files into our own s3 bucket.
This service now requests the timestamps direct from there.
I've put it in the public bucket for simplicity (it's not secret)

Eventually this can be driven by a page in support-admin-console