### PR TITLE
Further Editions DS banner fixes for mobile

### DIFF
--- a/src/components/ResponsiveImage.tsx
+++ b/src/components/ResponsiveImage.tsx
@@ -1,29 +1,33 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 type Image = {
     imgId: string;
     signature: string;
     size: number;
+    media: string;
 };
 
 type ResponsiveImageProps = {
     images: Array<Image>;
     baseImage: Image;
-    sizes: string;
 };
 
 function imageUrl({ imgId, signature, size }: Image): string {
     return `https://i.guim.co.uk/img/media/${imgId}/500.png?width=${size}&quality=85&s=${signature}`;
 }
 
-function createSrcset(images: Array<Image>): string {
-    return images.map(image => `${imageUrl(image)} ${image.size}w`).join(', ');
+function createSource(image: Image): ReactElement {
+    return <source media={image.media} srcSet={imageUrl(image)} />;
 }
 
 export const ResponsiveImage: React.FC<ResponsiveImageProps> = ({
     images,
     baseImage,
-    sizes,
 }: ResponsiveImageProps) => {
-    return <img srcSet={createSrcset(images)} sizes={sizes} src={imageUrl(baseImage)} alt="" />;
+    return (
+        <picture>
+            {images.map(createSource)}
+            <img src={imageUrl(baseImage)} />
+        </picture>
+    );
 };

--- a/src/components/ResponsiveImage.tsx
+++ b/src/components/ResponsiveImage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+type Image = {
+    imgId: string;
+    signature: string;
+    size: number;
+};
+
+type ResponsiveImageProps = {
+    images: Array<Image>;
+    baseImage: Image;
+    sizes: string;
+};
+
+function imageUrl({ imgId, signature, size }: Image): string {
+    return `https://i.guim.co.uk/img/media/${imgId}/500.png?width=${size}&quality=85&s=${signature}`;
+}
+
+function createSrcset(images: Array<Image>): string {
+    return images.map(image => `${imageUrl(image)} ${image.size}w`).join(', ');
+}
+
+export const ResponsiveImage: React.FC<ResponsiveImageProps> = ({
+    images,
+    baseImage,
+    sizes,
+}: ResponsiveImageProps) => {
+    return <img srcSet={createSrcset(images)} sizes={sizes} src={imageUrl(baseImage)} alt="" />;
+};

--- a/src/components/ResponsiveImage.tsx
+++ b/src/components/ResponsiveImage.tsx
@@ -1,9 +1,7 @@
 import React, { ReactElement } from 'react';
 
 type Image = {
-    imgId: string;
-    signature: string;
-    size: number;
+    url: string;
     media: string;
 };
 
@@ -12,12 +10,8 @@ type ResponsiveImageProps = {
     baseImage: Image;
 };
 
-function imageUrl({ imgId, signature, size }: Image): string {
-    return `https://i.guim.co.uk/img/media/${imgId}/500.png?width=${size}&quality=85&s=${signature}`;
-}
-
 function createSource(image: Image): ReactElement {
-    return <source media={image.media} srcSet={imageUrl(image)} />;
+    return <source media={image.media} srcSet={image.url} />;
 }
 
 export const ResponsiveImage: React.FC<ResponsiveImageProps> = ({
@@ -27,7 +21,7 @@ export const ResponsiveImage: React.FC<ResponsiveImageProps> = ({
     return (
         <picture>
             {images.map(createSource)}
-            <img src={imageUrl(baseImage)} />
+            <img src={baseImage.url} />
         </picture>
     );
 };

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { DigitalSubscriptionsBanner } from './DigitalSubscriptionsBanner';
 import { withKnobs, text } from '@storybook/addon-knobs';
-import { StorybookWrapper } from '../../../../utils/StorybookWrapper';
+import { StorybookWrapper, BannerWrapper } from '../../../../utils/StorybookWrapper';
 import { BannerContent, BannerProps, BannerTracking } from '../../../../types/BannerTypes';
 
 export default {
@@ -50,4 +50,13 @@ export const defaultStory = (): ReactElement => {
     );
 };
 
-defaultStory.story = { name: 'Digital Subscriptions Banner' };
+defaultStory.story = {
+    name: 'Digital Subscriptions Banner',
+    decorators: [
+        (Story: React.FC): ReactElement => (
+            <BannerWrapper>
+                <Story />
+            </BannerWrapper>
+        ),
+    ],
+};

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -42,16 +42,14 @@ const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
 const mobileImg = {
-    imgId: '3e6ecc7e48f11c5476fc2d7fad4b3af2aaff4263/4001_0_1986_1193',
-    signature: 'dd8a60d6bd0bf82ff17807736f016b56',
-    size: 400,
+    url:
+        'https://i.guim.co.uk/img/media/3e6ecc7e48f11c5476fc2d7fad4b3af2aaff4263/4001_0_1986_1193/500.png?width=400&quality=85&s=dd8a60d6bd0bf82ff17807736f016b56',
     media: '(max-width: 739px)',
 };
 
 const baseImg = {
-    imgId: '22841f3977aedb85be7b0cf442747b1da51f780f/0_0_2320_1890',
-    signature: 'ea72f5bae5069da178db8bacc11de720',
-    size: 500,
+    url:
+        'https://i.guim.co.uk/img/media/22841f3977aedb85be7b0cf442747b1da51f780f/0_0_2320_1890/500.png?width=500&quality=85&s=ea72f5bae5069da178db8bacc11de720',
     media: '(min-width: 740px)',
 };
 

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -30,6 +30,7 @@ import {
 } from './digitalSubscriptionsBannerStyles';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setChannelClosedTimestamp } from '../localStorage';
+import { ResponsiveImage } from '../../../ResponsiveImage';
 
 const subscriptionUrl = 'https://support.theguardian.com/subscribe/digital';
 const signInUrl =
@@ -39,6 +40,18 @@ const ctaComponentId = `${bannerId} : cta`;
 const notNowComponentId = `${bannerId} : not now`;
 const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
+
+const mobileImg = {
+    imgId: '3e6ecc7e48f11c5476fc2d7fad4b3af2aaff4263/4001_0_1986_1193',
+    signature: 'dd8a60d6bd0bf82ff17807736f016b56',
+    size: 400,
+};
+
+const baseImg = {
+    imgId: '22841f3977aedb85be7b0cf442747b1da51f780f/0_0_2320_1890',
+    signature: 'ea72f5bae5069da178db8bacc11de720',
+    size: 500,
+};
 
 export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     bannerChannel,
@@ -132,9 +145,10 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                         <div css={bottomRightComponent}>
                             <div css={packShotContainer}>
                                 <div css={packShot}>
-                                    <img
-                                        src="https://i.guim.co.uk/img/media/22841f3977aedb85be7b0cf442747b1da51f780f/0_0_2320_1890/500.png?width=500&quality=85&s=ea72f5bae5069da178db8bacc11de720"
-                                        alt=""
+                                    <ResponsiveImage
+                                        images={[mobileImg, baseImg]}
+                                        baseImage={baseImg}
+                                        sizes="(max-width: 739px) 400px, 500px"
                                     />
                                 </div>
                             </div>

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -45,12 +45,14 @@ const mobileImg = {
     imgId: '3e6ecc7e48f11c5476fc2d7fad4b3af2aaff4263/4001_0_1986_1193',
     signature: 'dd8a60d6bd0bf82ff17807736f016b56',
     size: 400,
+    media: '(max-width: 739px)',
 };
 
 const baseImg = {
     imgId: '22841f3977aedb85be7b0cf442747b1da51f780f/0_0_2320_1890',
     signature: 'ea72f5bae5069da178db8bacc11de720',
     size: 500,
+    media: '(min-width: 740px)',
 };
 
 export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
@@ -148,7 +150,6 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                     <ResponsiveImage
                                         images={[mobileImg, baseImg]}
                                         baseImage={baseImg}
-                                        sizes="(max-width: 739px) 400px, 500px"
                                     />
                                 </div>
                             </div>

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -7,7 +7,7 @@ import { space } from '@guardian/src-foundations';
 const mainBannerBackground = '#005689';
 const closeButtonWidthHeight = 35;
 const packShotWidth = 500;
-const packShotHeight = 407;
+const packShotHeight = 300;
 
 export const banner = css`
     html {
@@ -17,6 +17,9 @@ export const banner = css`
     *:before,
     *:after {
         box-sizing: inherit;
+    }
+    strong {
+        font-weight: bold;
     }
     box-sizing: border-box;
     display: flex;
@@ -50,6 +53,9 @@ export const topLeftComponent = css`
     padding: ${space[4]}px;
     button {
         margin-left: ${space[3]}px;
+    }
+    ${until.tablet} {
+        padding-bottom: 0;
     }
     ${from.tablet} {
         max-width: 60%;
@@ -171,7 +177,7 @@ export const buttonTextMobile = css`
 `;
 
 export const siteMessage = css`
-    margin: ${space[3]}px 0 ${space[4]}px;
+    margin: ${space[3]}px 0 ${space[2]}px;
     ${textSans.small()};
     color: ${neutral[100]};
     a,

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -6,8 +6,8 @@ import { space } from '@guardian/src-foundations';
 
 const mainBannerBackground = '#005689';
 const closeButtonWidthHeight = 35;
-const packShotWidth = 500;
-const packShotHeight = 300;
+const packShotWidth = 400;
+const packShotHeight = 240;
 
 export const banner = css`
     html {

--- a/src/utils/StorybookWrapper.tsx
+++ b/src/utils/StorybookWrapper.tsx
@@ -15,3 +15,15 @@ export const StorybookWrapper: React.FC<Props> = ({ children }: Props) => (
         <div css="preview">{children}</div>
     </div>
 );
+
+export const BannerWrapper: React.FC<Props> = ({ children }: Props) => (
+    <div
+        style={{
+            position: 'absolute',
+            bottom: 0,
+            width: '100%',
+        }}
+    >
+        {children}
+    </div>
+);


### PR DESCRIPTION
## What does this change?
Adjusts the mobile styles further to reduce height on mobile, and adds a ResponsiveImage component in order to show different versions of the packshot at different breakpoints. Also adds a utility Storybook component to pin banners to the bottom of the iframe, which helps with device testing.

## Images

On iPhone 6, iOS 11

**Before**
![Screenshot 2020-10-07 at 14 41 10](https://user-images.githubusercontent.com/29146931/95338873-4e3d4480-08ab-11eb-9f50-4d7821a5d8de.png)

**After**
![Screenshot 2020-10-07 at 14 36 31](https://user-images.githubusercontent.com/29146931/95338898-572e1600-08ab-11eb-85bc-aeb4e66a4c97.png)