### PR TITLE
Show article count opt out note on mobile

### DIFF
--- a/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
+++ b/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
@@ -112,11 +112,6 @@ const overlayNote = (type: ArticleCountOptOutType): SerializedStyles => css`
     margin-top: ${space[2]}px;
     ${textSans.xsmall()}
     font-style: italic;
-    display: none;
-
-    ${from.tablet} {
-        display: block;
-    }
 
     a {
         color: ${NOTE_LINK_COLOURS[type]} !important;


### PR DESCRIPTION
## What does this change?
For some reason we weren't showing the note on mobile - now we are!

## Images
<img width="332" alt="Screenshot 2020-12-07 at 15 13 48" src="https://user-images.githubusercontent.com/17720442/101370564-8c51e700-38a1-11eb-86e3-6845d5d34141.png">
