### PR TITLE
Fetch timeouts

### DIFF
--- a/src/api/contributionsApi.ts
+++ b/src/api/contributionsApi.ts
@@ -12,7 +12,7 @@ const configuredEpicTestsUrl = isProd
 export const fetchDefaultEpicContent = async (): Promise<Variant> => {
     const startTime = new Date().getTime();
 
-    const response = await fetch(defaultEpicUrl);
+    const response = await fetch(defaultEpicUrl, { timeout: 1000 * 20 });
     if (!response.ok) {
         throw new Error(
             `Encountered a non-ok response when fetching default epic: ${response.status}`,
@@ -53,7 +53,7 @@ export const fetchDefaultEpicContent = async (): Promise<Variant> => {
 };
 
 export const fetchConfiguredEpicTests = async (): Promise<EpicTests> => {
-    const response = await fetch(configuredEpicTestsUrl);
+    const response = await fetch(configuredEpicTestsUrl, { timeout: 1000 * 20 });
     if (!response.ok) {
         throw new Error(
             `Encountered a non-ok response when fetching configured epic tests: ${response.status}`,

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -59,12 +59,11 @@ describe('cache', () => {
 
         const [reset, fetchData] = cacheAsync(fn, 60, 'test4');
 
-        await expect(fetchData()).rejects;
+        await expect(fetchData()).rejects.toEqual(
+            new Error('Failed to make initial request for test4: Error: ERROR'),
+        );
 
         expect(fn).toHaveBeenCalledTimes(1);
-
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const x = await Promise.resolve(''); // necessary for running test locally, for some reason
 
         jest.runOnlyPendingTimers(); // fast-forward to retry
 

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -63,6 +63,9 @@ describe('cache', () => {
 
         expect(fn).toHaveBeenCalledTimes(1);
 
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const x = await Promise.resolve(''); // necessary for running test locally, for some reason
+
         jest.runOnlyPendingTimers(); // fast-forward to retry
 
         expect(fn).toHaveBeenCalledTimes(2);

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -44,7 +44,7 @@ export const cacheAsync = <T>(
                     setTimeout(async () => {
                         try {
                             cache[key] = await fn();
-                            scheduleRefresh(ms);
+                            scheduleRefresh(ttlSec * 1000);
                         } catch (err) {
                             console.log(`Error refreshing cached value for key ${key}: ${err}`);
                             scheduleRefresh(retryIntervalMs);

--- a/src/lib/fetchTickerData.ts
+++ b/src/lib/fetchTickerData.ts
@@ -35,7 +35,7 @@ export const fetchTickerDataCached = async (
     tickerSettings: TickerSettings,
 ): Promise<TickerData> => {
     const fetchForType = (): Promise<TickerData> => {
-        return fetch(tickerUrl(tickerSettings.countType))
+        return fetch(tickerUrl(tickerSettings.countType), { timeout: 1000 * 20 })
             .then(response => checkForErrors(response))
             .then(response => response.json())
             .then(parse);

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -84,7 +84,6 @@ const [, fetchConfiguredEpicTestsCached] = cacheAsync(
     fetchConfiguredEpicTests,
     60,
     'fetchConfiguredEpicTests',
-    true,
 );
 
 const buildEpicData = async (

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -84,6 +84,7 @@ const [, fetchConfiguredEpicTestsCached] = cacheAsync(
     fetchConfiguredEpicTests,
     60,
     'fetchConfiguredEpicTests',
+    true,
 );
 
 const buildEpicData = async (

--- a/src/tests/amp/ampEpicTests.ts
+++ b/src/tests/amp/ampEpicTests.ts
@@ -19,7 +19,7 @@ const url = isProd
     : 'https://gu-contributions-public.s3-eu-west-1.amazonaws.com/epic/CODE/amp-epic-tests.json';
 
 const fetchAmpEpicTests = (): Promise<AmpEpicTest[]> =>
-    fetch(url)
+    fetch(url, { timeout: 1000 * 20 })
         .then(response => response.json())
         .then(data => {
             return data.tests;

--- a/src/tests/banners/ChannelBannerTests.ts
+++ b/src/tests/banners/ChannelBannerTests.ts
@@ -62,7 +62,7 @@ export const createTestsGeneratorForChannel = (
     const bannerContentUrl = `${BannerContentBaseUrl}${channelFile}`;
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     return () =>
-        fetch(bannerContentUrl)
+        fetch(bannerContentUrl, { timeout: 1000 * 20 })
             .then(response => response.json())
             .then(json => json['tests'])
             .then(tests => {


### PR DESCRIPTION
We've had a couple of instances failing to refresh the epic tests cache. We don't know what's caused this.

This PR hopefully makes it a bit more robust:
1. add a timeout for fetch requests
2. fix scheduling interval after a failure (it was using 20secs forever, rather than going back to the original interval)

I did try to change the epic tests cache to be pre-warmed on startup but it made the tests break in strange ways. So I've parked this for now