### PR TITLE
Stop checking switches.remoteSubscriptionsBanner in Subs Banners canRun

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -271,9 +271,6 @@ app.post(
                 engagementBannerLastClosedAt: payload.targeting.engagementBannerLastClosedAt,
                 subscriptionBannerLastClosedAt: payload.targeting.subscriptionBannerLastClosedAt,
                 isPaidContent: payload.targeting.isPaidContent,
-                switches: {
-                    remoteSubscriptionsBanner: payload.targeting.switches.remoteSubscriptionsBanner,
-                },
             };
 
             res.send(response);

--- a/src/tests/banners/DigitalSubscriptionsBannerTest.ts
+++ b/src/tests/banners/DigitalSubscriptionsBannerTest.ts
@@ -10,11 +10,8 @@ export const DigitalSubscriptionsBanner: BannerTest = {
     testAudience: 'AllNonSupporters',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => {
-        if (targeting.switches.remoteSubscriptionsBanner) {
-            const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
-            return region !== 'EuropeanUnion';
-        }
-        return false;
+        const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
+        return region !== 'EuropeanUnion';
     },
     minPageViews: 2,
     variants: [

--- a/src/tests/banners/GuardianWeeklyBannerTest.ts
+++ b/src/tests/banners/GuardianWeeklyBannerTest.ts
@@ -10,11 +10,8 @@ export const GuardianWeeklyBanner: BannerTest = {
     testAudience: 'AllNonSupporters',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => {
-        if (targeting.switches.remoteSubscriptionsBanner) {
-            const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
-            return region === 'EuropeanUnion';
-        }
-        return false;
+        const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
+        return region === 'EuropeanUnion';
     },
     minPageViews: 2,
     variants: [

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -41,9 +41,6 @@ describe('selectBannerTest', () => {
             mvtId: 3,
             countryCode: 'US',
             engagementBannerLastClosedAt: secondDate,
-            switches: {
-                remoteSubscriptionsBanner: true,
-            },
             hasOptedOutOfArticleCount: false,
         };
 
@@ -112,9 +109,6 @@ describe('selectBannerTest', () => {
             mvtId: 3,
             countryCode: 'DE',
             engagementBannerLastClosedAt: secondDate,
-            switches: {
-                remoteSubscriptionsBanner: true,
-            },
             hasOptedOutOfArticleCount: false,
         };
 
@@ -128,42 +122,6 @@ describe('selectBannerTest', () => {
             const cache = getBannerDeployCache(secondDate);
 
             return selectBannerTest(targeting, tracking, '', getTests, cache).then(result => {
-                expect(result && result.test.name).toBe('GuardianWeeklyBanner');
-            });
-        });
-
-        it('returns null if other contributions banner was dismissed and subs switch is off', () => {
-            const cache = getBannerDeployCache(secondDate);
-
-            return selectBannerTest(
-                Object.assign(targeting, {
-                    switches: {
-                        remoteSubscriptionsBanner: false,
-                    },
-                }),
-                tracking,
-                '',
-                getTests,
-                cache,
-            ).then(result => {
-                expect(result && result.test.name).toBe(null);
-            });
-        });
-
-        it('returns banner if has been redeployed', () => {
-            const cache = getBannerDeployCache(firstDate);
-
-            return selectBannerTest(
-                Object.assign(targeting, {
-                    switches: {
-                        remoteSubscriptionsBanner: true,
-                    },
-                }),
-                tracking,
-                '',
-                getTests,
-                cache,
-            ).then(result => {
                 expect(result && result.test.name).toBe('GuardianWeeklyBanner');
             });
         });
@@ -198,9 +156,6 @@ describe('selectBannerTest', () => {
             mvtId: 3,
             countryCode: 'AU',
             engagementBannerLastClosedAt: firstDate,
-            switches: {
-                remoteSubscriptionsBanner: true,
-            },
             hasOptedOutOfArticleCount: false,
         };
 
@@ -323,9 +278,6 @@ describe('selectBannerTest', () => {
             mvtId: 3,
             countryCode: 'GB',
             engagementBannerLastClosedAt: firstDate,
-            switches: {
-                remoteSubscriptionsBanner: true,
-            },
             hasOptedOutOfArticleCount: false,
         };
 

--- a/src/tests/banners/bannerTest.test.ts
+++ b/src/tests/banners/bannerTest.test.ts
@@ -31,9 +31,6 @@ describe('DigitalSubscriptionsBanner canRun', () => {
             subscriptionBannerLastClosedAt: '1594059610944',
             mvtId: 3,
             countryCode: 'US',
-            switches: {
-                remoteSubscriptionsBanner: true,
-            },
             hasOptedOutOfArticleCount: false,
         };
         const targetingFalse = {
@@ -45,23 +42,6 @@ describe('DigitalSubscriptionsBanner canRun', () => {
             mvtId: 3,
             // Should show banner in Europe
             countryCode: 'DE',
-            switches: {
-                remoteSubscriptionsBanner: false,
-            },
-            hasOptedOutOfArticleCount: false,
-        };
-        const targetingFalse2 = {
-            alreadyVisitedCount: 3,
-            shouldHideReaderRevenue: false,
-            isPaidContent: false,
-            showSupportMessaging: true,
-            subscriptionBannerLastClosedAt: '1594059610944',
-            mvtId: 3,
-            countryCode: 'GB',
-            // Should not show banner if switch is off
-            switches: {
-                remoteSubscriptionsBanner: false,
-            },
             hasOptedOutOfArticleCount: false,
         };
         const tracking = {
@@ -74,8 +54,6 @@ describe('DigitalSubscriptionsBanner canRun', () => {
         expect(canRun1).toBe(true);
         const canRun2 = DigitalSubscriptionsBanner.canRun(targetingFalse, tracking);
         expect(canRun2).toBe(false);
-        const canRun3 = DigitalSubscriptionsBanner.canRun(targetingFalse2, tracking);
-        expect(canRun3).toBe(false);
     });
 });
 
@@ -89,9 +67,6 @@ describe('WeeklyBanner canRun', () => {
             subscriptionBannerLastClosedAt: '1594059610944',
             mvtId: 3,
             countryCode: 'AU',
-            switches: {
-                remoteSubscriptionsBanner: true,
-            },
             hasOptedOutOfArticleCount: false,
         };
         const targetingFalse = {
@@ -102,9 +77,6 @@ describe('WeeklyBanner canRun', () => {
             subscriptionBannerLastClosedAt: '1594059610944',
             mvtId: 3,
             countryCode: 'US',
-            switches: {
-                remoteSubscriptionsBanner: true,
-            },
             hasOptedOutOfArticleCount: false,
         };
         const tracking = {

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -14,9 +14,6 @@ export type BannerTargeting = {
     subscriptionBannerLastClosedAt?: string;
     mvtId: number;
     countryCode: string;
-    switches: {
-        remoteSubscriptionsBanner: boolean;
-    };
     weeklyArticleHistory?: WeeklyArticleHistory;
     hasOptedOutOfArticleCount: boolean;
 };


### PR DESCRIPTION
## What does this change?

When we first started using this Banner service we wanted to switch the Subscriptions Banners on/off via a switch in the Frontend admin tools. When the switch was ON we use the service, and when the switch was OFF we'd revert back to the old banners in frontend and not serve any subs banners from the service. The service has been running for a number of months now and this switch is no longer necessary.

This PR is the first step in removing it. The PR updates the `canRun` function in the `DigitalSubscriptionsBannerTest.ts` and `GuardianWeeklyBannerTest.ts` files to no longer check that whether this switch is turned ON. Peviously if the switch was OFF `canRun` would `return false;`.

The next steps are to stop sending the switch value un the payload from `frontend` and `dotcom-rendering`, and to remove the old banners js/css from `frontend`.
