### PR TITLE
Add payment method icons to banner template

### DIFF
--- a/src/components/modules/banners/contributionsTemplate/ContributionsTemplateCta.tsx
+++ b/src/components/modules/banners/contributionsTemplate/ContributionsTemplateCta.tsx
@@ -17,6 +17,12 @@ const container = css`
     }
 `;
 
+const paymentMethods = css`
+    display: block;
+    max-height: 1.25rem;
+    margin-top: ${space[2]}px;
+`;
+
 interface ContributionsTemplateCtaProps {
     primaryCta: React.ReactElement;
     secondaryCta: React.ReactElement;
@@ -26,10 +32,17 @@ const ContributionsTemplateCta: React.FC<ContributionsTemplateCtaProps> = ({
     primaryCta,
     secondaryCta,
 }: ContributionsTemplateCtaProps) => (
-    <div css={container}>
-        {primaryCta}
-        {secondaryCta}
-    </div>
+    <>
+        <div css={container}>
+            {primaryCta}
+            {secondaryCta}
+        </div>
+        <img
+            src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+            alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+            css={paymentMethods}
+        />
+    </>
 );
 
 export default ContributionsTemplateCta;

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
@@ -31,10 +31,10 @@ const GlobalEoyBody: React.FC<GlobalEoyBodyProps> = ({
                     <Hide below="tablet">
                         {shouldShowArticleCount ? (
                             <>
-                                In an extraordinary 2020, our independent journalism was powered by
-                                more than a million supporters. Thanks to you, we provided vital
-                                news and analysis for everyone, led by science and truth.
-                                You&apos;ve read{' '}
+                                In the extraordinary year that was 2020, our independent journalism
+                                was powered by more than a million supporters. Thanks to you, we
+                                provided vital news and analysis for everyone, led by science and
+                                truth. You&apos;ve read{' '}
                                 <ArticleCountOptOut
                                     numArticles={numArticles}
                                     nextWord=" articles"
@@ -46,11 +46,11 @@ const GlobalEoyBody: React.FC<GlobalEoyBodyProps> = ({
                             </>
                         ) : (
                             <>
-                                In an extraordinary 2020, our independent journalism was powered by
-                                more than a million supporters. Thanks to you, we provided vital
-                                news and analysis for everyone, led by science and truth. With 2021
-                                offering renewed hope, we commit to another year of high-impact
-                                reporting. Support us from as little as{' '}
+                                In the extraordinary year that was 2020, our independent journalism
+                                was powered by more than a million supporters. Thanks to you, we
+                                provided vital news and analysis for everyone, led by science and
+                                truth. With 2021 offering renewed hope, we commit to another year of
+                                high-impact reporting. Support us from as little as{' '}
                                 {getLocalCurrencySymbol(countryCode)}1.
                             </>
                         )}

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
@@ -41,7 +41,7 @@ const GlobalEoyBody: React.FC<GlobalEoyBodyProps> = ({
                                     type="global-eoy-banner"
                                 />{' '}
                                 in the last year. With 2021 offering renewed hope, we commit to
-                                another year of high-impact reporting. Support us from{' '}
+                                another year of high-impact reporting. Support us from as little as{' '}
                                 {getLocalCurrencySymbol(countryCode)}1.
                             </>
                         ) : (

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
@@ -57,7 +57,7 @@ const GlobalEoyCta: React.FC<GlobalEoyCtaProps> = ({
                             size="small"
                             priority="tertiary"
                         >
-                            Learn more
+                            2020 highlights
                         </LinkButton>
                     </Hide>
                     <Hide below="desktop">
@@ -67,7 +67,7 @@ const GlobalEoyCta: React.FC<GlobalEoyCtaProps> = ({
                             size="default"
                             priority="tertiary"
                         >
-                            Read our 2020 highlights
+                            2020 highlights
                         </LinkButton>
                     </Hide>
                 </div>


### PR DESCRIPTION
The payment method logos are known to improve conversion, so we've added them below the ctas, as with the yellow banner.
Also made a small copy update to the global banner on desktop.

### Global EOY banner:

![Screen Shot 2020-12-29 at 13 31 21](https://user-images.githubusercontent.com/1513454/103289402-ffe99e80-49de-11eb-9d6d-7e18d3af4ad6.png)

![Screen Shot 2020-12-29 at 13 31 52](https://user-images.githubusercontent.com/1513454/103289408-024bf880-49df-11eb-9bba-f2611e7860b0.png)

### US EOY banner:

![Screen Shot 2020-12-29 at 11 16 11](https://user-images.githubusercontent.com/1513454/103280255-d7a27580-49c7-11eb-9e74-648f9b1ea3b4.png)

![Screen Shot 2020-12-29 at 11 15 43](https://user-images.githubusercontent.com/1513454/103280303-f86acb00-49c7-11eb-9f3a-db96d1d93f97.png)

