### PR TITLE
US EOY epic reminder

### DIFF
--- a/src/lib/reminderFields.ts
+++ b/src/lib/reminderFields.ts
@@ -26,6 +26,23 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-export const getReminderFields = (reminderFields?: ReminderFields): ReminderFields => {
+const US_EOY_APPEAL_REMINDER_FIELDS: ReminderFields = {
+    reminderCTA: 'Remind me late December',
+    reminderDate: `2020-12-28 00:00:00`,
+    reminderDateAsString: `in late December`,
+};
+
+const US_EOY_APPEAL_REMINDER_CUT_OFF = Date.parse('2020-12-27');
+
+const shouldShowUsEoyReminder = (countryCode?: string): boolean =>
+    countryCode == 'US' && Date.now() < US_EOY_APPEAL_REMINDER_CUT_OFF;
+
+export const getReminderFields = (
+    reminderFields?: ReminderFields,
+    countryCode?: string,
+): ReminderFields => {
+    if (shouldShowUsEoyReminder(countryCode)) {
+        return US_EOY_APPEAL_REMINDER_FIELDS;
+    }
     return !!reminderFields ? reminderFields : buildReminderFields();
 };

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -356,7 +356,10 @@ export const findTestAndVariant = (
         const variant = selectVariant(test, targeting.mvtId || 1);
         const variantWithReminder: Variant = {
             ...variant,
-            showReminderFields: getReminderFields(variant.showReminderFields),
+            showReminderFields: getReminderFields(
+                variant.showReminderFields,
+                targeting.countryCode,
+            ),
         };
 
         return {


### PR DESCRIPTION
Adds a special reminder to the epic for the US end of year campaign.
This feature automatically finishes on 27/12/20.
The reminder email will be sent on 28/12/20.

### CTA
![Screen Shot 2020-12-02 at 10 16 32](https://user-images.githubusercontent.com/1513454/100859815-a184db00-3487-11eb-9f2f-a5d83bf9f3d1.png)

### Clicked
![Screen Shot 2020-12-02 at 10 16 43](https://user-images.githubusercontent.com/1513454/100859817-a2b60800-3487-11eb-87da-c5ae0bb43bcd.png)

### Payload
![Screen Shot 2020-12-02 at 10 17 07](https://user-images.githubusercontent.com/1513454/100859819-a34e9e80-3487-11eb-974a-824344643a23.png)

### Confirmation
![Screen Shot 2020-12-02 at 10 17 25](https://user-images.githubusercontent.com/1513454/100859822-a34e9e80-3487-11eb-9bf2-70e45f510a47.png)
