### PR TITLE
Deprecate Google Sheets for engagement banner copy

### DIFF
--- a/src/tests/banners/DefaultContributionsBannerContent.ts
+++ b/src/tests/banners/DefaultContributionsBannerContent.ts
@@ -1,0 +1,12 @@
+import { BannerContent } from '../../types/BannerTypes';
+
+export const DefaultBannerContent: BannerContent = {
+    heading: 'We chose a different approach. Will you support it?',
+    messageText:
+        'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
+    highlightedText: ' Support the Guardian today from as little as %%CURRENCY_SYMBOL%%1.',
+    cta: {
+        text: 'Support The Guardian',
+        baseUrl: 'https://support.theguardian.com/contribute',
+    },
+};

--- a/src/tests/banners/DefaultContributionsBannerTest.ts
+++ b/src/tests/banners/DefaultContributionsBannerTest.ts
@@ -1,55 +1,24 @@
-import fetch from 'node-fetch';
-import {
-    BannerTestGenerator,
-    BannerContent,
-    BannerTest,
-    BannerTargeting,
-    BannerPageTracking,
-} from '../../types/BannerTypes';
+import { BannerPageTracking, BannerTargeting, BannerTest } from '../../types/BannerTypes';
+import { DefaultBannerContent } from './DefaultContributionsBannerContent';
 
 export const DefaultContributionsBannerPath = 'contributions-banner.js';
 
-const defaultBannerContentUrl =
-    'https://interactive.guim.co.uk/docsdata/1CIHCoe87hyPHosXx1pYeVUoohvmIqh9cC_kNlV-CMHQ.json';
-
-const DefaultContributionsBanner = (bannerContent: BannerContent): BannerTest => {
-    return {
-        name: 'DefaultContributionsBanner',
-        bannerChannel: 'contributions',
-        testAudience: 'AllNonSupporters',
-        canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking): boolean =>
-            // Do not serve to frontend for now
-            pageTracking.clientName === 'dcr',
-        minPageViews: 2,
-        variants: [
-            {
-                name: 'control',
-                modulePath: DefaultContributionsBannerPath,
-                moduleName: 'ContributionsBanner',
-                bannerContent: bannerContent,
-                componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-            },
-        ],
-    };
+export const DefaultContributionsBanner: BannerTest = {
+    name: 'DefaultContributionsBanner',
+    bannerChannel: 'contributions',
+    testAudience: 'AllNonSupporters',
+    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => {
+        // Do not serve to frontend for now
+        return pageTracking.clientName === 'dcr';
+    },
+    minPageViews: 2,
+    variants: [
+        {
+            name: 'control',
+            modulePath: DefaultContributionsBannerPath,
+            moduleName: 'ContributionsBanner',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            bannerContent: DefaultBannerContent,
+        },
+    ],
 };
-
-const defaultBannerTest = (bannerContent: BannerContent): BannerTest => {
-    return DefaultContributionsBanner(bannerContent);
-};
-
-export const defaultBannerTestGenerator: BannerTestGenerator = () =>
-    fetch(defaultBannerContentUrl)
-        .then(response => response.json())
-        .then(json => json['sheets']['control'][0])
-        .then(defaultBannerContent => {
-            return [
-                defaultBannerTest({
-                    messageText: defaultBannerContent.messageText,
-                    highlightedText: defaultBannerContent.ctaText,
-                    cta: {
-                        baseUrl: defaultBannerContent.linkUrl,
-                        text: defaultBannerContent.buttonCaption,
-                    },
-                }),
-            ];
-        });

--- a/src/tests/banners/DefaultContributionsBannerTest.ts
+++ b/src/tests/banners/DefaultContributionsBannerTest.ts
@@ -7,10 +7,8 @@ export const DefaultContributionsBanner: BannerTest = {
     name: 'DefaultContributionsBanner',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
-    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => {
-        // Do not serve to frontend for now
-        return pageTracking.clientName === 'dcr';
-    },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    canRun: (_targeting: BannerTargeting, _pageTracking: BannerPageTracking) => true,
     minPageViews: 2,
     variants: [
         {

--- a/src/tests/banners/bannerTests.ts
+++ b/src/tests/banners/bannerTests.ts
@@ -5,7 +5,7 @@ import {
     EnvironmentMomentBannerSupporters,
     EnvironmentMomentBannerNonSupporters,
 } from './EnvironmentMomentBannerTest';
-import { defaultBannerTestGenerator } from './DefaultContributionsBannerTest';
+import { DefaultContributionsBanner } from './DefaultContributionsBannerTest';
 import {
     channel1BannersAllTestsGenerator,
     channel2BannersAllTestsGenerator,
@@ -20,6 +20,9 @@ const digitalSubscriptionsBannerGenerator: BannerTestGenerator = () =>
 
 const guardianWeeklyBannerGenerator: BannerTestGenerator = () =>
     Promise.resolve([GuardianWeeklyBanner]);
+
+const defaultBannerTestGenerator: BannerTestGenerator = () =>
+    Promise.resolve([DefaultContributionsBanner]);
 
 const flattenArray = <T>(array: T[][]): T[] => ([] as T[]).concat(...array);
 


### PR DESCRIPTION
Deprecate Google Sheets for engagement banner copy, per [this Trello card](https://trello.com/c/Cx2HmtOJ/2276-deprecate-both-google-sheets-for-engagement-banner).