### PR TITLE
AMP epic: get ticker settings

### DIFF
--- a/src/tests/amp/ampEpicModels.ts
+++ b/src/tests/amp/ampEpicModels.ts
@@ -1,4 +1,4 @@
-import {Cta, TickerSettings} from '../../lib/variants';
+import { Cta, TickerSettings } from '../../lib/variants';
 import { CountryGroupId } from '../../lib/geolocation';
 import { AMPTicker } from '../getAmpTicker';
 

--- a/src/tests/amp/ampEpicModels.ts
+++ b/src/tests/amp/ampEpicModels.ts
@@ -1,6 +1,6 @@
 import { Cta, TickerSettings } from '../../lib/variants';
 import { CountryGroupId } from '../../lib/geolocation';
-import { AMPTicker } from '../getAmpTicker';
+import { AMPTicker } from './ampTicker';
 
 /**
  * Models for the data returned to AMP

--- a/src/tests/amp/ampEpicModels.ts
+++ b/src/tests/amp/ampEpicModels.ts
@@ -1,6 +1,6 @@
-import { Cta } from '../../lib/variants';
+import {Cta, TickerSettings} from '../../lib/variants';
 import { CountryGroupId } from '../../lib/geolocation';
-import { AMPTicker } from '../ampTicker';
+import { AMPTicker } from '../getAmpTicker';
 
 /**
  * Models for the data returned to AMP
@@ -34,6 +34,7 @@ export interface AmpEpicTestVariant {
     paragraphs: string[];
     highlightedText?: string;
     cta?: Cta;
+    tickerSettings?: TickerSettings;
 }
 
 export interface AmpEpicTest {

--- a/src/tests/amp/ampEpicTests.ts
+++ b/src/tests/amp/ampEpicTests.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 import { cacheAsync } from '../../lib/cache';
 import { AMPEpic, AmpEpicTest } from './ampEpicModels';
 import { replaceNonArticleCountPlaceholders } from '../../lib/placeholders';
-import { getAmpTicker } from '../getAmpTicker';
+import { ampTicker } from './ampTicker';
 
 /**
  * Fetches AMP epic tests configuration from the tool.
@@ -59,7 +59,7 @@ export const selectAmpEpicTest = async (
         };
 
         if (variant.tickerSettings) {
-            const ticker = await getAmpTicker(variant.tickerSettings);
+            const ticker = await ampTicker(variant.tickerSettings);
             return { ...epicData, ticker };
         } else {
             return epicData;

--- a/src/tests/amp/ampEpicTests.ts
+++ b/src/tests/amp/ampEpicTests.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 import { cacheAsync } from '../../lib/cache';
 import { AMPEpic, AmpEpicTest } from './ampEpicModels';
 import { replaceNonArticleCountPlaceholders } from '../../lib/placeholders';
-import { getAmpTicker } from "../getAmpTicker";
+import { getAmpTicker } from '../getAmpTicker';
 
 /**
  * Fetches AMP epic tests configuration from the tool.
@@ -30,7 +30,10 @@ const [, getCachedAmpEpicTests] = cacheAsync<AmpEpicTest[]>(
     true,
 );
 
-export const selectAmpEpicTest = async (tests: AmpEpicTest[], countryCode?: string): Promise<AMPEpic | null> => {
+export const selectAmpEpicTest = async (
+    tests: AmpEpicTest[],
+    countryCode?: string,
+): Promise<AMPEpic | null> => {
     const test = tests.find(test => test.isOn && inCountryGroups(countryCode, test.locations));
 
     if (test && test.variants[0]) {
@@ -52,12 +55,12 @@ export const selectAmpEpicTest = async (tests: AmpEpicTest[], countryCode?: stri
                     : 'https://support.theguardian.com/contribute',
                 componentId: `${test.name}-${variant.name}`,
                 campaignCode: `${test.name}-${variant.name}`,
-            }
+            },
         };
 
         if (variant.tickerSettings) {
             const ticker = await getAmpTicker(variant.tickerSettings);
-            return {...epicData, ticker };
+            return { ...epicData, ticker };
         } else {
             return epicData;
         }

--- a/src/tests/amp/ampEpicTests.ts
+++ b/src/tests/amp/ampEpicTests.ts
@@ -4,6 +4,7 @@ import fetch from 'node-fetch';
 import { cacheAsync } from '../../lib/cache';
 import { AMPEpic, AmpEpicTest } from './ampEpicModels';
 import { replaceNonArticleCountPlaceholders } from '../../lib/placeholders';
+import { getAmpTicker } from "../getAmpTicker";
 
 /**
  * Fetches AMP epic tests configuration from the tool.
@@ -29,12 +30,13 @@ const [, getCachedAmpEpicTests] = cacheAsync<AmpEpicTest[]>(
     true,
 );
 
-export const selectAmpEpicTest = (tests: AmpEpicTest[], countryCode?: string): AMPEpic | null => {
+export const selectAmpEpicTest = async (tests: AmpEpicTest[], countryCode?: string): Promise<AMPEpic | null> => {
     const test = tests.find(test => test.isOn && inCountryGroups(countryCode, test.locations));
 
     if (test && test.variants[0]) {
         const variant = test.variants[0];
-        return {
+
+        const epicData = {
             heading: replaceNonArticleCountPlaceholders(variant.heading, countryCode),
             paragraphs: variant.paragraphs.map(p =>
                 replaceNonArticleCountPlaceholders(p, countryCode),
@@ -50,8 +52,15 @@ export const selectAmpEpicTest = (tests: AmpEpicTest[], countryCode?: string): A
                     : 'https://support.theguardian.com/contribute',
                 componentId: `${test.name}-${variant.name}`,
                 campaignCode: `${test.name}-${variant.name}`,
-            },
+            }
         };
+
+        if (variant.tickerSettings) {
+            const ticker = await getAmpTicker(variant.tickerSettings);
+            return {...epicData, ticker };
+        } else {
+            return epicData;
+        }
     }
     return null;
 };

--- a/src/tests/amp/ampTicker.ts
+++ b/src/tests/amp/ampTicker.ts
@@ -31,7 +31,7 @@ export const ampTicker = (tickerSettings: TickerSettings): Promise<AMPTicker> =>
         const bottomRight = goalReached ? tickerSettings.copy.countLabel : 'our goal';
 
         return {
-            percentage: (percentage > 100 ? 100 : percentage).toString(),
+            percentage: percentage.toString(),
             goalReached,
             topLeft,
             bottomLeft,

--- a/src/tests/amp/ampTicker.ts
+++ b/src/tests/amp/ampTicker.ts
@@ -1,12 +1,5 @@
-import fetch from 'node-fetch';
-import { TickerSettings } from '../lib/variants';
-
-interface TickerData {
-    total: number;
-    goal: number;
-}
-
-type TickerCountType = 'money' | 'people';
+import { TickerSettings } from '../../lib/variants';
+import { fetchTickerDataCached } from '../../lib/fetchTickerData';
 
 export interface AMPTicker {
     percentage: string;
@@ -17,33 +10,8 @@ export interface AMPTicker {
     bottomRight: string;
 }
 
-const parse = (json: any): Promise<TickerData> => {
-    const total = parseInt(json.total, 10);
-    const goal = parseInt(json.goal, 10);
-
-    if (!Number.isNaN(total) && !Number.isNaN(goal)) {
-        return Promise.resolve({
-            total,
-            goal,
-        });
-    }
-    return Promise.reject(Error(`Failed to parse ticker data: ${json}`));
-};
-
-const tickerDataUrl = (countType: TickerCountType): string => {
-    return countType === 'people'
-        ? 'https://support.theguardian.com/supporters-ticker.json'
-        : 'https://support.theguardian.com/ticker.json';
-};
-
-const fetchTickerData = async (url: string): Promise<TickerData> => {
-    return await fetch(url)
-        .then(response => response.json())
-        .then(parse);
-};
-
-export const getAmpTicker = (tickerSettings: TickerSettings): Promise<AMPTicker> =>
-    fetchTickerData(tickerDataUrl(tickerSettings.countType)).then(data => {
+export const ampTicker = (tickerSettings: TickerSettings): Promise<AMPTicker> =>
+    fetchTickerDataCached(tickerSettings).then(data => {
         const percentage = (data.total / data.goal) * 100;
         const prefix = tickerSettings.countType === 'money' ? tickerSettings.currencySymbol : '';
         const goalReached = percentage >= 100;

--- a/src/tests/getAmpTicker.ts
+++ b/src/tests/getAmpTicker.ts
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch';
-import {TickerSettings} from "../lib/variants";
+import { TickerSettings } from '../lib/variants';
 
 interface TickerData {
     total: number;
@@ -42,20 +42,32 @@ const fetchTickerData = async (url: string): Promise<TickerData> => {
         .then(parse);
 };
 
-export const getAmpTicker = (
-    tickerSettings: TickerSettings,
-): Promise<AMPTicker> =>
+export const getAmpTicker = (tickerSettings: TickerSettings): Promise<AMPTicker> =>
     fetchTickerData(tickerDataUrl(tickerSettings.countType)).then(data => {
         const percentage = (data.total / data.goal) * 100;
         const prefix = tickerSettings.countType === 'money' ? tickerSettings.currencySymbol : '';
         const goalReached = percentage >= 100;
 
+        const topLeft = goalReached
+            ? tickerSettings.copy.goalReachedPrimary
+            : `${prefix}${data.total.toLocaleString()}`;
+
+        const bottomLeft = goalReached
+            ? tickerSettings.copy.goalReachedSecondary
+            : tickerSettings.copy.countLabel;
+
+        const topRight = goalReached
+            ? `${prefix}${data.total.toLocaleString()}`
+            : `${prefix}${data.goal.toLocaleString()}`;
+
+        const bottomRight = goalReached ? tickerSettings.copy.countLabel : 'our goal';
+
         return {
             percentage: (percentage > 100 ? 100 : percentage).toString(),
             goalReached,
-            topLeft: goalReached ? tickerSettings.copy.goalReachedPrimary : `${prefix}${data.total.toLocaleString()}`,
-            bottomLeft: goalReached ? tickerSettings.copy.goalReachedSecondary : tickerSettings.copy.countLabel,
-            topRight: goalReached ? `${prefix}${data.total.toLocaleString()}` : `${prefix}${data.goal.toLocaleString()}`,
-            bottomRight: goalReached ? tickerSettings.copy.countLabel : 'our goal'
+            topLeft,
+            bottomLeft,
+            topRight,
+            bottomRight,
         };
     });


### PR DESCRIPTION
- Uses the `tickerSettings` field if present.
- Changes the `AMPTicker` type, which is returned to the client. Now we simply tell the client what text to put in each of the 4 positions. We want to keep things simple in the client on AMP.
- Also refactored things a bit to use the existing `fetchTickerDataCached` function

<img width="710" alt="Screen Shot 2020-11-13 at 13 40 17" src="https://user-images.githubusercontent.com/1513454/99078149-c89d6a80-25b5-11eb-842c-bfa5a0555af2.png">
