### PR TITLE
Fix reminder month

### DIFF
--- a/src/lib/reminderFields.test.ts
+++ b/src/lib/reminderFields.test.ts
@@ -4,27 +4,39 @@ describe('buildReminderFields', () => {
     it('should set date to the next calendar month if the current date is BEFORE the 20th', () => {
         const novemberNineteenth = new Date('2020-11-19 00:00:00');
 
-        const expected = 'December 2020';
-        const actual = buildReminderFields(novemberNineteenth).reminderDateAsString;
+        const expected = {
+            reminderCTA: `Remind me in December`,
+            reminderDate: `2020-12-19 00:00:00`,
+            reminderDateAsString: `December 2020`,
+        };
+        const actual = buildReminderFields(novemberNineteenth);
 
-        expect(actual).toBe(expected);
+        expect(actual).toEqual(expected);
     });
 
     it('should set date to the next + 1 calendar month if the current date is the 20th', () => {
         const novemberTwentieth = new Date('2020-11-20 00:00:00');
 
-        const expected = 'January 2021';
-        const actual = buildReminderFields(novemberTwentieth).reminderDateAsString;
+        const expected = {
+            reminderCTA: `Remind me in January`,
+            reminderDate: `2021-01-19 00:00:00`,
+            reminderDateAsString: `January 2021`,
+        };
+        const actual = buildReminderFields(novemberTwentieth);
 
-        expect(actual).toBe(expected);
+        expect(actual).toEqual(expected);
     });
 
     it('should set date to the next + 1 calendar month if the current date is AFTER the 20th', () => {
         const novemberTwentyFirst = new Date('2020-11-21 00:00:00');
 
-        const expected = 'January 2021';
-        const actual = buildReminderFields(novemberTwentyFirst).reminderDateAsString;
+        const expected = {
+            reminderCTA: `Remind me in January`,
+            reminderDate: `2021-01-19 00:00:00`,
+            reminderDateAsString: `January 2021`,
+        };
+        const actual = buildReminderFields(novemberTwentyFirst);
 
-        expect(actual).toBe(expected);
+        expect(actual).toEqual(expected);
     });
 });

--- a/src/lib/reminderFields.ts
+++ b/src/lib/reminderFields.ts
@@ -14,13 +14,14 @@ const getReminderDate = (date: Date): Date => {
 export const buildReminderFields = (today: Date = new Date()): ReminderFields => {
     const reminderDate = getReminderDate(today);
 
-    const month = reminderDate.getMonth();
+    const month = reminderDate.getMonth() + 1;
+    const paddedMonth = month.toString().padStart(2, '0');
     const monthName = reminderDate.toLocaleString('default', { month: 'long' });
     const year = reminderDate.getFullYear();
 
     return {
         reminderCTA: `Remind me in ${monthName}`,
-        reminderDate: `${year}-${month}-19 00:00:00`,
+        reminderDate: `${year}-${paddedMonth}-19 00:00:00`,
         reminderDateAsString: `${monthName} ${year}`,
     };
 };

--- a/src/lib/reminderFields.ts
+++ b/src/lib/reminderFields.ts
@@ -14,7 +14,7 @@ const getReminderDate = (date: Date): Date => {
 export const buildReminderFields = (today: Date = new Date()): ReminderFields => {
     const reminderDate = getReminderDate(today);
 
-    const month = reminderDate.getMonth() + 1;
+    const month = reminderDate.getMonth() + 1; // javascript dates run from 0-11, we want 1-12
     const paddedMonth = month.toString().padStart(2, '0');
     const monthName = reminderDate.toLocaleString('default', { month: 'long' });
     const year = reminderDate.getFullYear();


### PR DESCRIPTION
As with the thankyou page sign-up: https://github.com/guardian/support-frontend/blob/main/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx#L143

It's currently off by one.

Also updated the tests to verify the payload is correct

Tested in CODE:
![Screen Shot 2020-11-24 at 12 43 54](https://user-images.githubusercontent.com/1513454/100095658-bee7f280-2e52-11eb-851a-a1b577a0c974.png)
