### PR TITLE
Update article count opt out copy

### DIFF
--- a/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
+++ b/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
@@ -188,7 +188,7 @@ export const ArticleCountOptOutOverlay: React.FC<ArticleCountOptOutOverlayProps>
                         <a href="https://www.theguardian.com/help/contact-us">contact us.</a>
                     </span>
                 ) : (
-                    'Please note you cannot undo this action or opt back in.'
+                    "Please note that opting out is a permanent action and can't be reversed"
                 )}
             </div>
         </div>


### PR DESCRIPTION
## What does this change?
There was some [discussion](https://www.figma.com/file/igYtUxyn3TaGDMIoFcmDOT/US-EOY-Appeal-2020?node-id=2420%3A140) on the figma that the current copy is a little misleading. Here's the updated copy!

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<img width="353" alt="Screenshot 2020-11-25 at 14 45 49" src="https://user-images.githubusercontent.com/17720442/100242636-f32fe180-2f2c-11eb-9da5-d329f9d0c234.png">
<img width="353" alt="Screenshot 2020-11-25 at 14 45 52" src="https://user-images.githubusercontent.com/17720442/100242652-f7f49580-2f2c-11eb-8604-cab602efc9b7.png">
<img width="353" alt="Screenshot 2020-11-25 at 14 45 56" src="https://user-images.githubusercontent.com/17720442/100242660-faef8600-2f2c-11eb-8879-0762c54d2644.png">
