### PR TITLE
Increase ulimit

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -375,7 +375,7 @@
                                 {
                                     "Ref": "S3Key"
                                 },
-                                " app.tar.gz\ndocker load < app.tar.gz\ndocker run --ulimit nofile=2048:2048 --env-file .env -p 3030:3030 --log-driver=awslogs --log-opt awslogs-group=",
+                                " app.tar.gz\ndocker load < app.tar.gz\ndocker run --ulimit nofile=8192:8192 --env-file .env -p 3030:3030 --log-driver=awslogs --log-opt awslogs-group=",
                                 {
                                     "Ref": "Stack"
                                 },

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -375,7 +375,7 @@
                                 {
                                     "Ref": "S3Key"
                                 },
-                                " app.tar.gz\ndocker load < app.tar.gz\ndocker run             --env-file .env             -p 3030:3030             --log-driver=awslogs             --log-opt awslogs-group=",
+                                " app.tar.gz\ndocker load < app.tar.gz\ndocker run --ulimit nofile=2048:2048 --env-file .env -p 3030:3030 --log-driver=awslogs --log-opt awslogs-group=",
                                 {
                                     "Ref": "Stack"
                                 },


### PR DESCRIPTION
dotcom-components (node server) is sometimes reaching the socket limit and failing with:
```
Error: accept EMFILE
    at TCP.onconnection (net.js:1536:24)
Emitted 'error' event on Server instance at:
    at TCP.onconnection (net.js:1536:10) {
  errno: 'EMFILE',
  code: 'EMFILE',
  syscall: 'accept'
```
The default value is 1024