### PR TITLE
Update the US EOY banner for Giving Tuesday

### DIFF
--- a/src/components/modules/banners/contributionsTemplate/ContributionsTemplate.tsx
+++ b/src/components/modules/banners/contributionsTemplate/ContributionsTemplate.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { css } from '@emotion/core';
+import { css, SerializedStyles } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Hide } from '@guardian/src-layout';
 
-const banner = css`
+const banner = (backgroundColour: string): SerializedStyles => css`
     box-sizing: border-box;
     width: 100%;
     display: flex;
     justify-content: center;
-    background-color: #dddbd1;
+    background-color: ${backgroundColour};
 
     * {
         box-sizing: border-box;
@@ -153,6 +153,7 @@ export interface ContributionsTemplateProps {
     supportingText: React.ReactElement;
     ticker?: React.ReactElement;
     cta: React.ReactElement;
+    backgroundColour: string;
 }
 
 const ContributionsTemplate: React.FC<ContributionsTemplateProps> = ({
@@ -162,9 +163,10 @@ const ContributionsTemplate: React.FC<ContributionsTemplateProps> = ({
     supportingText,
     ticker,
     cta,
+    backgroundColour,
 }: ContributionsTemplateProps) => {
     return (
-        <div css={banner}>
+        <div css={banner(backgroundColour)}>
             <div css={container}>
                 <div css={closeButtonContainerMobile}>
                     <Hide above="tablet">{closeButton}</Hide>

--- a/src/components/modules/banners/contributionsTemplate/ContributionsTemplateWithVisual.tsx
+++ b/src/components/modules/banners/contributionsTemplate/ContributionsTemplateWithVisual.tsx
@@ -3,12 +3,12 @@ import { css, SerializedStyles } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 
-const banner = css`
+const banner = (backgroundColour: string): SerializedStyles => css`
     overflow: hidden;
     width: 100%;
     display: flex;
     justify-content: center;
-    background-color: #dddbd1;
+    background-color: ${backgroundColour};
 `;
 
 const container = css`
@@ -117,6 +117,7 @@ export interface ContributionsTemplateWithVisualProps {
     body: React.ReactElement;
     ticker?: React.ReactElement;
     cta: React.ReactElement;
+    backgroundColour: string;
 }
 
 const ContributionsTemplateWithVisual: React.FC<ContributionsTemplateWithVisualProps> = ({
@@ -126,9 +127,10 @@ const ContributionsTemplateWithVisual: React.FC<ContributionsTemplateWithVisualP
     body,
     ticker,
     cta,
+    backgroundColour,
 }: ContributionsTemplateWithVisualProps) => {
     return (
-        <div css={banner}>
+        <div css={banner(backgroundColour)}>
             <div css={container}>
                 <div css={visualContainer}>
                     <div css={visualSizer}>

--- a/src/components/modules/banners/contributionsTemplate/ExampleContributionsTemplate.tsx
+++ b/src/components/modules/banners/contributionsTemplate/ExampleContributionsTemplate.tsx
@@ -117,6 +117,7 @@ const cta = (
 export const Example: React.FC<BannerProps> = ({ tickerSettings }: BannerProps) => {
     return (
         <ContributionsTemplate
+            backgroundColour="#DDDBD1"
             closeButton={closeButton}
             header={header}
             body={body}

--- a/src/components/modules/banners/contributionsTemplate/ExampleContributionsTemplateWithVisual.tsx
+++ b/src/components/modules/banners/contributionsTemplate/ExampleContributionsTemplateWithVisual.tsx
@@ -137,6 +137,7 @@ const cta = (
 export const Example: React.FC<BannerProps> = ({}: BannerProps) => {
     return (
         <ContributionsTemplateWithVisual
+            backgroundColour="#DDDBD1"
             visual={visual}
             closeButton={closeButton}
             header={header}
@@ -149,6 +150,7 @@ export const Example: React.FC<BannerProps> = ({}: BannerProps) => {
 export const ExampleWithTicker: React.FC<BannerProps> = ({ tickerSettings }: BannerProps) => {
     return (
         <ContributionsTemplateWithVisual
+            backgroundColour="#DDDBD1"
             visual={visual}
             closeButton={closeButton}
             header={header}

--- a/src/components/modules/banners/usEoyAppeal/UsEoyAppeal.tsx
+++ b/src/components/modules/banners/usEoyAppeal/UsEoyAppeal.tsx
@@ -8,7 +8,7 @@ import UsEoyAppealTicker from './components/UsEoyAppealTicker';
 import UsEoyAppealCta from './components/UsEoyAppealCta';
 import {
     OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK,
-    OPHAN_COMPONENT_EVENT_NOT_NOW_CLICK,
+    OPHAN_COMPONENT_EVENT_READ_MORE_CLICK,
     OPHAN_COMPONENT_EVENT_CLOSE_CLICK,
 } from './helpers/ophan';
 import withCloseable, { CloseableBannerProps } from '../hocs/withCloseable';
@@ -26,8 +26,8 @@ const UsEoyAppealBanner: React.FC<CloseableBannerProps> = ({
     const onContributeClick = (): void =>
         submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK);
 
-    const onNotNowClick = (): void => {
-        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_NOT_NOW_CLICK);
+    const onReadMoreClick = (): void => {
+        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_READ_MORE_CLICK);
         onClose();
     };
 
@@ -57,7 +57,7 @@ const UsEoyAppealBanner: React.FC<CloseableBannerProps> = ({
             cta={
                 <UsEoyAppealCta
                     onContributeClick={onContributeClick}
-                    onNotNowClick={onNotNowClick}
+                    onReadMoreClick={onReadMoreClick}
                     tracking={tracking}
                     countryCode={countryCode || ''}
                     isSupporter={!!isSupporter}

--- a/src/components/modules/banners/usEoyAppeal/UsEoyAppeal.tsx
+++ b/src/components/modules/banners/usEoyAppeal/UsEoyAppeal.tsx
@@ -20,6 +20,8 @@ const UsEoyAppealBanner: React.FC<CloseableBannerProps> = ({
     submitComponentEvent,
     tracking,
     countryCode,
+    numArticles,
+    hasOptedOutOfArticleCount,
 }: CloseableBannerProps) => {
     const onContributeClick = (): void =>
         submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK);
@@ -43,7 +45,13 @@ const UsEoyAppealBanner: React.FC<CloseableBannerProps> = ({
         <ContributionsTemplate
             closeButton={<UsEoyAppealCloseButton onClose={onCloseClick} />}
             header={<UsEoyAppealHeader />}
-            body={<UsEoyAppealBody isSupporter={!!isSupporter} />}
+            body={
+                <UsEoyAppealBody
+                    isSupporter={!!isSupporter}
+                    numArticles={numArticles || 0}
+                    hasOptedOutOfArticleCount={!!hasOptedOutOfArticleCount}
+                />
+            }
             supportingText={<UsEoyAppealSupportingText goalReached={goalReached} />}
             ticker={tickerSettings && <UsEoyAppealTicker tickerSettings={tickerSettings} />}
             cta={

--- a/src/components/modules/banners/usEoyAppeal/UsEoyAppeal.tsx
+++ b/src/components/modules/banners/usEoyAppeal/UsEoyAppeal.tsx
@@ -43,6 +43,7 @@ const UsEoyAppealBanner: React.FC<CloseableBannerProps> = ({
 
     return (
         <ContributionsTemplate
+            backgroundColour="#DDDBD1"
             closeButton={<UsEoyAppealCloseButton onClose={onCloseClick} />}
             header={<UsEoyAppealHeader />}
             body={

--- a/src/components/modules/banners/usEoyAppeal/UsEoyAppealWithVisual.tsx
+++ b/src/components/modules/banners/usEoyAppeal/UsEoyAppealWithVisual.tsx
@@ -20,6 +20,8 @@ const UsEoyAppealBannerWithVisual: React.FC<CloseableBannerProps> = ({
     submitComponentEvent,
     tracking,
     countryCode,
+    numArticles,
+    hasOptedOutOfArticleCount,
 }: CloseableBannerProps) => {
     const onContributeClick = (): void =>
         submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK);
@@ -39,7 +41,13 @@ const UsEoyAppealBannerWithVisual: React.FC<CloseableBannerProps> = ({
             visual={<UsEoyAppealVisual />}
             closeButton={<UsEoyAppealCloseButton onClose={onCloseClick} />}
             header={<UsEoyAppealHeader />}
-            body={<UsEoyAppealBody isSupporter={!!isSupporter} />}
+            body={
+                <UsEoyAppealBody
+                    isSupporter={!!isSupporter}
+                    numArticles={numArticles || 0}
+                    hasOptedOutOfArticleCount={!!hasOptedOutOfArticleCount}
+                />
+            }
             ticker={tickerSettings && <UsEoyAppealTicker tickerSettings={tickerSettings} />}
             cta={
                 <UsEoyAppealCta

--- a/src/components/modules/banners/usEoyAppeal/UsEoyAppealWithVisual.tsx
+++ b/src/components/modules/banners/usEoyAppeal/UsEoyAppealWithVisual.tsx
@@ -8,7 +8,7 @@ import UsEoyAppealTicker from './components/UsEoyAppealTicker';
 import UsEoyAppealCta from './components/UsEoyAppealCta';
 import {
     OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK,
-    OPHAN_COMPONENT_EVENT_NOT_NOW_CLICK,
+    OPHAN_COMPONENT_EVENT_READ_MORE_CLICK,
     OPHAN_COMPONENT_EVENT_CLOSE_CLICK,
 } from './helpers/ophan';
 import withCloseable, { CloseableBannerProps } from '../hocs/withCloseable';
@@ -26,8 +26,8 @@ const UsEoyAppealBannerWithVisual: React.FC<CloseableBannerProps> = ({
     const onContributeClick = (): void =>
         submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK);
 
-    const onNotNowClick = (): void => {
-        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_NOT_NOW_CLICK);
+    const onReadMoreClick = (): void => {
+        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_READ_MORE_CLICK);
         onClose();
     };
 
@@ -52,7 +52,7 @@ const UsEoyAppealBannerWithVisual: React.FC<CloseableBannerProps> = ({
             cta={
                 <UsEoyAppealCta
                     onContributeClick={onContributeClick}
-                    onNotNowClick={onNotNowClick}
+                    onReadMoreClick={onReadMoreClick}
                     tracking={tracking}
                     countryCode={countryCode || ''}
                     isSupporter={!!isSupporter}

--- a/src/components/modules/banners/usEoyAppeal/UsEoyAppealWithVisual.tsx
+++ b/src/components/modules/banners/usEoyAppeal/UsEoyAppealWithVisual.tsx
@@ -38,6 +38,7 @@ const UsEoyAppealBannerWithVisual: React.FC<CloseableBannerProps> = ({
 
     return (
         <ContributionsTemplateWithVisual
+            backgroundColour="#E7D4B9"
             visual={<UsEoyAppealVisual />}
             closeButton={<UsEoyAppealCloseButton onClose={onCloseClick} />}
             header={<UsEoyAppealHeader />}

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealBody.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealBody.tsx
@@ -1,42 +1,76 @@
 import React from 'react';
 import { Hide } from '@guardian/src-layout';
 import ContributionsTemplateBody from '../../contributionsTemplate/ContributionsTemplateBody';
+import { ArticleCountOptOut } from '../../../shared/ArticleCountOptOut';
 
 interface UsEoyAppealBodyProps {
     isSupporter: boolean;
+    numArticles: number;
+    hasOptedOutOfArticleCount: boolean;
 }
 
-const UsEoyAppealBody: React.FC<UsEoyAppealBodyProps> = ({ isSupporter }: UsEoyAppealBodyProps) => (
-    <ContributionsTemplateBody
-        copy={
-            <>
-                <Hide above="tablet">
-                    The need for robust, fact-based journalism that highlights injustice and offers
-                    solutions is as great as ever.
-                </Hide>
+const MIN_NUM_ARTICLES_TO_SHOW_ARTICLE_COUNT = 5;
+
+const UsEoyAppealBody: React.FC<UsEoyAppealBodyProps> = ({
+    isSupporter,
+    hasOptedOutOfArticleCount,
+    numArticles,
+}: UsEoyAppealBodyProps) => {
+    const shouldShowArticleCount =
+        !hasOptedOutOfArticleCount && numArticles > MIN_NUM_ARTICLES_TO_SHOW_ARTICLE_COUNT;
+
+    return (
+        <ContributionsTemplateBody
+            copy={
                 <Hide below="tablet">
                     {isSupporter ? (
+                        shouldShowArticleCount ? (
+                            // supporter + article count
+                            <>
+                                Decency, civility and truth can help heal divisions. Fact-based
+                                journalism grounded in evidence can help unite the US. You&apos;ve
+                                read{' '}
+                                <ArticleCountOptOut
+                                    numArticles={44}
+                                    nextWord=" articles"
+                                    type="us-eoy-banner"
+                                />{' '}
+                                in the last year. We value your support and hope you’ll consider a
+                                year-end gift.
+                            </>
+                        ) : (
+                            // supporter + no article count
+                            <>
+                                Decency, civility and truth can help heal divisions. Fact-based
+                                journalism grounded in evidence can help unite the US. We value your
+                                support and hope you’ll consider a year-end gift.
+                            </>
+                        )
+                    ) : shouldShowArticleCount ? (
+                        // non-supporter + article count
                         <>
-                            Trump’s presidency is ending, but America’s systemic challenges remain.
-                            From a broken healthcare system to corrosive racial inequality, from
-                            rapacious corporations to a climate crisis, the need for robust,
-                            fact-based reporting that highlights injustice and offers solutions is
-                            as great as ever. We value your ongoing support and hope you’ll consider
-                            a year-end gift.
+                            Decency, civility and truth can help heal divisions. Fact-based
+                            journalism grounded in evidence can help unite the US. You&apos;ve read{' '}
+                            <ArticleCountOptOut
+                                numArticles={44}
+                                nextWord=" articles"
+                                type="us-eoy-banner"
+                            />{' '}
+                            in the last year. We hope you’ll consider a year-end gift to support the
+                            Guardian.
                         </>
                     ) : (
+                        // non-supporter + no article count
                         <>
-                            Trump’s presidency is ending, but America’s systemic challenges remain.
-                            From a broken healthcare system to corrosive racial inequality, from
-                            rapacious corporations to a climate crisis, the need for robust,
-                            fact-based reporting that highlights injustice and offers solutions is
-                            as great as ever. We hope you’ll consider a year-end gift.
+                            Decency, civility and truth can help heal divisions. Fact-based
+                            journalism grounded in evidence can help unite the US. We hope you’ll
+                            consider a year-end gift to support the Guardian.
                         </>
                     )}
                 </Hide>
-            </>
-        }
-    />
-);
+            }
+        />
+    );
+};
 
 export default UsEoyAppealBody;

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealBody.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealBody.tsx
@@ -31,7 +31,7 @@ const UsEoyAppealBody: React.FC<UsEoyAppealBodyProps> = ({
                                 journalism grounded in evidence can help unite the US. You&apos;ve
                                 read{' '}
                                 <ArticleCountOptOut
-                                    numArticles={44}
+                                    numArticles={numArticles}
                                     nextWord=" articles"
                                     type="us-eoy-banner"
                                 />{' '}
@@ -52,7 +52,7 @@ const UsEoyAppealBody: React.FC<UsEoyAppealBodyProps> = ({
                             Decency, civility and truth can help heal divisions. Fact-based
                             journalism grounded in evidence can help unite the US. You&apos;ve read{' '}
                             <ArticleCountOptOut
-                                numArticles={44}
+                                numArticles={numArticles}
                                 nextWord=" articles"
                                 type="us-eoy-banner"
                             />{' '}

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealCloseButton.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealCloseButton.tsx
@@ -8,6 +8,10 @@ import ContributionsTemplateCloseButton from '../../contributionsTemplate/Contri
 const closeButtonStyles = css`
     color: ${neutral[7]};
     border-color: ${neutral[7]};
+
+    &:hover {
+        background-color: #f3eade;
+    }
 `;
 
 const Roundel = (

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealCta.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealCta.tsx
@@ -14,6 +14,8 @@ const readMoreButtonStyles = css`
 `;
 
 const BASE_LANDING_PAGE_URL = 'https://support.theguardian.com/contribute';
+const IMPACT_REPORT_LINK =
+    'https://www.theguardian.com/us-news/2020/nov/24/guardian-fundraiser-end-of-year-2020-contribute?INTCMP=us_eoy_banner';
 
 interface UsEoyAppealCtaProps {
     onContributeClick: () => void;
@@ -66,11 +68,11 @@ const UsEoyAppealCta: React.FC<UsEoyAppealCtaProps> = ({
                     </div>
                 </ThemeProvider>
             }
-            // TODO: Add link to impact report
             secondaryCta={
                 <div>
                     <Hide above="tablet">
                         <LinkButton
+                            href={IMPACT_REPORT_LINK}
                             onClick={onReadMoreClick}
                             css={readMoreButtonStyles}
                             size="small"
@@ -81,6 +83,7 @@ const UsEoyAppealCta: React.FC<UsEoyAppealCtaProps> = ({
                     </Hide>
                     <Hide below="tablet">
                         <LinkButton
+                            href={IMPACT_REPORT_LINK}
                             onClick={onReadMoreClick}
                             css={readMoreButtonStyles}
                             size="default"

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealCta.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealCta.tsx
@@ -11,6 +11,10 @@ import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../../../lib/tra
 const readMoreButtonStyles = css`
     color: ${neutral[7]};
     border-color: ${neutral[7]};
+
+    &:hover {
+        background-color: #f3eade;
+    }
 `;
 
 const BASE_LANDING_PAGE_URL = 'https://support.theguardian.com/contribute';

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealCta.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealCta.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
+import { css } from '@emotion/core';
+import { neutral } from '@guardian/src-foundations/palette';
 import { Hide } from '@guardian/src-layout';
 import { ThemeProvider } from 'emotion-theming';
-import { LinkButton, Button, buttonBrandAlt } from '@guardian/src-button';
+import { LinkButton, buttonBrandAlt } from '@guardian/src-button';
 import ContributionsTemplateCta from '../../contributionsTemplate/ContributionsTemplateCta';
 import { BannerTracking } from '../../../../../types/BannerTypes';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../../../lib/tracking';
+
+const readMoreButtonStyles = css`
+    color: ${neutral[7]};
+    border-color: ${neutral[7]};
+`;
 
 const BASE_LANDING_PAGE_URL = 'https://support.theguardian.com/contribute';
 
 interface UsEoyAppealCtaProps {
     onContributeClick: () => void;
-    onNotNowClick: () => void;
+    onReadMoreClick: () => void;
     tracking: BannerTracking;
     countryCode: string;
     isSupporter: boolean;
@@ -18,7 +25,7 @@ interface UsEoyAppealCtaProps {
 
 const UsEoyAppealCta: React.FC<UsEoyAppealCtaProps> = ({
     onContributeClick,
-    onNotNowClick,
+    onReadMoreClick,
     tracking,
     countryCode,
     isSupporter,
@@ -59,21 +66,30 @@ const UsEoyAppealCta: React.FC<UsEoyAppealCtaProps> = ({
                     </div>
                 </ThemeProvider>
             }
+            // TODO: Add link to impact report
             secondaryCta={
-                <ThemeProvider theme={buttonBrandAlt}>
-                    <div>
-                        <Hide above="tablet">
-                            <Button onClick={onNotNowClick} size="small" priority="subdued">
-                                Not now
-                            </Button>
-                        </Hide>
-                        <Hide below="tablet">
-                            <Button onClick={onNotNowClick} size="default" priority="subdued">
-                                Not now
-                            </Button>
-                        </Hide>
-                    </div>
-                </ThemeProvider>
+                <div>
+                    <Hide above="tablet">
+                        <LinkButton
+                            onClick={onReadMoreClick}
+                            css={readMoreButtonStyles}
+                            size="small"
+                            priority="tertiary"
+                        >
+                            Read more
+                        </LinkButton>
+                    </Hide>
+                    <Hide below="tablet">
+                        <LinkButton
+                            onClick={onReadMoreClick}
+                            css={readMoreButtonStyles}
+                            size="default"
+                            priority="tertiary"
+                        >
+                            Read more
+                        </LinkButton>
+                    </Hide>
+                </div>
             }
         />
     );

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealCta.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealCta.tsx
@@ -51,7 +51,7 @@ const UsEoyAppealCta: React.FC<UsEoyAppealCtaProps> = ({
                                 onClick={onContributeClick}
                                 size="small"
                             >
-                                {isSupporter ? 'Support us again' : 'Support the Guardian'}
+                                {isSupporter ? 'Support' : 'Contribute'}
                             </LinkButton>
                         </Hide>
                         <Hide below="tablet">

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealHeader.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealHeader.tsx
@@ -16,11 +16,14 @@ const UsEoyAppealVisual: React.FC = () => (
     <ContributionsTemplateHeader
         copy={
             <>
-                <Hide above="tablet">As America begins a new chapter…</Hide>
+                <Hide above="tablet">
+                    <span css={firstLineStyles}>Help unite America</span>{' '}
+                    <span css={secondLineStyles}>this Giving Tuesday</span>
+                </Hide>
                 <Hide below="tablet">
-                    <span css={firstLineStyles}>America’s future:</span>
+                    <span css={firstLineStyles}>Help unite America</span>
                     <br />
-                    <span css={secondLineStyles}>what’s next?</span>
+                    <span css={secondLineStyles}>this Giving Tuesday</span>
                 </Hide>
             </>
         }

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealHeader.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealHeader.tsx
@@ -1,8 +1,30 @@
 import React from 'react';
+import { css } from '@emotion/core';
+import { Hide } from '@guardian/src-layout';
+import { news, brand } from '@guardian/src-foundations/palette';
 import ContributionsTemplateHeader from '../../contributionsTemplate/ContributionsTemplateHeader';
 
+const firstLineStyles = css`
+    color: ${news[400]};
+`;
+
+const secondLineStyles = css`
+    color: ${brand[400]};
+`;
+
 const UsEoyAppealVisual: React.FC = () => (
-    <ContributionsTemplateHeader copy={<>Help put America back together this Giving Tuesday</>} />
+    <ContributionsTemplateHeader
+        copy={
+            <>
+                <Hide above="tablet">As America begins a new chapter…</Hide>
+                <Hide below="tablet">
+                    <span css={firstLineStyles}>America’s future:</span>
+                    <br />
+                    <span css={secondLineStyles}>what’s next?</span>
+                </Hide>
+            </>
+        }
+    />
 );
 
 export default UsEoyAppealVisual;

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealHeader.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealHeader.tsx
@@ -17,8 +17,8 @@ const UsEoyAppealVisual: React.FC = () => (
         copy={
             <>
                 <Hide above="tablet">
-                    <span css={firstLineStyles}>Help unite America</span>{' '}
-                    <span css={secondLineStyles}>this Giving Tuesday</span>
+                    <span css={firstLineStyles}>Fact-based journalism</span>{' '}
+                    <span css={secondLineStyles}>can help rebuild America</span>
                 </Hide>
                 <Hide below="tablet">
                     <span css={firstLineStyles}>Help unite America</span>

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealHeader.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealHeader.tsx
@@ -1,20 +1,8 @@
 import React from 'react';
-import { Hide } from '@guardian/src-layout';
 import ContributionsTemplateHeader from '../../contributionsTemplate/ContributionsTemplateHeader';
 
 const UsEoyAppealVisual: React.FC = () => (
-    <ContributionsTemplateHeader
-        copy={
-            <>
-                <Hide above="tablet">Help us report on a new chapter for America</Hide>
-                <Hide below="tablet">
-                    America’s future:
-                    <br />
-                    what’s next?
-                </Hide>
-            </>
-        }
-    />
+    <ContributionsTemplateHeader copy={<>Help put America back together this Giving Tuesday</>} />
 );
 
 export default UsEoyAppealVisual;

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealTicker.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealTicker.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { lifestyle } from '@guardian/src-foundations/palette';
+import { brand } from '@guardian/src-foundations/palette';
 import { TickerSettings } from '../../../../../lib/variants';
 import ContributionsTemplateTicker from '../../contributionsTemplate/ContributionsTemplateTicker';
 
@@ -10,7 +10,7 @@ interface UsEoyAppealTickerProps {
 const UsEoyAppealTicker: React.FC<UsEoyAppealTickerProps> = ({
     tickerSettings,
 }: UsEoyAppealTickerProps) => (
-    <ContributionsTemplateTicker settings={tickerSettings} accentColour={lifestyle[300]} />
+    <ContributionsTemplateTicker settings={tickerSettings} accentColour={brand[400]} />
 );
 
 export default UsEoyAppealTicker;

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealVisual.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealVisual.tsx
@@ -15,15 +15,27 @@ const UsEoyAppealVisual: React.FC = () => (
     <ContributionsTemplateVisual
         image={
             <picture css={visualStyles}>
+                {/* mobile, reduced */}
                 <source
                     media="(max-width: 739px)"
                     srcSet="https://media.guim.co.uk/0c02b0c63cfdb5e73a86bb4c5a4e1e88b17e24c8/0_0_960_432/960.png"
                 />
+                {/* tablet, reduced */}
                 <source
-                    media="(max-width: 979px)"
+                    media="(max-width: 979px) and (prefers-reduced-motion: reduce)"
                     srcSet="https://media.guim.co.uk/3ccf1f7b696e373324fd9a2087a4152b2be9acac/0_0_720_681/720.png"
                 />
-                <source srcSet="https://media.guim.co.uk/1086a07886ece443319926c063468e58c6423106/0_0_720_681/720.png" />
+                {/* desktop, reduced */}
+                <source
+                    media="(prefers-reduced-motion: reduce)"
+                    srcSet="https://media.guim.co.uk/1086a07886ece443319926c063468e58c6423106/0_0_720_681/720.png"
+                />
+                {/* tablet + desktop, animated */}
+                <source
+                    media="(prefers-reduced-motion: no-preference)"
+                    srcSet="https://uploads.guim.co.uk/2020/11/27/us-eoy-gt-desktop.gif"
+                />
+                {/* fallback = mobile, reduced */}
                 <img src="https://media.guim.co.uk/0c02b0c63cfdb5e73a86bb4c5a4e1e88b17e24c8/0_0_960_432/960.png" />
             </picture>
         }

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealVisual.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealVisual.tsx
@@ -22,9 +22,9 @@ const UsEoyAppealVisual: React.FC = () => (
             <picture css={visualStyles}>
                 <source
                     media="(max-width: 739px)"
-                    srcSet="https://media.guim.co.uk/53cb3ec24999db33d9957cd5f70223350f4fbba1/0_0_960_432/960.png"
+                    srcSet="https://media.guim.co.uk/c7567686da9c9d6fcdb3fdbe14dc24acee86cc04/0_0_960_432/960.png"
                 />
-                <source srcSet="https://media.guim.co.uk/cdba08ee85134397376c8ad1a20a78c670431f26/0_122_720_681/720.png" />
+                <source srcSet="https://media.guim.co.uk/616cc303876506fd5849d55adb88e42d381153fe/0_0_720_681/720.png" />
                 <img src="https://media.guim.co.uk/53cb3ec24999db33d9957cd5f70223350f4fbba1/0_0_960_432/960.png" />
             </picture>
         }

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealVisual.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealVisual.tsx
@@ -8,11 +8,6 @@ const visualStyles = css`
         ${from.tablet} {
             object-fit: contain;
         }
-
-        ${from.desktop} {
-            margin-top: 1%;
-            height: 105%;
-        }
     }
 `;
 
@@ -22,10 +17,14 @@ const UsEoyAppealVisual: React.FC = () => (
             <picture css={visualStyles}>
                 <source
                     media="(max-width: 739px)"
-                    srcSet="https://media.guim.co.uk/c7567686da9c9d6fcdb3fdbe14dc24acee86cc04/0_0_960_432/960.png"
+                    srcSet="https://media.guim.co.uk/0c02b0c63cfdb5e73a86bb4c5a4e1e88b17e24c8/0_0_960_432/960.png"
                 />
-                <source srcSet="https://media.guim.co.uk/616cc303876506fd5849d55adb88e42d381153fe/0_0_720_681/720.png" />
-                <img src="https://media.guim.co.uk/53cb3ec24999db33d9957cd5f70223350f4fbba1/0_0_960_432/960.png" />
+                <source
+                    media="(max-width: 979px)"
+                    srcSet="https://media.guim.co.uk/3ccf1f7b696e373324fd9a2087a4152b2be9acac/0_0_720_681/720.png"
+                />
+                <source srcSet="https://media.guim.co.uk/1086a07886ece443319926c063468e58c6423106/0_0_720_681/720.png" />
+                <img src="https://media.guim.co.uk/0c02b0c63cfdb5e73a86bb4c5a4e1e88b17e24c8/0_0_960_432/960.png" />
             </picture>
         }
     />

--- a/src/components/modules/banners/usEoyAppeal/helpers/ophan.ts
+++ b/src/components/modules/banners/usEoyAppeal/helpers/ophan.ts
@@ -2,6 +2,7 @@ import { OphanComponentEvent } from '../../../../../types/OphanTypes';
 
 const OPHAN_COMPONENT_ID_CONTRIBUTE = 'us-eoy-appeal-2020-contribute';
 const OPHAN_COMPONENT_ID_NOT_NOW = 'us-eoy-appeal-2020-not-now';
+const OPHAN_COMPONENT_ID_READ_MORE = 'us-eoy-appeal-2020-read-more';
 const OPHAN_COMPONENT_ID_CLOSE = 'us-eoy-appeal-2020-close';
 
 export const OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK: OphanComponentEvent = {
@@ -16,6 +17,14 @@ export const OPHAN_COMPONENT_EVENT_NOT_NOW_CLICK: OphanComponentEvent = {
     component: {
         componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
         id: OPHAN_COMPONENT_ID_NOT_NOW,
+    },
+    action: 'CLICK',
+};
+
+export const OPHAN_COMPONENT_EVENT_READ_MORE_CLICK: OphanComponentEvent = {
+    component: {
+        componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+        id: OPHAN_COMPONENT_ID_READ_MORE,
     },
     action: 'CLICK',
 };

--- a/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
+++ b/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
@@ -30,7 +30,7 @@ const COLOURS = {
 const BACKGROUND_COLOURS = {
     epic: brand[400],
     banner: brandAltBackground.primary,
-    ['us-eoy-banner']: '#DDDBD1',
+    ['us-eoy-banner']: '#E7D4B9',
 };
 
 const BORDER_COLOURS = {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -184,6 +184,7 @@ const buildBannerData = async (
                 targeting.weeklyArticleHistory,
                 test.articlesViewedSettings?.periodInWeeks,
             ),
+            hasOptedOutOfArticleCount: targeting.hasOptedOutOfArticleCount,
             tickerSettings,
         };
 

--- a/src/tests/banners/UsEoyAppealBannerTest.ts
+++ b/src/tests/banners/UsEoyAppealBannerTest.ts
@@ -1,5 +1,5 @@
 import { BannerPageTracking, BannerTargeting, BannerTest } from '../../types/BannerTypes';
-import { usEoyAppeal, usEoyAppealWithVisual } from '../../modules';
+import { usEoyAppealWithVisual } from '../../modules';
 import { TickerCountType, TickerEndType } from '../../lib/variants';
 
 const tickerSettings = {
@@ -15,34 +15,8 @@ const tickerSettings = {
 
 const isLive = true;
 
-export const UsEoyAppealNonSupportersBanner: BannerTest = {
-    name: 'UsEoyAppealNonSupporters',
-    bannerChannel: 'contributions',
-    testAudience: 'AllNonSupporters',
-    locations: ['UnitedStates'],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => isLive,
-    minPageViews: 2,
-    variants: [
-        {
-            name: 'control',
-            modulePath: usEoyAppeal.endpointPath,
-            moduleName: 'UsEoyAppealBanner',
-            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-            tickerSettings,
-        },
-        {
-            name: 'variant',
-            modulePath: usEoyAppealWithVisual.endpointPath,
-            moduleName: 'UsEoyAppealBannerWithVisual',
-            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-            tickerSettings,
-        },
-    ],
-};
-
-export const UsEoyAppealSupportersBanner: BannerTest = {
-    name: 'UsEoyAppealSupporters',
+export const UsEoyAppealBanner: BannerTest = {
+    name: 'UsEoyAppeal',
     bannerChannel: 'contributions',
     testAudience: 'AllExistingSupporters',
     locations: ['UnitedStates'],
@@ -52,13 +26,6 @@ export const UsEoyAppealSupportersBanner: BannerTest = {
     variants: [
         {
             name: 'control',
-            modulePath: usEoyAppeal.endpointPath,
-            moduleName: 'UsEoyAppealBanner',
-            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-            tickerSettings,
-        },
-        {
-            name: 'variant',
             modulePath: usEoyAppealWithVisual.endpointPath,
             moduleName: 'UsEoyAppealBannerWithVisual',
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',

--- a/src/tests/banners/UsEoyAppealBannerTest.ts
+++ b/src/tests/banners/UsEoyAppealBannerTest.ts
@@ -16,7 +16,7 @@ const tickerSettings = {
 const isLive = true;
 
 export const UsEoyAppealBanner: BannerTest = {
-    name: 'UsEoyAppeal',
+    name: 'UsEoyGTAppeal',
     bannerChannel: 'contributions',
     testAudience: 'AllExistingSupporters',
     locations: ['UnitedStates'],

--- a/src/tests/banners/bannerTests.ts
+++ b/src/tests/banners/bannerTests.ts
@@ -4,17 +4,13 @@ import {
     channel1BannersAllTestsGenerator,
     channel2BannersAllTestsGenerator,
 } from './ChannelBannerTests';
-import {
-    UsEoyAppealNonSupportersBanner,
-    UsEoyAppealSupportersBanner,
-} from './UsEoyAppealBannerTest';
+import { UsEoyAppealBanner } from './UsEoyAppealBannerTest';
 import { cacheAsync } from '../../lib/cache';
 
 const defaultBannerTestGenerator: BannerTestGenerator = () =>
     Promise.resolve([DefaultContributionsBanner]);
 
-const usEoyAppealTestGenerator: BannerTestGenerator = () =>
-    Promise.resolve([UsEoyAppealNonSupportersBanner, UsEoyAppealSupportersBanner]);
+const usEoyAppealTestGenerator: BannerTestGenerator = () => Promise.resolve([UsEoyAppealBanner]);
 
 const flattenArray = <T>(array: T[][]): T[] => ([] as T[]).concat(...array);
 

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -109,6 +109,7 @@ export interface BannerProps {
     tickerSettings?: TickerSettings;
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
     numArticles?: number;
+    hasOptedOutOfArticleCount?: boolean;
 }
 
 export interface RawVariantParams {


### PR DESCRIPTION
## What does this change?
Updates the banner for the special Giving Tuesday design

## Images
### mobile
<img width="327" alt="Screenshot 2020-12-01 at 08 20 38" src="https://user-images.githubusercontent.com/17720442/100714775-23083a80-33ae-11eb-9a85-4e13cb99151d.png">

### tablet
<img width="747" alt="Screenshot 2020-11-26 at 13 42 13" src="https://user-images.githubusercontent.com/17720442/100358159-abbd5a00-2fed-11eb-85da-bbaefe354a4a.png">

### desktop
<img width="990" alt="Screenshot 2020-11-26 at 13 42 29" src="https://user-images.githubusercontent.com/17720442/100358172-afe97780-2fed-11eb-89a4-065c036f0265.png">

### wide
<img width="1305" alt="Screenshot 2020-11-26 at 13 43 40" src="https://user-images.githubusercontent.com/17720442/100358196-ba0b7600-2fed-11eb-98fd-a5037850b893.png">
