### PR TITLE
Remove us eoy appeal reminder

### DIFF
--- a/src/lib/reminderFields.ts
+++ b/src/lib/reminderFields.ts
@@ -26,23 +26,6 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-const US_EOY_APPEAL_REMINDER_FIELDS: ReminderFields = {
-    reminderCTA: 'Remind me on Giving Tuesday',
-    reminderDate: `2020-12-01 00:00:00`,
-    reminderDateAsString: `on Giving Tuesday`,
-};
-
-const US_EOY_APPEAL_REMINDER_CUT_OFF = Date.parse('2020-11-29');
-
-const shouldShowUsEoyReminder = (countryCode?: string): boolean =>
-    countryCode == 'US' && Date.now() < US_EOY_APPEAL_REMINDER_CUT_OFF;
-
-export const getReminderFields = (
-    reminderFields?: ReminderFields,
-    countryCode?: string,
-): ReminderFields => {
-    if (shouldShowUsEoyReminder(countryCode)) {
-        return US_EOY_APPEAL_REMINDER_FIELDS;
-    }
+export const getReminderFields = (reminderFields?: ReminderFields): ReminderFields => {
     return !!reminderFields ? reminderFields : buildReminderFields();
 };

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -356,10 +356,7 @@ export const findTestAndVariant = (
         const variant = selectVariant(test, targeting.mvtId || 1);
         const variantWithReminder: Variant = {
             ...variant,
-            showReminderFields: getReminderFields(
-                variant.showReminderFields,
-                targeting.countryCode,
-            ),
+            showReminderFields: getReminderFields(variant.showReminderFields),
         };
 
         return {


### PR DESCRIPTION
## What does this change?
Remove the special US EOY appeal reminder, as per [this card](https://trello.com/c/vWpsFUEv/2434-mon-30-11-switch-pre-contribution-epic-reminder-copy-out-giving-tuesday-to-next-month-us-only).

This didn't technically need to be done, as we'd automated the reminder to stop showing. Having the trello card felt like a good excuse to remove some old logic though!