### PR TITLE
Get tests using s3 api

### DIFF
--- a/custom-cfn.yaml
+++ b/custom-cfn.yaml
@@ -21,7 +21,8 @@ Resources:
               - s3:GetObject
             Resource:
               - !Sub arn:aws:s3:::support-admin-console/${Stage}/banner-deploy/*
-              - !Sub arn:aws:s3:::gu-contributions-public/${Stage}/*
+              - !Sub arn:aws:s3:::gu-contributions-public/epic/${Stage}/*
+              - !Sub arn:aws:s3:::gu-contributions-public/banner/${Stage}/*
       Roles:
         - !Ref Role
 

--- a/custom-cfn.yaml
+++ b/custom-cfn.yaml
@@ -21,6 +21,7 @@ Resources:
               - s3:GetObject
             Resource:
               - !Sub arn:aws:s3:::support-admin-console/${Stage}/banner-deploy/*
+              - !Sub arn:aws:s3:::gu-contributions-public/${Stage}/*
       Roles:
         - !Ref Role
 

--- a/src/api/contributionsApi.ts
+++ b/src/api/contributionsApi.ts
@@ -1,13 +1,10 @@
 import fetch from 'node-fetch';
 import { EpicTests, Variant } from '../lib/variants';
 import { isProd } from '../lib/env';
+import { fetchS3Data } from '../utils/S3';
 
 const defaultEpicUrl =
     'https://interactive.guim.co.uk/docsdata/1fy0JolB1bf1IEFLHGHfUYWx-niad7vR9K954OpTOvjE.json';
-
-const configuredEpicTestsUrl = isProd
-    ? 'https://support.theguardian.com/epic-tests.json'
-    : 'https://support.code.dev-theguardian.com/epic-tests.json';
 
 export const fetchDefaultEpicContent = async (): Promise<Variant> => {
     const startTime = new Date().getTime();
@@ -53,12 +50,8 @@ export const fetchDefaultEpicContent = async (): Promise<Variant> => {
 };
 
 export const fetchConfiguredEpicTests = async (): Promise<EpicTests> => {
-    const response = await fetch(configuredEpicTestsUrl, { timeout: 1000 * 20 });
-    if (!response.ok) {
-        throw new Error(
-            `Encountered a non-ok response when fetching configured epic tests: ${response.status}`,
-        );
-    }
-
-    return response.json();
+    return fetchS3Data(
+        'gu-contributions-public',
+        `epic/${isProd ? 'PROD' : 'CODE'}/epic-tests.json`,
+    ).then(JSON.parse);
 };

--- a/src/tests/amp/ampEpicTests.ts
+++ b/src/tests/amp/ampEpicTests.ts
@@ -1,12 +1,12 @@
 import { inCountryGroups } from '../../lib/geolocation';
 import { isProd } from '../../lib/env';
-import fetch from 'node-fetch';
 import { cacheAsync } from '../../lib/cache';
 import { AMPEpic, AmpEpicTest } from './ampEpicModels';
 import { replaceNonArticleCountPlaceholders } from '../../lib/placeholders';
 import { ampTicker } from './ampTicker';
 import { AmpVariantAssignments } from '../../lib/ampVariantAssignments';
 import { buildAmpEpicCampaignCode } from '../../lib/tracking';
+import { fetchS3Data } from '../../utils/S3';
 
 /**
  * Fetches AMP epic tests configuration from the tool.
@@ -14,13 +14,9 @@ import { buildAmpEpicCampaignCode } from '../../lib/tracking';
  * So each test will have a single variant.
  */
 
-const url = isProd
-    ? 'https://gu-contributions-public.s3-eu-west-1.amazonaws.com/epic/PROD/amp-epic-tests.json'
-    : 'https://gu-contributions-public.s3-eu-west-1.amazonaws.com/epic/CODE/amp-epic-tests.json';
-
 const fetchAmpEpicTests = (): Promise<AmpEpicTest[]> =>
-    fetch(url, { timeout: 1000 * 20 })
-        .then(response => response.json())
+    fetchS3Data('gu-contributions-public', `epic/${isProd ? 'PROD' : 'CODE'}/amp-epic-tests.json`)
+        .then(JSON.parse)
         .then(data => {
             return data.tests;
         });

--- a/src/tests/banners/ChannelBannerTests.ts
+++ b/src/tests/banners/ChannelBannerTests.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import {
     BannerChannel,
     BannerTemplate,
@@ -11,10 +10,7 @@ import {
 import { OphanComponentType, OphanProduct } from '../../types/OphanTypes';
 import { isProd } from '../../lib/env';
 import { contributionsBanner, digiSubs, guardianWeekly } from '../../modules';
-
-const BannerContentBaseUrl = isProd
-    ? 'https://gu-contributions-public.s3-eu-west-1.amazonaws.com/banner/PROD/'
-    : 'https://gu-contributions-public.s3-eu-west-1.amazonaws.com/banner/CODE/';
+import { fetchS3Data } from '../../utils/S3';
 
 const BannerChannelFiles: { [key in BannerChannel]: string } = {
     contributions: 'banner-tests.json',
@@ -59,11 +55,11 @@ export const createTestsGeneratorForChannel = (
     bannerChannel: BannerChannel,
 ): BannerTestGenerator => {
     const channelFile = BannerChannelFiles[bannerChannel];
-    const bannerContentUrl = `${BannerContentBaseUrl}${channelFile}`;
+    const key = `banner/${isProd ? 'PROD' : 'CODE'}/${channelFile}`;
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     return () =>
-        fetch(bannerContentUrl, { timeout: 1000 * 20 })
-            .then(response => response.json())
+        fetchS3Data('gu-contributions-public', key)
+            .then(JSON.parse)
             .then(json => json['tests'])
             .then(tests => {
                 return tests.map(


### PR DESCRIPTION
## What does this change?
Use s3 api to `getObject` the test json files instead of going via a regular fetch (we already do this for the banner deploy timestamps). 

A few things to think about:
- Are we happy with the default AWS timeout settings? (I'm currently trying to find what these are)
- Should we consolidate our buckets? I don't think we need gu-contributions-public anymore

I tested running locally with postman, but we should definitely test in CODE!

## Follow ups
- stop admin-console making the files public
- remove the endpoints from fastly 