### PR TITLE
Remove US giving tuesday banner

### DIFF
--- a/src/components/modules/banners/usEoyAppeal/UsEoyAppealWithVisual.tsx
+++ b/src/components/modules/banners/usEoyAppeal/UsEoyAppealWithVisual.tsx
@@ -38,7 +38,7 @@ const UsEoyAppealBannerWithVisual: React.FC<CloseableBannerProps> = ({
 
     return (
         <ContributionsTemplateWithVisual
-            backgroundColour="#E7D4B9"
+            backgroundColour="#DDDBD1"
             visual={<UsEoyAppealVisual />}
             closeButton={<UsEoyAppealCloseButton onClose={onCloseClick} />}
             header={<UsEoyAppealHeader />}

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealBody.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealBody.tsx
@@ -27,44 +27,53 @@ const UsEoyAppealBody: React.FC<UsEoyAppealBodyProps> = ({
                         shouldShowArticleCount ? (
                             // supporter + article count
                             <>
-                                Decency, civility and truth can help heal divisions. Fact-based
-                                journalism grounded in evidence can help unite the US. You&apos;ve
-                                read{' '}
+                                Trump’s presidency is ending, but America’s systemic challenges
+                                remain. From broken healthcare to corrosive racial inequality, from
+                                rapacious corporations to a climate crisis, the need for fact-based
+                                reporting that highlights injustice and offers solutions is as great
+                                as ever. You&apos;ve read{' '}
                                 <ArticleCountOptOut
                                     numArticles={numArticles}
                                     nextWord=" articles"
                                     type="us-eoy-banner"
                                 />{' '}
-                                in the last year. We value your support and hope you’ll consider a
+                                in the past year. We value your support and hope you’ll consider a
                                 year-end gift.
                             </>
                         ) : (
                             // supporter + no article count
                             <>
-                                Decency, civility and truth can help heal divisions. Fact-based
-                                journalism grounded in evidence can help unite the US. We value your
-                                support and hope you’ll consider a year-end gift.
+                                Trump’s presidency is ending, but America’s systemic challenges
+                                remain. From broken healthcare to corrosive racial inequality, from
+                                rapacious corporations to a climate crisis, the need for fact-based
+                                reporting that highlights injustice and offers solutions is as great
+                                as ever. We value your support and hope you’ll consider a year-end
+                                gift.
                             </>
                         )
                     ) : shouldShowArticleCount ? (
                         // non-supporter + article count
                         <>
-                            Decency, civility and truth can help heal divisions. Fact-based
-                            journalism grounded in evidence can help unite the US. You&apos;ve read{' '}
+                            Trump’s presidency is ending, but America’s systemic challenges remain.
+                            From a broken healthcare system to corrosive racial inequality, from
+                            rapacious corporations to a climate crisis, the need for robust,
+                            fact-based reporting that highlights injustice and offers solutions is
+                            as great as ever. You&apos;ve read{' '}
                             <ArticleCountOptOut
                                 numArticles={numArticles}
                                 nextWord=" articles"
                                 type="us-eoy-banner"
                             />{' '}
-                            in the last year. We hope you’ll consider a year-end gift to support the
-                            Guardian.
+                            in the past year. We hope you’ll consider a year-end gift.
                         </>
                     ) : (
                         // non-supporter + no article count
                         <>
-                            Decency, civility and truth can help heal divisions. Fact-based
-                            journalism grounded in evidence can help unite the US. We hope you’ll
-                            consider a year-end gift to support the Guardian.
+                            Trump’s presidency is ending, but America’s systemic challenges remain.
+                            From a broken healthcare system to corrosive racial inequality, from
+                            rapacious corporations to a climate crisis, the need for robust,
+                            fact-based reporting that highlights injustice and offers solutions is
+                            as great as ever. We hope you’ll consider a year-end gift.
                         </>
                     )}
                 </Hide>

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealHeader.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealHeader.tsx
@@ -1,29 +1,16 @@
 import React from 'react';
-import { css } from '@emotion/core';
 import { Hide } from '@guardian/src-layout';
-import { news, brand } from '@guardian/src-foundations/palette';
 import ContributionsTemplateHeader from '../../contributionsTemplate/ContributionsTemplateHeader';
-
-const firstLineStyles = css`
-    color: ${news[400]};
-`;
-
-const secondLineStyles = css`
-    color: ${brand[400]};
-`;
 
 const UsEoyAppealVisual: React.FC = () => (
     <ContributionsTemplateHeader
         copy={
             <>
-                <Hide above="tablet">
-                    <span css={firstLineStyles}>Fact-based journalism</span>{' '}
-                    <span css={secondLineStyles}>can help rebuild America</span>
-                </Hide>
+                <Hide above="tablet">Help us report on a new chapter for America</Hide>
                 <Hide below="tablet">
-                    <span css={firstLineStyles}>Help unite America</span>
+                    America’s future:
                     <br />
-                    <span css={secondLineStyles}>this Giving Tuesday</span>
+                    what’s next?
                 </Hide>
             </>
         }

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealTicker.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealTicker.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { brand } from '@guardian/src-foundations/palette';
+import { lifestyle } from '@guardian/src-foundations/palette';
 import { TickerSettings } from '../../../../../lib/variants';
 import ContributionsTemplateTicker from '../../contributionsTemplate/ContributionsTemplateTicker';
 
@@ -10,7 +10,7 @@ interface UsEoyAppealTickerProps {
 const UsEoyAppealTicker: React.FC<UsEoyAppealTickerProps> = ({
     tickerSettings,
 }: UsEoyAppealTickerProps) => (
-    <ContributionsTemplateTicker settings={tickerSettings} accentColour={brand[400]} />
+    <ContributionsTemplateTicker settings={tickerSettings} accentColour={lifestyle[300]} />
 );
 
 export default UsEoyAppealTicker;

--- a/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealVisual.tsx
+++ b/src/components/modules/banners/usEoyAppeal/components/UsEoyAppealVisual.tsx
@@ -8,6 +8,11 @@ const visualStyles = css`
         ${from.tablet} {
             object-fit: contain;
         }
+
+        ${from.desktop} {
+            margin-top: 1%;
+            height: 105%;
+        }
     }
 `;
 
@@ -15,28 +20,12 @@ const UsEoyAppealVisual: React.FC = () => (
     <ContributionsTemplateVisual
         image={
             <picture css={visualStyles}>
-                {/* mobile, reduced */}
                 <source
                     media="(max-width: 739px)"
-                    srcSet="https://media.guim.co.uk/0c02b0c63cfdb5e73a86bb4c5a4e1e88b17e24c8/0_0_960_432/960.png"
+                    srcSet="https://media.guim.co.uk/53cb3ec24999db33d9957cd5f70223350f4fbba1/0_0_960_432/960.png"
                 />
-                {/* tablet, reduced */}
-                <source
-                    media="(max-width: 979px) and (prefers-reduced-motion: reduce)"
-                    srcSet="https://media.guim.co.uk/3ccf1f7b696e373324fd9a2087a4152b2be9acac/0_0_720_681/720.png"
-                />
-                {/* desktop, reduced */}
-                <source
-                    media="(prefers-reduced-motion: reduce)"
-                    srcSet="https://media.guim.co.uk/1086a07886ece443319926c063468e58c6423106/0_0_720_681/720.png"
-                />
-                {/* tablet + desktop, animated */}
-                <source
-                    media="(prefers-reduced-motion: no-preference)"
-                    srcSet="https://uploads.guim.co.uk/2020/11/27/us-eoy-gt-desktop.gif"
-                />
-                {/* fallback = mobile, reduced */}
-                <img src="https://media.guim.co.uk/0c02b0c63cfdb5e73a86bb4c5a4e1e88b17e24c8/0_0_960_432/960.png" />
+                <source srcSet="https://media.guim.co.uk/cdba08ee85134397376c8ad1a20a78c670431f26/0_122_720_681/720.png" />
+                <img src="https://media.guim.co.uk/53cb3ec24999db33d9957cd5f70223350f4fbba1/0_0_960_432/960.png" />
             </picture>
         }
     />

--- a/src/tests/banners/UsEoyAppealBannerTest.ts
+++ b/src/tests/banners/UsEoyAppealBannerTest.ts
@@ -1,5 +1,5 @@
 import { BannerPageTracking, BannerTargeting, BannerTest } from '../../types/BannerTypes';
-import { usEoyAppealWithVisual } from '../../modules';
+import { usEoyAppeal, usEoyAppealWithVisual } from '../../modules';
 import { TickerCountType, TickerEndType } from '../../lib/variants';
 
 const tickerSettings = {
@@ -15,27 +15,8 @@ const tickerSettings = {
 
 const isLive = true;
 
-export const UsEoyAppealBannerSupporters: BannerTest = {
-    name: 'UsEoyGTAppealSupporters',
-    bannerChannel: 'contributions',
-    testAudience: 'AllExistingSupporters',
-    locations: ['UnitedStates'],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => isLive,
-    minPageViews: 2,
-    variants: [
-        {
-            name: 'control',
-            modulePath: usEoyAppealWithVisual.endpointPath,
-            moduleName: 'UsEoyAppealBannerWithVisual',
-            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-            tickerSettings,
-        },
-    ],
-};
-
-export const UsEoyAppealBannerNonSupporters: BannerTest = {
-    name: 'UsEoyGTAppealNonSupporters',
+export const UsEoyAppealNonSupportersBanner: BannerTest = {
+    name: 'UsEoyAppealNonSupporters',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
     locations: ['UnitedStates'],
@@ -45,6 +26,39 @@ export const UsEoyAppealBannerNonSupporters: BannerTest = {
     variants: [
         {
             name: 'control',
+            modulePath: usEoyAppeal.endpointPath,
+            moduleName: 'UsEoyAppealBanner',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            tickerSettings,
+        },
+        {
+            name: 'variant',
+            modulePath: usEoyAppealWithVisual.endpointPath,
+            moduleName: 'UsEoyAppealBannerWithVisual',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            tickerSettings,
+        },
+    ],
+};
+
+export const UsEoyAppealSupportersBanner: BannerTest = {
+    name: 'UsEoyAppealSupporters',
+    bannerChannel: 'contributions',
+    testAudience: 'AllExistingSupporters',
+    locations: ['UnitedStates'],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => isLive,
+    minPageViews: 2,
+    variants: [
+        {
+            name: 'control',
+            modulePath: usEoyAppeal.endpointPath,
+            moduleName: 'UsEoyAppealBanner',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            tickerSettings,
+        },
+        {
+            name: 'variant',
             modulePath: usEoyAppealWithVisual.endpointPath,
             moduleName: 'UsEoyAppealBannerWithVisual',
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',

--- a/src/tests/banners/bannerTests.ts
+++ b/src/tests/banners/bannerTests.ts
@@ -5,8 +5,8 @@ import {
     channel2BannersAllTestsGenerator,
 } from './ChannelBannerTests';
 import {
-    UsEoyAppealBannerSupporters,
-    UsEoyAppealBannerNonSupporters,
+    UsEoyAppealNonSupportersBanner,
+    UsEoyAppealSupportersBanner,
 } from './UsEoyAppealBannerTest';
 import { cacheAsync } from '../../lib/cache';
 
@@ -14,7 +14,7 @@ const defaultBannerTestGenerator: BannerTestGenerator = () =>
     Promise.resolve([DefaultContributionsBanner]);
 
 const usEoyAppealTestGenerator: BannerTestGenerator = () =>
-    Promise.resolve([UsEoyAppealBannerSupporters, UsEoyAppealBannerNonSupporters]);
+    Promise.resolve([UsEoyAppealSupportersBanner, UsEoyAppealNonSupportersBanner]);
 
 const flattenArray = <T>(array: T[][]): T[] => ([] as T[]).concat(...array);
 


### PR DESCRIPTION
We're going back to the previous US EOY banner, but keeping the "Read more" cta and article count.
From tablet we have new body copy.
The mobile banner does not have body copy.

### Tablet, supporter, article count
![Screen Shot 2020-12-01 at 14 51 31](https://user-images.githubusercontent.com/1513454/100756840-8c577000-33e5-11eb-833d-9e32c7740665.png)

### Tablet, non-supporter, article count
![Screen Shot 2020-12-01 at 14 52 41](https://user-images.githubusercontent.com/1513454/100756846-8f526080-33e5-11eb-8201-7745e74a1094.png)

### Tablet, non-supporter, no article count
![Screen Shot 2020-12-01 at 14 53 01](https://user-images.githubusercontent.com/1513454/100756852-8feaf700-33e5-11eb-99ea-ad809c97f7b8.png)

### Tablet, supporter, no article count
![Screen Shot 2020-12-01 at 14 53 17](https://user-images.githubusercontent.com/1513454/100756855-90838d80-33e5-11eb-945f-1ee34e18dc87.png)

### Mobile
![Screen Shot 2020-12-01 at 14 56 54](https://user-images.githubusercontent.com/1513454/100756860-911c2400-33e5-11eb-9ead-567afcbea9d6.png)


### Tablet, no image
![Screen Shot 2020-12-01 at 15 08 58](https://user-images.githubusercontent.com/1513454/100758321-49969780-33e7-11eb-9e11-1783ec7bb731.png)

### Mobile, no image
![Screen Shot 2020-12-01 at 15 09 18](https://user-images.githubusercontent.com/1513454/100758327-4a2f2e00-33e7-11eb-9ce8-56eaf265c417.png)
