### PR TITLE
Update pre-contribution reminder copy

### DIFF
--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -259,9 +259,8 @@ export const ContributionsEpicReminder: React.FC<Props> = ({
 
                 {!isSuccessState && (
                     <p css={formTextStyles}>
-                        We will use this to send you a single email {reminderDateWithPreposition}.
-                        To find out what personal data we collect and how we use it, please visit
-                        our{' '}
+                        We will send you a maximum of two emails {reminderDateWithPreposition}. To
+                        find out what personal data we collect and how we use it, view our{' '}
                         <a
                             css={linkStyles}
                             href="https://www.theguardian.com/help/privacy-policy"


### PR DESCRIPTION
## What does this change?
Update the copy in the pre-contribution reminder, as per [this card](https://trello.com/c/VDVEcAbq/2406-update-the-reminders-copy-to-advertise-the-fact-were-going-to-send-up-to-2-emails-from-now)

## Images
<img width="1445" alt="Screenshot 2020-11-09 at 11 09 06" src="https://user-images.githubusercontent.com/17720442/98534344-3c6d0980-227c-11eb-912e-fb9fcd649b84.png">
