### PR TITLE
AMP epic: fetch configuration from the tool

### DIFF
--- a/src/lib/geolocation.ts
+++ b/src/lib/geolocation.ts
@@ -423,7 +423,7 @@ export const getCountryName = (geolocation?: string): string | undefined => {
     return undefined;
 };
 
-export const countryCodeToSupportRegionId = (countryCode: string): SupportRegionId =>
+const countryCodeToSupportRegionId = (countryCode: string): SupportRegionId =>
     countryGroups[countryCodeToCountryGroupId(countryCode)]?.supportRegionId;
 
 export const addRegionIdToSupportUrl = (originalUrl: string, countryCode?: string): string => {

--- a/src/lib/geolocation.ts
+++ b/src/lib/geolocation.ts
@@ -423,7 +423,7 @@ export const getCountryName = (geolocation?: string): string | undefined => {
     return undefined;
 };
 
-const countryCodeToSupportRegionId = (countryCode: string): SupportRegionId =>
+export const countryCodeToSupportRegionId = (countryCode: string): SupportRegionId =>
     countryGroups[countryCodeToCountryGroupId(countryCode)]?.supportRegionId;
 
 export const addRegionIdToSupportUrl = (originalUrl: string, countryCode?: string): string => {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -436,6 +436,7 @@ app.get(
             'https://amp-theguardian-com.cdn.ampproject.org',
             'https://amp.theguardian.com',
             'http://localhost:3030',
+            'https://amp.code.dev-theguardian.com',
         ],
         credentials: true,
         allowedHeaders: ['x-gu-geoip-country-code'],

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -18,7 +18,7 @@ import {
 import { getAllHardcodedTests } from './tests';
 import { logTargeting } from './lib/logging';
 import { getQueryParams, Params } from './lib/params';
-import { ampEpic } from './tests/ampEpic';
+import { ampEpic } from './tests/amp/ampEpic';
 import fs from 'fs';
 import { EpicProps } from './components/modules/epics/ContributionsEpic';
 import { isProd, isDev, baseUrl } from './lib/env';

--- a/src/tests/amp/ampEpic.ts
+++ b/src/tests/amp/ampEpic.ts
@@ -1,25 +1,6 @@
-import { getLocalCurrencySymbol } from '../lib/geolocation';
-import { AMPTicker } from './ampTicker';
-
-interface AMPCta {
-    text: string;
-    url: string;
-    componentId: string;
-    campaignCode: string;
-}
-
-interface AMPEpic {
-    heading?: string;
-    paragraphs: string[];
-    highlightedText?: string;
-    cta: AMPCta;
-    ticker?: AMPTicker;
-}
-
-// See https://amp.dev/documentation/components/amp-list/
-interface AMPEpicResponse {
-    items: AMPEpic[];
-}
+import {getLocalCurrencySymbol} from '../../lib/geolocation';
+import {AMPEpicResponse} from "./ampEpicModels";
+import {selectAmpEpic} from "./ampEpicTests";
 
 async function ampDefaultEpic(geolocation?: string): Promise<AMPEpicResponse> {
     const campaignCode = 'AMP_EPIC_AUGUST2020';
@@ -71,6 +52,14 @@ async function ampUsEpic(): Promise<AMPEpicResponse> {
     };
 }
 
-export function ampEpic(geolocation?: string): Promise<AMPEpicResponse> {
-    return geolocation === 'US' ? ampUsEpic() : ampDefaultEpic(geolocation);
+export async function ampEpic(countryCode?: string): Promise<AMPEpicResponse> {
+    const ampEpic = await selectAmpEpic(countryCode);
+    if (ampEpic) {
+        return {
+            items: [ampEpic]
+        }
+    }
+
+    // No epic from the tool, fall back on a hardcoded epic
+    return countryCode === 'US' ? ampUsEpic() : ampDefaultEpic(countryCode);
 }

--- a/src/tests/amp/ampEpic.ts
+++ b/src/tests/amp/ampEpic.ts
@@ -1,6 +1,6 @@
-import {getLocalCurrencySymbol} from '../../lib/geolocation';
-import {AMPEpicResponse} from "./ampEpicModels";
-import {selectAmpEpic} from "./ampEpicTests";
+import { getLocalCurrencySymbol } from '../../lib/geolocation';
+import { AMPEpicResponse } from './ampEpicModels';
+import { selectAmpEpic } from './ampEpicTests';
 
 async function ampDefaultEpic(geolocation?: string): Promise<AMPEpicResponse> {
     const campaignCode = 'AMP_EPIC_AUGUST2020';
@@ -56,8 +56,8 @@ export async function ampEpic(countryCode?: string): Promise<AMPEpicResponse> {
     const ampEpic = await selectAmpEpic(countryCode);
     if (ampEpic) {
         return {
-            items: [ampEpic]
-        }
+            items: [ampEpic],
+        };
     }
 
     // No epic from the tool, fall back on a hardcoded epic

--- a/src/tests/amp/ampEpicModels.ts
+++ b/src/tests/amp/ampEpicModels.ts
@@ -1,0 +1,49 @@
+import {Cta} from "../../lib/variants";
+import {CountryGroupId} from "../../lib/geolocation";
+import {AMPTicker} from "../ampTicker";
+
+/**
+ * Models for the data returned to AMP
+ */
+export interface AMPCta {
+    text: string;
+    url: string;
+    componentId: string;
+    campaignCode: string;
+}
+
+export interface AMPEpic {
+    heading?: string;
+    paragraphs: string[];
+    highlightedText?: string;
+    cta: AMPCta;
+    ticker?: AMPTicker;
+}
+
+// See https://amp.dev/documentation/components/amp-list/
+export interface AMPEpicResponse {
+    items: AMPEpic[];
+}
+
+/**
+ * Models for the data published by the epic tool
+ */
+export interface AmpEpicTestVariant {
+    name: string;
+    heading?: string;
+    paragraphs: string[];
+    highlightedText?: string;
+    cta?: Cta;
+}
+
+export interface AmpEpicTest {
+    name: string;
+    nickname?: string;
+    isOn: boolean;
+    locations: CountryGroupId[];
+    tagIds: string[];
+    sections: string[];
+    excludedTagIds: string[];
+    excludedSections: string[];
+    variants: AmpEpicTestVariant[];
+}

--- a/src/tests/amp/ampEpicModels.ts
+++ b/src/tests/amp/ampEpicModels.ts
@@ -1,6 +1,6 @@
-import {Cta} from "../../lib/variants";
-import {CountryGroupId} from "../../lib/geolocation";
-import {AMPTicker} from "../ampTicker";
+import { Cta } from '../../lib/variants';
+import { CountryGroupId } from '../../lib/geolocation';
+import { AMPTicker } from '../ampTicker';
 
 /**
  * Models for the data returned to AMP
@@ -41,9 +41,5 @@ export interface AmpEpicTest {
     nickname?: string;
     isOn: boolean;
     locations: CountryGroupId[];
-    tagIds: string[];
-    sections: string[];
-    excludedTagIds: string[];
-    excludedSections: string[];
     variants: AmpEpicTestVariant[];
 }

--- a/src/tests/amp/ampEpicTests.test.ts
+++ b/src/tests/amp/ampEpicTests.test.ts
@@ -1,0 +1,65 @@
+import { selectAmpEpicTest } from './ampEpicTests';
+import { CountryGroupId } from '../../lib/geolocation';
+
+const epicTest = {
+    name: 'TEST1',
+    nickname: 'TEST1',
+    isOn: true,
+    locations: [],
+    variants: [
+        {
+            name: 'CONTROL',
+            heading: 'a',
+            paragraphs: ['b'],
+            highlightedText:
+                'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
+            cta: {
+                text: 'Show your support',
+                baseUrl: 'https://support.theguardian.com/contribute',
+            },
+            showTicker: false,
+        },
+    ],
+};
+
+describe('ampEpicTests', () => {
+    it('should select test with no targeting', () => {
+        const tests = [epicTest];
+        expect(selectAmpEpicTest(tests, 'GB')).toEqual({
+            heading: 'a',
+            paragraphs: ['b'],
+            highlightedText:
+                'Support the Guardian from as little as £1 – and it only takes a minute. Thank you.',
+            cta: {
+                text: 'Show your support',
+                url: 'https://support.theguardian.com/contribute',
+                componentId: 'TEST1-CONTROL',
+                campaignCode: 'TEST1-CONTROL',
+            },
+        });
+    });
+
+    it('should not select test if disabled', () => {
+        const tests = [{ ...epicTest, isOn: false }];
+        expect(selectAmpEpicTest(tests, 'GB')).toEqual(null);
+    });
+
+    it('should select test with matching locations', () => {
+        const tests = [
+            { ...epicTest, locations: ['UnitedStates' as CountryGroupId] },
+            { ...epicTest, name: 'TEST2', nickname: 'TEST2' },
+        ];
+        expect(selectAmpEpicTest(tests, 'GB')).toEqual({
+            heading: 'a',
+            paragraphs: ['b'],
+            highlightedText:
+                'Support the Guardian from as little as £1 – and it only takes a minute. Thank you.',
+            cta: {
+                text: 'Show your support',
+                url: 'https://support.theguardian.com/contribute',
+                componentId: 'TEST2-CONTROL',
+                campaignCode: 'TEST2-CONTROL',
+            },
+        });
+    });
+});

--- a/src/tests/amp/ampEpicTests.ts
+++ b/src/tests/amp/ampEpicTests.ts
@@ -1,8 +1,15 @@
-import {inCountryGroups} from "../../lib/geolocation";
-import {isProd} from "../../lib/env";
+import { inCountryGroups } from '../../lib/geolocation';
+import { isProd } from '../../lib/env';
 import fetch from 'node-fetch';
-import {cacheAsync} from "../../lib/cache";
-import {AMPEpic, AmpEpicTest} from "./ampEpicModels";
+import { cacheAsync } from '../../lib/cache';
+import { AMPEpic, AmpEpicTest } from './ampEpicModels';
+import { replaceNonArticleCountPlaceholders } from '../../lib/placeholders';
+
+/**
+ * Fetches AMP epic tests configuration from the tool.
+ * Everything is a 'test' in the tool, even though we do not currently support A/B testing for AMP.
+ * So each test will have a single variant.
+ */
 
 const url = isProd
     ? 'https://gu-contributions-public.s3-eu-west-1.amazonaws.com/epic/PROD/amp-epic-tests.json'
@@ -12,29 +19,52 @@ const fetchAmpEpicTests = (): Promise<AmpEpicTest[]> =>
     fetch(url)
         .then(response => response.json())
         .then(data => {
-            console.log(data)
             return data.tests;
         });
 
+const [, getCachedAmpEpicTests] = cacheAsync<AmpEpicTest[]>(
+    fetchAmpEpicTests,
+    60,
+    'ampEpicTests',
+    true,
+);
 
-const [, getCachedAmpEpicTests] = cacheAsync<AmpEpicTest[]>(fetchAmpEpicTests, 60, 'ampEpicTests', true);
+export const selectAmpEpicTest = (tests: AmpEpicTest[], countryCode?: string): AMPEpic | null => {
+    const test = tests.find(test => test.isOn && inCountryGroups(countryCode, test.locations));
 
-export const selectAmpEpic = (countryCode?: string): Promise<AMPEpic | null> =>
-    getCachedAmpEpicTests().then(tests => {
-        const test = tests.find(test => inCountryGroups(countryCode, test.locations));
-        if (test && test.variants[0]) {
-            const variant = test.variants[0];
+    if (test && test.variants[0]) {
+        const variant = test.variants[0];
+        if (variant) {
             return {
-                heading: variant.heading,
-                paragraphs: variant.paragraphs,
-                highlightedText: variant.highlightedText,
+                heading: replaceNonArticleCountPlaceholders(variant.heading, countryCode),
+                paragraphs: variant.paragraphs.map(p =>
+                    replaceNonArticleCountPlaceholders(p, countryCode),
+                ),
+                highlightedText: replaceNonArticleCountPlaceholders(
+                    variant.highlightedText,
+                    countryCode,
+                ),
                 cta: {
                     text: variant.cta ? variant.cta.text : 'Support the Guardian',
-                    url: variant.cta ? variant.cta.baseUrl : 'https://support.theguardian.com/contribute',
+                    url: variant.cta
+                        ? variant.cta.baseUrl
+                        : 'https://support.theguardian.com/contribute',
                     componentId: `${test.name}-${variant.name}`,
                     campaignCode: `${test.name}-${variant.name}`,
-                }
-            }
+                },
+            };
         }
-        return null;
-    });
+    }
+    return null;
+};
+
+// These should have been replaced, but do a final check just in case
+const hasPlaceholder = (epic: AMPEpic): boolean =>
+    (!!epic.heading && epic.heading.includes('%%')) ||
+    epic.paragraphs.some(p => p.includes('%%')) ||
+    (!!epic.highlightedText && epic.highlightedText.includes('%%'));
+
+export const selectAmpEpic = (countryCode?: string): Promise<AMPEpic | null> =>
+    getCachedAmpEpicTests()
+        .then(tests => selectAmpEpicTest(tests, countryCode))
+        .then(test => (!!test && hasPlaceholder(test) ? null : test));

--- a/src/tests/amp/ampEpicTests.ts
+++ b/src/tests/amp/ampEpicTests.ts
@@ -34,26 +34,24 @@ export const selectAmpEpicTest = (tests: AmpEpicTest[], countryCode?: string): A
 
     if (test && test.variants[0]) {
         const variant = test.variants[0];
-        if (variant) {
-            return {
-                heading: replaceNonArticleCountPlaceholders(variant.heading, countryCode),
-                paragraphs: variant.paragraphs.map(p =>
-                    replaceNonArticleCountPlaceholders(p, countryCode),
-                ),
-                highlightedText: replaceNonArticleCountPlaceholders(
-                    variant.highlightedText,
-                    countryCode,
-                ),
-                cta: {
-                    text: variant.cta ? variant.cta.text : 'Support the Guardian',
-                    url: variant.cta
-                        ? variant.cta.baseUrl
-                        : 'https://support.theguardian.com/contribute',
-                    componentId: `${test.name}-${variant.name}`,
-                    campaignCode: `${test.name}-${variant.name}`,
-                },
-            };
-        }
+        return {
+            heading: replaceNonArticleCountPlaceholders(variant.heading, countryCode),
+            paragraphs: variant.paragraphs.map(p =>
+                replaceNonArticleCountPlaceholders(p, countryCode),
+            ),
+            highlightedText: replaceNonArticleCountPlaceholders(
+                variant.highlightedText,
+                countryCode,
+            ),
+            cta: {
+                text: variant.cta ? variant.cta.text : 'Support the Guardian',
+                url: variant.cta
+                    ? variant.cta.baseUrl
+                    : 'https://support.theguardian.com/contribute',
+                componentId: `${test.name}-${variant.name}`,
+                campaignCode: `${test.name}-${variant.name}`,
+            },
+        };
     }
     return null;
 };

--- a/src/tests/amp/ampEpicTests.ts
+++ b/src/tests/amp/ampEpicTests.ts
@@ -1,0 +1,40 @@
+import {inCountryGroups} from "../../lib/geolocation";
+import {isProd} from "../../lib/env";
+import fetch from 'node-fetch';
+import {cacheAsync} from "../../lib/cache";
+import {AMPEpic, AmpEpicTest} from "./ampEpicModels";
+
+const url = isProd
+    ? 'https://gu-contributions-public.s3-eu-west-1.amazonaws.com/epic/PROD/amp-epic-tests.json'
+    : 'https://gu-contributions-public.s3-eu-west-1.amazonaws.com/epic/CODE/amp-epic-tests.json';
+
+const fetchAmpEpicTests = (): Promise<AmpEpicTest[]> =>
+    fetch(url)
+        .then(response => response.json())
+        .then(data => {
+            console.log(data)
+            return data.tests;
+        });
+
+
+const [, getCachedAmpEpicTests] = cacheAsync<AmpEpicTest[]>(fetchAmpEpicTests, 60, 'ampEpicTests', true);
+
+export const selectAmpEpic = (countryCode?: string): Promise<AMPEpic | null> =>
+    getCachedAmpEpicTests().then(tests => {
+        const test = tests.find(test => inCountryGroups(countryCode, test.locations));
+        if (test && test.variants[0]) {
+            const variant = test.variants[0];
+            return {
+                heading: variant.heading,
+                paragraphs: variant.paragraphs,
+                highlightedText: variant.highlightedText,
+                cta: {
+                    text: variant.cta ? variant.cta.text : 'Support the Guardian',
+                    url: variant.cta ? variant.cta.baseUrl : 'https://support.theguardian.com/contribute',
+                    componentId: `${test.name}-${variant.name}`,
+                    campaignCode: `${test.name}-${variant.name}`,
+                }
+            }
+        }
+        return null;
+    });


### PR DESCRIPTION
We now have a tool for configuring AMP epics.
This PR makes dotcom-components poll this configuration.
For now it only supports targeting by country.
I've left the hard-coded tests in as a fallback.

![Screen Shot 2020-11-11 at 13 50 29](https://user-images.githubusercontent.com/1513454/98819540-e2f40e80-2424-11eb-96e3-5745fdddd461.png)

![Screen Shot 2020-11-11 at 13 49 13](https://user-images.githubusercontent.com/1513454/98819411-bb9d4180-2424-11eb-84ae-4b16990821b3.png)

