### PR TITLE
Guardian Weekly brand refresh: banner

### DIFF
--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -6,14 +6,18 @@ import {
     contentContainer,
     topLeftComponent,
     heading,
+    iconAndCloseMobile,
     paragraph,
     buttonTextDesktop,
     buttonTextMobileTablet,
     siteMessage,
     bottomRightComponent,
-    packShot,
+    packShotContainer,
+    packShotTablet,
+    packShotMobileAndDesktop,
     iconPanel,
-    closeButton,
+    closeButtonIconPanel,
+    closeButtonMobile,
     logoContainer,
     notNowButton,
     becomeASubscriberButton,
@@ -35,6 +39,39 @@ const ctaComponentId = `${bannerId} : cta`;
 const notNowComponentId = `${bannerId} : not now`;
 const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
+
+const mobileAndDesktopImg =
+    'https://media.guim.co.uk/d544f4e24e4275d3434e6465d8676d2b5bcd0851/0_0_3430_1665/500.png';
+
+const tabletImage =
+    'https://media.guim.co.uk/a213adf3f68f788b3f9434a1e88787fce1fa10bd/245_0_2839_1632/500.png';
+
+type ButtonPropTypes = {
+    onClick: () => null;
+    css: string;
+};
+
+const CloseButtonIconPanel = (props: ButtonPropTypes): null => (
+    <button
+        data-link-name={closeComponentId}
+        css={closeButtonIconPanel}
+        onClick={props.onClick}
+        aria-label="Close"
+    >
+        <SvgClose />
+    </button>
+);
+
+const CloseButtonMobile = (props: ButtonPropTypes): null => (
+    <button
+        data-link-name={closeComponentId}
+        css={closeButtonMobile}
+        onClick={props.onClick}
+        aria-label="Close"
+    >
+        <SvgClose />
+    </button>
+);
 
 export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
     bannerChannel,
@@ -95,6 +132,9 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                     <div css={contentContainer}>
                         <div css={topLeftComponent}>
                             <h3 css={heading}>{content?.heading}</h3>
+                            <div css={iconAndCloseMobile}>
+                                <CloseButtonMobile onClick={onCloseClick} css={closeButtonMobile} />
+                            </div>
                             <p css={paragraph}>{content?.messageText}</p>
                             <a
                                 data-link-name={ctaComponentId}
@@ -128,20 +168,16 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                             </div>
                         </div>
                         <div css={bottomRightComponent}>
-                            <img
-                                css={packShot}
-                                src="https://i.guim.co.uk/img/media/f5c66a31a7d352acaee1c574e5cc009909f25119/0_0_2210_2062/500.png?quality=85&s=46fb180930f0ec0dc2f6b34a4e94cb06"
-                                alt=""
-                            />
+                            <div css={packShotContainer}>
+                                <img css={packShotTablet} src={tabletImage} alt="" />
+                                <img
+                                    css={packShotMobileAndDesktop}
+                                    src={mobileAndDesktopImg}
+                                    alt=""
+                                />
+                            </div>
                             <div css={iconPanel}>
-                                <button
-                                    data-link-name={closeComponentId}
-                                    css={closeButton}
-                                    onClick={onCloseClick}
-                                    aria-label="Close"
-                                >
-                                    <SvgClose />
-                                </button>
+                                <CloseButtonIconPanel onClick={onCloseClick} />
                                 <div css={logoContainer}>
                                     <SvgGuardianLogo />
                                 </div>

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -7,7 +7,6 @@ import {
     topLeftComponent,
     heading,
     iconAndCloseAlign,
-    iconAndCloseFlex,
     iconAndClosePosition,
     logoContainer,
     closeButton,

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, ReactElement } from 'react';
 import { SvgRoundel } from '@guardian/src-brand';
 import { SvgClose } from '@guardian/src-icons';
 import {
@@ -47,10 +47,10 @@ const tabletImage =
     'https://media.guim.co.uk/a213adf3f68f788b3f9434a1e88787fce1fa10bd/322_0_2430_1632/500.png';
 
 type ButtonPropTypes = {
-    onClick: () => null;
+    onClick: (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 };
 
-const CloseButton = (props: ButtonPropTypes): null => (
+const CloseButton = (props: ButtonPropTypes): ReactElement => (
     <button
         data-link-name={closeComponentId}
         css={closeButton}

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -41,10 +41,10 @@ const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
 const mobileAndDesktopImg =
-    'https://media.guim.co.uk/d544f4e24e4275d3434e6465d8676d2b5bcd0851/128_122_3218_1543/500.png';
+    'https://i.guim.co.uk/img/media/d544f4e24e4275d3434e6465d8676d2b5bcd0851/128_122_3218_1543/500.png?quality=85&s=718ce35eab4f021fcba8893be654cfda';
 
 const tabletImage =
-    'https://media.guim.co.uk/a213adf3f68f788b3f9434a1e88787fce1fa10bd/322_0_2430_1632/500.png';
+    'https://i.guim.co.uk/img/media/a213adf3f68f788b3f9434a1e88787fce1fa10bd/322_0_2430_1632/500.png?quality=85&s=70749c1c97ffaac614c1e357d3e7f616';
 
 type ButtonPropTypes = {
     onClick: (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -169,14 +169,6 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                                     alt=""
                                 />
                             </div>
-                            <div css={iconAndCloseFlex}>
-                                <div css={iconAndCloseAlign}>
-                                    <div css={logoContainer}>
-                                        <SvgRoundel />
-                                    </div>
-                                    <CloseButton onClick={onCloseClick} />
-                                </div>
-                            </div>
                         </div>
                     </div>
                 </section>

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -1,12 +1,16 @@
 import React, { useState } from 'react';
-import { SvgGuardianLogo } from '@guardian/src-brand';
+import { SvgRoundel } from '@guardian/src-brand';
 import { SvgClose } from '@guardian/src-icons';
 import {
     banner,
     contentContainer,
     topLeftComponent,
     heading,
-    iconAndCloseMobile,
+    iconAndCloseAlign,
+    iconAndCloseFlex,
+    iconAndClosePosition,
+    logoContainer,
+    closeButton,
     paragraph,
     buttonTextDesktop,
     buttonTextMobileTablet,
@@ -15,10 +19,6 @@ import {
     packShotContainer,
     packShotTablet,
     packShotMobileAndDesktop,
-    iconPanel,
-    closeButtonIconPanel,
-    closeButtonMobile,
-    logoContainer,
     notNowButton,
     becomeASubscriberButton,
     linkStyle,
@@ -41,31 +41,19 @@ const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
 const mobileAndDesktopImg =
-    'https://media.guim.co.uk/d544f4e24e4275d3434e6465d8676d2b5bcd0851/0_0_3430_1665/500.png';
+    'https://media.guim.co.uk/d544f4e24e4275d3434e6465d8676d2b5bcd0851/128_122_3218_1543/500.png';
 
 const tabletImage =
-    'https://media.guim.co.uk/a213adf3f68f788b3f9434a1e88787fce1fa10bd/245_0_2839_1632/500.png';
+    'https://media.guim.co.uk/a213adf3f68f788b3f9434a1e88787fce1fa10bd/322_0_2430_1632/500.png';
 
 type ButtonPropTypes = {
     onClick: () => null;
-    css: string;
 };
 
-const CloseButtonIconPanel = (props: ButtonPropTypes): null => (
+const CloseButton = (props: ButtonPropTypes): null => (
     <button
         data-link-name={closeComponentId}
-        css={closeButtonIconPanel}
-        onClick={props.onClick}
-        aria-label="Close"
-    >
-        <SvgClose />
-    </button>
-);
-
-const CloseButtonMobile = (props: ButtonPropTypes): null => (
-    <button
-        data-link-name={closeComponentId}
-        css={closeButtonMobile}
+        css={closeButton}
         onClick={props.onClick}
         aria-label="Close"
     >
@@ -130,11 +118,16 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
             {showBanner ? (
                 <section css={banner} data-target={bannerId}>
                     <div css={contentContainer}>
+                        <div css={iconAndClosePosition}>
+                            <div css={iconAndCloseAlign}>
+                                <div css={logoContainer}>
+                                    <SvgRoundel />
+                                </div>
+                                <CloseButton onClick={onCloseClick} />
+                            </div>
+                        </div>
                         <div css={topLeftComponent}>
                             <h3 css={heading}>{content?.heading}</h3>
-                            <div css={iconAndCloseMobile}>
-                                <CloseButtonMobile onClick={onCloseClick} css={closeButtonMobile} />
-                            </div>
                             <p css={paragraph}>{content?.messageText}</p>
                             <a
                                 data-link-name={ctaComponentId}
@@ -176,10 +169,12 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                                     alt=""
                                 />
                             </div>
-                            <div css={iconPanel}>
-                                <CloseButtonIconPanel onClick={onCloseClick} />
-                                <div css={logoContainer}>
-                                    <SvgGuardianLogo />
+                            <div css={iconAndCloseFlex}>
+                                <div css={iconAndCloseAlign}>
+                                    <div css={logoContainer}>
+                                        <SvgRoundel />
+                                    </div>
+                                    <CloseButton onClick={onCloseClick} />
                                 </div>
                             </div>
                         </div>

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
@@ -31,7 +31,7 @@ export const defaultStory = (): ReactElement => {
         heading: text('heading', 'Read The Guardian in print'),
         messageText: text(
             'messageText',
-            "Support The Guardian's independent journalism by subscribing to The Guardian Weekly, our essential world news magazine. Home delivery available wherever you are.",
+            "Make sense of a chaotic world with The Guardian's weekly news magazine.",
         ),
     };
 

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -4,6 +4,9 @@ import { neutral, text, brandAlt } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
+const mainBannerBackground = '#66c2e9';
+const closeButtonWidthHeight = 35;
+
 export const banner = css`
     html {
         box-sizing: border-box;
@@ -17,8 +20,8 @@ export const banner = css`
     display: flex;
     justify-content: center;
     width: 100%;
-    background-color: #3f464a;
-    color: ${neutral[100]};
+    background-color: ${mainBannerBackground};
+    color: ${neutral[7]};
 `;
 
 export const contentContainer = css`
@@ -43,6 +46,8 @@ export const contentContainer = css`
 export const topLeftComponent = css`
     width: 100%;
     padding: ${space[3]}px ${space[3]}px 0 ${space[3]}px;
+    display: relative;
+
     button {
         margin-left: ${space[3]}px;
     }
@@ -122,7 +127,7 @@ export const becomeASubscriberButton = css`
 export const notNowButton = css`
     ${textSans.medium()};
     font-weight: bold;
-    color: ${text.ctaPrimary};
+    color: ${text.primary};
     border: 0;
     border-radius: 0.25rem;
     background: none;
@@ -135,10 +140,10 @@ export const notNowButton = css`
 export const siteMessage = css`
     margin: ${space[3]}px 0 ${space[4]}px;
     ${textSans.small()};
-    color: ${neutral[100]};
+    color: ${text.primary};
     a,
     :visited {
-        color: ${neutral[100]};
+        color: ${text.primary};
         font-weight: bold;
     }
 `;
@@ -174,33 +179,75 @@ export const bottomRightComponent = css`
     }
 `;
 
-export const packShot = css`
+export const packShotContainer = css`
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    margin: 0;
     max-width: 100%;
-    ${from.tablet} {
-        max-width: 100%;
-        margin-bottom: -40px;
-    }
-    ${from.desktop} {
-        max-width: 75%;
-        margin-bottom: -55px;
-    }
-    ${from.leftCol} {
-        margin-bottom: -80px;
-    }
+
     ${from.wide} {
+        margin-top: ${space[4]}px;
+    }
+`;
+
+export const packShotMobileAndDesktop = css`
+    display: block;
+    width: 100%;
+    margin: 0 auto;
+
+    img {
+        position: absolute;
+        bottom: 0;
         max-width: 100%;
-        width: 75%;
+        max-height: 100%;
+    }
+
+    ${from.tablet} {
+        display: none;
+    }
+
+    ${from.leftCol} {
+        display: block;
+        width: 100%;
+        height: 100%;
+    }
+`;
+
+export const packShotTablet = css`
+    display: none;
+
+    ${from.tablet} {
+        display: block;
+        width: 100%;
+        margin: 0 auto;
+    }
+
+    img {
+        position: absolute;
+        bottom: 0;
+        max-width: 100%;
+        max-height: 100%;
+    }
+
+    ${from.leftCol} {
+        display: none;
     }
 `;
 
 export const iconPanel = css`
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: flex-end;
-    height: 100%;
-    padding: ${space[4]}px 0;
-    margin: 0 ${space[4]}px;
+    display: none;
+
+    ${from.leftCol} {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: flex-end;
+        height: 100%;
+        padding: ${space[4]}px 0;
+        margin: 0 ${space[4]}px;
+    }
 `;
 
 export const logoContainer = css`
@@ -208,7 +255,7 @@ export const logoContainer = css`
 
     ${from.desktop} {
         display: block;
-        fill: ${neutral[100]};
+        fill: ${text.primary};
         width: 70px;
     }
     ${from.leftCol} {
@@ -216,22 +263,22 @@ export const logoContainer = css`
     }
 `;
 
-export const closeButton = css`
+export const closeButtonIconPanel = css`
     display: flex;
     align-items: center;
     justify-content: center;
     padding: 0;
-    border: 1px solid ${neutral[100]};
+    border: 1px solid ${text.primary};
     border-radius: 50%;
     outline: none;
     background: transparent;
     cursor: pointer;
-    width: 35px;
-    height: 35px;
+    width: ${closeButtonWidthHeight};
+    height: ${closeButtonWidthHeight};
     svg {
         width: 25px;
         height: 25px;
-        fill: ${neutral[100]};
+        fill: ${text.primary};
         transition: background-color 0.5s ease;
         border-radius: 50%;
     }
@@ -239,10 +286,41 @@ export const closeButton = css`
         cursor: pointer;
         background-color: rgba(237, 237, 237, 0.5);
     }
-    ${until.desktop} {
-        position: absolute;
-        top: 10px;
-        right: 10px;
+`;
+
+export const iconAndCloseMobile = css`
+    display: block;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+
+    ${from.leftCol} {
+        display: none;
+    }
+`;
+
+export const closeButtonMobile = css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid ${text.primary};
+    border-radius: 50%;
+    outline: none;
+    background: transparent;
+    cursor: pointer;
+    width: ${closeButtonWidthHeight};
+    height: ${closeButtonWidthHeight};
+    svg {
+        width: 25px;
+        height: 25px;
+        fill: ${text.primary};
+        transition: background-color 0.5s ease;
+        border-radius: 50%;
+    }
+    :hover {
+        cursor: pointer;
+        background-color: rgba(237, 237, 237, 0.5);
     }
 `;
 

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -53,7 +53,7 @@ export const topLeftComponent = css`
         margin-left: ${space[3]}px;
     }
     ${from.tablet} {
-        padding: ${space[4]}px;
+        padding: ${space[2]}px ${space[4]}px 0 ${space[4]}px;
         width: 50%;
     }
     ${from.desktop} {

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -61,6 +61,10 @@ export const topLeftComponent = css`
     ${from.leftCol} {
         width: 47%;
     }
+
+    @media screen and (min-width: 1400px) {
+        padding-left: 0;
+    }
 `;
 
 export const heading = css`
@@ -285,6 +289,14 @@ export const iconAndClosePosition = css`
     position: absolute;
     top: 10px;
     right: 10px;
+
+    ${from.leftCol} {
+        right: ${space[4]}px;
+    }
+
+    @media screen and (min-width: 1400px) {
+        right: 0;
+    }
 `;
 
 export const iconAndCloseAlign = css`

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -37,6 +37,7 @@ export const contentContainer = css`
     }
     ${from.leftCol} {
         max-width: 1140px;
+        justify-content: center;
     }
     ${from.wide} {
         max-width: 1300px;
@@ -282,6 +283,7 @@ export const iconAndCloseFlex = css`
         height: 100%;
         align-items: flex-start;
         margin-top: ${space[9]}px;
+        margin-right: ${space[3]}px;
     }
 `;
 

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -46,7 +46,7 @@ export const contentContainer = css`
 
 export const topLeftComponent = css`
     width: 100%;
-    padding: ${space[3]}px ${space[3]}px 0 ${space[3]}px;
+    padding: ${space[2]}px ${space[3]}px 0 ${space[3]}px;
     display: relative;
 
     button {
@@ -57,7 +57,6 @@ export const topLeftComponent = css`
         width: 50%;
     }
     ${from.desktop} {
-        padding-top: ${space[2]}px;
         width: 45%;
     }
     ${from.leftCol} {
@@ -105,7 +104,6 @@ export const paragraph = css`
 
     ${from.desktop} {
         font-size: 20px;
-        margin: ${space[2]}px 0 ${space[6]}px;
     }
 `;
 

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 import { body, headline, textSans } from '@guardian/src-foundations/typography/cjs';
 import { neutral, text, brandAlt } from '@guardian/src-foundations/palette';
-import { from, until } from '@guardian/src-foundations/mq';
+import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
 const mainBannerBackground = '#66c2e9';
@@ -53,30 +53,32 @@ export const topLeftComponent = css`
     }
     ${from.tablet} {
         padding: ${space[4]}px;
-        width: 80%;
+        width: 50%;
     }
     ${from.desktop} {
-        width: 50%;
+        width: 43%;
     }
     ${from.leftCol} {
         padding-left: 0;
-    }
-    ${from.wide} {
-        width: 53%;
+        width: 40%;
     }
 `;
 
 export const heading = css`
-    ${headline.small({ fontWeight: 'bold' })};
+    ${headline.xsmall({ fontWeight: 'bold' })};
     margin: 0;
-    max-width: 100%;
+    max-width: 80%;
 
-    ${until.mobileLandscape} {
-        max-width: 80%;
+    ${from.mobileLandscape} {
+        max-width: 70%;
     }
 
-    ${until.mobileMedium} {
-        ${headline.xsmall({ fontWeight: 'bold' })};
+    ${from.phablet} {
+        max-width: 100%;
+    }
+
+    ${from.mobileMedium} {
+        ${headline.small({ fontWeight: 'bold' })};
     }
 `;
 
@@ -86,6 +88,14 @@ export const paragraph = css`
     margin: ${space[2]}px 0 ${space[6]}px;
     max-width: 100%;
 
+    ${from.mobileLandscape} {
+        max-width: 80%;
+    }
+
+    ${from.tablet} {
+        max-width: 100%;
+    }
+
     ${from.desktop} {
         font-size: 20px;
         margin: ${space[3]}px 0 ${space[9]}px;
@@ -94,14 +104,14 @@ export const paragraph = css`
 
 export const buttonTextDesktop = css`
     display: none;
-    ${from.desktop} {
+    ${from.leftCol} {
         display: block;
     }
 `;
 
 export const buttonTextMobileTablet = css`
     display: block;
-    ${from.desktop} {
+    ${from.leftCol} {
         display: none;
     }
 `;
@@ -160,17 +170,16 @@ export const bottomRightComponent = css`
         display: flex;
         align-items: flex-end;
         margin-top: 0;
-        max-width: 50%;
+        max-width: 60%;
         max-height: 100%;
     }
     ${from.desktop} {
         align-items: center;
-        max-width: 50%;
+        max-width: 60%;
         margin-top: 0;
         max-height: 100%;
     }
     ${from.leftCol} {
-        justify-content: space-between;
         padding-right: 0;
     }
     ${from.wide} {
@@ -187,6 +196,11 @@ export const packShotContainer = css`
     margin: 0;
     max-width: 100%;
 
+    ${from.desktop} {
+        flex-direction: row;
+        align-self: flex-end;
+    }
+
     ${from.wide} {
         margin-top: ${space[4]}px;
     }
@@ -194,7 +208,7 @@ export const packShotContainer = css`
 
 export const packShotMobileAndDesktop = css`
     display: block;
-    width: 100%;
+    width: 90%;
     margin: 0 auto;
 
     img {
@@ -204,14 +218,28 @@ export const packShotMobileAndDesktop = css`
         max-height: 100%;
     }
 
+    ${from.mobileMedium} {
+        width: 95%;
+        margin-top: ${space[2]}px;
+    }
+
+    ${from.phablet} {
+        width: 90%;
+        margin-top: ${space[4]}px;
+    }
+
     ${from.tablet} {
         display: none;
     }
 
-    ${from.leftCol} {
+    ${from.desktop} {
         display: block;
-        width: 100%;
-        height: 100%;
+        width: 95%;
+    }
+
+    ${from.leftCol} {
+        width: 110%;
+        margin-left: 0;
     }
 `;
 
@@ -221,86 +249,64 @@ export const packShotTablet = css`
     ${from.tablet} {
         display: block;
         width: 100%;
-        margin: 0 auto;
+        margin: 0;
     }
 
     img {
         position: absolute;
         bottom: 0;
+        right: 0;
         max-width: 100%;
         max-height: 100%;
     }
 
-    ${from.leftCol} {
+    ${from.desktop} {
         display: none;
     }
 `;
 
-export const iconPanel = css`
-    display: none;
-
-    ${from.leftCol} {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        align-items: flex-end;
-        height: 100%;
-        padding: ${space[4]}px 0;
-        margin: 0 ${space[4]}px;
-    }
-`;
-
-export const logoContainer = css`
-    display: none;
-
-    ${from.desktop} {
-        display: block;
-        fill: ${text.primary};
-        width: 70px;
-    }
-    ${from.leftCol} {
-        min-width: 90px;
-    }
-`;
-
-export const closeButtonIconPanel = css`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-    border: 1px solid ${text.primary};
-    border-radius: 50%;
-    outline: none;
-    background: transparent;
-    cursor: pointer;
-    width: ${closeButtonWidthHeight};
-    height: ${closeButtonWidthHeight};
-    svg {
-        width: 25px;
-        height: 25px;
-        fill: ${text.primary};
-        transition: background-color 0.5s ease;
-        border-radius: 50%;
-    }
-    :hover {
-        cursor: pointer;
-        background-color: rgba(237, 237, 237, 0.5);
-    }
-`;
-
-export const iconAndCloseMobile = css`
+export const iconAndClosePosition = css`
     display: block;
     position: absolute;
     top: 10px;
     right: 10px;
-
-    ${from.leftCol} {
+    ${from.desktop} {
         display: none;
     }
 `;
 
-export const closeButtonMobile = css`
-    display: flex;
+export const iconAndCloseFlex = css`
+    display: none;
+    ${from.desktop} {
+        display: inline-flex;
+        height: 100%;
+        align-items: flex-start;
+        margin-top: ${space[9]}px;
+    }
+`;
+
+export const iconAndCloseAlign = css`
+    display: inline-flex;
+    justify-content: flex-end;
+`;
+
+export const logoContainer = css`
+    display: none;
+    ${from.mobileMedium} {
+        display: block;
+        width: ${closeButtonWidthHeight}px;
+        height: ${closeButtonWidthHeight}px;
+        svg {
+            width: 100%;
+        }
+    }
+    ${from.leftCol} {
+        margin-left: ${space[3]}px;
+    }
+`;
+
+export const closeButton = css`
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     padding: 0;
@@ -309,8 +315,8 @@ export const closeButtonMobile = css`
     outline: none;
     background: transparent;
     cursor: pointer;
-    width: ${closeButtonWidthHeight};
-    height: ${closeButtonWidthHeight};
+    width: ${closeButtonWidthHeight}px;
+    height: ${closeButtonWidthHeight}px;
     svg {
         width: 25px;
         height: 25px;
@@ -321,6 +327,10 @@ export const closeButtonMobile = css`
     :hover {
         cursor: pointer;
         background-color: rgba(237, 237, 237, 0.5);
+    }
+    margin-left: ${space[1]}px;
+    ${from.mobileLandscape} {
+        margin-left: ${space[2]}px;
     }
 `;
 

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -57,7 +57,8 @@ export const topLeftComponent = css`
         width: 50%;
     }
     ${from.desktop} {
-        width: 43%;
+        padding-top: ${space[2]}px;
+        width: 45%;
     }
     ${from.leftCol} {
         padding-left: 0;
@@ -81,6 +82,11 @@ export const heading = css`
     ${from.mobileMedium} {
         ${headline.small({ fontWeight: 'bold' })};
     }
+
+    ${from.desktop} {
+        ${headline.large({ fontWeight: 'bold' })};
+        line-height: 100%;
+    }
 `;
 
 export const paragraph = css`
@@ -99,7 +105,7 @@ export const paragraph = css`
 
     ${from.desktop} {
         font-size: 20px;
-        margin: ${space[3]}px 0 ${space[9]}px;
+        margin: ${space[2]}px 0 ${space[6]}px;
     }
 `;
 
@@ -149,7 +155,7 @@ export const notNowButton = css`
 `;
 
 export const siteMessage = css`
-    margin: ${space[3]}px 0 ${space[4]}px;
+    margin: ${space[2]}px 0 ${space[4]}px;
     ${textSans.small()};
     color: ${text.primary};
     a,
@@ -235,7 +241,7 @@ export const packShotMobileAndDesktop = css`
 
     ${from.desktop} {
         display: block;
-        width: 95%;
+        width: 100%;
     }
 
     ${from.leftCol} {

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -37,7 +37,6 @@ export const contentContainer = css`
     }
     ${from.leftCol} {
         max-width: 1140px;
-        justify-content: center;
     }
     ${from.wide} {
         max-width: 1300px;
@@ -57,11 +56,10 @@ export const topLeftComponent = css`
         width: 50%;
     }
     ${from.desktop} {
-        width: 45%;
+        width: 43%;
     }
     ${from.leftCol} {
-        padding-left: 0;
-        width: 40%;
+        width: 47%;
     }
 `;
 
@@ -86,6 +84,10 @@ export const heading = css`
         ${headline.large({ fontWeight: 'bold' })};
         line-height: 100%;
     }
+
+    ${from.leftCol} {
+        max-width: 80%;
+    }
 `;
 
 export const paragraph = css`
@@ -104,6 +106,10 @@ export const paragraph = css`
 
     ${from.desktop} {
         font-size: 20px;
+    }
+
+    ${from.leftCol} {
+        max-width: 90%;
     }
 `;
 
@@ -188,8 +194,7 @@ export const bottomRightComponent = css`
         padding-right: 0;
     }
     ${from.wide} {
-        max-width: 47%;
-        max-height: 290px;
+        width: 45%;
     }
 `;
 
@@ -239,12 +244,17 @@ export const packShotMobileAndDesktop = css`
 
     ${from.desktop} {
         display: block;
-        width: 100%;
+        width: 93%;
     }
 
     ${from.leftCol} {
         width: 110%;
-        margin-left: 0;
+        margin: 0;
+    }
+
+    ${from.leftCol} {
+        width: 100%;
+        margin: 0;
     }
 `;
 
@@ -275,20 +285,6 @@ export const iconAndClosePosition = css`
     position: absolute;
     top: 10px;
     right: 10px;
-    ${from.desktop} {
-        display: none;
-    }
-`;
-
-export const iconAndCloseFlex = css`
-    display: none;
-    ${from.desktop} {
-        display: inline-flex;
-        height: 100%;
-        align-items: flex-start;
-        margin-top: ${space[9]}px;
-        margin-right: ${space[3]}px;
-    }
 `;
 
 export const iconAndCloseAlign = css`

--- a/src/tests/banners/DigitalSubscriptionsBannerTest.ts
+++ b/src/tests/banners/DigitalSubscriptionsBannerTest.ts
@@ -12,7 +12,7 @@ export const DigitalSubscriptionsBanner: BannerTest = {
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => {
         if (targeting.switches.remoteSubscriptionsBanner) {
             const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
-            return region !== 'Australia';
+            return region !== 'EuropeanUnion';
         }
         return false;
     },

--- a/src/tests/banners/GuardianWeeklyBannerTest.ts
+++ b/src/tests/banners/GuardianWeeklyBannerTest.ts
@@ -12,7 +12,7 @@ export const GuardianWeeklyBanner: BannerTest = {
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => {
         if (targeting.switches.remoteSubscriptionsBanner) {
             const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
-            return region === 'Australia';
+            return region === 'EuropeanUnion';
         }
         return false;
     },

--- a/src/tests/banners/GuardianWeeklyBannerTest.ts
+++ b/src/tests/banners/GuardianWeeklyBannerTest.ts
@@ -24,7 +24,7 @@ export const GuardianWeeklyBanner: BannerTest = {
             moduleName: name,
             bannerContent: {
                 messageText:
-                    "Support The Guardian's independent journalism by subscribing to The Guardian Weekly, our essential world news magazine. Home delivery available wherever you are.",
+                    "Make sense of a chaotic world with The Guardian's weekly news magazine.",
                 heading: 'Read The Guardian in print',
             },
             componentType: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -109,7 +109,7 @@ describe('selectBannerTest', () => {
             isPaidContent: false,
             showSupportMessaging: true,
             mvtId: 3,
-            countryCode: 'AU',
+            countryCode: 'DE',
             engagementBannerLastClosedAt: secondDate,
             switches: {
                 remoteSubscriptionsBanner: true,
@@ -126,7 +126,7 @@ describe('selectBannerTest', () => {
             const cache = getBannerDeployCache(secondDate);
 
             return selectBannerTest(targeting, tracking, '', getTests, cache).then(result => {
-                expect(result && result.test.name).toBe('GuardianWeeklyBanner');
+                expect(result && result.test.name).toBe('DigitalSubscriptionsBanner');
             });
         });
 
@@ -162,7 +162,7 @@ describe('selectBannerTest', () => {
                 getTests,
                 cache,
             ).then(result => {
-                expect(result && result.test.name).toBe('GuardianWeeklyBanner');
+                expect(result && result.test.name).toBe('DigitalSubscriptionsBanner');
             });
         });
 

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -126,7 +126,7 @@ describe('selectBannerTest', () => {
             const cache = getBannerDeployCache(secondDate);
 
             return selectBannerTest(targeting, tracking, '', getTests, cache).then(result => {
-                expect(result && result.test.name).toBe('DigitalSubscriptionsBanner');
+                expect(result && result.test.name).toBe('GuardianWeeklyBanner');
             });
         });
 
@@ -162,7 +162,7 @@ describe('selectBannerTest', () => {
                 getTests,
                 cache,
             ).then(result => {
-                expect(result && result.test.name).toBe('DigitalSubscriptionsBanner');
+                expect(result && result.test.name).toBe('GuardianWeeklyBanner');
             });
         });
 

--- a/src/tests/banners/bannerTest.test.ts
+++ b/src/tests/banners/bannerTest.test.ts
@@ -42,10 +42,10 @@ describe('DigitalSubscriptionsBanner canRun', () => {
             showSupportMessaging: true,
             subscriptionBannerLastClosedAt: '1594059610944',
             mvtId: 3,
-            // Should not show banner in Australia
-            countryCode: 'AU',
+            // Should show banner in Europe
+            countryCode: 'DE',
             switches: {
-                remoteSubscriptionsBanner: true,
+                remoteSubscriptionsBanner: false,
             },
         };
         const targetingFalse2 = {
@@ -109,7 +109,7 @@ describe('WeeklyBanner canRun', () => {
             clientName: '',
         };
         const canRun1 = GuardianWeeklyBanner.canRun(targetingTrue, tracking);
-        expect(canRun1).toBe(true);
+        expect(canRun1).toBe(false);
         const canRun2 = GuardianWeeklyBanner.canRun(targetingFalse, tracking);
         expect(canRun2).toBe(false);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5359,11 +5359,6 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clone@2.x:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -10151,13 +10146,6 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
-
-node-cache@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.0.tgz#266786c28dcec0fd34385ee29c383e6d6f1aa5de"
-  integrity sha512-gFQwYdoOztBuPlwg6DKQEf50G+gkK69aqLnw4djkmlHCzeVrLJfwvg9xl4RCAGviTIMUVoqcyoZ/V/wPEu/VVg==
-  dependencies:
-    clone "2.x"
 
 node-dir@^0.1.10:
   version "0.1.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5359,6 +5359,11 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -10146,6 +10151,13 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
+
+node-cache@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.0.tgz#266786c28dcec0fd34385ee29c383e6d6f1aa5de"
+  integrity sha512-gFQwYdoOztBuPlwg6DKQEf50G+gkK69aqLnw4djkmlHCzeVrLJfwvg9xl4RCAGviTIMUVoqcyoZ/V/wPEu/VVg==
+  dependencies:
+    clone "2.x"
 
 node-dir@^0.1.10:
   version "0.1.17"


### PR DESCRIPTION
## What does this change?
This is part of a larger piece of work to update the Guardian Weekly brand across the support site.

[Trello card](https://trello.com/c/1eR4UOQi/3360-gw-banner-updates)

## Risk
**~We need to test the alignment of this banner against dcr before merging it in~**

## Images
![Screen Shot 2020-10-12 at 15 07 24](https://user-images.githubusercontent.com/16781258/95755885-df8e2b80-0c9c-11eb-8b3e-66504e226482.png)

![Screen Shot 2020-10-12 at 15 07 47](https://user-images.githubusercontent.com/16781258/95755904-e5840c80-0c9c-11eb-8bab-c28ffee1cadb.png)

![Screen Shot 2020-10-12 at 15 08 01](https://user-images.githubusercontent.com/16781258/95755913-e9179380-0c9c-11eb-8e54-4f4e52c3d1e8.png)
