### PR TITLE
Use LB for health checks

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -416,6 +416,7 @@
                     "Ref": "ASGLaunchConfigC00AF12B"
                 },
                 "HealthCheckType": "ELB",
+                "HealthCheckGracePeriod": 60,
                 "Tags": [
                 {
                     "Key": "App",

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -415,6 +415,7 @@
                 "LaunchConfigurationName": {
                     "Ref": "ASGLaunchConfigC00AF12B"
                 },
+                "HealthCheckType": "ELB",
                 "Tags": [
                 {
                     "Key": "App",


### PR DESCRIPTION
Currently, the ASG does not replace an instance if the load balancer health check fails (i.e. if the node server dies but the ec2 instance is still ok).

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-healthchecktype