### PR TITLE
adjust open component event to better match equivalent non-AMP events

### DIFF
--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -63,6 +63,9 @@ export const buildCampaignCode = (test: Test, variant: Variant): string =>
 export const buildBannerCampaignCode = (test: BannerTest, variant: BannerVariant): string =>
     `${test.name}_${variant.name}`;
 
+export const buildAmpEpicCampaignCode = (testName: string, variantName: string): string =>
+    `AMP__${testName}__${variantName}`;
+
 export const createClickEventFromTracking = (
     tracking: BannerTracking,
     componentId: string,

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -448,16 +448,20 @@ app.get(
             const countryCode = req.header('X-GU-GeoIP-Country-Code');
             const ampVariantAssignments = getAmpVariantAssignments(req);
             const epic = await ampEpic(ampVariantAssignments, countryCode);
+            const campaignCode = `AMP__${epic.testName}__${epic.variantName}`;
             const { viewId, ampViewId } = req.query;
             const ophanComponentEvent: OphanComponentEvent = {
                 component: {
                     componentType: 'ACQUISITIONS_EPIC',
+                    products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+                    campaignCode: campaignCode,
+                    id: campaignCode,
                 },
-                action: 'VIEW',
                 abTest: {
                     name: epic.testName,
                     variant: epic.variantName,
                 },
+                action: 'VIEW',
             };
 
             const ophanUrl = `https://ophan.theguardian.com/img/2?viewId=${viewId}&ampViewId=${ampViewId}&componentEvent=${encodeURI(

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -11,7 +11,11 @@ import cors from 'cors';
 import { validateBannerPayload, validateEpicPayload } from './lib/validation';
 import { Debug, findTestAndVariant, Result, Variant } from './lib/variants';
 import { getArticleViewCountForWeeks } from './lib/history';
-import { buildBannerCampaignCode, buildCampaignCode } from './lib/tracking';
+import {
+    buildAmpEpicCampaignCode,
+    buildBannerCampaignCode,
+    buildCampaignCode,
+} from './lib/tracking';
 import {
     errorHandling as errorHandlingMiddleware,
     logging as loggingMiddleware,
@@ -448,7 +452,7 @@ app.get(
             const countryCode = req.header('X-GU-GeoIP-Country-Code');
             const ampVariantAssignments = getAmpVariantAssignments(req);
             const epic = await ampEpic(ampVariantAssignments, countryCode);
-            const campaignCode = `AMP__${epic.testName}__${epic.variantName}`;
+            const campaignCode = buildAmpEpicCampaignCode(epic.testName, epic.variantName);
             const { viewId, ampViewId } = req.query;
             const ophanComponentEvent: OphanComponentEvent = {
                 component: {

--- a/src/tests/amp/ampEpic.ts
+++ b/src/tests/amp/ampEpic.ts
@@ -2,13 +2,16 @@ import { getLocalCurrencySymbol } from '../../lib/geolocation';
 import { AMPEpic } from './ampEpicModels';
 import { selectAmpEpic } from './ampEpicTests';
 import { AmpVariantAssignments } from '../../lib/ampVariantAssignments';
+import { buildAmpEpicCampaignCode } from '../../lib/tracking';
 
 async function ampFallbackEpic(geolocation?: string): Promise<AMPEpic> {
-    const campaignCode = 'AMP__FALLBACK__CONTROL';
+    const testName = 'FALLBACK';
+    const variantName = 'CONTROL';
+    const campaignCode = buildAmpEpicCampaignCode(testName, variantName);
     const currencySymbol = getLocalCurrencySymbol(geolocation);
     return {
-        testName: 'FALLBACK',
-        variantName: 'CONTROL',
+        testName: testName,
+        variantName: variantName,
         heading: "Since you're here ...",
         paragraphs: [
             '... we have a small favour to ask. Millions turn to the Guardian every day for vital, independent, quality journalism. Readers in 180 countries around the world now support us financially.',

--- a/src/tests/amp/ampEpicTests.ts
+++ b/src/tests/amp/ampEpicTests.ts
@@ -6,6 +6,7 @@ import { AMPEpic, AmpEpicTest } from './ampEpicModels';
 import { replaceNonArticleCountPlaceholders } from '../../lib/placeholders';
 import { ampTicker } from './ampTicker';
 import { AmpVariantAssignments } from '../../lib/ampVariantAssignments';
+import { buildAmpEpicCampaignCode } from '../../lib/tracking';
 
 /**
  * Fetches AMP epic tests configuration from the tool.
@@ -81,6 +82,7 @@ export const selectAmpEpicTestAndVariant = async (
         );
 
         if (variant) {
+            const campaignCode = buildAmpEpicCampaignCode(test.name, variant.name);
             const epicData = {
                 testName: test.name,
                 variantName: variant.name,
@@ -97,8 +99,8 @@ export const selectAmpEpicTestAndVariant = async (
                     url: variant.cta
                         ? variant.cta.baseUrl
                         : 'https://support.theguardian.com/contribute',
-                    componentId: `AMP__${test.name}__${variant.name}`,
-                    campaignCode: `AMP__${test.name}__${variant.name}`,
+                    componentId: campaignCode,
+                    campaignCode: campaignCode,
                 },
             };
 


### PR DESCRIPTION
This adds `products`, `campaignCode`, and `id` to the Ophan component.