### PR TITLE
Mj implement ticker for amp epics

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -444,7 +444,7 @@ app.get(
         try {
             // We use the fastly geo header for determining the correct currency symbol
             const countryCode = req.header('X-GU-GeoIP-Country-Code');
-            const response = ampEpic(countryCode);
+            const response = await ampEpic(countryCode);
 
             // The cache key in fastly is the X-GU-GeoIP-Country-Code header
             res.setHeader('Surrogate-Control', 'max-age=300');

--- a/src/tests/ampEpic.ts
+++ b/src/tests/ampEpic.ts
@@ -1,5 +1,5 @@
 import { getLocalCurrencySymbol } from '../lib/geolocation';
-import { AMPTicker, ampTicker } from './ampTicker';
+import { AMPTicker } from './ampTicker';
 
 interface AMPCta {
     text: string;
@@ -41,13 +41,12 @@ async function ampDefaultEpic(geolocation?: string): Promise<AMPEpicResponse> {
                     campaignCode: campaignCode,
                     componentId: campaignCode,
                 },
-                ticker: await ampTicker('people', 'our goal', 'new supporters'),
             },
         ],
     };
 }
 
-function ampUsEpic(): AMPEpicResponse {
+async function ampUsEpic(): Promise<AMPEpicResponse> {
     const campaignCode = 'AMP_USREGION_EPIC';
     return {
         items: [

--- a/src/tests/ampEpic.ts
+++ b/src/tests/ampEpic.ts
@@ -1,18 +1,11 @@
 import { getLocalCurrencySymbol } from '../lib/geolocation';
+import { AMPTicker, ampTicker } from './ampTicker';
 
 interface AMPCta {
     text: string;
     url: string;
     componentId: string;
     campaignCode: string;
-}
-
-interface AMPTicker {
-    percentage: string;
-    goalAmountFigure: string;
-    goalAmountCaption: string;
-    currentAmountFigure: string;
-    currentAmountCaption: string;
 }
 
 interface AMPEpic {
@@ -28,25 +21,7 @@ interface AMPEpicResponse {
     items: AMPEpic[];
 }
 
-function ampEpicTickerData(
-    goalAmountFigure: number,
-    goalAmountCaption: string,
-    currentAmountFigure: number,
-    currentAmountCaption: string,
-    currencySymbol?: string,
-): AMPTicker {
-    const percentage = (currentAmountFigure / goalAmountFigure) * 100;
-
-    return {
-        percentage: percentage.toString(),
-        goalAmountCaption: goalAmountCaption,
-        goalAmountFigure: `${currencySymbol}${goalAmountFigure.toLocaleString()}`,
-        currentAmountCaption: currentAmountCaption,
-        currentAmountFigure: `${currencySymbol}${currentAmountFigure.toLocaleString()}`,
-    };
-}
-
-function ampDefaultEpic(geolocation?: string): AMPEpicResponse {
+async function ampDefaultEpic(geolocation?: string): Promise<AMPEpicResponse> {
     const campaignCode = 'AMP_EPIC_AUGUST2020';
     const currencySymbol = getLocalCurrencySymbol(geolocation);
     return {
@@ -66,13 +41,7 @@ function ampDefaultEpic(geolocation?: string): AMPEpicResponse {
                     campaignCode: campaignCode,
                     componentId: campaignCode,
                 },
-                ticker: ampEpicTickerData(
-                    150000,
-                    'our goal',
-                    132455,
-                    'raised so far',
-                    currencySymbol,
-                ),
+                ticker: await ampTicker('people', 'our goal', 'new supporters'),
             },
         ],
     };
@@ -101,7 +70,7 @@ function ampUsEpic(): AMPEpicResponse {
     };
 }
 
-export function ampEpic(geolocation?: string): AMPEpicResponse {
+export function ampEpic(geolocation?: string): AMPEpicResponse | Promise<AMPEpicResponse> {
     const epic = geolocation === 'US' ? ampUsEpic() : ampDefaultEpic(geolocation);
     return epic;
 }

--- a/src/tests/ampEpic.ts
+++ b/src/tests/ampEpic.ts
@@ -7,16 +7,43 @@ interface AMPCta {
     campaignCode: string;
 }
 
+interface AMPTicker {
+    percentage: string;
+    goalAmountFigure: string;
+    goalAmountCaption: string;
+    currentAmountFigure: string;
+    currentAmountCaption: string;
+}
+
 interface AMPEpic {
     heading?: string;
     paragraphs: string[];
     highlightedText?: string;
     cta: AMPCta;
+    ticker?: AMPTicker;
 }
 
 // See https://amp.dev/documentation/components/amp-list/
 interface AMPEpicResponse {
     items: AMPEpic[];
+}
+
+function ampEpicTickerData(
+    goalAmountFigure: number,
+    goalAmountCaption: string,
+    currentAmountFigure: number,
+    currentAmountCaption: string,
+    currencySymbol?: string,
+): AMPTicker {
+    const percentage = (currentAmountFigure / goalAmountFigure) * 100;
+
+    return {
+        percentage: percentage.toString(),
+        goalAmountCaption: goalAmountCaption,
+        goalAmountFigure: `${currencySymbol}${goalAmountFigure.toLocaleString()}`,
+        currentAmountCaption: currentAmountCaption,
+        currentAmountFigure: `${currencySymbol}${currentAmountFigure.toLocaleString()}`,
+    };
 }
 
 function ampDefaultEpic(geolocation?: string): AMPEpicResponse {
@@ -39,6 +66,13 @@ function ampDefaultEpic(geolocation?: string): AMPEpicResponse {
                     campaignCode: campaignCode,
                     componentId: campaignCode,
                 },
+                ticker: ampEpicTickerData(
+                    150000,
+                    'our goal',
+                    132455,
+                    'raised so far',
+                    currencySymbol,
+                ),
             },
         ],
     };

--- a/src/tests/ampEpic.ts
+++ b/src/tests/ampEpic.ts
@@ -69,7 +69,6 @@ async function ampUsEpic(): Promise<AMPEpicResponse> {
     };
 }
 
-export function ampEpic(geolocation?: string): AMPEpicResponse | Promise<AMPEpicResponse> {
-    const epic = geolocation === 'US' ? ampUsEpic() : ampDefaultEpic(geolocation);
-    return epic;
+export function ampEpic(geolocation?: string): Promise<AMPEpicResponse> {
+    return geolocation === 'US' ? ampUsEpic() : ampDefaultEpic(geolocation);
 }

--- a/src/tests/ampTicker.ts
+++ b/src/tests/ampTicker.ts
@@ -1,0 +1,60 @@
+import fetch from 'node-fetch';
+
+interface TickerData {
+    total: number;
+    goal: number;
+}
+
+type TickerCountType = 'money' | 'people';
+
+export interface AMPTicker {
+    percentage: string;
+    goalAmountFigure: string;
+    goalAmountCaption: string;
+    currentAmountFigure: string;
+    currentAmountCaption: string;
+}
+
+const parse = (json: any): Promise<TickerData> => {
+    const total = parseInt(json.total, 10);
+    const goal = parseInt(json.goal, 10);
+
+    if (!Number.isNaN(total) && !Number.isNaN(goal)) {
+        return Promise.resolve({
+            total,
+            goal,
+        });
+    }
+    return Promise.reject(Error(`Failed to parse ticker data: ${json}`));
+};
+
+const tickerDataUrl = (countType: TickerCountType): string => {
+    return countType === 'people'
+        ? 'https://support.theguardian.com/supporters-ticker.json'
+        : 'https://support.theguardian.com/ticker.json';
+};
+
+const fetchTickerData = async (url: string): Promise<TickerData> => {
+    return await fetch(url)
+        .then(response => response.json())
+        .then(parse);
+};
+
+export const ampTicker = async (
+    type: TickerCountType,
+    goalCaption: string,
+    totalCaption: string,
+    currencySymbol: string = '',
+): Promise<AMPTicker> => {
+    return await fetchTickerData(tickerDataUrl(type)).then(data => {
+        const percentage = (data.total / data.goal) * 100;
+
+        return {
+            percentage: (percentage > 100 ? 100 : percentage).toString(),
+            goalAmountCaption: goalCaption,
+            goalAmountFigure: `${currencySymbol}${data.goal.toLocaleString()}`,
+            currentAmountCaption: totalCaption,
+            currentAmountFigure: `${currencySymbol}${data.total.toLocaleString()}`,
+        };
+    });
+};

--- a/src/tests/ampTicker.ts
+++ b/src/tests/ampTicker.ts
@@ -44,17 +44,18 @@ export const ampTicker = async (
     type: TickerCountType,
     goalCaption: string,
     totalCaption: string,
-    currencySymbol: string = '',
+    currencySymbol?: string,
 ): Promise<AMPTicker> => {
     return await fetchTickerData(tickerDataUrl(type)).then(data => {
         const percentage = (data.total / data.goal) * 100;
+        const prefix = type === 'money' && currencySymbol ? currencySymbol : '';
 
         return {
             percentage: (percentage > 100 ? 100 : percentage).toString(),
             goalAmountCaption: goalCaption,
-            goalAmountFigure: `${currencySymbol}${data.goal.toLocaleString()}`,
+            goalAmountFigure: `${prefix}${data.goal.toLocaleString()}`,
             currentAmountCaption: totalCaption,
-            currentAmountFigure: `${currencySymbol}${data.total.toLocaleString()}`,
+            currentAmountFigure: `${prefix}${data.total.toLocaleString()}`,
         };
     });
 };


### PR DESCRIPTION
### What does this PR do?
Implements the logic and types for returning ticker data along with existing AMP epic data, for use with DCR AMP articles.

### Screenshots
[See the related PR on DCR](https://github.com/guardian/dotcom-rendering/pull/2029)