### PR TITLE
DO NOT MERGE: Add special US pre contribution reminder

### DIFF
--- a/src/lib/reminderFields.ts
+++ b/src/lib/reminderFields.ts
@@ -24,3 +24,24 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
         reminderDateAsString: `${monthName} ${year}`,
     };
 };
+
+const US_EOY_APPEAL_REMINDER_FIELDS: ReminderFields = {
+    reminderCTA: 'Remind me on Giving Tuesday',
+    reminderDate: `2020-12-01 00:00:00`,
+    reminderDateAsString: `on Giving Tuesday`,
+};
+
+const US_EOY_APPEAL_REMINDER_CUT_OFF = Date.parse('2020-11-29');
+
+const shouldShowUsEoyReminder = (countryCode?: string): boolean =>
+    countryCode == 'US' && Date.now() < US_EOY_APPEAL_REMINDER_CUT_OFF;
+
+export const getReminderFields = (
+    reminderFields?: ReminderFields,
+    countryCode?: string,
+): ReminderFields => {
+    if (shouldShowUsEoyReminder(countryCode)) {
+        return US_EOY_APPEAL_REMINDER_FIELDS;
+    }
+    return !!reminderFields ? reminderFields : buildReminderFields();
+};

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -8,7 +8,7 @@ import { getCountryName, inCountryGroups, CountryGroupId } from '../lib/geolocat
 import { getArticleViewCountForWeeks, historyWithinArticlesViewedSettings } from '../lib/history';
 import { isRecentOneOffContributor } from '../lib/dates';
 import { ArticlesViewedSettings, WeeklyArticleHistory } from '../types/shared';
-import { buildReminderFields, ReminderFields } from './reminderFields';
+import { getReminderFields, ReminderFields } from './reminderFields';
 
 export enum TickerEndType {
     unlimited = 'unlimited',
@@ -352,7 +352,10 @@ export const findTestAndVariant = (
         const variant = selectVariant(test, targeting.mvtId || 1);
         const variantWithReminder: Variant = {
             ...variant,
-            showReminderFields: variant.showReminderFields || buildReminderFields(),
+            showReminderFields: getReminderFields(
+                variant.showReminderFields,
+                targeting.countryCode,
+            ),
         };
 
         return {


### PR DESCRIPTION
## What does this change?
Add a special pre-contribution reminder for the US EOY appeal


## Images
in the US, before 29/11

<img width="632" alt="Screenshot 2020-11-02 at 14 34 53" src="https://user-images.githubusercontent.com/17720442/97880599-468d8600-1d19-11eb-9d58-eecf30207dbf.png">

<img width="632" alt="Screenshot 2020-11-02 at 14 36 35" src="https://user-images.githubusercontent.com/17720442/97880681-5d33dd00-1d19-11eb-89da-ed8f3314e4bf.png">

else

<img width="632" alt="Screenshot 2020-11-02 at 14 35 43" src="https://user-images.githubusercontent.com/17720442/97880724-6e7ce980-1d19-11eb-8edd-ccff732e4c8a.png">

<img width="632" alt="Screenshot 2020-11-02 at 14 36 04" src="https://user-images.githubusercontent.com/17720442/97880738-73419d80-1d19-11eb-9f28-305c36755ebd.png">

