### PR TITLE
Mj implement pre contrib reminder

### DIFF
--- a/src/components/modules/epics/ContributionsEpicButtons.tsx
+++ b/src/components/modules/epics/ContributionsEpicButtons.tsx
@@ -5,6 +5,7 @@ import { Button } from './Button';
 import { EpicTracking } from './ContributionsEpicTypes';
 import { Cta, Variant } from '../../../lib/variants';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
+import { getCookie } from '../../../lib/cookies';
 
 const buttonWrapperStyles = css`
     margin: ${space[6]}px ${space[2]}px ${space[1]}px 0;
@@ -90,6 +91,7 @@ export const ContributionsEpicButtons = ({
     onOpenReminderClick: Function;
 }): JSX.Element | null => {
     const { cta, secondaryCta, showReminderFields } = variant;
+    const showReminderCta = !getCookie('gu_epic_contribution_reminder');
     if (!cta) {
         return null;
     }
@@ -105,6 +107,7 @@ export const ContributionsEpicButtons = ({
                     countryCode={countryCode}
                 />
             ) : (
+                showReminderCta &&
                 showReminderFields && (
                     <div css={buttonMargins}>
                         <Button onClickAction={onOpenReminderClick} isTertiary>

--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -122,7 +122,7 @@ type ReminderPayload = {
 
 const dateDiff = (start: Date, end: Date): number => {
     const twentyFourHours = 86400000;
-    return Math.round(Math.abs((start.valueOf() - end.valueOf()) / twentyFourHours));
+    return Math.round((end.valueOf() - start.valueOf()) / twentyFourHours);
 };
 
 const addContributionReminderCookie = (reminderDateString: string): void => {

--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -9,8 +9,6 @@ import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';
 import { SvgArrowRightStraight, SvgClose } from '@guardian/src-svgs';
 import { addCookie } from '../../../lib/cookies';
-import { int } from 'aws-sdk/clients/datapipeline';
-import { date } from '@storybook/addon-knobs';
 
 const rootStyles = css`
     position: relative;

--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -3,7 +3,7 @@ import { css, SerializedStyles } from '@emotion/core';
 import { headline, textSans, body } from '@guardian/src-foundations/typography';
 import { palette, space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { ReminderFields } from '../../../lib/variants';
+import { ReminderFields } from '../../../lib/reminderFields';
 import { Lines } from '../../Lines';
 import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';

--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -8,6 +8,9 @@ import { Lines } from '../../Lines';
 import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';
 import { SvgArrowRightStraight, SvgClose } from '@guardian/src-svgs';
+import { addCookie } from '../../../lib/cookies';
+import { int } from 'aws-sdk/clients/datapipeline';
+import { date } from '@storybook/addon-knobs';
 
 const rootStyles = css`
     position: relative;
@@ -119,6 +122,18 @@ type ReminderPayload = {
     reminderDate: string;
 };
 
+const dateDiff = (start: Date, end: Date): number => {
+    const twentyFourHours = 86400000;
+    return Math.round(Math.abs((start.valueOf() - end.valueOf()) / twentyFourHours));
+};
+
+const addContributionReminderCookie = (reminderDateString: string): void => {
+    const today = new Date();
+    const reminderDate = new Date(Date.parse(reminderDateString));
+
+    addCookie('gu_epic_contribution_reminder', '1', dateDiff(today, reminderDate));
+};
+
 const contributionsReminderUrl =
     'https://contribution-reminders.support.guardianapis.com/remind-me';
 
@@ -188,6 +203,7 @@ export const ContributionsEpicReminder: React.FC<Props> = ({
                                     if (json !== 'OK') {
                                         throw Error('Server error');
                                     }
+                                    addContributionReminderCookie(reminderDate);
                                     setIsSuccessState(true);
                                 })
                                 .catch((): void => setIsErrorState(true))

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -23,6 +23,30 @@ const getDomainAttribute = (isCrossSubdomain = false): string => {
     return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
 };
 
+const getCookieValues = (name: string): string[] => {
+    const nameEq = `${name}=`;
+    const cookies = document.cookie.split(';');
+
+    return cookies.reduce<string[]>((acc, cookie) => {
+        const cookieTrimmed = cookie.trim();
+
+        if (cookieTrimmed.startsWith(nameEq)) {
+            acc.push(cookieTrimmed.substring(nameEq.length, cookieTrimmed.length));
+        }
+
+        return acc;
+    }, []);
+};
+
+export const getCookie = (name: string): string | null => {
+    const cookieVal = getCookieValues(name);
+
+    if (cookieVal.length > 0) {
+        return cookieVal[0];
+    }
+    return null;
+};
+
 export const addCookie = (
     name: string,
     value: string,

--- a/src/lib/reminderFields.test.ts
+++ b/src/lib/reminderFields.test.ts
@@ -1,0 +1,30 @@
+import { buildReminderFields } from './reminderFields';
+
+describe('buildReminderFields', () => {
+    it('should set date to the next calendar month if the current date is BEFORE the 20th', () => {
+        const novemberNineteenth = new Date('2020-11-19 00:00:00');
+
+        const expected = 'December 2020';
+        const actual = buildReminderFields(novemberNineteenth).reminderDateAsString;
+
+        expect(actual).toBe(expected);
+    });
+
+    it('should set date to the next + 1 calendar month if the current date is the 20th', () => {
+        const novemberTwentieth = new Date('2020-11-20 00:00:00');
+
+        const expected = 'January 2021';
+        const actual = buildReminderFields(novemberTwentieth).reminderDateAsString;
+
+        expect(actual).toBe(expected);
+    });
+
+    it('should set date to the next + 1 calendar month if the current date is AFTER the 20th', () => {
+        const novemberTwentyFirst = new Date('2020-11-21 00:00:00');
+
+        const expected = 'January 2021';
+        const actual = buildReminderFields(novemberTwentyFirst).reminderDateAsString;
+
+        expect(actual).toBe(expected);
+    });
+});

--- a/src/lib/reminderFields.ts
+++ b/src/lib/reminderFields.ts
@@ -1,0 +1,26 @@
+export interface ReminderFields {
+    reminderCTA: string;
+    reminderDate: string;
+    reminderDateAsString: string;
+}
+
+const getReminderDate = (date: Date): Date => {
+    const monthsAhead = date.getDate() < 20 ? 1 : 2;
+    date.setMonth(date.getMonth() + monthsAhead);
+
+    return date;
+};
+
+export const buildReminderFields = (today: Date = new Date()): ReminderFields => {
+    const reminderDate = getReminderDate(today);
+
+    const month = reminderDate.getMonth();
+    const monthName = reminderDate.toLocaleString('default', { month: 'long' });
+    const year = reminderDate.getFullYear();
+
+    return {
+        reminderCTA: `Remind me in ${monthName}`,
+        reminderDate: `${year}-${month}-19 00:00:00`,
+        reminderDateAsString: `${monthName} ${year}`,
+    };
+};

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -304,8 +304,10 @@ export interface Result {
 
 const reminderDate = (): Date => {
     const date = new Date();
-    if (date.getDate() >= 20) {
+    if (date.getDate() < 20) {
         date.setMonth(date.getMonth() + 1);
+    } else {
+        date.setMonth(date.getMonth() + 2);
     }
 
     return date;

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -302,17 +302,25 @@ export interface Result {
     debug?: Debug;
 }
 
-// Temporarily hard-coded while we decide on requirement
-const defaultReminderFields: ReminderFields = {
-    reminderCTA: 'Remind me in October',
-    reminderDate: '2020-10-14 00:00:00',
-    reminderDateAsString: 'October 2020',
-};
-const defaultReminderCutoff = new Date('2020-09-14');
+const reminderDate = (): Date => {
+    const date = new Date();
+    if (date.getDate() >= 20) {
+        date.setMonth(date.getMonth() + 1);
+    }
 
-const getDefaultReminderFields = (): ReminderFields | undefined => {
-    const now = new Date();
-    return now <= defaultReminderCutoff ? defaultReminderFields : undefined;
+    return date;
+};
+
+const reminderFields = (): ReminderFields => {
+    const month = reminderDate().getMonth();
+    const monthName = reminderDate().toLocaleString('default', { month: 'long' });
+    const year = reminderDate().getFullYear();
+
+    return {
+        reminderCTA: `Remind me in ${monthName}`,
+        reminderDate: `${year}-${month}-19 00:00:00`,
+        reminderDateAsString: `${monthName} ${year}`,
+    };
 };
 
 export const findTestAndVariant = (
@@ -370,11 +378,11 @@ export const findTestAndVariant = (
         const variant = selectVariant(test, targeting.mvtId || 1);
         const variantWithReminder: Variant = {
             ...variant,
-            showReminderFields: variant.showReminderFields || getDefaultReminderFields(),
+            showReminderFields: variant.showReminderFields || reminderFields(),
         };
 
         return {
-            result: { test, variant: variantWithReminder },
+            result: { test, variant: variant.secondaryCta ? variant : variantWithReminder },
             debug: includeDebug ? debug : undefined,
         };
     }

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -382,7 +382,7 @@ export const findTestAndVariant = (
         };
 
         return {
-            result: { test, variant: variant.secondaryCta ? variant : variantWithReminder },
+            result: { test, variant: variantWithReminder },
             debug: includeDebug ? debug : undefined,
         };
     }

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -8,6 +8,7 @@ import { getCountryName, inCountryGroups, CountryGroupId } from '../lib/geolocat
 import { getArticleViewCountForWeeks, historyWithinArticlesViewedSettings } from '../lib/history';
 import { isRecentOneOffContributor } from '../lib/dates';
 import { ArticlesViewedSettings, WeeklyArticleHistory } from '../types/shared';
+import { buildReminderFields, ReminderFields } from './reminderFields';
 
 export enum TickerEndType {
     unlimited = 'unlimited',
@@ -45,12 +46,6 @@ interface MaxViews {
 export interface Cta {
     text: string;
     baseUrl: string;
-}
-
-export interface ReminderFields {
-    reminderCTA: string;
-    reminderDate: string;
-    reminderDateAsString: string;
 }
 
 export interface Variant {
@@ -302,29 +297,6 @@ export interface Result {
     debug?: Debug;
 }
 
-const reminderDate = (): Date => {
-    const date = new Date();
-    if (date.getDate() < 20) {
-        date.setMonth(date.getMonth() + 1);
-    } else {
-        date.setMonth(date.getMonth() + 2);
-    }
-
-    return date;
-};
-
-const reminderFields = (): ReminderFields => {
-    const month = reminderDate().getMonth();
-    const monthName = reminderDate().toLocaleString('default', { month: 'long' });
-    const year = reminderDate().getFullYear();
-
-    return {
-        reminderCTA: `Remind me in ${monthName}`,
-        reminderDate: `${year}-${month}-19 00:00:00`,
-        reminderDateAsString: `${monthName} ${year}`,
-    };
-};
-
 export const findTestAndVariant = (
     tests: Test[],
     targeting: EpicTargeting,
@@ -380,7 +352,7 @@ export const findTestAndVariant = (
         const variant = selectVariant(test, targeting.mvtId || 1);
         const variantWithReminder: Variant = {
             ...variant,
-            showReminderFields: variant.showReminderFields || reminderFields(),
+            showReminderFields: variant.showReminderFields || buildReminderFields(),
         };
 
         return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5359,11 +5359,6 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clone@2.x:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -10151,13 +10146,6 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
-
-node-cache@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.0.tgz#266786c28dcec0fd34385ee29c383e6d6f1aa5de"
-  integrity sha512-gFQwYdoOztBuPlwg6DKQEf50G+gkK69aqLnw4djkmlHCzeVrLJfwvg9xl4RCAGviTIMUVoqcyoZ/V/wPEu/VVg==
-  dependencies:
-    clone "2.x"
 
 node-dir@^0.1.10:
   version "0.1.17"


### PR DESCRIPTION
## What does this PR do?

Implements the client-side logic for pre-contributions reminders, as per [this Trello card](https://trello.com/c/jrnqkXSl/2315-implement-the-pre-contribution-reminder-as-a-proper-feature-no-expiry-date). 

- If the selected Epic variant doesn't have a secondary CTA, the reminder button will be displayed instead.
- If the current date is before the 20th, the reminder will be set for the following month.
- If the current date is on, or after, the 20th, the reminder will be set for the month after next.
- If the user has a reminder set, they won't see a reminder button again until after they receive the email.
- Reminder emails will be sent on the 19th of each month, this is to differentiate them from post-contribution reminders (sent on the 15th of the month).