### PR TITLE
MJ - Add Goal Reached Behaviour to AMP Ticker

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -43,8 +43,6 @@ app.options('*', cors());
 
 app.use(loggingMiddleware);
 
-app.use(express.static(__dirname + '/public'));
-
 app.get('/healthcheck', (req: express.Request, res: express.Response) => {
     res.header('Content-Type', 'text/plain');
     res.send('OK');

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -45,6 +45,8 @@ app.options('*', cors());
 
 app.use(loggingMiddleware);
 
+app.use(express.static(__dirname + '/public'));
+
 app.get('/healthcheck', (req: express.Request, res: express.Response) => {
     res.header('Content-Type', 'text/plain');
     res.send('OK');

--- a/src/tests/amp/ampEpicTests.test.ts
+++ b/src/tests/amp/ampEpicTests.test.ts
@@ -58,7 +58,6 @@ const expectedAmpEpic: AMPEpic = {
     ticker: {
         bottomLeft: 'contributions',
         bottomRight: 'our goal',
-        goalReached: false,
         percentage: '99.9',
         topLeft: '$999',
         topRight: '$1,000',

--- a/src/tests/amp/ampTicker.ts
+++ b/src/tests/amp/ampTicker.ts
@@ -3,7 +3,7 @@ import { fetchTickerDataCached } from '../../lib/fetchTickerData';
 
 export interface AMPTicker {
     percentage: string;
-    goalReached: boolean;
+    goalExceededMarkerPercentage?: string;
     topLeft: string;
     bottomLeft: string;
     topRight: string;
@@ -12,9 +12,13 @@ export interface AMPTicker {
 
 export const ampTicker = (tickerSettings: TickerSettings): Promise<AMPTicker> =>
     fetchTickerDataCached(tickerSettings).then(data => {
-        const percentage = (data.total / data.goal) * 100;
         const prefix = tickerSettings.countType === 'money' ? tickerSettings.currencySymbol : '';
-        const goalReached = percentage >= 100;
+        const goalReached = data.total >= data.goal;
+        const totalPlusFifteen = data.total + data.total * 0.15;
+        const percentage = (data.total / (goalReached ? totalPlusFifteen : data.goal)) * 100;
+        const goalExceededMarkerPercentage = goalReached
+            ? ((data.goal / totalPlusFifteen) * 100).toString()
+            : undefined;
 
         const topLeft = goalReached
             ? tickerSettings.copy.goalReachedPrimary
@@ -32,7 +36,7 @@ export const ampTicker = (tickerSettings: TickerSettings): Promise<AMPTicker> =>
 
         return {
             percentage: percentage.toString(),
-            goalReached,
+            goalExceededMarkerPercentage,
             topLeft,
             bottomLeft,
             topRight,


### PR DESCRIPTION
### What does this PR do?
As per the linked Trello card, this allows tickers in AMP epics to handle the exceeding of our goal, in the same way that our tickers do elsewhere. See screenshots in the related DCR pull request [here](https://github.com/guardian/dotcom-rendering/pull/2090).