### PR TITLE
Support controlProportion in epic tests

### DIFF
--- a/src/lib/ab.test.ts
+++ b/src/lib/ab.test.ts
@@ -1,5 +1,5 @@
 import { Test } from './variants';
-import { selectVariant } from './ab';
+import { selectVariant, withinRange } from './ab';
 
 const test: Test = {
     name: 'example-1',
@@ -41,7 +41,7 @@ const controlProportion = 0.1;
 const controlLower = 592754;
 const controlUpper = 692753;
 
-describe('ab', () => {
+describe('selectVariant', () => {
     it('should select control (no controlProportion)', () => {
         const variant = selectVariant(test, 0);
         expect(variant.name).toBe('control');
@@ -70,5 +70,35 @@ describe('ab', () => {
     it('should select variant (above controlProportion)', () => {
         const variant = selectVariant({ ...test, controlProportion }, controlUpper + 1);
         expect(variant.name).toBe('v1');
+    });
+});
+
+describe('withinRange', () => {
+    it('should return false if below range (no wrap)', () => {
+        expect(withinRange(10, 0.1, 1)).toBe(false);
+    });
+
+    it('should return false if above range (no wrap)', () => {
+        expect(withinRange(10, 0.1, 100010)).toBe(false);
+    });
+
+    it('should return true if at start of range (no wrap)', () => {
+        expect(withinRange(10, 0.1, 10)).toBe(true);
+    });
+
+    it('should return true if at end of range (no wrap)', () => {
+        expect(withinRange(10, 0.1, 100009)).toBe(true);
+    });
+
+    it('should return true if above lower (wrap)', () => {
+        expect(withinRange(999990, 0.1, 999999)).toBe(true);
+    });
+
+    it('should return true if below upper (wrap)', () => {
+        expect(withinRange(999990, 0.1, 1)).toBe(true);
+    });
+
+    it('should return false if above upper and below lower (wrap)', () => {
+        expect(withinRange(999990, 0.1, 99990)).toBe(false);
     });
 });

--- a/src/lib/ab.test.ts
+++ b/src/lib/ab.test.ts
@@ -1,0 +1,74 @@
+import { Test } from './variants';
+import { selectVariant } from './ab';
+
+const test: Test = {
+    name: 'example-1',
+    isOn: true,
+    locations: [],
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: true,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
+    userCohort: 'AllNonSupporters',
+    isLiveBlog: false,
+    hasCountryName: false,
+    variants: [
+        {
+            name: 'control',
+            heading: '',
+            paragraphs: [''],
+            highlightedText: '',
+        },
+        {
+            name: 'v1',
+            heading: '',
+            paragraphs: [''],
+            highlightedText: '',
+        },
+    ],
+    highPriority: false,
+    useLocalViewLog: false,
+};
+
+// With test name 'example-1' and controlProportion 0.1, the control range is [592754, 692753]
+const controlProportion = 0.1;
+const controlLower = 592754;
+const controlUpper = 692753;
+
+describe('ab', () => {
+    it('should select control (no controlProportion)', () => {
+        const variant = selectVariant(test, 0);
+        expect(variant.name).toBe('control');
+    });
+
+    it('should select variant (no controlProportion)', () => {
+        const variant = selectVariant(test, 1);
+        expect(variant.name).toBe('v1');
+    });
+
+    it('should select control (lower end of controlProportion)', () => {
+        const variant = selectVariant({ ...test, controlProportion }, controlLower);
+        expect(variant.name).toBe('control');
+    });
+
+    it('should select control (upper end of controlProportion)', () => {
+        const variant = selectVariant({ ...test, controlProportion }, controlUpper);
+        expect(variant.name).toBe('control');
+    });
+
+    it('should select variant (below controlProportion)', () => {
+        const variant = selectVariant({ ...test, controlProportion }, controlLower - 1);
+        expect(variant.name).toBe('v1');
+    });
+
+    it('should select variant (above controlProportion)', () => {
+        const variant = selectVariant({ ...test, controlProportion }, controlUpper + 1);
+        expect(variant.name).toBe('v1');
+    });
+});

--- a/src/lib/ab.test.ts
+++ b/src/lib/ab.test.ts
@@ -36,10 +36,10 @@ const test: Test = {
     useLocalViewLog: false,
 };
 
-// With test name 'example-1' and controlProportion 0.1, the control range is [592754, 692753]
-const controlProportion = 0.1;
-const controlLower = 592754;
-const controlUpper = 692753;
+const controlProportionSettings = {
+    proportion: 0.1,
+    offset: 500000,
+};
 
 describe('selectVariant', () => {
     it('should select control (no controlProportion)', () => {
@@ -53,22 +53,22 @@ describe('selectVariant', () => {
     });
 
     it('should select control (lower end of controlProportion)', () => {
-        const variant = selectVariant({ ...test, controlProportion }, controlLower);
+        const variant = selectVariant({ ...test, controlProportionSettings }, 500000);
         expect(variant.name).toBe('control');
     });
 
     it('should select control (upper end of controlProportion)', () => {
-        const variant = selectVariant({ ...test, controlProportion }, controlUpper);
+        const variant = selectVariant({ ...test, controlProportionSettings }, 599999);
         expect(variant.name).toBe('control');
     });
 
     it('should select variant (below controlProportion)', () => {
-        const variant = selectVariant({ ...test, controlProportion }, controlLower - 1);
+        const variant = selectVariant({ ...test, controlProportionSettings }, 499999);
         expect(variant.name).toBe('v1');
     });
 
     it('should select variant (above controlProportion)', () => {
-        const variant = selectVariant({ ...test, controlProportion }, controlUpper + 1);
+        const variant = selectVariant({ ...test, controlProportionSettings }, 600000);
         expect(variant.name).toBe('v1');
     });
 });

--- a/src/lib/ab.ts
+++ b/src/lib/ab.ts
@@ -1,0 +1,43 @@
+import { Test, Variant } from './variants';
+
+const maxMvt = 1000000;
+
+/**
+ * If controlProportion is set then we use this to define the range of mvt values for the control variant.
+ * Otherwise we evenly distribute all variants across maxMvt.
+ *
+ * If controlProportion is set then the start of the mvt range for the control is derived using a hash of the test name.
+ * This is to avoid always putting the same users in the control for each test.
+ *
+ * So:
+ * controlProportion is in [0, 1]
+ * seed is in [0, maxMvt]
+ * controlRange is [seed, (seed + (maxMvt * controlProportion)) % maxMvt]
+ */
+
+export const getSeed = (name: string): number => {
+    let hash = 0;
+    if (name.length == 0) {
+        return hash;
+    }
+    for (let i = 0; i < name.length; i++) {
+        const char = name.charCodeAt(i);
+        hash = (hash << 5) - hash + char;
+        hash = hash & hash; // Convert to 32bit integer
+    }
+    return Math.abs(hash) % maxMvt;
+};
+
+export const selectVariant = (test: Test, mvtId: number): Variant => {
+    const control = test.variants.find(v => v.name.toLowerCase() === 'control');
+    if (test.controlProportion && control) {
+        const seed = getSeed(test.name);
+        if (mvtId >= seed && mvtId < (seed + maxMvt * test.controlProportion) % maxMvt) {
+            return control;
+        }
+        const otherVariants = test.variants.filter(v => v.name.toLowerCase() !== 'control');
+        return otherVariants[mvtId % otherVariants.length];
+    }
+
+    return test.variants[mvtId % test.variants.length];
+};

--- a/src/lib/ab.ts
+++ b/src/lib/ab.ts
@@ -2,27 +2,6 @@ import { Test, Variant } from './variants';
 
 const maxMvt = 1000000;
 
-/**
- * If controlProportion is set then we use this to define the range of mvt values for the control variant.
- * Otherwise we evenly distribute all variants across maxMvt.
- *
- * If controlProportion is set then the start of the mvt range for the control is derived using a hash of the test name.
- * This is to avoid always putting the same users in the control for each test.
- */
-
-export const getSeed = (name: string): number => {
-    let hash = 0;
-    if (name.length == 0) {
-        return hash;
-    }
-    for (let i = 0; i < name.length; i++) {
-        const char = name.charCodeAt(i);
-        hash = (hash << 5) - hash + char;
-        hash = hash & hash; // Convert to 32bit integer
-    }
-    return Math.abs(hash) % maxMvt;
-};
-
 export const withinRange = (lower: number, proportion: number, mvtId: number): boolean => {
     const upper = (lower + maxMvt * proportion) % maxMvt;
 
@@ -34,11 +13,20 @@ export const withinRange = (lower: number, proportion: number, mvtId: number): b
     }
 };
 
+/**
+ * If controlProportionSettings is set then we use this to define the range of mvt values for the control variant.
+ * Otherwise we evenly distribute all variants across maxMvt.
+ */
 export const selectVariant = (test: Test, mvtId: number): Variant => {
     const control = test.variants.find(v => v.name.toLowerCase() === 'control');
-    if (test.controlProportion && control) {
-        const seed = getSeed(test.name);
-        if (withinRange(seed, test.controlProportion, mvtId)) {
+    if (test.controlProportionSettings && control) {
+        if (
+            withinRange(
+                test.controlProportionSettings.offset,
+                test.controlProportionSettings.proportion,
+                mvtId,
+            )
+        ) {
             return control;
         } else {
             const otherVariants = test.variants.filter(v => v.name.toLowerCase() !== 'control');

--- a/src/lib/ab.ts
+++ b/src/lib/ab.ts
@@ -34,9 +34,10 @@ export const selectVariant = (test: Test, mvtId: number): Variant => {
         const seed = getSeed(test.name);
         if (mvtId >= seed && mvtId < (seed + maxMvt * test.controlProportion) % maxMvt) {
             return control;
+        } else {
+            const otherVariants = test.variants.filter(v => v.name.toLowerCase() !== 'control');
+            return otherVariants[mvtId % otherVariants.length];
         }
-        const otherVariants = test.variants.filter(v => v.name.toLowerCase() !== 'control');
-        return otherVariants[mvtId % otherVariants.length];
     }
 
     return test.variants[mvtId % test.variants.length];

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -9,6 +9,7 @@ import { getArticleViewCountForWeeks, historyWithinArticlesViewedSettings } from
 import { isRecentOneOffContributor } from '../lib/dates';
 import { ArticlesViewedSettings, WeeklyArticleHistory } from '../types/shared';
 import { getReminderFields, ReminderFields } from './reminderFields';
+import { selectVariant } from './ab';
 
 export enum TickerEndType {
     unlimited = 'unlimited',
@@ -87,6 +88,8 @@ export interface Test {
     // These are specific to hardcoded tests
     expiry?: string;
     campaignId?: string;
+
+    controlProportion?: number; // between 0-1
 }
 
 export interface EpicTests {
@@ -97,10 +100,6 @@ interface Filter {
     id: string;
     test: (test: Test, targeting: EpicTargeting) => boolean;
 }
-
-export const selectVariant = (test: Test, mvtId: number): Variant => {
-    return test.variants[mvtId % test.variants.length];
-};
 
 export const getUserCohorts = (targeting: EpicTargeting): UserCohort[] => {
     const { showSupportMessaging, isRecurringContributor } = targeting;

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -62,6 +62,11 @@ export interface Variant {
     showReminderFields?: ReminderFields;
 }
 
+interface ControlProportionSettings {
+    proportion: number;
+    offset: number;
+}
+
 export interface Test {
     name: string;
     isOn: boolean;
@@ -89,7 +94,7 @@ export interface Test {
     expiry?: string;
     campaignId?: string;
 
-    controlProportion?: number; // between 0-1
+    controlProportionSettings?: ControlProportionSettings;
 }
 
 export interface EpicTests {


### PR DESCRIPTION
To allow the epic tool to configure the size of the audience that should be put into the control.
The tool will ensure that the control is the smallest variant (or joint-smallest).

It's important to still use the mvt cookie value because it ensures a user remains in the same variant across page views.

If `controlProportionSettings` is set then we use this to define the range of mvt values for the control variant.
Otherwise we evenly distribute all variants across the mvt range (as before).

The tool also provides an `offset` value to avoid putting the same users in the control for each test.
The tool will randomly generate the offset (a value between 0-1000000) and this should not change during the lifetime of the test.