### PR TITLE
Global EOY banner

### DIFF
--- a/src/components/modules/banners/contributionsTemplate/ContributionsTemplateWithVisual.tsx
+++ b/src/components/modules/banners/contributionsTemplate/ContributionsTemplateWithVisual.tsx
@@ -3,12 +3,12 @@ import { css, SerializedStyles } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 
-const banner = (backgroundColour: string): SerializedStyles => css`
+const banner = (cssOverrides?: SerializedStyles): SerializedStyles => css`
+    ${cssOverrides};
     overflow: hidden;
     width: 100%;
     display: flex;
     justify-content: center;
-    background-color: ${backgroundColour};
 `;
 
 const container = css`
@@ -117,7 +117,7 @@ export interface ContributionsTemplateWithVisualProps {
     body: React.ReactElement;
     ticker?: React.ReactElement;
     cta: React.ReactElement;
-    backgroundColour: string;
+    cssOverrides?: SerializedStyles;
 }
 
 const ContributionsTemplateWithVisual: React.FC<ContributionsTemplateWithVisualProps> = ({
@@ -127,10 +127,10 @@ const ContributionsTemplateWithVisual: React.FC<ContributionsTemplateWithVisualP
     body,
     ticker,
     cta,
-    backgroundColour,
+    cssOverrides,
 }: ContributionsTemplateWithVisualProps) => {
     return (
-        <div css={banner(backgroundColour)}>
+        <div css={banner(cssOverrides)}>
             <div css={container}>
                 <div css={visualContainer}>
                     <div css={visualSizer}>

--- a/src/components/modules/banners/contributionsTemplate/ExampleContributionsTemplateWithVisual.tsx
+++ b/src/components/modules/banners/contributionsTemplate/ExampleContributionsTemplateWithVisual.tsx
@@ -134,10 +134,14 @@ const cta = (
     />
 );
 
+const bannerStyles = css`
+    background-color: #dddbd1;
+`;
+
 export const Example: React.FC<BannerProps> = ({}: BannerProps) => {
     return (
         <ContributionsTemplateWithVisual
-            backgroundColour="#DDDBD1"
+            cssOverrides={bannerStyles}
             visual={visual}
             closeButton={closeButton}
             header={header}
@@ -150,7 +154,7 @@ export const Example: React.FC<BannerProps> = ({}: BannerProps) => {
 export const ExampleWithTicker: React.FC<BannerProps> = ({ tickerSettings }: BannerProps) => {
     return (
         <ContributionsTemplateWithVisual
-            backgroundColour="#DDDBD1"
+            cssOverrides={bannerStyles}
             visual={visual}
             closeButton={closeButton}
             header={header}

--- a/src/components/modules/banners/globalEoy/GlobalEoy.stories.tsx
+++ b/src/components/modules/banners/globalEoy/GlobalEoy.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { GlobalEoyBanner } from './GlobalEoy';
+import { props } from '../utils/storybook';
+import { BannerProps } from '../../../../types/BannerTypes';
+
+export default {
+    component: GlobalEoyBanner,
+    title: 'Banners/GlobalEoy',
+    args: props,
+} as Meta;
+
+const Template: Story<BannerProps> = (props: BannerProps) => <GlobalEoyBanner {...props} />;
+
+export const NonSupporters = Template.bind({});
+
+export const Supporters = Template.bind({});
+Supporters.args = {
+    isSupporter: true,
+};

--- a/src/components/modules/banners/globalEoy/GlobalEoy.tsx
+++ b/src/components/modules/banners/globalEoy/GlobalEoy.tsx
@@ -15,7 +15,7 @@ import withCloseable, { CloseableBannerProps } from '../hocs/withCloseable';
 
 const bannerStyles = css`
     background-color: #fff7e5;
-    box-shadow: 0px -1px 0px #052962;
+    border-top: 1px solid #052962;
 `;
 
 const GlobalEoyBanner: React.FC<CloseableBannerProps> = ({

--- a/src/components/modules/banners/globalEoy/GlobalEoy.tsx
+++ b/src/components/modules/banners/globalEoy/GlobalEoy.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import ContributionsTemplateWithVisual from '../contributionsTemplate/ContributionsTemplateWithVisual';
 import GlobalEoyBody from './components/GlobalEoyBody';
 import GlobalEoyVisual from './components/GlobalEoyVisual';
@@ -11,6 +12,11 @@ import {
     OPHAN_COMPONENT_EVENT_CLOSE_CLICK,
 } from './helpers/ophan';
 import withCloseable, { CloseableBannerProps } from '../hocs/withCloseable';
+
+const bannerStyles = css`
+    background-color: #fff7e5;
+    box-shadow: 0px -1px 0px #052962;
+`;
 
 const GlobalEoyBanner: React.FC<CloseableBannerProps> = ({
     isSupporter,
@@ -36,7 +42,7 @@ const GlobalEoyBanner: React.FC<CloseableBannerProps> = ({
 
     return (
         <ContributionsTemplateWithVisual
-            backgroundColour="#FFF7E5"
+            cssOverrides={bannerStyles}
             visual={<GlobalEoyVisual />}
             closeButton={<GlobalEoyCloseButton onClose={onCloseClick} />}
             header={<GlobalEoyHeader />}

--- a/src/components/modules/banners/globalEoy/GlobalEoy.tsx
+++ b/src/components/modules/banners/globalEoy/GlobalEoy.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import ContributionsTemplateWithVisual from '../contributionsTemplate/ContributionsTemplateWithVisual';
+import GlobalEoyBody from './components/GlobalEoyBody';
+import GlobalEoyVisual from './components/GlobalEoyVisual';
+import GlobalEoyCloseButton from './components/GlobalEoyCloseButton';
+import GlobalEoyHeader from './components/GlobalEoyHeader';
+import GlobalEoyCta from './components/GlobalEoyCta';
+import {
+    OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK,
+    OPHAN_COMPONENT_EVENT_READ_MORE_CLICK,
+    OPHAN_COMPONENT_EVENT_CLOSE_CLICK,
+} from './helpers/ophan';
+import withCloseable, { CloseableBannerProps } from '../hocs/withCloseable';
+
+const GlobalEoyBanner: React.FC<CloseableBannerProps> = ({
+    isSupporter,
+    onClose,
+    submitComponentEvent,
+    tracking,
+    countryCode,
+    numArticles,
+    hasOptedOutOfArticleCount,
+}: CloseableBannerProps) => {
+    const onContributeClick = (): void =>
+        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK);
+
+    const onReadMoreClick = (): void => {
+        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_READ_MORE_CLICK);
+        onClose();
+    };
+
+    const onCloseClick = (): void => {
+        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_CLOSE_CLICK);
+        onClose();
+    };
+
+    return (
+        <ContributionsTemplateWithVisual
+            backgroundColour="#FFF7E5"
+            visual={<GlobalEoyVisual />}
+            closeButton={<GlobalEoyCloseButton onClose={onCloseClick} />}
+            header={<GlobalEoyHeader />}
+            body={
+                <GlobalEoyBody
+                    isSupporter={!!isSupporter}
+                    numArticles={numArticles || 0}
+                    hasOptedOutOfArticleCount={!!hasOptedOutOfArticleCount}
+                />
+            }
+            cta={
+                <GlobalEoyCta
+                    onContributeClick={onContributeClick}
+                    onReadMoreClick={onReadMoreClick}
+                    tracking={tracking}
+                    countryCode={countryCode || ''}
+                    isSupporter={!!isSupporter}
+                />
+            }
+        />
+    );
+};
+
+const wrapped = withCloseable(GlobalEoyBanner, 'contributions');
+
+export { wrapped as GlobalEoyBanner };

--- a/src/components/modules/banners/globalEoy/GlobalEoy.tsx
+++ b/src/components/modules/banners/globalEoy/GlobalEoy.tsx
@@ -19,7 +19,6 @@ const bannerStyles = css`
 `;
 
 const GlobalEoyBanner: React.FC<CloseableBannerProps> = ({
-    isSupporter,
     onClose,
     submitComponentEvent,
     tracking,
@@ -48,9 +47,9 @@ const GlobalEoyBanner: React.FC<CloseableBannerProps> = ({
             header={<GlobalEoyHeader />}
             body={
                 <GlobalEoyBody
-                    isSupporter={!!isSupporter}
                     numArticles={numArticles || 0}
                     hasOptedOutOfArticleCount={!!hasOptedOutOfArticleCount}
+                    countryCode={countryCode}
                 />
             }
             cta={
@@ -59,7 +58,6 @@ const GlobalEoyBanner: React.FC<CloseableBannerProps> = ({
                     onReadMoreClick={onReadMoreClick}
                     tracking={tracking}
                     countryCode={countryCode || ''}
-                    isSupporter={!!isSupporter}
                 />
             }
         />

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
@@ -40,7 +40,7 @@ const GlobalEoyBody: React.FC<GlobalEoyBodyProps> = ({
                                     <ArticleCountOptOut
                                         numArticles={numArticles}
                                         nextWord=" articles"
-                                        type="us-eoy-banner"
+                                        type="global-eoy-banner"
                                     />{' '}
                                     in the past year. We value your support and hope you’ll consider
                                     a year-end gift.

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
@@ -2,19 +2,20 @@ import React from 'react';
 import { Hide } from '@guardian/src-layout';
 import ContributionsTemplateBody from '../../contributionsTemplate/ContributionsTemplateBody';
 import { ArticleCountOptOut } from '../../../shared/ArticleCountOptOut';
+import { getLocalCurrencySymbol } from '../../../../../lib/geolocation';
 
 interface GlobalEoyBodyProps {
-    isSupporter: boolean;
     numArticles: number;
     hasOptedOutOfArticleCount: boolean;
+    countryCode?: string;
 }
 
 const MIN_NUM_ARTICLES_TO_SHOW_ARTICLE_COUNT = 5;
 
 const GlobalEoyBody: React.FC<GlobalEoyBodyProps> = ({
-    isSupporter,
     hasOptedOutOfArticleCount,
     numArticles,
+    countryCode,
 }: GlobalEoyBodyProps) => {
     const shouldShowArticleCount =
         !hasOptedOutOfArticleCount && numArticles > MIN_NUM_ARTICLES_TO_SHOW_ARTICLE_COUNT;
@@ -24,62 +25,33 @@ const GlobalEoyBody: React.FC<GlobalEoyBodyProps> = ({
             copy={
                 <>
                     <Hide above="tablet">
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor
-                        sit ame lorem ipsum dolor
+                        With 2021 offering new hope, we commit to another year of quality reporting.
+                        Support us from {getLocalCurrencySymbol(countryCode)}1.
                     </Hide>
                     <Hide below="tablet">
-                        {isSupporter ? (
-                            shouldShowArticleCount ? (
-                                // supporter + article count
-                                <>
-                                    Trump’s presidency is ending, but America’s systemic challenges
-                                    remain. From broken healthcare to corrosive racial inequality,
-                                    from rapacious corporations to a climate crisis, the need for
-                                    fact-based reporting that highlights injustice and offers
-                                    solutions is as great as ever. You&apos;ve read{' '}
-                                    <ArticleCountOptOut
-                                        numArticles={numArticles}
-                                        nextWord=" articles"
-                                        type="global-eoy-banner"
-                                    />{' '}
-                                    in the past year. We value your support and hope you’ll consider
-                                    a year-end gift.
-                                </>
-                            ) : (
-                                // supporter + no article count
-                                <>
-                                    Trump’s presidency is ending, but America’s systemic challenges
-                                    remain. From broken healthcare to corrosive racial inequality,
-                                    from rapacious corporations to a climate crisis, the need for
-                                    fact-based reporting that highlights injustice and offers
-                                    solutions is as great as ever. We value your support and hope
-                                    you’ll consider a year-end gift.
-                                </>
-                            )
-                        ) : shouldShowArticleCount ? (
-                            // non-supporter + article count
+                        {shouldShowArticleCount ? (
                             <>
-                                Trump’s presidency is ending, but America’s systemic challenges
-                                remain. From a broken healthcare system to corrosive racial
-                                inequality, from rapacious corporations to a climate crisis, the
-                                need for robust, fact-based reporting that highlights injustice and
-                                offers solutions is as great as ever. You&apos;ve read{' '}
+                                In an extraordinary 2020, our independent journalism was powered by
+                                more than a million supporters. Thanks to you, we provided vital
+                                news and analysis for everyone, led by science and truth.
+                                You&apos;ve read{' '}
                                 <ArticleCountOptOut
                                     numArticles={numArticles}
                                     nextWord=" articles"
-                                    type="us-eoy-banner"
+                                    type="global-eoy-banner"
                                 />{' '}
-                                in the past year. We hope you’ll consider a year-end gift.
+                                in the last year. With 2021 offering renewed hope, we commit to
+                                another year of high-impact reporting. Support us from{' '}
+                                {getLocalCurrencySymbol(countryCode)}1.
                             </>
                         ) : (
-                            // non-supporter + no article count
                             <>
-                                Trump’s presidency is ending, but America’s systemic challenges
-                                remain. From a broken healthcare system to corrosive racial
-                                inequality, from rapacious corporations to a climate crisis, the
-                                need for robust, fact-based reporting that highlights injustice and
-                                offers solutions is as great as ever. We hope you’ll consider a
-                                year-end gift.
+                                In an extraordinary 2020, our independent journalism was powered by
+                                more than a million supporters. Thanks to you, we provided vital
+                                news and analysis for everyone, led by science and truth. With 2021
+                                offering renewed hope, we commit to another year of high-impact
+                                reporting. Support us from as little as{' '}
+                                {getLocalCurrencySymbol(countryCode)}1.
                             </>
                         )}
                     </Hide>

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Hide } from '@guardian/src-layout';
+import ContributionsTemplateBody from '../../contributionsTemplate/ContributionsTemplateBody';
+import { ArticleCountOptOut } from '../../../shared/ArticleCountOptOut';
+
+interface GlobalEoyBodyProps {
+    isSupporter: boolean;
+    numArticles: number;
+    hasOptedOutOfArticleCount: boolean;
+}
+
+const MIN_NUM_ARTICLES_TO_SHOW_ARTICLE_COUNT = 5;
+
+const GlobalEoyBody: React.FC<GlobalEoyBodyProps> = ({
+    isSupporter,
+    hasOptedOutOfArticleCount,
+    numArticles,
+}: GlobalEoyBodyProps) => {
+    const shouldShowArticleCount =
+        !hasOptedOutOfArticleCount && numArticles > MIN_NUM_ARTICLES_TO_SHOW_ARTICLE_COUNT;
+
+    return (
+        <ContributionsTemplateBody
+            copy={
+                <>
+                    <Hide above="tablet">
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor
+                        sit ame lorem ipsum dolor
+                    </Hide>
+                    <Hide below="tablet">
+                        {isSupporter ? (
+                            shouldShowArticleCount ? (
+                                // supporter + article count
+                                <>
+                                    Trump’s presidency is ending, but America’s systemic challenges
+                                    remain. From broken healthcare to corrosive racial inequality,
+                                    from rapacious corporations to a climate crisis, the need for
+                                    fact-based reporting that highlights injustice and offers
+                                    solutions is as great as ever. You&apos;ve read{' '}
+                                    <ArticleCountOptOut
+                                        numArticles={numArticles}
+                                        nextWord=" articles"
+                                        type="us-eoy-banner"
+                                    />{' '}
+                                    in the past year. We value your support and hope you’ll consider
+                                    a year-end gift.
+                                </>
+                            ) : (
+                                // supporter + no article count
+                                <>
+                                    Trump’s presidency is ending, but America’s systemic challenges
+                                    remain. From broken healthcare to corrosive racial inequality,
+                                    from rapacious corporations to a climate crisis, the need for
+                                    fact-based reporting that highlights injustice and offers
+                                    solutions is as great as ever. We value your support and hope
+                                    you’ll consider a year-end gift.
+                                </>
+                            )
+                        ) : shouldShowArticleCount ? (
+                            // non-supporter + article count
+                            <>
+                                Trump’s presidency is ending, but America’s systemic challenges
+                                remain. From a broken healthcare system to corrosive racial
+                                inequality, from rapacious corporations to a climate crisis, the
+                                need for robust, fact-based reporting that highlights injustice and
+                                offers solutions is as great as ever. You&apos;ve read{' '}
+                                <ArticleCountOptOut
+                                    numArticles={numArticles}
+                                    nextWord=" articles"
+                                    type="us-eoy-banner"
+                                />{' '}
+                                in the past year. We hope you’ll consider a year-end gift.
+                            </>
+                        ) : (
+                            // non-supporter + no article count
+                            <>
+                                Trump’s presidency is ending, but America’s systemic challenges
+                                remain. From a broken healthcare system to corrosive racial
+                                inequality, from rapacious corporations to a climate crisis, the
+                                need for robust, fact-based reporting that highlights injustice and
+                                offers solutions is as great as ever. We hope you’ll consider a
+                                year-end gift.
+                            </>
+                        )}
+                    </Hide>
+                </>
+            }
+        />
+    );
+};
+
+export default GlobalEoyBody;

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyCloseButton.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyCloseButton.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import { Button } from '@guardian/src-button';
+import { neutral, brand } from '@guardian/src-foundations/palette';
+import { SvgCross } from '@guardian/src-icons';
+import ContributionsTemplateCloseButton from '../../contributionsTemplate/ContributionsTemplateCloseButton';
+
+const closeButtonStyles = css`
+    color: ${neutral[7]};
+    border-color: ${neutral[7]};
+
+    &:hover {
+        background-color: #f3eade;
+    }
+`;
+
+const Roundel = (
+    <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M18.0001 0C8.05903 0 0 8.05873 0 18C0 27.9412 8.05903 36 18.0001 36C27.9412 36 36 27.9412 36 18C36 8.05873 27.9412 0 18.0001 0Z"
+            fill={brand[400]}
+        />
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M28.8837 18.9866L27.0361 19.8125V28.3322C25.9968 29.3221 23.3408 30.8651 20.8003 31.3954V30.7765V29.6149V19.6268L18.8372 18.9332V18.4187H28.8837V18.9866ZM19.6745 4.79612C19.6745 4.79612 19.6365 4.79577 19.6178 4.79577C15.4528 4.79577 13.07 10.4117 13.1901 17.9868C13.07 25.5895 15.4528 31.2052 19.6178 31.2052C19.6365 31.2052 19.6745 31.205 19.6745 31.205V31.7887C13.4303 32.2062 4.90449 27.5543 5.02457 18.0142C4.90449 8.44674 13.4303 3.79484 19.6745 4.21235V4.79612ZM20.9301 4.18604C23.3719 4.55897 26.1626 6.1627 27.2092 7.30124V12.5581H26.6079L20.9301 4.76617V4.18604Z"
+            fill="white"
+        />
+    </svg>
+);
+
+interface GlobalEoyCloseButtonProps {
+    onClose: () => void;
+}
+
+const GlobalEoyCloseButton: React.FC<GlobalEoyCloseButtonProps> = ({
+    onClose,
+}: GlobalEoyCloseButtonProps) => (
+    <ContributionsTemplateCloseButton
+        closeButton={
+            <Button
+                onClick={onClose}
+                cssOverrides={closeButtonStyles}
+                size="small"
+                priority="tertiary"
+                icon={<SvgCross />}
+                hideLabel
+            >
+                Close
+            </Button>
+        }
+        roundel={Roundel}
+    />
+);
+
+export default GlobalEoyCloseButton;

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
@@ -7,14 +7,13 @@ import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../../../lib/tra
 
 const BASE_LANDING_PAGE_URL = 'https://support.theguardian.com/contribute';
 const IMPACT_REPORT_LINK =
-    'https://www.theguardian.com/us-news/2020/nov/24/guardian-fundraiser-end-of-year-2020-contribute?INTCMP=us_eoy_banner';
+    'https://www.theguardian.com/info/ng-interactive/2020/dec/21/the-guardian-in-2020?INTCMP=global_eoy_banner';
 
 interface GlobalEoyCtaProps {
     onContributeClick: () => void;
     onReadMoreClick: () => void;
     tracking: BannerTracking;
     countryCode: string;
-    isSupporter: boolean;
 }
 
 const GlobalEoyCta: React.FC<GlobalEoyCtaProps> = ({
@@ -22,58 +21,53 @@ const GlobalEoyCta: React.FC<GlobalEoyCtaProps> = ({
     onReadMoreClick,
     tracking,
     countryCode,
-    isSupporter,
 }: GlobalEoyCtaProps) => {
-    let landingPageUrl = addRegionIdAndTrackingParamsToSupportUrl(
+    const landingPageUrl = addRegionIdAndTrackingParamsToSupportUrl(
         BASE_LANDING_PAGE_URL,
         tracking,
         countryCode,
     );
 
-    if (isSupporter) {
-        landingPageUrl += '&selected-contribution-type=ONE_OFF';
-    }
-
     return (
         <ContributionsTemplateCta
             primaryCta={
                 <div>
-                    <Hide above="tablet">
+                    <Hide above="desktop">
                         <LinkButton href={landingPageUrl} onClick={onContributeClick} size="small">
-                            {isSupporter ? 'Support' : 'Contribute'}
+                            Support us
                         </LinkButton>
                     </Hide>
-                    <Hide below="tablet">
+                    <Hide below="desktop">
                         <LinkButton
                             href={landingPageUrl}
                             onClick={onContributeClick}
                             size="default"
                         >
-                            {isSupporter ? 'Support us again' : 'Support the Guardian'}
+                            Support the Guardian
                         </LinkButton>
                     </Hide>
                 </div>
             }
             secondaryCta={
                 <div>
-                    <Hide above="tablet">
+                    <Hide above="desktop">
                         <LinkButton
                             href={IMPACT_REPORT_LINK}
                             onClick={onReadMoreClick}
                             size="small"
                             priority="tertiary"
                         >
-                            Read more
+                            Learn more
                         </LinkButton>
                     </Hide>
-                    <Hide below="tablet">
+                    <Hide below="desktop">
                         <LinkButton
                             href={IMPACT_REPORT_LINK}
                             onClick={onReadMoreClick}
                             size="default"
                             priority="tertiary"
                         >
-                            Read more
+                            Read our 2020 highlights
                         </LinkButton>
                     </Hide>
                 </div>

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Hide } from '@guardian/src-layout';
+import { LinkButton } from '@guardian/src-button';
+import ContributionsTemplateCta from '../../contributionsTemplate/ContributionsTemplateCta';
+import { BannerTracking } from '../../../../../types/BannerTypes';
+import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../../../lib/tracking';
+
+const BASE_LANDING_PAGE_URL = 'https://support.theguardian.com/contribute';
+const IMPACT_REPORT_LINK =
+    'https://www.theguardian.com/us-news/2020/nov/24/guardian-fundraiser-end-of-year-2020-contribute?INTCMP=us_eoy_banner';
+
+interface GlobalEoyCtaProps {
+    onContributeClick: () => void;
+    onReadMoreClick: () => void;
+    tracking: BannerTracking;
+    countryCode: string;
+    isSupporter: boolean;
+}
+
+const GlobalEoyCta: React.FC<GlobalEoyCtaProps> = ({
+    onContributeClick,
+    onReadMoreClick,
+    tracking,
+    countryCode,
+    isSupporter,
+}: GlobalEoyCtaProps) => {
+    let landingPageUrl = addRegionIdAndTrackingParamsToSupportUrl(
+        BASE_LANDING_PAGE_URL,
+        tracking,
+        countryCode,
+    );
+
+    if (isSupporter) {
+        landingPageUrl += '&selected-contribution-type=ONE_OFF';
+    }
+
+    return (
+        <ContributionsTemplateCta
+            primaryCta={
+                <div>
+                    <Hide above="tablet">
+                        <LinkButton href={landingPageUrl} onClick={onContributeClick} size="small">
+                            {isSupporter ? 'Support' : 'Contribute'}
+                        </LinkButton>
+                    </Hide>
+                    <Hide below="tablet">
+                        <LinkButton
+                            href={landingPageUrl}
+                            onClick={onContributeClick}
+                            size="default"
+                        >
+                            {isSupporter ? 'Support us again' : 'Support the Guardian'}
+                        </LinkButton>
+                    </Hide>
+                </div>
+            }
+            secondaryCta={
+                <div>
+                    <Hide above="tablet">
+                        <LinkButton
+                            href={IMPACT_REPORT_LINK}
+                            onClick={onReadMoreClick}
+                            size="small"
+                            priority="tertiary"
+                        >
+                            Read more
+                        </LinkButton>
+                    </Hide>
+                    <Hide below="tablet">
+                        <LinkButton
+                            href={IMPACT_REPORT_LINK}
+                            onClick={onReadMoreClick}
+                            size="default"
+                            priority="tertiary"
+                        >
+                            Read more
+                        </LinkButton>
+                    </Hide>
+                </div>
+            }
+        />
+    );
+};
+export default GlobalEoyCta;

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyHeader.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyHeader.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Hide } from '@guardian/src-layout';
+import ContributionsTemplateHeader from '../../contributionsTemplate/ContributionsTemplateHeader';
+
+const GlobalEoyHeader: React.FC = () => (
+    <ContributionsTemplateHeader
+        copy={
+            <>
+                <Hide above="tablet">Lorem ipsum dolor sit amet, consectetur</Hide>
+                <Hide below="tablet">
+                    America’s future:
+                    <br />
+                    what’s next?
+                </Hide>
+            </>
+        }
+    />
+);
+
+export default GlobalEoyHeader;

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyHeader.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyHeader.tsx
@@ -1,20 +1,8 @@
 import React from 'react';
-import { Hide } from '@guardian/src-layout';
 import ContributionsTemplateHeader from '../../contributionsTemplate/ContributionsTemplateHeader';
 
 const GlobalEoyHeader: React.FC = () => (
-    <ContributionsTemplateHeader
-        copy={
-            <>
-                <Hide above="tablet">Lorem ipsum dolor sit amet, consectetur</Hide>
-                <Hide below="tablet">
-                    America’s future:
-                    <br />
-                    what’s next?
-                </Hide>
-            </>
-        }
-    />
+    <ContributionsTemplateHeader copy={<>Show your support for high-impact reporting</>} />
 );
 
 export default GlobalEoyHeader;

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyVisual.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyVisual.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import { from } from '@guardian/src-foundations/mq';
+import ContributionsTemplateVisual from '../../contributionsTemplate/ContributionsTemplateVisual';
+
+const visualStyles = css`
+    img {
+        ${from.tablet} {
+            object-fit: contain;
+        }
+
+        ${from.desktop} {
+            margin-top: 1%;
+            height: 105%;
+        }
+    }
+`;
+
+const GlobalEoyVisual: React.FC = () => (
+    <ContributionsTemplateVisual
+        image={
+            <picture css={visualStyles}>
+                <source
+                    media="(max-width: 739px)"
+                    srcSet="https://media.guim.co.uk/e901715a478eef5f0515b990ebecca76f8572280/0_0_960_432/960.png"
+                />
+                <source srcSet="https://media.guim.co.uk/fa23ce83c3455c9b3c12edddf6a138d5151cdb06/0_0_720_681/720.png" />
+                <img src="https://media.guim.co.uk/e901715a478eef5f0515b990ebecca76f8572280/0_0_960_432/960.png" />
+            </picture>
+        }
+    />
+);
+
+export default GlobalEoyVisual;

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyVisual.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyVisual.tsx
@@ -7,11 +7,19 @@ const visualStyles = css`
     img {
         ${from.tablet} {
             object-fit: contain;
+            transform: scale(1.1);
         }
 
         ${from.desktop} {
-            margin-top: 1%;
-            height: 105%;
+            transform: scale(1.2);
+        }
+
+        ${from.leftCol} {
+            transform: scale(1.3);
+        }
+
+        ${from.wide} {
+            transform: scale(1.4);
         }
     }
 `;
@@ -22,10 +30,10 @@ const GlobalEoyVisual: React.FC = () => (
             <picture css={visualStyles}>
                 <source
                     media="(max-width: 739px)"
-                    srcSet="https://media.guim.co.uk/e901715a478eef5f0515b990ebecca76f8572280/0_0_960_432/960.png"
+                    srcSet="https://media.guim.co.uk/e9012f30db4814101252a0f76ec653c80e3d81b4/0_0_960_432/960.jpg"
                 />
-                <source srcSet="https://media.guim.co.uk/fa23ce83c3455c9b3c12edddf6a138d5151cdb06/0_0_720_681/720.png" />
-                <img src="https://media.guim.co.uk/e901715a478eef5f0515b990ebecca76f8572280/0_0_960_432/960.png" />
+                <source srcSet="https://media.guim.co.uk/3b2c4eb1ef1e354a851fe7ea5a547266ceaba981/0_0_720_681/720.jpg" />
+                <img src="https://media.guim.co.uk/e9012f30db4814101252a0f76ec653c80e3d81b4/0_0_960_432/960.jpg" />
             </picture>
         }
     />

--- a/src/components/modules/banners/globalEoy/helpers/ophan.ts
+++ b/src/components/modules/banners/globalEoy/helpers/ophan.ts
@@ -1,0 +1,38 @@
+import { OphanComponentEvent } from '../../../../../types/OphanTypes';
+
+const OPHAN_COMPONENT_ID_CONTRIBUTE = 'global-eoy-2020-contribute';
+const OPHAN_COMPONENT_ID_NOT_NOW = 'global-eoy-2020-not-now';
+const OPHAN_COMPONENT_ID_READ_MORE = 'global-eoy-2020-read-more';
+const OPHAN_COMPONENT_ID_CLOSE = 'global-eoy-2020-close';
+
+export const OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK: OphanComponentEvent = {
+    component: {
+        componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+        id: OPHAN_COMPONENT_ID_CONTRIBUTE,
+    },
+    action: 'CLICK',
+};
+
+export const OPHAN_COMPONENT_EVENT_NOT_NOW_CLICK: OphanComponentEvent = {
+    component: {
+        componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+        id: OPHAN_COMPONENT_ID_NOT_NOW,
+    },
+    action: 'CLICK',
+};
+
+export const OPHAN_COMPONENT_EVENT_READ_MORE_CLICK: OphanComponentEvent = {
+    component: {
+        componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+        id: OPHAN_COMPONENT_ID_READ_MORE,
+    },
+    action: 'CLICK',
+};
+
+export const OPHAN_COMPONENT_EVENT_CLOSE_CLICK: OphanComponentEvent = {
+    component: {
+        componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+        id: OPHAN_COMPONENT_ID_CLOSE,
+    },
+    action: 'CLICK',
+};

--- a/src/components/modules/banners/usEoyAppeal/UsEoyAppealWithVisual.tsx
+++ b/src/components/modules/banners/usEoyAppeal/UsEoyAppealWithVisual.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import ContributionsTemplateWithVisual from '../contributionsTemplate/ContributionsTemplateWithVisual';
 import UsEoyAppealBody from './components/UsEoyAppealBody';
 import UsEoyAppealVisual from './components/UsEoyAppealVisual';
@@ -12,6 +13,10 @@ import {
     OPHAN_COMPONENT_EVENT_CLOSE_CLICK,
 } from './helpers/ophan';
 import withCloseable, { CloseableBannerProps } from '../hocs/withCloseable';
+
+const bannerStyles = css`
+    background-color: #dddbd1;
+`;
 
 const UsEoyAppealBannerWithVisual: React.FC<CloseableBannerProps> = ({
     isSupporter,
@@ -38,7 +43,7 @@ const UsEoyAppealBannerWithVisual: React.FC<CloseableBannerProps> = ({
 
     return (
         <ContributionsTemplateWithVisual
-            backgroundColour="#DDDBD1"
+            cssOverrides={bannerStyles}
             visual={<UsEoyAppealVisual />}
             closeButton={<UsEoyAppealCloseButton onClose={onCloseClick} />}
             header={<UsEoyAppealHeader />}

--- a/src/components/modules/shared/ArticleCountOptOut.tsx
+++ b/src/components/modules/shared/ArticleCountOptOut.tsx
@@ -49,7 +49,7 @@ const overlayContainer = (type: ArticleCountOptOutType): SerializedStyles => css
     }
 `;
 
-export type ArticleCountOptOutType = 'epic' | 'banner' | 'us-eoy-banner';
+export type ArticleCountOptOutType = 'epic' | 'banner' | 'us-eoy-banner' | 'global-eoy-banner';
 
 export interface ArticleCountOptOutProps {
     numArticles: number;

--- a/src/components/modules/shared/ArticleCountOptOutOverlay.stories.tsx
+++ b/src/components/modules/shared/ArticleCountOptOutOverlay.stories.tsx
@@ -36,6 +36,6 @@ UsEoyAppealBanner.args = {
 };
 
 export const GlobalEoyAppealBanner = Template.bind({});
-UsEoyAppealBanner.args = {
+GlobalEoyAppealBanner.args = {
     type: 'global-eoy-banner',
 };

--- a/src/components/modules/shared/ArticleCountOptOutOverlay.stories.tsx
+++ b/src/components/modules/shared/ArticleCountOptOutOverlay.stories.tsx
@@ -34,3 +34,8 @@ export const UsEoyAppealBanner = Template.bind({});
 UsEoyAppealBanner.args = {
     type: 'us-eoy-banner',
 };
+
+export const GlobalEoyAppealBanner = Template.bind({});
+UsEoyAppealBanner.args = {
+    type: 'global-eoy-banner',
+};

--- a/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
+++ b/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
@@ -39,7 +39,7 @@ const BORDER_COLOURS = {
     epic: 'transparent',
     banner: brandAltLine.primary,
     ['us-eoy-banner']: neutral[0],
-    ['global-eoy-banner']: neutral[0],
+    ['global-eoy-banner']: '#052962',
 };
 
 const BUTTON_THEMES = {

--- a/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
+++ b/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
@@ -9,7 +9,7 @@ import {
 } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
-import { Button } from '@guardian/src-button';
+import { Button, buttonDefault as buttonDefaultTheme } from '@guardian/src-button';
 import { SvgCross } from '@guardian/src-icons';
 import { ThemeProvider } from 'emotion-theming';
 import {
@@ -25,24 +25,28 @@ const COLOURS = {
     epic: 'white',
     banner: brandAltText.primary,
     ['us-eoy-banner']: neutral[0],
+    ['global-eoy-banner']: neutral[0],
 };
 
 const BACKGROUND_COLOURS = {
     epic: brand[400],
     banner: brandAltBackground.primary,
     ['us-eoy-banner']: '#E7D4B9',
+    ['global-eoy-banner']: '#FFF7E5',
 };
 
 const BORDER_COLOURS = {
     epic: 'transparent',
     banner: brandAltLine.primary,
     ['us-eoy-banner']: neutral[0],
+    ['global-eoy-banner']: neutral[0],
 };
 
 const BUTTON_THEMES = {
     epic: brandTheme,
     banner: brandAltTheme,
     ['us-eoy-banner']: buttonBrandAltTheme,
+    ['global-eoy-banner']: buttonDefaultTheme,
 };
 
 const overlayContainer = (type: ArticleCountOptOutType): SerializedStyles => css`
@@ -94,6 +98,7 @@ const NOTE_LINK_COLOURS = {
     epic: neutral[100],
     banner: brandAltText.primary,
     ['us-eoy-banner']: neutral[0],
+    ['global-eoy-banner']: neutral[0],
 };
 
 const usEoyBannerOverrides = css`
@@ -106,6 +111,7 @@ const BUTTON_OVERRIDES = {
     epic: css``,
     banner: css``,
     ['us-eoy-banner']: usEoyBannerOverrides,
+    ['global-eoy-banner']: css``,
 };
 
 const overlayNote = (type: ArticleCountOptOutType): SerializedStyles => css`

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -51,6 +51,11 @@ export const usEoyAppealWithVisual: ModuleInfo = getDefaultModuleInfo(
     'banners/usEoyAppeal/UsEoyAppealWithVisual',
 );
 
+export const globalEoy: ModuleInfo = getDefaultModuleInfo(
+    'global-eoy-banner',
+    'banners/globalEoy/GlobalEoy',
+);
+
 export const moduleInfos: ModuleInfo[] = [
     epic,
     epicACAbove,
@@ -60,4 +65,5 @@ export const moduleInfos: ModuleInfo[] = [
     guardianWeekly,
     usEoyAppeal,
     usEoyAppealWithVisual,
+    globalEoy,
 ];

--- a/src/tests/banners/GlobalEoyBannerTest.ts
+++ b/src/tests/banners/GlobalEoyBannerTest.ts
@@ -6,27 +6,62 @@ import {
 } from '../../types/BannerTypes';
 import { contributionsBanner, globalEoy } from '../../modules';
 
-const DEPLOY_TIMESTAMP = Date.parse('2020-12-29');
+//TODO
+// const DEPLOY_TIMESTAMP = Date.parse('2020-12-29');
+const DEPLOY_TIMESTAMP = Date.parse('2020-11-29');
 
-const control: BannerVariant = {
+const control = (body: string): BannerVariant => ({
     name: 'control',
     modulePath: contributionsBanner.endpointPath,
     moduleName: 'ContributionsBanner',
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     bannerContent: {
         heading: 'We chose a different approach. Will you support it?',
-        messageText:
-            'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
-        highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
+        messageText: body,
+        highlightedText:
+            'Support the Guardian today from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
         cta: {
             text: 'Support the guardian',
             baseUrl: 'https://support.theguardian.com/contribute',
         },
     },
+});
+
+export const GlobalEoyNonSupportersACBanner: BannerTest = {
+    name: 'GlobalEoyNonSupporters__AC',
+    bannerChannel: 'contributions',
+    testAudience: 'AllNonSupporters',
+    locations: [
+        'GBPCountries',
+        'AUDCountries',
+        'EURCountries',
+        'International',
+        'NZDCountries',
+        'Canada',
+    ],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) =>
+        Date.now() >= DEPLOY_TIMESTAMP,
+    minPageViews: 2,
+    articlesViewedSettings: {
+        minViews: 5,
+        periodInWeeks: 52,
+    },
+    variants: [
+        control(
+            'We believe everyone deserves to read quality, independent, factual news and authoritative, calm analysis – that’s why we keep Guardian journalism open to all. The free press has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. You’ve read %%ARTICLE_COUNT%% articles in the last year. Every contribution, however big or small, is so valuable for our future – in times of crisis and beyond.',
+        ),
+        {
+            name: 'variant',
+            modulePath: globalEoy.endpointPath,
+            moduleName: 'GlobalEoyBanner',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+        },
+    ],
 };
 
-export const GlobalEoyNonSupportersBanner: BannerTest = {
-    name: 'GlobalEoyNonSupporters',
+export const GlobalEoyNonSupportersNoACBanner: BannerTest = {
+    name: 'GlobalEoyNonSupporters__NoAC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
     locations: [
@@ -42,34 +77,9 @@ export const GlobalEoyNonSupportersBanner: BannerTest = {
         Date.now() >= DEPLOY_TIMESTAMP,
     minPageViews: 2,
     variants: [
-        control,
-        {
-            name: 'variant',
-            modulePath: globalEoy.endpointPath,
-            moduleName: 'GlobalEoyBanner',
-            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-        },
-    ],
-};
-
-export const GlobalEoySupportersBanner: BannerTest = {
-    name: 'GlobalEoySupporters',
-    bannerChannel: 'contributions',
-    testAudience: 'AllExistingSupporters',
-    locations: [
-        'GBPCountries',
-        'AUDCountries',
-        'EURCountries',
-        'International',
-        'NZDCountries',
-        'Canada',
-    ],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) =>
-        Date.now() >= DEPLOY_TIMESTAMP,
-    minPageViews: 2,
-    variants: [
-        control,
+        control(
+            'We believe everyone deserves to read quality, independent, factual news and authoritative, calm analysis – that’s why we keep Guardian journalism open to all. The free press has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. Every contribution, however big or small, is so valuable for our future – in times of crisis and beyond.',
+        ),
         {
             name: 'variant',
             modulePath: globalEoy.endpointPath,

--- a/src/tests/banners/GlobalEoyBannerTest.ts
+++ b/src/tests/banners/GlobalEoyBannerTest.ts
@@ -1,0 +1,80 @@
+import {
+    BannerPageTracking,
+    BannerTargeting,
+    BannerTest,
+    BannerVariant,
+} from '../../types/BannerTypes';
+import { contributionsBanner, globalEoy } from '../../modules';
+
+const DEPLOY_TIMESTAMP = Date.parse('2020-12-29');
+
+const control: BannerVariant = {
+    name: 'control',
+    modulePath: contributionsBanner.endpointPath,
+    moduleName: 'ContributionsBanner',
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    bannerContent: {
+        heading: 'We chose a different approach. Will you support it?',
+        messageText:
+            'We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.',
+        highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
+        cta: {
+            text: 'Support the guardian',
+            baseUrl: 'https://support.theguardian.com/contribute',
+        },
+    },
+};
+
+export const GlobalEoyNonSupportersBanner: BannerTest = {
+    name: 'GlobalEoyNonSupporters',
+    bannerChannel: 'contributions',
+    testAudience: 'AllNonSupporters',
+    locations: [
+        'GBPCountries',
+        'AUDCountries',
+        'EURCountries',
+        'International',
+        'NZDCountries',
+        'Canada',
+    ],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) =>
+        Date.now() >= DEPLOY_TIMESTAMP,
+    minPageViews: 2,
+    variants: [
+        control,
+        {
+            name: 'variant',
+            modulePath: globalEoy.endpointPath,
+            moduleName: 'GlobalEoyBanner',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+        },
+    ],
+};
+
+export const GlobalEoySupportersBanner: BannerTest = {
+    name: 'GlobalEoySupporters',
+    bannerChannel: 'contributions',
+    testAudience: 'AllExistingSupporters',
+    locations: [
+        'GBPCountries',
+        'AUDCountries',
+        'EURCountries',
+        'International',
+        'NZDCountries',
+        'Canada',
+    ],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) =>
+        Date.now() >= DEPLOY_TIMESTAMP,
+    minPageViews: 2,
+    variants: [
+        control,
+        {
+            name: 'variant',
+            modulePath: globalEoy.endpointPath,
+            moduleName: 'GlobalEoyBanner',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+        },
+    ],
+};

--- a/src/tests/banners/GlobalEoyBannerTest.ts
+++ b/src/tests/banners/GlobalEoyBannerTest.ts
@@ -6,9 +6,7 @@ import {
 } from '../../types/BannerTypes';
 import { contributionsBanner, globalEoy } from '../../modules';
 
-//TODO
-// const DEPLOY_TIMESTAMP = Date.parse('2020-12-29');
-const DEPLOY_TIMESTAMP = Date.parse('2020-11-29');
+const DEPLOY_TIMESTAMP = Date.parse('2020-12-29');
 
 const control = (body: string): BannerVariant => ({
     name: 'control',

--- a/src/tests/banners/bannerTests.ts
+++ b/src/tests/banners/bannerTests.ts
@@ -8,6 +8,7 @@ import {
     UsEoyAppealNonSupportersBanner,
     UsEoyAppealSupportersBanner,
 } from './UsEoyAppealBannerTest';
+import { GlobalEoyNonSupportersBanner, GlobalEoySupportersBanner } from './GlobalEoyBannerTest';
 import { cacheAsync } from '../../lib/cache';
 
 const defaultBannerTestGenerator: BannerTestGenerator = () =>
@@ -16,10 +17,14 @@ const defaultBannerTestGenerator: BannerTestGenerator = () =>
 const usEoyAppealTestGenerator: BannerTestGenerator = () =>
     Promise.resolve([UsEoyAppealSupportersBanner, UsEoyAppealNonSupportersBanner]);
 
+const globalEoyTestGenerator: BannerTestGenerator = () =>
+    Promise.resolve([GlobalEoySupportersBanner, GlobalEoyNonSupportersBanner]);
+
 const flattenArray = <T>(array: T[][]): T[] => ([] as T[]).concat(...array);
 
 const testGenerators: BannerTestGenerator[] = [
     usEoyAppealTestGenerator,
+    globalEoyTestGenerator,
     channel1BannersAllTestsGenerator,
     channel2BannersAllTestsGenerator,
     defaultBannerTestGenerator,

--- a/src/tests/banners/bannerTests.ts
+++ b/src/tests/banners/bannerTests.ts
@@ -8,7 +8,10 @@ import {
     UsEoyAppealNonSupportersBanner,
     UsEoyAppealSupportersBanner,
 } from './UsEoyAppealBannerTest';
-import { GlobalEoyNonSupportersBanner, GlobalEoySupportersBanner } from './GlobalEoyBannerTest';
+import {
+    GlobalEoyNonSupportersACBanner,
+    GlobalEoyNonSupportersNoACBanner,
+} from './GlobalEoyBannerTest';
 import { cacheAsync } from '../../lib/cache';
 
 const defaultBannerTestGenerator: BannerTestGenerator = () =>
@@ -18,7 +21,7 @@ const usEoyAppealTestGenerator: BannerTestGenerator = () =>
     Promise.resolve([UsEoyAppealSupportersBanner, UsEoyAppealNonSupportersBanner]);
 
 const globalEoyTestGenerator: BannerTestGenerator = () =>
-    Promise.resolve([GlobalEoySupportersBanner, GlobalEoyNonSupportersBanner]);
+    Promise.resolve([GlobalEoyNonSupportersACBanner, GlobalEoyNonSupportersNoACBanner]);
 
 const flattenArray = <T>(array: T[][]): T[] => ([] as T[]).concat(...array);
 


### PR DESCRIPTION
We're A/B testing this against the control yellow banner. Because it has article count, we have to run it as 2 separate tests. This is ok because the dashboard will ignore anything after the `__` in the test name, so the data will be combined.

### Mobile
<img width="326" alt="Screen Shot 2020-12-22 at 14 38 25" src="https://user-images.githubusercontent.com/1513454/102900195-d8855580-4463-11eb-8f5c-f6e701b304c4.png">

### Desktop, no AC
<img width="1027" alt="Screen Shot 2020-12-22 at 14 37 43" src="https://user-images.githubusercontent.com/1513454/102900192-d7542880-4463-11eb-8ef5-62fa0e035497.png">

### Tablet, no AC
<img width="568" alt="Screen Shot 2020-12-22 at 14 38 04" src="https://user-images.githubusercontent.com/1513454/102900194-d7ecbf00-4463-11eb-9395-d8cb51b146c8.png">

### Desktop, AC
<img width="905" alt="Screen Shot 2020-12-22 at 14 36 28" src="https://user-images.githubusercontent.com/1513454/102900177-d58a6500-4463-11eb-9755-3e1d3f17ccb2.png">

### Tablet, AC
<img width="571" alt="Screen Shot 2020-12-22 at 14 36 45" src="https://user-images.githubusercontent.com/1513454/102900187-d6bb9200-4463-11eb-9cb9-0a371c07d572.png">

### Control, AC
<img width="887" alt="Screen Shot 2020-12-22 at 14 34 31" src="https://user-images.githubusercontent.com/1513454/102900162-d28f7480-4463-11eb-8bfc-3b40ae3de3a6.png">

### Control, no AC
<img width="887" alt="Screen Shot 2020-12-22 at 14 34 48" src="https://user-images.githubusercontent.com/1513454/102900173-d4f1ce80-4463-11eb-8c86-f5b8e364deb5.png">

