### PR TITLE
Update the environment moment banner

### DIFF
--- a/src/components/modules/banners/environmentMomentBanner/EnvironmentMomentBanner.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/EnvironmentMomentBanner.tsx
@@ -218,7 +218,7 @@ export const EnvironmentMomentBanner: React.FC<BannerProps> = ({
                                 <div css={bodyAndCtasContainer}>
                                     <EnvironmentMomentBannerBody
                                         isSupporter={!!isSupporter}
-                                        countryCode={countryCode || 'GB'}
+                                        countryCode={countryCode}
                                     />
                                     <EnvironmentMomentBannerCtas
                                         isSupporter={!!isSupporter}

--- a/src/components/modules/banners/environmentMomentBanner/EnvironmentMomentBanner.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/EnvironmentMomentBanner.tsx
@@ -151,7 +151,7 @@ const lineContainer = css`
     top: 0;
     left: 0;
     width: 50%;
-    height: 126px;
+    height: 141px;
     box-sizing: border-box;
     border-bottom: 1px solid ${neutral[86]};
     display: flex;

--- a/src/components/modules/banners/environmentMomentBanner/EnvironmentMomentBanner.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/EnvironmentMomentBanner.tsx
@@ -214,9 +214,12 @@ export const EnvironmentMomentBanner: React.FC<BannerProps> = ({
                                 </div>
                             </div>
                             <div css={textContainer}>
-                                <EnvironmentMomentBannerHeader />
+                                <EnvironmentMomentBannerHeader isSupporter={!!isSupporter} />
                                 <div css={bodyAndCtasContainer}>
-                                    <EnvironmentMomentBannerBody isSupporter={!!isSupporter} />
+                                    <EnvironmentMomentBannerBody
+                                        isSupporter={!!isSupporter}
+                                        countryCode={countryCode || 'GB'}
+                                    />
                                     <EnvironmentMomentBannerCtas
                                         isSupporter={!!isSupporter}
                                         countryCode={countryCode || ''}

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerBody.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerBody.tsx
@@ -16,7 +16,7 @@ const paragraphsContainer = css`
 
 interface EnvironmentMomentBannerBodyProps {
     isSupporter: boolean;
-    countryCode: string;
+    countryCode?: string;
 }
 
 const EnvironmentMomentBannerBody: React.FC<EnvironmentMomentBannerBodyProps> = ({

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerBody.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerBody.tsx
@@ -34,15 +34,14 @@ const EnvironmentMomentBannerBody: React.FC<EnvironmentMomentBannerBodyProps> = 
                     <div>
                         At the Guardian, we’ve been trying to live up to the ambitious promises we
                         made a year ago. We pledged to do more in service of the escalating climate
-                        emergency, and this was just the start.
+                        emergency.
                     </div>
                     <div>
-                        Thanks to your support, we can continue to provide independent,
-                        authoritative, persistent journalism that is always led by science and
-                        truth. And we can keep it open for all to read so more people become better
-                        informed, and inspired to take meaningful action. We were able to stop
-                        taking advertising from fossil fuel companies, and we’re now on track to
-                        reach net zero carbon emissions by 2030.
+                        Thanks to your support, we can provide independent, authoritative,
+                        persistent journalism that is always led by science and truth. And we can
+                        keep it open for all so more people can be informed, and inspired to take
+                        action. We’ve stopped taking advertising from fossil fuel companies, and
+                        we’re set to reach net zero carbon emissions by 2030.
                     </div>
                     <div>
                         Thank you for helping to sustain our open, independent journalism. Together
@@ -54,14 +53,14 @@ const EnvironmentMomentBannerBody: React.FC<EnvironmentMomentBannerBodyProps> = 
                     <div>
                         At the Guardian, we’ve been trying to live up to the ambitious promises we
                         made a year ago. We pledged to do more in service of the escalating climate
-                        emergency, and this was just the start.
+                        emergency.
                     </div>
                     <div>
-                        We will continue to provide independent, authoritative, persistent
-                        journalism that is always led by science and truth. And we’ll keep it open
-                        for all to read so more people can be better informed, and inspired to take
-                        meaningful action. We’ve stopped taking advertising from fossil fuel
-                        companies, and we’re on track to reach net zero carbon emissions by 2030.
+                        We will provide independent, authoritative, persistent journalism that is
+                        always led by science and truth. And we’ll keep it open for all so more
+                        people can be informed, and inspired to take action. We’ve stopped taking
+                        advertising from fossil fuel companies, and we’re set to reach net zero
+                        carbon emissions by 2030.
                     </div>
                     <div>
                         From as little as {getLocalCurrencySymbol(countryCode)}1, today you can help

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerBody.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerBody.tsx
@@ -25,8 +25,8 @@ const EnvironmentMomentBannerBody: React.FC<EnvironmentMomentBannerBodyProps> = 
 }: EnvironmentMomentBannerBodyProps) => (
     <div css={container}>
         <div css={styles.hideAfterTablet}>
-            We will not sideline the climate crisis. Today, one year on from our pledge, we want to
-            update you on our progress.
+            We want to show you how the Guardian’s been trying to live up to the ambitious promises
+            we made a year ago. With your support, we can achieve more.
         </div>
         <div css={styles.hideBeforeTablet}>
             {isSupporter ? (
@@ -56,8 +56,8 @@ const EnvironmentMomentBannerBody: React.FC<EnvironmentMomentBannerBodyProps> = 
                         We will provide independent, authoritative, persistent journalism that is
                         always led by science and truth. And we’ll keep it open for all so more
                         people can be informed, and inspired to take action. We’ve stopped taking
-                        advertising from fossil fuel companies, and we’re set to reach net zero
-                        carbon emissions by 2030.
+                        advertising from fossil fuel companies, and we’re on course to reach net
+                        zero carbon emissions by 2030.
                     </div>
                     <div>
                         From as little as {getLocalCurrencySymbol(countryCode)}1, today you can help

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerBody.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerBody.tsx
@@ -2,17 +2,26 @@ import React from 'react';
 import { css } from '@emotion/core';
 import { body } from '@guardian/src-foundations/typography';
 import styles from '../helpers/styles';
+import { getLocalCurrencySymbol } from '../../../../../lib/geolocation';
 
 const container = css`
     ${body.small()}
 `;
 
+const paragraphsContainer = css`
+    & > * + * {
+        margin-top: 8px;
+    }
+`;
+
 interface EnvironmentMomentBannerBodyProps {
     isSupporter: boolean;
+    countryCode: string;
 }
 
 const EnvironmentMomentBannerBody: React.FC<EnvironmentMomentBannerBodyProps> = ({
     isSupporter,
+    countryCode,
 }: EnvironmentMomentBannerBodyProps) => (
     <div css={container}>
         <div css={styles.hideAfterTablet}>
@@ -21,26 +30,44 @@ const EnvironmentMomentBannerBody: React.FC<EnvironmentMomentBannerBodyProps> = 
         </div>
         <div css={styles.hideBeforeTablet}>
             {isSupporter ? (
-                <>
-                    One year ago, we outlined our plans to confront the escalating climate crisis.
-                    We promised to report with authority on the defining issue of our lifetime –
-                    giving it the sustained attention it demands. Then came the global pandemic.
-                    <br />
-                    Today we want to update you on our progress, and assure you that the Guardian
-                    will not sideline the climate emergency in 2020, or in the years to come.
-                    Generosity from supporters like you sustains our open, independent journalism.
-                    Thank you.
-                </>
+                <div css={paragraphsContainer}>
+                    <div>
+                        At the Guardian, we’ve been trying to live up to the ambitious promises we
+                        made a year ago. We pledged to do more in service of the escalating climate
+                        emergency, and this was just the start.
+                    </div>
+                    <div>
+                        Thanks to your support, we can continue to provide independent,
+                        authoritative, persistent journalism that is always led by science and
+                        truth. And we can keep it open for all to read so more people become better
+                        informed, and inspired to take meaningful action. We were able to stop
+                        taking advertising from fossil fuel companies, and we’re now on track to
+                        reach net zero carbon emissions by 2030.
+                    </div>
+                    <div>
+                        Thank you for helping to sustain our open, independent journalism. Together
+                        we can achieve so much more.
+                    </div>
+                </div>
             ) : (
-                <>
-                    One year ago, we outlined our plans to confront the escalating climate crisis.
-                    We promised to report with authority on the defining issue of our lifetime –
-                    giving it the sustained attention it demands. Then came the global pandemic.
-                    <br />
-                    Today we want to update you on our progress, and assure you that the Guardian
-                    will not sideline the climate emergency in 2020, or in the years to come. Your
-                    support sustains our open, independent journalism.
-                </>
+                <div css={paragraphsContainer}>
+                    <div>
+                        At the Guardian, we’ve been trying to live up to the ambitious promises we
+                        made a year ago. We pledged to do more in service of the escalating climate
+                        emergency, and this was just the start.
+                    </div>
+                    <div>
+                        We will continue to provide independent, authoritative, persistent
+                        journalism that is always led by science and truth. And we’ll keep it open
+                        for all to read so more people can be better informed, and inspired to take
+                        meaningful action. We’ve stopped taking advertising from fossil fuel
+                        companies, and we’re on track to reach net zero carbon emissions by 2030.
+                    </div>
+                    <div>
+                        From as little as {getLocalCurrencySymbol(countryCode)}1, today you can help
+                        us achieve so much more.
+                    </div>
+                </div>
             )}
         </div>
     </div>

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerBody.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerBody.tsx
@@ -41,12 +41,9 @@ const EnvironmentMomentBannerBody: React.FC<EnvironmentMomentBannerBodyProps> = 
                         persistent journalism that is always led by science and truth. And we can
                         keep it open for all so more people can be informed, and inspired to take
                         action. We’ve stopped taking advertising from fossil fuel companies, and
-                        we’re set to reach net zero carbon emissions by 2030.
+                        we’re on course to reach net zero carbon emissions by 2030.
                     </div>
-                    <div>
-                        Thank you for helping to sustain our open, independent journalism. Together
-                        we can achieve so much more.
-                    </div>
+                    <div>Thank you for helping to sustain our open, independent journalism.</div>
                 </div>
             ) : (
                 <div css={paragraphsContainer}>

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerCtas.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerCtas.tsx
@@ -61,7 +61,7 @@ const EnvironmentMomentBannerCtas: React.FC<EnvironmentMomentBannerCtasProps> = 
     const PrimaryCta: React.FC<CtaProps> = ({ size }: CtaProps) => (
         <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
             <LinkButton onClick={onContributeClick} size={size} href={landingPageUrl}>
-                <span css={styles.hideAfterTablet}>Contribute</span>
+                <span css={styles.hideAfterTablet}>Support us</span>
                 <span css={styles.hideBeforeTablet}>
                     {isSupporter ? 'Support again' : 'Support the Guardian'}
                 </span>

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerCtas.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerCtas.tsx
@@ -17,7 +17,7 @@ const container = css`
     }
 `;
 
-const contributeButton = css`
+const secondaryButton = css`
     color: ${neutral[7]};
     border: 1px solid ${neutral[7]};
 `;
@@ -49,20 +49,6 @@ const EnvironmentMomentBannerCtas: React.FC<EnvironmentMomentBannerCtasProps> = 
     onHearFromOurEditorClick,
     tracking,
 }: EnvironmentMomentBannerCtasProps) => {
-    const PrimaryCta: React.FC<CtaProps> = ({ size }: CtaProps) => (
-        <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
-            {countryCode === 'AU' ? (
-                <LinkButton onClick={onHearFromOurEditorClick} size={size} href={LENORE_LINK}>
-                    Hear from our editor
-                </LinkButton>
-            ) : (
-                <LinkButton onClick={onReadPledgeClick} size={size} href={PLEDGE_LINK}>
-                    Read our pledge
-                </LinkButton>
-            )}
-        </ThemeProvider>
-    );
-
     let landingPageUrl = addRegionIdAndTrackingParamsToSupportUrl(
         BASE_LANDING_PAGE_URL,
         tracking,
@@ -72,19 +58,41 @@ const EnvironmentMomentBannerCtas: React.FC<EnvironmentMomentBannerCtasProps> = 
         landingPageUrl += '&selected-contribution-type=ONE_OFF';
     }
 
+    const PrimaryCta: React.FC<CtaProps> = ({ size }: CtaProps) => (
+        <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
+            <LinkButton onClick={onContributeClick} size={size} href={landingPageUrl}>
+                <span css={styles.hideAfterTablet}>Contribute</span>
+                <span css={styles.hideBeforeTablet}>
+                    {isSupporter ? 'Support again' : 'Support the Guardian'}
+                </span>
+            </LinkButton>
+        </ThemeProvider>
+    );
+
     const SecondaryCta: React.FC<CtaProps> = ({ size }: CtaProps) => (
-        <LinkButton
-            onClick={onContributeClick}
-            css={contributeButton}
-            size={size}
-            priority="tertiary"
-            href={landingPageUrl}
-        >
-            <span css={styles.hideAfterTablet}>Contribute</span>
-            <span css={styles.hideBeforeTablet}>
-                {isSupporter ? 'Support again' : 'Support the Guardian'}
-            </span>
-        </LinkButton>
+        <>
+            {countryCode === 'AU' ? (
+                <LinkButton
+                    onClick={onHearFromOurEditorClick}
+                    css={secondaryButton}
+                    size={size}
+                    href={LENORE_LINK}
+                    priority="tertiary"
+                >
+                    Hear from our editor
+                </LinkButton>
+            ) : (
+                <LinkButton
+                    onClick={onReadPledgeClick}
+                    css={secondaryButton}
+                    size={size}
+                    href={PLEDGE_LINK}
+                    priority="tertiary"
+                >
+                    Read our pledge
+                </LinkButton>
+            )}
+        </>
     );
 
     return (

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerHeader.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerHeader.tsx
@@ -115,8 +115,23 @@ const EnvironmentMomentBannerHeader: React.FC<EnvironmentMomentBannerHeaderProps
                 <div css={textContainer}>
                     {isSupporter ? (
                         <>
-                            <span>You help power our</span>
-                            <span>climate pledge</span>
+                            <span>You help power</span>
+                            <span>our climate pledge</span>
+                        </>
+                    ) : (
+                        <>
+                            <span>Help power</span>
+                            <span>our climate pledge</span>
+                        </>
+                    )}
+                </div>
+            </div>
+            <div css={hideBeforeTablet}>
+                <div css={textContainer}>
+                    {isSupporter ? (
+                        <>
+                            <span>You help power</span>
+                            <span>our pledge</span>
                         </>
                     ) : (
                         <>
@@ -124,12 +139,6 @@ const EnvironmentMomentBannerHeader: React.FC<EnvironmentMomentBannerHeaderProps
                             <span>climate pledge</span>
                         </>
                     )}
-                </div>
-            </div>
-            <div css={hideBeforeTablet}>
-                <div css={textContainer}>
-                    <span>You help power</span>
-                    <span>our climate pledge</span>
                 </div>
             </div>
         </div>

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerHeader.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerHeader.tsx
@@ -38,11 +38,11 @@ const iconContainer = css`
     }
 
     ${from.tablet} {
-        height: 85px;
+        height: 91px;
     }
 
     ${from.desktop} {
-        height: 125px;
+        height: 140px;
     }
 `;
 
@@ -57,12 +57,20 @@ const textContainer = css`
         font-size: 40px;
         line-height: 100%;
         margin-top: 3px;
+
+        & > * + * {
+            margin-top: ${space[2]}px;
+        }
     }
 
     ${from.desktop} {
         font-size: 60px;
         margin-top: ${space[1]}px;
         margin-left: ${space[4]}px;
+
+        & > * + * {
+            margin-top: ${space[4]}px;
+        }
     }
 `;
 

--- a/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerHeader.tsx
+++ b/src/components/modules/banners/environmentMomentBanner/components/EnvironmentMomentBannerHeader.tsx
@@ -99,7 +99,13 @@ const hideBeforeTablet = css`
     }
 `;
 
-const EnvironmentMomentBannerHeader: React.FC = () => (
+interface EnvironmentMomentBannerHeaderProps {
+    isSupporter: boolean;
+}
+
+const EnvironmentMomentBannerHeader: React.FC<EnvironmentMomentBannerHeaderProps> = ({
+    isSupporter,
+}: EnvironmentMomentBannerHeaderProps) => (
     <header css={container}>
         <div css={iconAndTextContainer}>
             <div css={iconContainer}>
@@ -107,14 +113,23 @@ const EnvironmentMomentBannerHeader: React.FC = () => (
             </div>
             <div css={hideAfterTablet}>
                 <div css={textContainer}>
-                    <span>Our climate promise</span>
-                    <span>to you</span>
+                    {isSupporter ? (
+                        <>
+                            <span>You help power our</span>
+                            <span>climate pledge</span>
+                        </>
+                    ) : (
+                        <>
+                            <span>Help power our</span>
+                            <span>climate pledge</span>
+                        </>
+                    )}
                 </div>
             </div>
             <div css={hideBeforeTablet}>
                 <div css={textContainer}>
-                    <span>Our climate</span>
-                    <span>promise to you</span>
+                    <span>You help power</span>
+                    <span>our climate pledge</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## What does this change?
Update the environment moment banner as per [this card](https://trello.com/c/5EcIi6Xo/2330-update-environment-moment-banner). We've changed the body + header copy, plus added some extra spacing between the paragraphs and the header lines.

## Images
mobile non-supporter
<img width="325" alt="Screenshot 2020-10-13 at 08 42 35" src="https://user-images.githubusercontent.com/17720442/95830846-3133c600-0d30-11eb-8261-b80b9d5be90f.png">

mobile supporter
<img width="325" alt="Screenshot 2020-10-13 at 08 42 31" src="https://user-images.githubusercontent.com/17720442/95830828-2c6f1200-0d30-11eb-9d08-1fe768f3c41c.png">

tablet non-supporter
<img width="744" alt="Screenshot 2020-10-13 at 08 14 41" src="https://user-images.githubusercontent.com/17720442/95828969-89b59400-0d2d-11eb-8403-c33d253c5bbf.png">

tablet supporter
<img width="744" alt="Screenshot 2020-10-13 at 08 14 50" src="https://user-images.githubusercontent.com/17720442/95828985-8e7a4800-0d2d-11eb-8c1e-9f38ad0aa9a6.png">

desktop non-supporter
<img width="984" alt="Screenshot 2020-10-13 at 08 15 07" src="https://user-images.githubusercontent.com/17720442/95828992-920dcf00-0d2d-11eb-820d-a5ef974bfd66.png">

desktop supporter
<img width="984" alt="Screenshot 2020-10-13 at 08 15 14" src="https://user-images.githubusercontent.com/17720442/95828995-94702900-0d2d-11eb-8765-1fcee02018db.png">

wide non-supporter
<img width="1302" alt="Screenshot 2020-10-13 at 08 17 23" src="https://user-images.githubusercontent.com/17720442/95828999-95a15600-0d2d-11eb-935f-06dfc0ad76a6.png">

wide supporter
<img width="1302" alt="Screenshot 2020-10-13 at 08 17 34" src="https://user-images.githubusercontent.com/17720442/95829588-4f002b80-0d2e-11eb-8c87-eda74050433a.png">

