### PR TITLE
Update global eoy banner for inauguration

### DIFF
--- a/src/components/modules/banners/globalEoy/GlobalEoy.tsx
+++ b/src/components/modules/banners/globalEoy/GlobalEoy.tsx
@@ -24,7 +24,7 @@ const GlobalEoyBanner: React.FC<CloseableBannerProps> = ({
     tracking,
     countryCode,
     numArticles,
-    hasOptedOutOfArticleCount,
+    content,
 }: CloseableBannerProps) => {
     const onContributeClick = (): void =>
         submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK);
@@ -39,29 +39,34 @@ const GlobalEoyBanner: React.FC<CloseableBannerProps> = ({
         onClose();
     };
 
-    return (
-        <ContributionsTemplateWithVisual
-            cssOverrides={bannerStyles}
-            visual={<GlobalEoyVisual />}
-            closeButton={<GlobalEoyCloseButton onClose={onCloseClick} />}
-            header={<GlobalEoyHeader />}
-            body={
-                <GlobalEoyBody
-                    numArticles={numArticles || 0}
-                    hasOptedOutOfArticleCount={!!hasOptedOutOfArticleCount}
-                    countryCode={countryCode}
-                />
-            }
-            cta={
-                <GlobalEoyCta
-                    onContributeClick={onContributeClick}
-                    onReadMoreClick={onReadMoreClick}
-                    tracking={tracking}
-                    countryCode={countryCode || ''}
-                />
-            }
-        />
-    );
+    if (content && content.mobileMessageText) {
+        return (
+            <ContributionsTemplateWithVisual
+                cssOverrides={bannerStyles}
+                visual={<GlobalEoyVisual />}
+                closeButton={<GlobalEoyCloseButton onClose={onCloseClick} />}
+                header={<GlobalEoyHeader />}
+                body={
+                    <GlobalEoyBody
+                        numArticles={numArticles || 0}
+                        countryCode={countryCode}
+                        body={content.messageText}
+                        mobileBody={content.mobileMessageText}
+                    />
+                }
+                cta={
+                    <GlobalEoyCta
+                        onContributeClick={onContributeClick}
+                        onReadMoreClick={onReadMoreClick}
+                        tracking={tracking}
+                        countryCode={countryCode || ''}
+                    />
+                }
+            />
+        );
+    }
+
+    return null;
 };
 
 const wrapped = withCloseable(GlobalEoyBanner, 'contributions');

--- a/src/components/modules/banners/globalEoy/GlobalEoy.tsx
+++ b/src/components/modules/banners/globalEoy/GlobalEoy.tsx
@@ -8,7 +8,6 @@ import GlobalEoyHeader from './components/GlobalEoyHeader';
 import GlobalEoyCta from './components/GlobalEoyCta';
 import {
     OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK,
-    OPHAN_COMPONENT_EVENT_READ_MORE_CLICK,
     OPHAN_COMPONENT_EVENT_CLOSE_CLICK,
 } from './helpers/ophan';
 import withCloseable, { CloseableBannerProps } from '../hocs/withCloseable';
@@ -28,11 +27,6 @@ const GlobalEoyBanner: React.FC<CloseableBannerProps> = ({
 }: CloseableBannerProps) => {
     const onContributeClick = (): void =>
         submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_CONTRIBUTE_CLICK);
-
-    const onReadMoreClick = (): void => {
-        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_READ_MORE_CLICK);
-        onClose();
-    };
 
     const onCloseClick = (): void => {
         submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_EVENT_CLOSE_CLICK);
@@ -57,7 +51,6 @@ const GlobalEoyBanner: React.FC<CloseableBannerProps> = ({
                 cta={
                     <GlobalEoyCta
                         onContributeClick={onContributeClick}
-                        onReadMoreClick={onReadMoreClick}
                         tracking={tracking}
                         countryCode={countryCode || ''}
                     />

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyBody.tsx
@@ -1,59 +1,33 @@
 import React from 'react';
 import { Hide } from '@guardian/src-layout';
 import ContributionsTemplateBody from '../../contributionsTemplate/ContributionsTemplateBody';
-import { ArticleCountOptOut } from '../../../shared/ArticleCountOptOut';
-import { getLocalCurrencySymbol } from '../../../../../lib/geolocation';
+import { replaceNonArticleCountPlaceholders } from '../../../../../lib/placeholders';
+import { replaceArticleCount } from '../../../../../lib/replaceArticleCount';
 
 interface GlobalEoyBodyProps {
     numArticles: number;
-    hasOptedOutOfArticleCount: boolean;
     countryCode?: string;
+    body: string;
+    mobileBody: string;
 }
 
-const MIN_NUM_ARTICLES_TO_SHOW_ARTICLE_COUNT = 5;
-
 const GlobalEoyBody: React.FC<GlobalEoyBodyProps> = ({
-    hasOptedOutOfArticleCount,
     numArticles,
     countryCode,
+    body,
+    mobileBody,
 }: GlobalEoyBodyProps) => {
-    const shouldShowArticleCount =
-        !hasOptedOutOfArticleCount && numArticles > MIN_NUM_ARTICLES_TO_SHOW_ARTICLE_COUNT;
-
+    const cleanMobileBody = replaceNonArticleCountPlaceholders(mobileBody, countryCode);
+    const cleanBody = replaceNonArticleCountPlaceholders(body, countryCode);
     return (
         <ContributionsTemplateBody
             copy={
                 <>
                     <Hide above="tablet">
-                        With 2021 offering new hope, we commit to another year of quality reporting.
-                        Support us from {getLocalCurrencySymbol(countryCode)}1.
+                        {replaceArticleCount(cleanMobileBody, numArticles, 'global-eoy-banner')}
                     </Hide>
                     <Hide below="tablet">
-                        {shouldShowArticleCount ? (
-                            <>
-                                In the extraordinary year that was 2020, our independent journalism
-                                was powered by more than a million supporters. Thanks to you, we
-                                provided vital news and analysis for everyone, led by science and
-                                truth. You&apos;ve read{' '}
-                                <ArticleCountOptOut
-                                    numArticles={numArticles}
-                                    nextWord=" articles"
-                                    type="global-eoy-banner"
-                                />{' '}
-                                in the last year. With 2021 offering renewed hope, we commit to
-                                another year of high-impact reporting. Support us from as little as{' '}
-                                {getLocalCurrencySymbol(countryCode)}1.
-                            </>
-                        ) : (
-                            <>
-                                In the extraordinary year that was 2020, our independent journalism
-                                was powered by more than a million supporters. Thanks to you, we
-                                provided vital news and analysis for everyone, led by science and
-                                truth. With 2021 offering renewed hope, we commit to another year of
-                                high-impact reporting. Support us from as little as{' '}
-                                {getLocalCurrencySymbol(countryCode)}1.
-                            </>
-                        )}
+                        {replaceArticleCount(cleanBody, numArticles, 'global-eoy-banner')}
                     </Hide>
                 </>
             }

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
@@ -30,7 +30,7 @@ const GlobalEoyCta: React.FC<GlobalEoyCtaProps> = ({
                 <div>
                     <Hide above="desktop">
                         <LinkButton href={landingPageUrl} onClick={onContributeClick} size="small">
-                            Support us
+                            Support the Guardian
                         </LinkButton>
                     </Hide>
                     <Hide below="desktop">

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
@@ -6,8 +6,6 @@ import { BannerTracking } from '../../../../../types/BannerTypes';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../../../lib/tracking';
 
 const BASE_LANDING_PAGE_URL = 'https://support.theguardian.com/contribute';
-const IMPACT_REPORT_LINK =
-    'https://www.theguardian.com/info/ng-interactive/2020/dec/21/the-guardian-in-2020?INTCMP=global_eoy_banner';
 
 interface GlobalEoyCtaProps {
     onContributeClick: () => void;
@@ -48,32 +46,7 @@ const GlobalEoyCta: React.FC<GlobalEoyCtaProps> = ({
                     </Hide>
                 </div>
             }
-            secondaryCta={
-                countryCode.toUpperCase() === 'US' ? null : (
-                    <div>
-                        <Hide above="desktop">
-                            <LinkButton
-                                href={IMPACT_REPORT_LINK}
-                                onClick={onReadMoreClick}
-                                size="small"
-                                priority="tertiary"
-                            >
-                                2020 highlights
-                            </LinkButton>
-                        </Hide>
-                        <Hide below="desktop">
-                            <LinkButton
-                                href={IMPACT_REPORT_LINK}
-                                onClick={onReadMoreClick}
-                                size="default"
-                                priority="tertiary"
-                            >
-                                2020 highlights
-                            </LinkButton>
-                        </Hide>
-                    </div>
-                )
-            }
+            secondaryCta={null}
         />
     );
 };

--- a/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
+++ b/src/components/modules/banners/globalEoy/components/GlobalEoyCta.tsx
@@ -9,14 +9,12 @@ const BASE_LANDING_PAGE_URL = 'https://support.theguardian.com/contribute';
 
 interface GlobalEoyCtaProps {
     onContributeClick: () => void;
-    onReadMoreClick: () => void;
     tracking: BannerTracking;
     countryCode: string;
 }
 
 const GlobalEoyCta: React.FC<GlobalEoyCtaProps> = ({
     onContributeClick,
-    onReadMoreClick,
     tracking,
     countryCode,
 }: GlobalEoyCtaProps) => {

--- a/src/components/modules/shared/ArticleCountOptOut.tsx
+++ b/src/components/modules/shared/ArticleCountOptOut.tsx
@@ -14,6 +14,10 @@ const ARTICLE_COUNT_OPT_OUT_COOKIE = {
 const DAILY_ARTICLE_COUNT_STORAGE_KEY = 'gu.history.dailyArticleCount';
 const WEEKLY_ARTICLE_COUNT_STORAGE_KEY = 'gu.history.weeklyArticleCount';
 
+export type ArticleCountOptOutType = 'epic' | 'banner' | 'global-eoy-banner';
+const isBanner = (type: ArticleCountOptOutType): boolean =>
+    type === 'banner' || type === 'global-eoy-banner';
+
 const optOutContainer = css`
     display: inline-block;
 
@@ -41,15 +45,14 @@ const overlayContainer = (type: ArticleCountOptOutType): SerializedStyles => css
     z-index: 100;
     left: ${space[4]}px;
     right: ${space[4]}px;
-    ${type === 'banner' ? 'bottom: 21px;' : ''}
+    ${isBanner(type) ? 'bottom: 21px;' : ''}
 
     ${from.tablet} {
-        width: 325px;
+        width: 400px;
         left: 0;
+        ${isBanner(type) ? 'bottom: -90px;' : ''}
     }
 `;
-
-export type ArticleCountOptOutType = 'epic' | 'banner' | 'global-eoy-banner';
 
 export interface ArticleCountOptOutProps {
     numArticles: number;

--- a/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
+++ b/src/components/modules/shared/ArticleCountOptOutOverlay.tsx
@@ -48,10 +48,6 @@ const overlayContainer = (type: ArticleCountOptOutType): SerializedStyles => css
     ${textSans.medium()}
     padding: ${space[2]}px;
     box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
-
-    ${from.tablet} {
-        width: 325px;
-    }
 `;
 
 const overlayHeader = css`

--- a/src/tests/banners/GlobalEoyBannerTest.ts
+++ b/src/tests/banners/GlobalEoyBannerTest.ts
@@ -1,6 +1,7 @@
 import { BannerPageTracking, BannerTargeting, BannerTest } from '../../types/BannerTypes';
 import { globalEoy } from '../../modules';
 
+const heading = 'Show your support for high-impact reporting';
 const mobileCopy =
     'With 2021 offering new hope, we commit to another year of quality reporting. Support us from %%CURRENCY_SYMBOL%%1.';
 
@@ -8,14 +9,6 @@ export const GlobalEoyInaugurationACBanner: BannerTest = {
     name: 'GlobalEoyInauguration__AC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
-    locations: [
-        'GBPCountries',
-        'AUDCountries',
-        'EURCountries',
-        'International',
-        'NZDCountries',
-        'Canada',
-    ],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => true,
     minPageViews: 2,
@@ -30,7 +23,7 @@ export const GlobalEoyInaugurationACBanner: BannerTest = {
             moduleName: 'GlobalEoyBanner',
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             bannerContent: {
-                heading: 'Test heading',
+                heading,
                 messageText:
                     'In the extraordinary year that was 2020, our independent journalism was powered by more than a million supporters. Thanks to you, we provided vital news and analysis for everyone, led by science and truth. You’ve read %%ARTICLE_COUNT%% articles in the last year. As 2021 begins and offers new hope, we commit to another year of high-impact reporting. Support us from as little as %%CURRENCY_SYMBOL%%1.',
                 mobileMessageText: mobileCopy,
@@ -42,9 +35,9 @@ export const GlobalEoyInaugurationACBanner: BannerTest = {
             moduleName: 'GlobalEoyBanner',
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             bannerContent: {
-                heading: 'Test heading',
+                heading,
                 messageText:
-                    'The Trump era is over, and a Biden-Harris administration can begin. With 2021 offering new hope, the Guardian’s independence allows us to scrutinise the new presidency just as rigorously as we did the last. You’ve read %%ARTICLE_COUNT%% articles in the last year. Millions around the world rely on our efforts to counter misinformation and conspiracy, with journalism grounded in truth and integrity. Support us from as little as %%CURRENCY_SYMBOL%%1.',
+                    'The Trump presidency is over, and the Biden-Harris era can begin. In a year of renewed hope, the Guardian will scrutinise the new administration just as rigorously as we did the last. You’ve read %%ARTICLE_COUNT%% articles in the last year. Millions around the world rely on our efforts to counter misinformation and conspiracy, with independent journalism grounded in truth and integrity. Support us from as little as %%CURRENCY_SYMBOL%%1.',
                 mobileMessageText: mobileCopy,
             },
         },
@@ -55,14 +48,6 @@ export const GlobalEoyInaugurationNoACBanner: BannerTest = {
     name: 'GlobalEoyInauguration__NoAC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
-    locations: [
-        'GBPCountries',
-        'AUDCountries',
-        'EURCountries',
-        'International',
-        'NZDCountries',
-        'Canada',
-    ],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => true,
     minPageViews: 2,
@@ -73,21 +58,21 @@ export const GlobalEoyInaugurationNoACBanner: BannerTest = {
             moduleName: 'GlobalEoyBanner',
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             bannerContent: {
-                heading: 'Test heading',
+                heading,
                 messageText:
                     'In the extraordinary year that was 2020, our independent journalism was powered by more than a million supporters. Thanks to you, we provided vital news and analysis for everyone, led by science and truth. As 2021 begins and offers new hope, we commit to another year of high-impact reporting. Support us from as little as %%CURRENCY_SYMBOL%%1.',
                 mobileMessageText: mobileCopy,
             },
         },
         {
-            name: 'control',
+            name: 'variant',
             modulePath: globalEoy.endpointPath,
             moduleName: 'GlobalEoyBanner',
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             bannerContent: {
-                heading: 'Test heading',
+                heading,
                 messageText:
-                    'The Trump era is over, and a Biden-Harris administration can begin. With 2021 offering new hope, the Guardian’s independence allows us to scrutinise the new presidency just as rigorously as we did the last. Millions around the world rely on our efforts to counter misinformation and conspiracy, with journalism grounded in truth and integrity. Support us from as little as %%CURRENCY_SYMBOL%%1.',
+                    'The Trump presidency is over, and the Biden-Harris era can begin. In a year of renewed hope, the Guardian will scrutinise the new administration just as rigorously as we did the last. Millions around the world rely on our efforts to counter misinformation and conspiracy, with independent journalism grounded in truth and integrity. Support us from as little as %%CURRENCY_SYMBOL%%1.',
                 mobileMessageText: mobileCopy,
             },
         },

--- a/src/tests/banners/GlobalEoyBannerTest.ts
+++ b/src/tests/banners/GlobalEoyBannerTest.ts
@@ -8,6 +8,14 @@ export const GlobalEoyInaugurationACBanner: BannerTest = {
     name: 'GlobalEoyInauguration__AC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
+    locations: [
+        'GBPCountries',
+        'AUDCountries',
+        'EURCountries',
+        'International',
+        'NZDCountries',
+        'Canada',
+    ],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => true,
     minPageViews: 2,
@@ -47,6 +55,14 @@ export const GlobalEoyInaugurationNoACBanner: BannerTest = {
     name: 'GlobalEoyInauguration__NoAC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
+    locations: [
+        'GBPCountries',
+        'AUDCountries',
+        'EURCountries',
+        'International',
+        'NZDCountries',
+        'Canada',
+    ],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => true,
     minPageViews: 2,

--- a/src/tests/banners/GlobalEoyBannerTest.ts
+++ b/src/tests/banners/GlobalEoyBannerTest.ts
@@ -1,15 +1,15 @@
 import { BannerPageTracking, BannerTargeting, BannerTest } from '../../types/BannerTypes';
 import { globalEoy } from '../../modules';
 
-const DEPLOY_TIMESTAMP = Date.parse('2020-12-29');
+const mobileCopy =
+    'With 2021 offering new hope, we commit to another year of quality reporting. Support us from %%CURRENCY_SYMBOL%%1.';
 
 export const GlobalEoyInaugurationACBanner: BannerTest = {
     name: 'GlobalEoyInauguration__AC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) =>
-        Date.now() >= DEPLOY_TIMESTAMP,
+    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => true,
     minPageViews: 2,
     articlesViewedSettings: {
         minViews: 5,
@@ -23,8 +23,9 @@ export const GlobalEoyInaugurationACBanner: BannerTest = {
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             bannerContent: {
                 heading: 'Test heading',
-                messageText: 'Test desktop body %%ARTICLE_COUNT%% articles',
-                mobileMessageText: 'Test mobile body %%ARTICLE_COUNT%% articles',
+                messageText:
+                    'In the extraordinary year that was 2020, our independent journalism was powered by more than a million supporters. Thanks to you, we provided vital news and analysis for everyone, led by science and truth. You’ve read %%ARTICLE_COUNT%% articles in the last year. As 2021 begins and offers new hope, we commit to another year of high-impact reporting. Support us from as little as %%CURRENCY_SYMBOL%%1.',
+                mobileMessageText: mobileCopy,
             },
         },
         {
@@ -34,8 +35,9 @@ export const GlobalEoyInaugurationACBanner: BannerTest = {
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             bannerContent: {
                 heading: 'Test heading',
-                messageText: 'Test desktop body %%ARTICLE_COUNT%% articles',
-                mobileMessageText: 'Test mobile body %%ARTICLE_COUNT%% articles',
+                messageText:
+                    'The Trump era is over, and a Biden-Harris administration can begin. With 2021 offering new hope, the Guardian’s independence allows us to scrutinise the new presidency just as rigorously as we did the last. You’ve read %%ARTICLE_COUNT%% articles in the last year. Millions around the world rely on our efforts to counter misinformation and conspiracy, with journalism grounded in truth and integrity. Support us from as little as %%CURRENCY_SYMBOL%%1.',
+                mobileMessageText: mobileCopy,
             },
         },
     ],
@@ -46,8 +48,7 @@ export const GlobalEoyInaugurationNoACBanner: BannerTest = {
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) =>
-        Date.now() >= DEPLOY_TIMESTAMP,
+    canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => true,
     minPageViews: 2,
     variants: [
         {
@@ -57,8 +58,9 @@ export const GlobalEoyInaugurationNoACBanner: BannerTest = {
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             bannerContent: {
                 heading: 'Test heading',
-                messageText: 'Test desktop body',
-                mobileMessageText: 'Test mobile body',
+                messageText:
+                    'In the extraordinary year that was 2020, our independent journalism was powered by more than a million supporters. Thanks to you, we provided vital news and analysis for everyone, led by science and truth. As 2021 begins and offers new hope, we commit to another year of high-impact reporting. Support us from as little as %%CURRENCY_SYMBOL%%1.',
+                mobileMessageText: mobileCopy,
             },
         },
         {
@@ -68,8 +70,9 @@ export const GlobalEoyInaugurationNoACBanner: BannerTest = {
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             bannerContent: {
                 heading: 'Test heading',
-                messageText: 'Test desktop body',
-                mobileMessageText: 'Test mobile body',
+                messageText:
+                    'The Trump era is over, and a Biden-Harris administration can begin. With 2021 offering new hope, the Guardian’s independence allows us to scrutinise the new presidency just as rigorously as we did the last. Millions around the world rely on our efforts to counter misinformation and conspiracy, with journalism grounded in truth and integrity. Support us from as little as %%CURRENCY_SYMBOL%%1.',
+                mobileMessageText: mobileCopy,
             },
         },
     ],

--- a/src/tests/banners/GlobalEoyBannerTest.ts
+++ b/src/tests/banners/GlobalEoyBannerTest.ts
@@ -3,8 +3,8 @@ import { globalEoy } from '../../modules';
 
 const DEPLOY_TIMESTAMP = Date.parse('2020-12-29');
 
-export const GlobalEoyNonSupportersACBanner: BannerTest = {
-    name: 'GlobalEoyNonSupporters__AC',
+export const GlobalEoyInaugurationACBanner: BannerTest = {
+    name: 'GlobalEoyInauguration__AC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -21,12 +21,28 @@ export const GlobalEoyNonSupportersACBanner: BannerTest = {
             modulePath: globalEoy.endpointPath,
             moduleName: 'GlobalEoyBanner',
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            bannerContent: {
+                heading: 'Test heading',
+                messageText: 'Test desktop body %%ARTICLE_COUNT%% articles',
+                mobileMessageText: 'Test mobile body %%ARTICLE_COUNT%% articles',
+            },
+        },
+        {
+            name: 'variant',
+            modulePath: globalEoy.endpointPath,
+            moduleName: 'GlobalEoyBanner',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            bannerContent: {
+                heading: 'Test heading',
+                messageText: 'Test desktop body %%ARTICLE_COUNT%% articles',
+                mobileMessageText: 'Test mobile body %%ARTICLE_COUNT%% articles',
+            },
         },
     ],
 };
 
-export const GlobalEoyNonSupportersNoACBanner: BannerTest = {
-    name: 'GlobalEoyNonSupporters__NoAC',
+export const GlobalEoyInaugurationNoACBanner: BannerTest = {
+    name: 'GlobalEoyInauguration__NoAC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -39,6 +55,22 @@ export const GlobalEoyNonSupportersNoACBanner: BannerTest = {
             modulePath: globalEoy.endpointPath,
             moduleName: 'GlobalEoyBanner',
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            bannerContent: {
+                heading: 'Test heading',
+                messageText: 'Test desktop body',
+                mobileMessageText: 'Test mobile body',
+            },
+        },
+        {
+            name: 'control',
+            modulePath: globalEoy.endpointPath,
+            moduleName: 'GlobalEoyBanner',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            bannerContent: {
+                heading: 'Test heading',
+                messageText: 'Test desktop body',
+                mobileMessageText: 'Test mobile body',
+            },
         },
     ],
 };

--- a/src/tests/banners/bannerTests.ts
+++ b/src/tests/banners/bannerTests.ts
@@ -5,8 +5,8 @@ import {
     channel2BannersAllTestsGenerator,
 } from './ChannelBannerTests';
 import {
-    GlobalEoyNonSupportersACBanner,
-    GlobalEoyNonSupportersNoACBanner,
+    GlobalEoyInaugurationACBanner,
+    GlobalEoyInaugurationNoACBanner,
 } from './GlobalEoyBannerTest';
 import { cacheAsync } from '../../lib/cache';
 
@@ -14,7 +14,7 @@ const defaultBannerTestGenerator: BannerTestGenerator = () =>
     Promise.resolve([DefaultContributionsBanner]);
 
 const globalEoyTestGenerator: BannerTestGenerator = () =>
-    Promise.resolve([GlobalEoyNonSupportersACBanner, GlobalEoyNonSupportersNoACBanner]);
+    Promise.resolve([GlobalEoyInaugurationACBanner, GlobalEoyInaugurationNoACBanner]);
 
 const flattenArray = <T>(array: T[][]): T[] => ([] as T[]).concat(...array);
 

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -48,6 +48,7 @@ export interface Cta {
 export interface BannerContent {
     heading?: string;
     messageText: string;
+    mobileMessageText?: string;
     highlightedText?: string;
     cta?: Cta;
     secondaryCta?: Cta;


### PR DESCRIPTION
1. Adds a `mobileMessageText` field to the banner props to enable us to configure the copy for mobile widths
2. Removes the hardcoded copy from the global eoy banner and uses the props
3. Adds a variant to both global eoy banner tests (AC and non-AC). This is for copy testing.
4. Also made a quick fix to the issue of the article count opt-out popup dropping out of view. We do need a proper solution to this though

### Variant with AC
<img width="1479" alt="Screen Shot 2021-01-20 at 08 39 38" src="https://user-images.githubusercontent.com/1513454/105149713-c26ac380-5afb-11eb-9c73-ed3f08507554.png">

### Variant no AC
<img width="1479" alt="Screen Shot 2021-01-20 at 08 39 52" src="https://user-images.githubusercontent.com/1513454/105149805-df9f9200-5afb-11eb-8a50-5d5506f9e514.png">

### Control with AC
<img width="1479" alt="Screen Shot 2021-01-20 at 08 39 17" src="https://user-images.githubusercontent.com/1513454/105149759-ceef1c00-5afb-11eb-914d-1e60b4570f01.png">

### Control no AC
<img width="1479" alt="Screen Shot 2021-01-20 at 08 40 05" src="https://user-images.githubusercontent.com/1513454/105150012-1bd2f280-5afc-11eb-9b99-836e6c3a13e6.png">

### Mobile (same for all)
<img width="323" alt="Screen Shot 2021-01-20 at 08 40 51" src="https://user-images.githubusercontent.com/1513454/105149881-f2b26200-5afb-11eb-886a-3cc4448d4036.png">
