### PR TITLE
custom cfn for s3 permission

### DIFF
--- a/custom-cfn.yaml
+++ b/custom-cfn.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Additional stack for dotcom-components
+
+Parameters:
+  Stage:
+    Type: String
+  Role:
+    Type: String
+    Description: ARN of the role
+
+Resources:
+  S3Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: S3Policy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+            Resource:
+              - !Sub arn:aws:s3:::support-admin-console/${Stage}/banner-deploy/*
+      Roles:
+        - !Ref Role
+

--- a/nest.json
+++ b/nest.json
@@ -4,5 +4,6 @@
     "vcsURL": "https://github.com/guardian/support-dotcom-components",
     "deploymentType": "alb-ec2-service",
     "artifactBucket": "membership-dist",
-    "cloudformationStackName": "dotcom-components"
+    "cloudformationStackName": "dotcom-components",
+    "customCloudformation": "custom-cfn.yaml"
 }


### PR DESCRIPTION
With nest, we have to provide an additional cloudformation stack for any additional features like permissions.
This PR make it possible for dotcom-components to fetch private s3 files for the banner deploy timestamps