### PR TITLE
 Australian variant of the Digital Subs banners packshot

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -41,21 +41,22 @@ const notNowComponentId = `${bannerId} : not now`;
 const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
-// const ausMobImg = 'https://media.guim.co.uk/155b9ad007e59571fe9c60218246ddf8c758e1f8/0_12_1894_1137/500.png';
-const ausMobImg = 'https://i.guim.co.uk/img/media/155b9ad007e59571fe9c60218246ddf8c758e1f8/0_12_1894_1137/500.png?width=400&quality=85&s=206fa8b876a4929ed268504a9bc1695e';
-// const ausBaseImg = 'https://media.guim.co.uk/287779fce55ae40d86d0041d93d259ce9bcf631b/0_0_2320_1890/500.png';
-const ausBaseImg = 'https://i.guim.co.uk/img/media/287779fce55ae40d86d0041d93d259ce9bcf631b/0_0_2320_1890/500.png?width=500&quality=85&s=19f098f42624a9efc6758413e83a86c0';
-
-const rowMobImg = 'https://i.guim.co.uk/img/media/3e6ecc7e48f11c5476fc2d7fad4b3af2aaff4263/4001_0_1986_1193/500.png?width=400&quality=85&s=dd8a60d6bd0bf82ff17807736f016b56';
-const rowBaseImg = 'https://i.guim.co.uk/img/media/22841f3977aedb85be7b0cf442747b1da51f780f/0_0_2320_1890/500.png?width=500&quality=85&s=ea72f5bae5069da178db8bacc11de720';
+const ausMobImg =
+    'https://i.guim.co.uk/img/media/155b9ad007e59571fe9c60218246ddf8c758e1f8/0_12_1894_1137/500.png?width=400&quality=85&s=206fa8b876a4929ed268504a9bc1695e';
+const ausBaseImg =
+    'https://i.guim.co.uk/img/media/287779fce55ae40d86d0041d93d259ce9bcf631b/0_0_2320_1890/500.png?width=500&quality=85&s=19f098f42624a9efc6758413e83a86c0';
+const rowMobImg =
+    'https://i.guim.co.uk/img/media/3e6ecc7e48f11c5476fc2d7fad4b3af2aaff4263/4001_0_1986_1193/500.png?width=400&quality=85&s=dd8a60d6bd0bf82ff17807736f016b56';
+const rowBaseImg =
+    'https://i.guim.co.uk/img/media/22841f3977aedb85be7b0cf442747b1da51f780f/0_0_2320_1890/500.png?width=500&quality=85&s=ea72f5bae5069da178db8bacc11de720';
 
 const getMobileImg = (countryCode: string | undefined) => ({
-    url: true ? ausMobImg : rowMobImg,
+    url: countryCode === 'AU' ? ausMobImg : rowMobImg,
     media: '(max-width: 739px)',
 });
 
 const getBaseImg = (countryCode: string | undefined) => ({
-    url: true ? ausBaseImg : rowBaseImg,
+    url: countryCode === 'AU' ? ausBaseImg : rowBaseImg,
     media: '(min-width: 740px)',
 });
 

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -41,17 +41,23 @@ const notNowComponentId = `${bannerId} : not now`;
 const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
-const mobileImg = {
-    url:
-        'https://i.guim.co.uk/img/media/3e6ecc7e48f11c5476fc2d7fad4b3af2aaff4263/4001_0_1986_1193/500.png?width=400&quality=85&s=dd8a60d6bd0bf82ff17807736f016b56',
-    media: '(max-width: 739px)',
-};
+// const ausMobImg = 'https://media.guim.co.uk/155b9ad007e59571fe9c60218246ddf8c758e1f8/0_12_1894_1137/500.png';
+const ausMobImg = 'https://i.guim.co.uk/img/media/155b9ad007e59571fe9c60218246ddf8c758e1f8/0_12_1894_1137/500.png?width=400&quality=85&s=206fa8b876a4929ed268504a9bc1695e';
+// const ausBaseImg = 'https://media.guim.co.uk/287779fce55ae40d86d0041d93d259ce9bcf631b/0_0_2320_1890/500.png';
+const ausBaseImg = 'https://i.guim.co.uk/img/media/287779fce55ae40d86d0041d93d259ce9bcf631b/0_0_2320_1890/500.png?width=500&quality=85&s=19f098f42624a9efc6758413e83a86c0';
 
-const baseImg = {
-    url:
-        'https://i.guim.co.uk/img/media/22841f3977aedb85be7b0cf442747b1da51f780f/0_0_2320_1890/500.png?width=500&quality=85&s=ea72f5bae5069da178db8bacc11de720',
+const rowMobImg = 'https://i.guim.co.uk/img/media/3e6ecc7e48f11c5476fc2d7fad4b3af2aaff4263/4001_0_1986_1193/500.png?width=400&quality=85&s=dd8a60d6bd0bf82ff17807736f016b56';
+const rowBaseImg = 'https://i.guim.co.uk/img/media/22841f3977aedb85be7b0cf442747b1da51f780f/0_0_2320_1890/500.png?width=500&quality=85&s=ea72f5bae5069da178db8bacc11de720';
+
+const getMobileImg = (countryCode: string | undefined) => ({
+    url: true ? ausMobImg : rowMobImg,
+    media: '(max-width: 739px)',
+});
+
+const getBaseImg = (countryCode: string | undefined) => ({
+    url: true ? ausBaseImg : rowBaseImg,
     media: '(min-width: 740px)',
-};
+});
 
 export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     bannerChannel,
@@ -61,6 +67,9 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     countryCode,
 }: BannerProps) => {
     const [showBanner, setShowBanner] = useState(true);
+
+    const mobileImg = getMobileImg(countryCode);
+    const baseImg = getBaseImg(countryCode);
 
     const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
         evt.preventDefault();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5359,11 +5359,6 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clone@2.x:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -10151,13 +10146,6 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
-
-node-cache@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.0.tgz#266786c28dcec0fd34385ee29c383e6d6f1aa5de"
-  integrity sha512-gFQwYdoOztBuPlwg6DKQEf50G+gkK69aqLnw4djkmlHCzeVrLJfwvg9xl4RCAGviTIMUVoqcyoZ/V/wPEu/VVg==
-  dependencies:
-    clone "2.x"
 
 node-dir@^0.1.10:
   version "0.1.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5359,6 +5359,11 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -10146,6 +10151,13 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
+
+node-cache@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.0.tgz#266786c28dcec0fd34385ee29c383e6d6f1aa5de"
+  integrity sha512-gFQwYdoOztBuPlwg6DKQEf50G+gkK69aqLnw4djkmlHCzeVrLJfwvg9xl4RCAGviTIMUVoqcyoZ/V/wPEu/VVg==
+  dependencies:
+    clone "2.x"
 
 node-dir@^0.1.10:
   version "0.1.17"


### PR DESCRIPTION
## What does this change?

This PR introduces an Australian variant of the Digital Subs banners packshot:

**Australian variant (mobile, tablet and desktop)**

Mobile...
<img width="372" alt="Screenshot 2020-10-12 at 10 00 49" src="https://user-images.githubusercontent.com/1590704/95736897-c1b1ce00-0c7e-11eb-98a5-0ec478f01ab3.png">

Tablet...
<img width="738" alt="Screenshot 2020-10-12 at 10 01 35" src="https://user-images.githubusercontent.com/1590704/95736910-c7a7af00-0c7e-11eb-9dce-86135f4feaa5.png">

Desktop...
<img width="1368" alt="Screenshot 2020-10-12 at 09 58 49" src="https://user-images.githubusercontent.com/1590704/95736920-cc6c6300-0c7e-11eb-9a3f-ab481d6af7e5.png">

**Rest of World variant (mobile, tablet and desktop)**

Mobile...
<img width="378" alt="Screenshot 2020-10-12 at 11 31 22" src="https://user-images.githubusercontent.com/1590704/95736956-ddb56f80-0c7e-11eb-8dd9-cb03311f7c4c.png">

Tablet...
<img width="739" alt="Screenshot 2020-10-12 at 11 31 38" src="https://user-images.githubusercontent.com/1590704/95736970-e27a2380-0c7e-11eb-8eb3-6ad2f2b37994.png">

Desktop...
<img width="1370" alt="Screenshot 2020-10-12 at 11 31 03" src="https://user-images.githubusercontent.com/1590704/95736979-e73ed780-0c7e-11eb-8f3c-51a8c86864f6.png">
