### PR TITLE
Fetch new banner deploy timestamps 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN yarn --immutable install
 
 # Then install rest of code (which likely changes more frequently)
 COPY . .
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 ENV NODE_ENV=production
 RUN yarn build
 COPY src/schemas dist/schemas

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "lodash.debounce": "^4.0.8",
     "node-fetch": "^2.6.0",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "aws-sdk": "^2.604.0"
   },
   "devDependencies": {
     "@aws-cdk/aws-apigateway": "^1.22.0",

--- a/src/tests/banners/DigitalSubscriptionsBannerTest.ts
+++ b/src/tests/banners/DigitalSubscriptionsBannerTest.ts
@@ -12,7 +12,7 @@ export const DigitalSubscriptionsBanner: BannerTest = {
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => {
         if (targeting.switches.remoteSubscriptionsBanner) {
             const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
-            return region !== 'australia';
+            return region !== 'Australia';
         }
         return false;
     },

--- a/src/tests/banners/GuardianWeeklyBannerTest.ts
+++ b/src/tests/banners/GuardianWeeklyBannerTest.ts
@@ -12,7 +12,7 @@ export const GuardianWeeklyBanner: BannerTest = {
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => {
         if (targeting.switches.remoteSubscriptionsBanner) {
             const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
-            return region === 'australia';
+            return region === 'Australia';
         }
         return false;
     },

--- a/src/tests/banners/bannerDeployCache.ts
+++ b/src/tests/banners/bannerDeployCache.ts
@@ -1,65 +1,58 @@
 import { cacheAsync } from '../../lib/cache';
 import { BannerChannel } from '../../types/BannerTypes';
-import fetch from 'node-fetch';
+import { fetchS3Data } from '../../utils/S3';
 
 export type ReaderRevenueRegion =
-    | 'united-kingdom'
-    | 'united-states'
-    | 'australia'
-    | 'rest-of-world'
-    | 'european-union';
+    | 'UnitedKingdom'
+    | 'UnitedStates'
+    | 'Australia'
+    | 'RestOfWorld'
+    | 'EuropeanUnion';
 
-const fetchBannerDeployTime = (
-    region: ReaderRevenueRegion,
-    bannerChannel: BannerChannel,
-) => (): Promise<Date> => {
+const AdminConsoleBucket = 'support-admin-console';
+
+const fetchBannerDeployTimes = (bannerChannel: BannerChannel) => (): Promise<BannerDeployTimes> => {
     const channel = bannerChannel === 'contributions' ? 'channel1' : 'channel2';
-    return fetch(
-        `https://gu-contributions-public.s3-eu-west-1.amazonaws.com/banner-deploy/PROD/${channel}/${region}.json`,
-    )
-        .then(response => response.json())
-        .then(data => {
-            console.log(`Got banner deploy time for ${channel}/${region}`, data.time);
-            return new Date(data.time);
-        });
+    return (
+        fetchS3Data(AdminConsoleBucket, `${process.env.stage}/banner-deploy/${channel}.json`)
+            .then(JSON.parse)
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            .then((data: any) => {
+                const times: BannerDeployTimes = {
+                    UnitedKingdom: new Date(data.UnitedKingdom.timestamp),
+                    UnitedStates: new Date(data.UnitedStates.timestamp),
+                    Australia: new Date(data.Australia.timestamp),
+                    RestOfWorld: new Date(data.RestOfWorld.timestamp),
+                    EuropeanUnion: new Date(data.EuropeanUnion.timestamp),
+                };
+                console.log(`Got banner deploy times for ${channel}`, times);
+                return times;
+            })
+    );
 };
 
 const fiveMinutes = 60 * 5;
+interface BannerDeployTimes {
+    UnitedKingdom: Date;
+    UnitedStates: Date;
+    Australia: Date;
+    RestOfWorld: Date;
+    EuropeanUnion: Date;
+}
 export interface BannerDeployCaches {
-    contributions: {
-        [key in ReaderRevenueRegion]: () => Promise<Date>;
-    };
-    subscriptions: {
-        [key in ReaderRevenueRegion]: () => Promise<Date>;
-    };
+    contributions: () => Promise<BannerDeployTimes>;
+    subscriptions: () => Promise<BannerDeployTimes>;
 }
 
-const cachedDeployTime = (
-    region: ReaderRevenueRegion,
-    bannerChannel: BannerChannel,
-): (() => Promise<Date>) =>
+const cachedDeployTime = (bannerChannel: BannerChannel): (() => Promise<BannerDeployTimes>) =>
     cacheAsync(
-        fetchBannerDeployTime(region, bannerChannel),
+        fetchBannerDeployTimes(bannerChannel),
         fiveMinutes,
-        `fetch${bannerChannel}BannerDeployTime_${region}`,
+        `fetch${bannerChannel}BannerDeployTime`,
         true,
     )[1];
 
 export const bannerDeployCaches: BannerDeployCaches = {
-    contributions: {
-        'united-kingdom': cachedDeployTime('united-kingdom', 'contributions'),
-        'united-states': cachedDeployTime('united-states', 'contributions'),
-        australia: cachedDeployTime('australia', 'contributions'),
-        'rest-of-world': cachedDeployTime('rest-of-world', 'contributions'),
-        // Contributions doesn't separate europe from row
-        'european-union': cachedDeployTime('rest-of-world', 'contributions'),
-    },
-    subscriptions: {
-        'united-kingdom': cachedDeployTime('united-kingdom', 'subscriptions'),
-        'united-states': cachedDeployTime('united-states', 'subscriptions'),
-        australia: cachedDeployTime('australia', 'subscriptions'),
-        'rest-of-world': cachedDeployTime('rest-of-world', 'subscriptions'),
-        // Subscriptions separates europe from row
-        'european-union': cachedDeployTime('european-union', 'subscriptions'),
-    },
+    contributions: cachedDeployTime('contributions'),
+    subscriptions: cachedDeployTime('subscriptions'),
 };

--- a/src/tests/banners/bannerDeployCache.ts
+++ b/src/tests/banners/bannerDeployCache.ts
@@ -1,6 +1,7 @@
 import { cacheAsync } from '../../lib/cache';
 import { BannerChannel } from '../../types/BannerTypes';
 import { fetchS3Data } from '../../utils/S3';
+import {isProd} from "../../lib/env";
 
 export type ReaderRevenueRegion =
     | 'UnitedKingdom'
@@ -14,7 +15,7 @@ const AdminConsoleBucket = 'support-admin-console';
 const fetchBannerDeployTimes = (bannerChannel: BannerChannel) => (): Promise<BannerDeployTimes> => {
     const channel = bannerChannel === 'contributions' ? 'channel1' : 'channel2';
     return (
-        fetchS3Data(AdminConsoleBucket, `${process.env.stage}/banner-deploy/${channel}.json`)
+        fetchS3Data(AdminConsoleBucket, `${isProd ? 'PROD' : 'CODE'}/banner-deploy/${channel}.json`)
             .then(JSON.parse)
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             .then((data: any) => {

--- a/src/tests/banners/bannerDeployCache.ts
+++ b/src/tests/banners/bannerDeployCache.ts
@@ -1,7 +1,7 @@
 import { cacheAsync } from '../../lib/cache';
 import { BannerChannel } from '../../types/BannerTypes';
 import { fetchS3Data } from '../../utils/S3';
-import {isProd} from "../../lib/env";
+import { isProd } from '../../lib/env';
 
 export type ReaderRevenueRegion =
     | 'UnitedKingdom'

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -1,6 +1,5 @@
 import { selectBannerTest } from './bannerSelection';
-// import { getTests } from './bannerTests';
-import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
+import { BannerDeployCaches } from './bannerDeployCache';
 import { BannerTargeting, BannerTest } from '../../types/BannerTypes';
 import { ContributionsBannerPath, DigitalSubscriptionsBannerPath } from './ChannelBannerTests';
 import { DigitalSubscriptionsBanner } from './DigitalSubscriptionsBannerTest';
@@ -9,14 +8,24 @@ import { GuardianWeeklyBanner } from './GuardianWeeklyBannerTest';
 const getTests = (): Promise<BannerTest[]> =>
     Promise.resolve([DigitalSubscriptionsBanner, GuardianWeeklyBanner]);
 
-const getBannerDeployCache = (date: string, region: ReaderRevenueRegion): BannerDeployCaches =>
+const getBannerDeployCache = (date: string): BannerDeployCaches =>
     ({
-        subscriptions: {
-            [region]: () => Promise.resolve(new Date(date)),
-        },
-        contributions: {
-            [region]: () => Promise.resolve(new Date(date)),
-        },
+        subscriptions: () =>
+            Promise.resolve({
+                UnitedKingdom: new Date(date),
+                UnitedStates: new Date(date),
+                Australia: new Date(date),
+                RestOfWorld: new Date(date),
+                EuropeanUnion: new Date(date),
+            }),
+        contributions: () =>
+            Promise.resolve({
+                UnitedKingdom: new Date(date),
+                UnitedStates: new Date(date),
+                Australia: new Date(date),
+                RestOfWorld: new Date(date),
+                EuropeanUnion: new Date(date),
+            }),
     } as BannerDeployCaches);
 
 describe('selectBannerTest', () => {
@@ -45,7 +54,7 @@ describe('selectBannerTest', () => {
         };
 
         it('returns banner if it has never been dismissed', () => {
-            const cache = getBannerDeployCache(secondDate, 'united-states');
+            const cache = getBannerDeployCache(secondDate, 'UnitedStates');
 
             return selectBannerTest(targeting, tracking, '', getTests, cache).then(result => {
                 expect(result && result.test.name).toBe('DigitalSubscriptionsBanner');
@@ -53,7 +62,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns banner if has been redeployed', () => {
-            const cache = getBannerDeployCache(firstDate, 'united-states');
+            const cache = getBannerDeployCache(firstDate, 'UnitedStates');
 
             return selectBannerTest(targeting, tracking, '', getTests, cache).then(result => {
                 expect(result && result.test.name).toBe('DigitalSubscriptionsBanner');
@@ -61,7 +70,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns null if there are insufficient page views', () => {
-            const cache = getBannerDeployCache(firstDate, 'united-states');
+            const cache = getBannerDeployCache(firstDate, 'UnitedStates');
 
             return selectBannerTest(
                 Object.assign(targeting, {
@@ -77,7 +86,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns null if user is logged in and has a subscription', () => {
-            const cache = getBannerDeployCache(firstDate, 'united-states');
+            const cache = getBannerDeployCache(firstDate, 'UnitedStates');
 
             return selectBannerTest(
                 Object.assign(targeting, {
@@ -114,7 +123,7 @@ describe('selectBannerTest', () => {
             clientName: '',
         };
         it('returns banner if it has never been dismissed', () => {
-            const cache = getBannerDeployCache(secondDate, 'australia');
+            const cache = getBannerDeployCache(secondDate, 'Australia');
 
             return selectBannerTest(targeting, tracking, '', getTests, cache).then(result => {
                 expect(result && result.test.name).toBe('GuardianWeeklyBanner');
@@ -122,7 +131,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns null if other contributions banner was dismissed and subs switch is off', () => {
-            const cache = getBannerDeployCache(secondDate, 'australia');
+            const cache = getBannerDeployCache(secondDate, 'Australia');
 
             return selectBannerTest(
                 Object.assign(targeting, {
@@ -140,7 +149,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns banner if has been redeployed', () => {
-            const cache = getBannerDeployCache(firstDate, 'australia');
+            const cache = getBannerDeployCache(firstDate, 'Australia');
 
             return selectBannerTest(
                 Object.assign(targeting, {
@@ -158,7 +167,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns null if shouldHideReaderRevenue', () => {
-            const cache = getBannerDeployCache(firstDate, 'australia');
+            const cache = getBannerDeployCache(firstDate, 'Australia');
 
             return selectBannerTest(
                 Object.assign(targeting, {
@@ -177,7 +186,7 @@ describe('selectBannerTest', () => {
     describe('Contributions banner rules', () => {
         const now = new Date('2020-03-31T12:30:00');
 
-        const cache = getBannerDeployCache(secondDate, 'australia');
+        const cache = getBannerDeployCache(secondDate, 'Australia');
 
         const targeting: BannerTargeting = {
             alreadyVisitedCount: 3,
@@ -285,7 +294,7 @@ describe('selectBannerTest', () => {
     describe('Channel 2 banner rules', () => {
         const now = new Date('2020-03-31T12:30:00');
 
-        const cache = getBannerDeployCache(secondDate, 'australia');
+        const cache = getBannerDeployCache(secondDate, 'Australia');
 
         const targeting: BannerTargeting = {
             alreadyVisitedCount: 3,

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -54,7 +54,7 @@ describe('selectBannerTest', () => {
         };
 
         it('returns banner if it has never been dismissed', () => {
-            const cache = getBannerDeployCache(secondDate, 'UnitedStates');
+            const cache = getBannerDeployCache(secondDate);
 
             return selectBannerTest(targeting, tracking, '', getTests, cache).then(result => {
                 expect(result && result.test.name).toBe('DigitalSubscriptionsBanner');
@@ -62,7 +62,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns banner if has been redeployed', () => {
-            const cache = getBannerDeployCache(firstDate, 'UnitedStates');
+            const cache = getBannerDeployCache(firstDate);
 
             return selectBannerTest(targeting, tracking, '', getTests, cache).then(result => {
                 expect(result && result.test.name).toBe('DigitalSubscriptionsBanner');
@@ -70,7 +70,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns null if there are insufficient page views', () => {
-            const cache = getBannerDeployCache(firstDate, 'UnitedStates');
+            const cache = getBannerDeployCache(firstDate);
 
             return selectBannerTest(
                 Object.assign(targeting, {
@@ -86,7 +86,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns null if user is logged in and has a subscription', () => {
-            const cache = getBannerDeployCache(firstDate, 'UnitedStates');
+            const cache = getBannerDeployCache(firstDate);
 
             return selectBannerTest(
                 Object.assign(targeting, {
@@ -123,7 +123,7 @@ describe('selectBannerTest', () => {
             clientName: '',
         };
         it('returns banner if it has never been dismissed', () => {
-            const cache = getBannerDeployCache(secondDate, 'Australia');
+            const cache = getBannerDeployCache(secondDate);
 
             return selectBannerTest(targeting, tracking, '', getTests, cache).then(result => {
                 expect(result && result.test.name).toBe('GuardianWeeklyBanner');
@@ -131,7 +131,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns null if other contributions banner was dismissed and subs switch is off', () => {
-            const cache = getBannerDeployCache(secondDate, 'Australia');
+            const cache = getBannerDeployCache(secondDate);
 
             return selectBannerTest(
                 Object.assign(targeting, {
@@ -149,7 +149,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns banner if has been redeployed', () => {
-            const cache = getBannerDeployCache(firstDate, 'Australia');
+            const cache = getBannerDeployCache(firstDate);
 
             return selectBannerTest(
                 Object.assign(targeting, {
@@ -167,7 +167,7 @@ describe('selectBannerTest', () => {
         });
 
         it('returns null if shouldHideReaderRevenue', () => {
-            const cache = getBannerDeployCache(firstDate, 'Australia');
+            const cache = getBannerDeployCache(firstDate);
 
             return selectBannerTest(
                 Object.assign(targeting, {
@@ -186,7 +186,7 @@ describe('selectBannerTest', () => {
     describe('Contributions banner rules', () => {
         const now = new Date('2020-03-31T12:30:00');
 
-        const cache = getBannerDeployCache(secondDate, 'Australia');
+        const cache = getBannerDeployCache(secondDate);
 
         const targeting: BannerTargeting = {
             alreadyVisitedCount: 3,
@@ -294,7 +294,7 @@ describe('selectBannerTest', () => {
     describe('Channel 2 banner rules', () => {
         const now = new Date('2020-03-31T12:30:00');
 
-        const cache = getBannerDeployCache(secondDate, 'Australia');
+        const cache = getBannerDeployCache(secondDate);
 
         const targeting: BannerTargeting = {
             alreadyVisitedCount: 3,

--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -15,15 +15,15 @@ import { userIsInTest } from '../../lib/targeting';
 export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
     switch (true) {
         case countryCode === 'GB':
-            return 'united-kingdom';
+            return 'UnitedKingdom';
         case countryCode === 'US':
-            return 'united-states';
+            return 'UnitedStates';
         case countryCode === 'AU':
-            return 'australia';
+            return 'Australia';
         case countryCodeToCountryGroupId(countryCode) === 'EURCountries':
-            return 'european-union';
+            return 'EuropeanUnion';
         default:
-            return 'rest-of-world';
+            return 'RestOfWorld';
     }
 };
 
@@ -45,18 +45,17 @@ export const redeployedSinceLastClosed = (
     const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
 
     if (bannerChannel === 'subscriptions') {
-        const getCached = bannerDeployCaches.subscriptions[region];
-        return getCached().then(deployDate => {
+        return bannerDeployCaches.subscriptions().then(deployTimes => {
             return (
                 !subscriptionBannerLastClosedAt ||
-                deployDate > new Date(subscriptionBannerLastClosedAt)
+                deployTimes[region] > new Date(subscriptionBannerLastClosedAt)
             );
         });
     } else if (bannerChannel === 'contributions') {
-        const getCached = bannerDeployCaches.contributions[region];
-        return getCached().then(deployDate => {
+        return bannerDeployCaches.contributions().then(deployTimes => {
             return (
-                !engagementBannerLastClosedAt || deployDate > new Date(engagementBannerLastClosedAt)
+                !engagementBannerLastClosedAt ||
+                deployTimes[region] > new Date(engagementBannerLastClosedAt)
             );
         });
     }

--- a/src/tests/banners/bannerTest.test.ts
+++ b/src/tests/banners/bannerTest.test.ts
@@ -5,19 +5,19 @@ import { GuardianWeeklyBanner } from './GuardianWeeklyBannerTest';
 describe('readerRevenueRegionFromCountryCode', () => {
     it('should return a region', () => {
         const unitedKingdom = readerRevenueRegionFromCountryCode('GB');
-        expect(unitedKingdom).toBe('united-kingdom');
+        expect(unitedKingdom).toBe('UnitedKingdom');
 
         const germany = readerRevenueRegionFromCountryCode('DE');
-        expect(germany).toBe('european-union');
+        expect(germany).toBe('EuropeanUnion');
 
         const australia = readerRevenueRegionFromCountryCode('AU');
-        expect(australia).toBe('australia');
+        expect(australia).toBe('Australia');
 
         const fiji = readerRevenueRegionFromCountryCode('FJ');
-        expect(fiji).toBe('rest-of-world');
+        expect(fiji).toBe('RestOfWorld');
 
         const usa = readerRevenueRegionFromCountryCode('US');
-        expect(usa).toBe('united-states');
+        expect(usa).toBe('UnitedStates');
     });
 });
 

--- a/src/utils/S3.ts
+++ b/src/utils/S3.ts
@@ -17,5 +17,6 @@ export const fetchS3Data = (bucket: string, key: string): Promise<string> => {
                     new Error(`Missing Body in S3 response for ${bucket}/${key}`),
                 );
             }
-        });
+        })
+        .catch(err => Promise.reject(`Failed to fetch S3 object ${bucket}/${key}: ${err}`));
 };

--- a/src/utils/S3.ts
+++ b/src/utils/S3.ts
@@ -1,0 +1,21 @@
+import { GetObjectOutput } from 'aws-sdk/clients/s3';
+
+import AWS from 'aws-sdk';
+const S3 = new AWS.S3();
+
+export const fetchS3Data = (bucket: string, key: string): Promise<string> => {
+    return S3.getObject({
+        Bucket: bucket,
+        Key: key,
+    })
+        .promise()
+        .then((result: GetObjectOutput) => {
+            if (result.Body) {
+                return Promise.resolve(result.Body.toString('utf-8'));
+            } else {
+                return Promise.reject(
+                    new Error(`Missing Body in S3 response for ${bucket}/${key}`),
+                );
+            }
+        });
+};


### PR DESCRIPTION
Tool: https://github.com/guardian/support-admin-console/pull/164

We now store the timestamps in 2 files, for channel1 and channel 2.
These files are private and maintained by the tool