### PR TITLE
Fix packshot on Digital Subs Banner at Tablet and above

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -6,8 +6,13 @@ import { space } from '@guardian/src-foundations';
 
 const mainBannerBackground = '#005689';
 const closeButtonWidthHeight = 35;
-const packShotWidth = 400;
-const packShotHeight = 240;
+
+// Phablet and lower
+const mobilePackShotWidth = 400;
+const mobilePackShotHeight = 240;
+// Tablet and higher
+const packShotWidth = 500;
+const packShotHeight = 407;
 
 export const banner = css`
     html {
@@ -217,7 +222,11 @@ export const packShotContainer = css`
     flex-direction: column;
     justify-content: flex-end;
     margin: 0 ${space[4]}px;
-    max-width: ${packShotWidth}px;
+    max-width: ${mobilePackShotWidth}px;
+
+    ${from.tablet} {
+        max-width: ${packShotWidth}px;
+    }
 
     ${from.wide} {
         margin-top: ${space[4]}px;
@@ -228,14 +237,15 @@ const imageWidthPercentage = 100;
 const mobileImageWidthPercentage = 80;
 
 export const packShot = css`
-    width: ${imageWidthPercentage}%;
     position: relative;
-    padding-bottom: ${(packShotHeight / packShotWidth) * imageWidthPercentage}%;
+    padding-bottom: ${(mobilePackShotHeight / mobilePackShotWidth) * mobileImageWidthPercentage}%;
+    width: ${mobileImageWidthPercentage}%;
+    margin: 0 auto;
 
-    ${until.tablet} {
-        padding-bottom: ${(packShotHeight / packShotWidth) * mobileImageWidthPercentage}%;
-        width: ${mobileImageWidthPercentage}%;
-        margin: 0 auto;
+    ${from.tablet} {
+        padding-bottom: ${(packShotHeight / packShotWidth) * imageWidthPercentage}%;
+        width: ${imageWidthPercentage}%;
+        margin: none;
     }
 
     img {

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -245,7 +245,7 @@ export const packShot = css`
     ${from.tablet} {
         padding-bottom: ${(packShotHeight / packShotWidth) * imageWidthPercentage}%;
         width: ${imageWidthPercentage}%;
-        margin: none;
+        margin: 0;
     }
 
     img {


### PR DESCRIPTION
## What does this change?

The digital subscriptions banner has two packshot images, one used at the breakpoint `until.tablet` (w400px x h240px) and the other used at the breakpoints `from.tablet`(w500px x h407px). 

In `digitalSubscriptionsBannerStyles.ts` we use the image dimensions to reserve space at the correct aspect-ratio for the image until it loads. However before this PR we were only using the dimensions of the image used at the breakpoints `until.tablet`. This meant at the breakpoints `from.tablet` and up the aspect-ratio reserved for the image-container wasn't the correct size, and was in-fact too short, meaning the image's width was automatically restricted by the shortness of the image-container. This resulted in the packshot looking short and narrow...

<img width="449" alt="Screenshot 2020-10-12 at 11 44 38" src="https://user-images.githubusercontent.com/1590704/95772833-461f4380-0cb5-11eb-9529-f711f5357120.png">
 
This PR fixes that by using the correct dimensions for the image at the breakpoints `from.tablet` and up. Doing this means the image-container's height is now taller, and the image is wider, as intended. Please see the "Tablet" screenshot below to see this, Mobile and Desktop following this change are also included for reference...

Mobile...

<img width="322" alt="Screenshot 2020-10-12 at 17 50 25" src="https://user-images.githubusercontent.com/1590704/95772918-67802f80-0cb5-11eb-8073-bffc74a2686f.png">

Tablet...

<img width="738" alt="Screenshot 2020-10-12 at 17 50 49" src="https://user-images.githubusercontent.com/1590704/95772929-6cdd7a00-0cb5-11eb-83f9-57fce49827d6.png">

Desktop...

<img width="979" alt="Screenshot 2020-10-12 at 17 51 21" src="https://user-images.githubusercontent.com/1590704/95773019-9ac2be80-0cb5-11eb-9508-2cd6e96c827b.png">

