### PR TITLE
Include US in global EOY banner

### DIFF
--- a/src/components/modules/banners/contributionsTemplate/ContributionsTemplateCta.tsx
+++ b/src/components/modules/banners/contributionsTemplate/ContributionsTemplateCta.tsx
@@ -25,7 +25,7 @@ const paymentMethods = css`
 
 interface ContributionsTemplateCtaProps {
     primaryCta: React.ReactElement;
-    secondaryCta: React.ReactElement;
+    secondaryCta: React.ReactElement | null;
 }
 
 const ContributionsTemplateCta: React.FC<ContributionsTemplateCtaProps> = ({

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
@@ -48,7 +48,7 @@ const GlobalEoyCta: React.FC<GlobalEoyCtaProps> = ({
                     </Hide>
                 </div>
             }
-            secondaryCta={
+            secondaryCta={ countryCode === 'US' ? null : (
                 <div>
                     <Hide above="desktop">
                         <LinkButton
@@ -71,7 +71,7 @@ const GlobalEoyCta: React.FC<GlobalEoyCtaProps> = ({
                         </LinkButton>
                     </Hide>
                 </div>
-            }
+            )}
         />
     );
 };

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
@@ -48,30 +48,32 @@ const GlobalEoyCta: React.FC<GlobalEoyCtaProps> = ({
                     </Hide>
                 </div>
             }
-            secondaryCta={ countryCode === 'US' ? null : (
-                <div>
-                    <Hide above="desktop">
-                        <LinkButton
-                            href={IMPACT_REPORT_LINK}
-                            onClick={onReadMoreClick}
-                            size="small"
-                            priority="tertiary"
-                        >
-                            2020 highlights
-                        </LinkButton>
-                    </Hide>
-                    <Hide below="desktop">
-                        <LinkButton
-                            href={IMPACT_REPORT_LINK}
-                            onClick={onReadMoreClick}
-                            size="default"
-                            priority="tertiary"
-                        >
-                            2020 highlights
-                        </LinkButton>
-                    </Hide>
-                </div>
-            )}
+            secondaryCta={
+                countryCode.toUpperCase() === 'US' ? null : (
+                    <div>
+                        <Hide above="desktop">
+                            <LinkButton
+                                href={IMPACT_REPORT_LINK}
+                                onClick={onReadMoreClick}
+                                size="small"
+                                priority="tertiary"
+                            >
+                                2020 highlights
+                            </LinkButton>
+                        </Hide>
+                        <Hide below="desktop">
+                            <LinkButton
+                                href={IMPACT_REPORT_LINK}
+                                onClick={onReadMoreClick}
+                                size="default"
+                                priority="tertiary"
+                            >
+                                2020 highlights
+                            </LinkButton>
+                        </Hide>
+                    </div>
+                )
+            }
         />
     );
 };

--- a/src/tests/banners/GlobalEoyBannerTest.ts
+++ b/src/tests/banners/GlobalEoyBannerTest.ts
@@ -7,14 +7,6 @@ export const GlobalEoyNonSupportersACBanner: BannerTest = {
     name: 'GlobalEoyNonSupporters__AC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
-    locations: [
-        'GBPCountries',
-        'AUDCountries',
-        'EURCountries',
-        'International',
-        'NZDCountries',
-        'Canada',
-    ],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) =>
         Date.now() >= DEPLOY_TIMESTAMP,
@@ -37,14 +29,6 @@ export const GlobalEoyNonSupportersNoACBanner: BannerTest = {
     name: 'GlobalEoyNonSupporters__NoAC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
-    locations: [
-        'GBPCountries',
-        'AUDCountries',
-        'EURCountries',
-        'International',
-        'NZDCountries',
-        'Canada',
-    ],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) =>
         Date.now() >= DEPLOY_TIMESTAMP,


### PR DESCRIPTION
The only difference is that the US audience should not see the secondary CTA

### Non-US
<img width="1329" alt="Screen Shot 2021-01-15 at 11 13 59" src="https://user-images.githubusercontent.com/1513454/104718764-5404ba80-5723-11eb-9dcd-ce4651cd809b.png">

### US
<img width="1329" alt="Screen Shot 2021-01-15 at 11 14 17" src="https://user-images.githubusercontent.com/1513454/104718776-5830d800-5723-11eb-832e-f6d4c2e7f4d4.png">
