### PR TITLE
Remove json ophan response

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -480,7 +480,6 @@ app.get(
                 res.json({
                     ophanUrl: ophanUrl,
                     ophanResponseStatus: ophanResponse.status,
-                    ophanResponseJson: ophanResponse.json(),
                 });
             });
         } catch (error) {


### PR DESCRIPTION
## What does this change?
Remove the `ophanJsonResponse` from the `epic_view` end point. This causes errors when ophan doesn't return a body (which it doesn't for valid responses!)
