### PR TITLE
Epic ticker amount / shorter copy

### DIFF
--- a/src/components/modules/epics/ContributionsEpicTicker.tsx
+++ b/src/components/modules/epics/ContributionsEpicTicker.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
 import { useHasBeenSeen, HasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import useTicker from '../../../hooks/useTicker';
@@ -79,19 +78,11 @@ const filledProgressStyles = (end: number, runningTotal: number, total: number):
         background-color: ${palette.brandAlt.main};
     `;
 
-const goalReachedGoalContainerStyles = css`
-    display: none;
-    ${from.tablet} {
-        display: initial;
-    }
-`;
-
-const goalContainerStyles = (goalReached: boolean): SerializedStyles => css`
+const goalContainerStyles: SerializedStyles = css`
     position: absolute;
     right: 0;
     bottom: ${progressBarHeight + 5}px;
     text-align: right;
-    ${goalReached && goalReachedGoalContainerStyles}
 `;
 
 const goalMarkerStyles = (transform: string): SerializedStyles => css`
@@ -167,7 +158,7 @@ export const ContributionsEpicTicker: React.FC<Props> = ({ settings, total, goal
                     </div>
                 </div>
 
-                <div css={goalContainerStyles(goalReached)}>
+                <div css={goalContainerStyles}>
                     <div css={totalCountStyles}>
                         {goalReached
                             ? `${currencySymbol}${total.toLocaleString()}`

--- a/src/tests/banners/UsEoyAppealBannerTest.ts
+++ b/src/tests/banners/UsEoyAppealBannerTest.ts
@@ -8,7 +8,7 @@ const tickerSettings = {
     currencySymbol: '$',
     copy: {
         countLabel: 'contributed',
-        goalReachedPrimary: "It's not too late to give!",
+        goalReachedPrimary: 'You can still give!',
         goalReachedSecondary: '',
     },
 };


### PR DESCRIPTION
### Shorter banner ticker copy:
(smallest desktop)
![Screen Shot 2021-01-04 at 09 52 18](https://user-images.githubusercontent.com/1513454/103522664-9c45f200-4e72-11eb-88f4-31980f542d25.png)
(smallest mobile)
![Screen Shot 2021-01-04 at 09 52 32](https://user-images.githubusercontent.com/1513454/103522667-9cde8880-4e72-11eb-9ef6-616637a24414.png)

### Show amount on epic:
(smallest mobile)
![Screen Shot 2021-01-04 at 09 52 44](https://user-images.githubusercontent.com/1513454/103522671-9e0fb580-4e72-11eb-9176-523d1c257451.png)
