### PR TITLE
Liveblog epic design test

### DIFF
--- a/src/components/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { css } from '@emotion/core';
-import {body, titlepiece} from '@guardian/src-foundations/typography';
+import { css, SerializedStyles } from '@emotion/core';
+import { body, titlepiece } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { palette } from '@guardian/src-foundations';
 import { neutral, brandAlt } from '@guardian/src-foundations/palette';
@@ -14,15 +14,19 @@ import { EpicTracking } from './ContributionsEpicTypes';
 import { Variant } from '../../../lib/variants';
 import { replaceArticleCount } from '../../../lib/replaceArticleCount';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
-import {LiveblogEpicDesignTestVariants} from "../../../tests/liveblogEpicDesignTest";
+import { LiveblogEpicDesignTestVariants } from '../../../tests/liveblogEpicDesignTest';
 
-const container = (designTestVariant: LiveblogEpicDesignTestVariants) => css`
+const container = (designTestVariant: LiveblogEpicDesignTestVariants): SerializedStyles => css`
     padding: 6px 10px 28px 10px;
     border-top: 1px solid ${brandAlt[400]};
     border-bottom: 1px solid ${neutral[86]};
-    ${designTestVariant === LiveblogEpicDesignTestVariants.control ? `background: ${neutral[93]};` : `background: ${neutral[100]};`}
-    
-    ${designTestVariant === LiveblogEpicDesignTestVariants.yellowHeader ? `border: 1px solid ${neutral[0]};` : ''}
+    ${designTestVariant === LiveblogEpicDesignTestVariants.control
+        ? `background: ${neutral[93]};`
+        : `background: ${neutral[100]};`}
+
+    ${designTestVariant === LiveblogEpicDesignTestVariants.yellowHeader
+        ? `border: 1px solid ${neutral[0]};`
+        : ''}
 
     * {
         ::selection {
@@ -44,8 +48,7 @@ const container = (designTestVariant: LiveblogEpicDesignTestVariants) => css`
     }
 `;
 
-// TODO - remove param?
-const textContainer = (designTestVariant: LiveblogEpicDesignTestVariants) => css`
+const textContainer = css`
     ${body.medium()};
     font-size: 16px;
 
@@ -64,9 +67,13 @@ const textContainer = (designTestVariant: LiveblogEpicDesignTestVariants) => css
     }
 `;
 
-const cta = (designTestVariant: LiveblogEpicDesignTestVariants) => css`
+const cta = (designTestVariant: LiveblogEpicDesignTestVariants): SerializedStyles => css`
     color: ${neutral[7]};
-    ${designTestVariant === LiveblogEpicDesignTestVariants.control ? `border: 1px solid ${neutral[0]};` : ''}
+    ${
+        designTestVariant === LiveblogEpicDesignTestVariants.control
+            ? `border: 1px solid ${neutral[0]};`
+            : ''
+    }
     background-color: ${brandAlt[400]};
 
     &:hover {
@@ -81,8 +88,8 @@ const designTestYellowHeading = css`
     border-top: 1px solid ${neutral[0]};
     border-left: 1px solid ${neutral[0]};
     border-right: 1px solid ${neutral[0]};
-    
-    padding: 4px 10px 13px 10px; 
+
+    padding: 4px 10px 13px 10px;
     ${from.tablet} {
         padding-left: 80px;
         padding-right: 20px;
@@ -121,10 +128,10 @@ const LiveblogEpicBody: React.FC<LiveblogEpicBodyProps> = ({
     designTestVariant,
 }: LiveblogEpicBodyProps) => {
     return (
-        <div css={textContainer(designTestVariant)}>
-            { designTestVariant === LiveblogEpicDesignTestVariants.smallHeader && heading &&
+        <div css={textContainer}>
+            {designTestVariant === LiveblogEpicDesignTestVariants.smallHeader && heading && (
                 <div css={designTestSmallHeading}>{heading}</div>
-            }
+            )}
             {paragraphs.map(paragraph => (
                 <LiveblogEpicBodyParagraph
                     key={paragraph}
@@ -174,13 +181,13 @@ interface LiveblogEpicProps {
 }
 
 export const ContributionsLiveblogEpicComponent: (
-    designTestVariant: LiveblogEpicDesignTestVariants
+    designTestVariant: LiveblogEpicDesignTestVariants,
 ) => React.FC<LiveblogEpicProps> = designTestVariant => ({
     variant,
     countryCode,
     numArticles,
     tracking,
-}: LiveblogEpicProps) => {
+}: LiveblogEpicProps): JSX.Element | null => {
     const cleanParagraphs = variant.paragraphs.map(paragraph =>
         replaceNonArticleCountPlaceholders(paragraph, countryCode),
     );
@@ -195,15 +202,16 @@ export const ContributionsLiveblogEpicComponent: (
 
     return (
         <>
-            { designTestVariant === LiveblogEpicDesignTestVariants.yellowHeader && cleanHeading &&
+            {designTestVariant === LiveblogEpicDesignTestVariants.yellowHeader && cleanHeading && (
                 <div css={designTestYellowHeading}>{cleanHeading}</div>
-            }
+            )}
             <section css={container(designTestVariant)}>
                 <LiveblogEpicBody
                     heading={cleanHeading}
                     paragraphs={cleanParagraphs}
                     numArticles={numArticles}
-                    designTestVariant={designTestVariant}/>
+                    designTestVariant={designTestVariant}
+                />
                 <LiveblogEpicCta
                     text={variant.cta?.text}
                     baseUrl={variant.cta?.baseUrl}
@@ -215,5 +223,6 @@ export const ContributionsLiveblogEpicComponent: (
     );
 };
 
-export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> =
-    ContributionsLiveblogEpicComponent(LiveblogEpicDesignTestVariants.control);
+export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ContributionsLiveblogEpicComponent(
+    LiveblogEpicDesignTestVariants.control,
+);

--- a/src/components/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/core';
-import { body } from '@guardian/src-foundations/typography';
+import {body, titlepiece} from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { palette } from '@guardian/src-foundations';
 import { neutral, brandAlt } from '@guardian/src-foundations/palette';
@@ -14,12 +14,15 @@ import { EpicTracking } from './ContributionsEpicTypes';
 import { Variant } from '../../../lib/variants';
 import { replaceArticleCount } from '../../../lib/replaceArticleCount';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
+import {LiveblogEpicDesignTestVariants} from "../../../tests/liveblogEpicDesignTest";
 
-const container = css`
+const container = (designTestVariant: LiveblogEpicDesignTestVariants) => css`
     padding: 6px 10px 28px 10px;
     border-top: 1px solid ${brandAlt[200]};
     border-bottom: 1px solid ${neutral[86]};
-    background: ${neutral[93]};
+    ${designTestVariant === LiveblogEpicDesignTestVariants.control ? `background: ${neutral[93]};` : `background: ${neutral[100]};`}
+    
+    ${designTestVariant === LiveblogEpicDesignTestVariants.yellowHeader ? `border: 1px solid ${neutral[0]};` : ''}
 
     * {
         ::selection {
@@ -41,7 +44,8 @@ const container = css`
     }
 `;
 
-const textContainer = css`
+// TODO - remove param?
+const textContainer = (designTestVariant: LiveblogEpicDesignTestVariants) => css`
     ${body.medium()};
     font-size: 16px;
 
@@ -49,25 +53,44 @@ const textContainer = css`
         margin: 0;
     }
 
-    & > * + p {
+    & > p + p {
         margin-top: ${space[3]}px;
     }
 
     ${from.tablet} {
-        & > * + p {
+        & > p + p {
             margin-top: ${space[4]}px;
         }
     }
 `;
 
-const cta = css`
+const cta = (designTestVariant: LiveblogEpicDesignTestVariants) => css`
     color: ${neutral[7]};
-    border: 1px solid ${neutral[0]};
+    ${designTestVariant === LiveblogEpicDesignTestVariants.control ? `border: 1px solid ${neutral[0]};` : ''}
     background-color: ${brandAlt[400]};
 
     &:hover {
         background-color: ${brandAlt[200]};
     }
+`;
+
+const designTestYellowHeading = css`
+    ${titlepiece.small()};
+    font-size: 32px;
+    background-color: ${brandAlt[400]};
+    border-top: 1px solid ${neutral[0]};
+    border-left: 1px solid ${neutral[0]};
+    border-right: 1px solid ${neutral[0]};
+    
+    padding: 4px 10px 10px 10px; 
+    ${from.tablet} {
+        padding-left: 80px;
+        padding-right: 20px;
+    }
+`;
+
+const designTestSmallHeading = css`
+    font-weight: 700;
 `;
 
 interface LiveblogEpicBodyParagraphProps {
@@ -85,16 +108,23 @@ const LiveblogEpicBodyParagraph: React.FC<LiveblogEpicBodyParagraphProps> = ({
 };
 
 interface LiveblogEpicBodyProps {
+    heading: string | undefined;
     paragraphs: string[];
     numArticles: number;
+    designTestVariant: LiveblogEpicDesignTestVariants;
 }
 
 const LiveblogEpicBody: React.FC<LiveblogEpicBodyProps> = ({
+    heading,
     numArticles,
     paragraphs,
+    designTestVariant,
 }: LiveblogEpicBodyProps) => {
     return (
-        <div css={textContainer}>
+        <div css={textContainer(designTestVariant)}>
+            { designTestVariant === LiveblogEpicDesignTestVariants.smallHeader && heading &&
+                <div css={designTestSmallHeading}>{heading}</div>
+            }
             {paragraphs.map(paragraph => (
                 <LiveblogEpicBodyParagraph
                     key={paragraph}
@@ -114,6 +144,7 @@ interface LiveblogEpicCtaProps {
     baseUrl?: string;
     countryCode?: string;
     tracking: EpicTracking;
+    designTestVariant: LiveblogEpicDesignTestVariants;
 }
 
 const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
@@ -121,6 +152,7 @@ const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
     baseUrl,
     tracking,
     countryCode,
+    designTestVariant,
 }: LiveblogEpicCtaProps) => {
     const url = addRegionIdAndTrackingParamsToSupportUrl(
         baseUrl || DEFAULT_CTA_BASE_URL,
@@ -128,7 +160,7 @@ const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
         countryCode,
     );
     return (
-        <LinkButton css={cta} priority="primary" href={url}>
+        <LinkButton css={cta(designTestVariant)} priority="primary" href={url}>
             {text || DEFAULT_CTA_TEXT}
         </LinkButton>
     );
@@ -141,7 +173,9 @@ interface LiveblogEpicProps {
     numArticles: number;
 }
 
-export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
+export const ContributionsLiveblogEpicComponent: (
+    designTestVariant: LiveblogEpicDesignTestVariants
+) => React.FC<LiveblogEpicProps> = designTestVariant => ({
     variant,
     countryCode,
     numArticles,
@@ -150,19 +184,36 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
     const cleanParagraphs = variant.paragraphs.map(paragraph =>
         replaceNonArticleCountPlaceholders(paragraph, countryCode),
     );
+    const cleanHeading = replaceNonArticleCountPlaceholders(variant.heading);
 
-    if (cleanParagraphs.some(containsNonArticleCountPlaceholder)) {
+    if (
+        cleanParagraphs.some(containsNonArticleCountPlaceholder) ||
+        containsNonArticleCountPlaceholder(cleanHeading)
+    ) {
         return null;
     }
 
     return (
-        <section css={container}>
-            <LiveblogEpicBody paragraphs={cleanParagraphs} numArticles={numArticles} />
-            <LiveblogEpicCta
-                text={variant.cta?.text}
-                baseUrl={variant.cta?.baseUrl}
-                tracking={tracking}
-            />
-        </section>
+        <>
+            { designTestVariant === LiveblogEpicDesignTestVariants.yellowHeader && cleanHeading &&
+                <div css={designTestYellowHeading}>{cleanHeading}</div>
+            }
+            <section css={container(designTestVariant)}>
+                <LiveblogEpicBody
+                    heading={cleanHeading}
+                    paragraphs={cleanParagraphs}
+                    numArticles={numArticles}
+                    designTestVariant={designTestVariant}/>
+                <LiveblogEpicCta
+                    text={variant.cta?.text}
+                    baseUrl={variant.cta?.baseUrl}
+                    tracking={tracking}
+                    designTestVariant={designTestVariant}
+                />
+            </section>
+        </>
     );
 };
+
+export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> =
+    ContributionsLiveblogEpicComponent(LiveblogEpicDesignTestVariants.control);

--- a/src/components/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.tsx
@@ -18,7 +18,7 @@ import {LiveblogEpicDesignTestVariants} from "../../../tests/liveblogEpicDesignT
 
 const container = (designTestVariant: LiveblogEpicDesignTestVariants) => css`
     padding: 6px 10px 28px 10px;
-    border-top: 1px solid ${brandAlt[200]};
+    border-top: 1px solid ${brandAlt[400]};
     border-bottom: 1px solid ${neutral[86]};
     ${designTestVariant === LiveblogEpicDesignTestVariants.control ? `background: ${neutral[93]};` : `background: ${neutral[100]};`}
     
@@ -76,13 +76,13 @@ const cta = (designTestVariant: LiveblogEpicDesignTestVariants) => css`
 
 const designTestYellowHeading = css`
     ${titlepiece.small()};
-    font-size: 32px;
+    font-size: 28px;
     background-color: ${brandAlt[400]};
     border-top: 1px solid ${neutral[0]};
     border-left: 1px solid ${neutral[0]};
     border-right: 1px solid ${neutral[0]};
     
-    padding: 4px 10px 10px 10px; 
+    padding: 4px 10px 13px 10px; 
     ${from.tablet} {
         padding-left: 80px;
         padding-right: 20px;

--- a/src/components/modules/epics/ContributionsLiveblogEpicSmallHeader.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpicSmallHeader.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import {EpicProps} from "./ContributionsEpic";
+import {ContributionsLiveblogEpicComponent} from "./ContributionsLiveblogEpic";
+import {LiveblogEpicDesignTestVariants} from "../../../tests/liveblogEpicDesignTest";
+
+export const ContributionsLiveblogEpic: React.FC<EpicProps> = ContributionsLiveblogEpicComponent(
+    LiveblogEpicDesignTestVariants.smallHeader
+);

--- a/src/components/modules/epics/ContributionsLiveblogEpicSmallHeader.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpicSmallHeader.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import {EpicProps} from "./ContributionsEpic";
-import {ContributionsLiveblogEpicComponent} from "./ContributionsLiveblogEpic";
-import {LiveblogEpicDesignTestVariants} from "../../../tests/liveblogEpicDesignTest";
+import React from 'react';
+import { EpicProps } from './ContributionsEpic';
+import { ContributionsLiveblogEpicComponent } from './ContributionsLiveblogEpic';
+import { LiveblogEpicDesignTestVariants } from '../../../tests/liveblogEpicDesignTest';
 
 export const ContributionsLiveblogEpic: React.FC<EpicProps> = ContributionsLiveblogEpicComponent(
-    LiveblogEpicDesignTestVariants.smallHeader
+    LiveblogEpicDesignTestVariants.smallHeader,
 );

--- a/src/components/modules/epics/ContributionsLiveblogEpicYellowHeader.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpicYellowHeader.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import {EpicProps} from "./ContributionsEpic";
-import {ContributionsLiveblogEpicComponent} from "./ContributionsLiveblogEpic";
-import {LiveblogEpicDesignTestVariants} from "../../../tests/liveblogEpicDesignTest";
+import React from 'react';
+import { EpicProps } from './ContributionsEpic';
+import { ContributionsLiveblogEpicComponent } from './ContributionsLiveblogEpic';
+import { LiveblogEpicDesignTestVariants } from '../../../tests/liveblogEpicDesignTest';
 
 export const ContributionsLiveblogEpic: React.FC<EpicProps> = ContributionsLiveblogEpicComponent(
-    LiveblogEpicDesignTestVariants.yellowHeader
+    LiveblogEpicDesignTestVariants.yellowHeader,
 );

--- a/src/components/modules/epics/ContributionsLiveblogEpicYellowHeader.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpicYellowHeader.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import {EpicProps} from "./ContributionsEpic";
+import {ContributionsLiveblogEpicComponent} from "./ContributionsLiveblogEpic";
+import {LiveblogEpicDesignTestVariants} from "../../../tests/liveblogEpicDesignTest";
+
+export const ContributionsLiveblogEpic: React.FC<EpicProps> = ContributionsLiveblogEpicComponent(
+    LiveblogEpicDesignTestVariants.yellowHeader
+);

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -31,6 +31,16 @@ export const liveblogEpic: ModuleInfo = getDefaultModuleInfo(
     'epics/ContributionsLiveblogEpic',
 );
 
+export const liveblogEpicSmallHeader: ModuleInfo = getDefaultModuleInfo(
+    'liveblog-epic-small-header',
+    'epics/ContributionsLiveblogEpicSmallHeader',
+);
+
+export const liveblogEpicYellowHeader: ModuleInfo = getDefaultModuleInfo(
+    'liveblog-epic-yellow-header',
+    'epics/ContributionsLiveblogEpicYellowHeader',
+);
+
 export const contributionsBanner: ModuleInfo = getDefaultModuleInfo(
     'contributions-banner',
     'banners/contributions/ContributionsBanner',
@@ -53,11 +63,13 @@ export const globalEoy: ModuleInfo = getDefaultModuleInfo(
 
 export const moduleInfos: ModuleInfo[] = [
     epic,
-    epicACAbove,
-    epicACInline,
+    // epicACAbove,
+    // epicACInline,
     liveblogEpic,
-    contributionsBanner,
-    digiSubs,
-    guardianWeekly,
-    globalEoy,
+    liveblogEpicSmallHeader,
+    liveblogEpicYellowHeader,
+    // contributionsBanner,
+    // digiSubs,
+    // guardianWeekly,
+    // globalEoy,
 ];

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -63,13 +63,13 @@ export const globalEoy: ModuleInfo = getDefaultModuleInfo(
 
 export const moduleInfos: ModuleInfo[] = [
     epic,
-    // epicACAbove,
-    // epicACInline,
+    epicACAbove,
+    epicACInline,
     liveblogEpic,
     liveblogEpicSmallHeader,
     liveblogEpicYellowHeader,
-    // contributionsBanner,
-    // digiSubs,
-    // guardianWeekly,
-    // globalEoy,
+    contributionsBanner,
+    digiSubs,
+    guardianWeekly,
+    globalEoy,
 ];

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -103,13 +103,13 @@ const fetchCachedEpicTests: { [key in EpicType]: () => Promise<EpicTests> } = {
 };
 
 const getArticleEpicTests = async (): Promise<Test[]> => {
-    const configuredTests = await fetchCachedEpicTests['ARTICLE']();
+    const configuredTests = await fetchCachedEpicTests.ARTICLE();
     const hardcodedTests = await getAllHardcodedTests();
     return [...configuredTests.tests, ...hardcodedTests];
 };
 
 const getLiveblogEpicTests = async (): Promise<Test[]> => {
-    const configuredTests = await fetchCachedEpicTests['LIVEBLOG']();
+    const configuredTests = await fetchCachedEpicTests.LIVEBLOG();
     return [liveblogEpicDesignTestUS, liveblogEpicDesignTestGlobal, ...configuredTests.tests];
 };
 
@@ -163,20 +163,15 @@ const buildEpicData = async (
         countryCode: targeting.countryCode,
     };
 
-    const moduleUrl = (): string => {
-        if (variantWithTickerData.modulePath) {
-            return `${baseUrl}/${variantWithTickerData.modulePath}`;
-        } else {
-            return `${baseUrl}/${type === 'ARTICLE' ? 'epic.js' : 'liveblog-epic.js'}`;
-        }
-    };
+    const modulePath =
+        variantWithTickerData.modulePath || (type === 'ARTICLE' ? 'epic.js' : 'liveblog-epic.js');
 
     return {
         data: {
             variant: variantWithTickerData,
             meta: testTracking,
             module: {
-                url: moduleUrl(),
+                url: `${baseUrl}/${modulePath}`,
                 props,
             },
         },

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -10,7 +10,7 @@ import {
 } from './components/modules/epics/ContributionsEpicTypes';
 import cors from 'cors';
 import { validateBannerPayload, validateEpicPayload } from './lib/validation';
-import {EpicTests, Debug, findTestAndVariant, Result, Variant, Test} from './lib/variants';
+import { EpicTests, Debug, findTestAndVariant, Result, Variant, Test } from './lib/variants';
 import { getArticleViewCountForWeeks } from './lib/history';
 import {
     buildAmpEpicCampaignCode,
@@ -42,7 +42,10 @@ import { ModuleInfo, moduleInfos } from './modules';
 import { getAmpVariantAssignments } from './lib/ampVariantAssignments';
 import { getAmpExperimentData } from './tests/amp/ampEpicTests';
 import { OphanComponentEvent } from './types/OphanTypes';
-import {liveblogEpicDesignTest} from "./tests/liveblogEpicDesignTest";
+import {
+    liveblogEpicDesignTestGlobal,
+    liveblogEpicDesignTestUS,
+} from './tests/liveblogEpicDesignTest';
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -107,7 +110,7 @@ const getArticleEpicTests = async (): Promise<Test[]> => {
 
 const getLiveblogEpicTests = async (): Promise<Test[]> => {
     const configuredTests = await fetchCachedEpicTests['LIVEBLOG']();
-    return [liveblogEpicDesignTest, ...configuredTests.tests];
+    return [liveblogEpicDesignTestUS, liveblogEpicDesignTestGlobal, ...configuredTests.tests];
 };
 
 const buildEpicData = async (
@@ -160,9 +163,12 @@ const buildEpicData = async (
         countryCode: targeting.countryCode,
     };
 
-    const moduleUrl = () => {
-        if (variantWithTickerData.modulePath) return `${baseUrl}/${variantWithTickerData.modulePath}`;
-        else return `${baseUrl}/${type === 'ARTICLE' ? 'epic.js' : 'liveblog-epic.js'}`;
+    const moduleUrl = (): string => {
+        if (variantWithTickerData.modulePath) {
+            return `${baseUrl}/${variantWithTickerData.modulePath}`;
+        } else {
+            return `${baseUrl}/${type === 'ARTICLE' ? 'epic.js' : 'liveblog-epic.js'}`;
+        }
     };
 
     return {

--- a/src/tests/liveblogEpicDesignTest.ts
+++ b/src/tests/liveblogEpicDesignTest.ts
@@ -75,12 +75,12 @@ const liveblogEpicDesignTest = (
 });
 
 export const liveblogEpicDesignTestGlobal: Test = liveblogEpicDesignTest(
-    '2020-01-20-LiveblogEpicDesignTestGlobal',
+    '2020-01-20-LiveblogEpicDesignTest__Global',
     globalParagraphs,
     ['GBPCountries', 'AUDCountries', 'EURCountries', 'International', 'NZDCountries', 'Canada'],
 );
 export const liveblogEpicDesignTestUS: Test = liveblogEpicDesignTest(
-    '2020-01-20-LiveblogEpicDesignTestUS',
+    '2020-01-20-LiveblogEpicDesignTest__US',
     USParagraphs,
     ['UnitedStates'],
 );

--- a/src/tests/liveblogEpicDesignTest.ts
+++ b/src/tests/liveblogEpicDesignTest.ts
@@ -1,7 +1,6 @@
-import {Test, Variant} from "../lib/variants";
-import {liveblogEpic, liveblogEpicSmallHeader, liveblogEpicYellowHeader} from "../modules";
-
-const TestName = '2020-01-19-LiveblogEpicDesignTest';
+import { Test, Variant } from '../lib/variants';
+import { liveblogEpic, liveblogEpicSmallHeader, liveblogEpicYellowHeader } from '../modules';
+import { CountryGroupId } from '../lib/geolocation';
 
 export enum LiveblogEpicDesignTestVariants {
     control = 'control',
@@ -9,27 +8,44 @@ export enum LiveblogEpicDesignTestVariants {
     yellowHeader = 'yellowHeader',
 }
 
-const variant = (name: string, modulePath: string, heading?: string): Variant => ({
+const globalParagraphs = [
+    'In these extraordinary times, the Guardian’s editorial independence has never been more important. Because no one sets our agenda, or edits our editor, we can keep delivering high-impact, trustworthy journalism each and every day. Free from commercial or political influence, we can report fearlessly on world events and challenge those in power.',
+    'We believe everyone deserves equal access to accurate news and calm explanation. Your support enables us to keep our journalism open for all. No matter how unpredictable the future feels, we will provide vital information so we can all make decisions about our lives, health and security – based on fact, not fiction.',
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.',
+];
+
+const USParagraphs = [
+    'Since you’re here, we have a small favour to ask. Millions are flocking to the Guardian for independent, quality news every day. As the new year begins, we’re asking you to consider a gift to help fund our journalism.',
+    'We believe everyone deserves to access information that’s grounded in science and truth. That’s why we made a different choice: to keep our reporting open for all readers, regardless of where they live or what they can afford to pay.',
+    'If you’ve enjoyed our live updates and in-depth coverage, support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.',
+];
+
+const variant = (
+    name: string,
+    modulePath: string,
+    paragraphs: string[],
+    heading?: string,
+): Variant => ({
     name,
     heading,
-    paragraphs: [
-        'In these extraordinary times, the Guardian’s editorial independence has never been more important. Because no one sets our agenda, or edits our editor, we can keep delivering high-impact, trustworthy journalism each and every day. Free from commercial or political influence, we can report fearlessly on world events and challenge those in power.',
-        'We believe everyone deserves equal access to accurate news and calm explanation. Your support enables us to keep our journalism open for all. No matter how unpredictable the future feels, we will provide vital information so we can all make decisions about our lives, health and security – based on fact, not fiction.',
-        'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.',
-    ],
+    paragraphs,
     cta: {
         text: 'Show your support',
-        baseUrl: 'https://support.theguardian.com/contribute'
+        baseUrl: 'https://support.theguardian.com/contribute',
     },
     modulePath,
 });
 
-export const liveblogEpicDesignTest: Test = {
-    name: TestName,
+const liveblogEpicDesignTest = (
+    name: string,
+    paragraphs: string[],
+    locations: CountryGroupId[],
+): Test => ({
+    name: name,
     expiry: '2021-03-01',
-    campaignId: TestName,
+    campaignId: name,
     isOn: true,
-    locations: [],
+    locations,
     audience: 1,
     tagIds: [],
     sections: [],
@@ -40,10 +56,31 @@ export const liveblogEpicDesignTest: Test = {
     isLiveBlog: false,
     hasCountryName: false,
     variants: [
-        variant(LiveblogEpicDesignTestVariants.control, liveblogEpic.endpointPath),
-        variant(LiveblogEpicDesignTestVariants.yellowHeader, liveblogEpicYellowHeader.endpointPath, 'Support the Guardian'),
-        variant(LiveblogEpicDesignTestVariants.smallHeader,liveblogEpicSmallHeader.endpointPath, 'Support the Guardian'),
+        variant(LiveblogEpicDesignTestVariants.control, liveblogEpic.endpointPath, paragraphs),
+        variant(
+            LiveblogEpicDesignTestVariants.yellowHeader,
+            liveblogEpicYellowHeader.endpointPath,
+            paragraphs,
+            'Support the Guardian',
+        ),
+        variant(
+            LiveblogEpicDesignTestVariants.smallHeader,
+            liveblogEpicSmallHeader.endpointPath,
+            paragraphs,
+            'Support the Guardian',
+        ),
     ],
     highPriority: false,
     useLocalViewLog: false,
-};
+});
+
+export const liveblogEpicDesignTestGlobal: Test = liveblogEpicDesignTest(
+    '2020-01-20-LiveblogEpicDesignTestGlobal',
+    globalParagraphs,
+    ['GBPCountries', 'AUDCountries', 'EURCountries', 'International', 'NZDCountries', 'Canada'],
+);
+export const liveblogEpicDesignTestUS: Test = liveblogEpicDesignTest(
+    '2020-01-20-LiveblogEpicDesignTestUS',
+    USParagraphs,
+    ['UnitedStates'],
+);

--- a/src/tests/liveblogEpicDesignTest.ts
+++ b/src/tests/liveblogEpicDesignTest.ts
@@ -1,0 +1,49 @@
+import {Test, Variant} from "../lib/variants";
+import {liveblogEpic, liveblogEpicSmallHeader, liveblogEpicYellowHeader} from "../modules";
+
+const TestName = '2020-01-19-LiveblogEpicDesignTest';
+
+export enum LiveblogEpicDesignTestVariants {
+    control = 'control',
+    smallHeader = 'smallHeader',
+    yellowHeader = 'yellowHeader',
+}
+
+const variant = (name: string, modulePath: string, heading?: string): Variant => ({
+    name,
+    heading,
+    paragraphs: [
+        'In these extraordinary times, the Guardian’s editorial independence has never been more important. Because no one sets our agenda, or edits our editor, we can keep delivering high-impact, trustworthy journalism each and every day. Free from commercial or political influence, we can report fearlessly on world events and challenge those in power.',
+        'We believe everyone deserves equal access to accurate news and calm explanation. Your support enables us to keep our journalism open for all. No matter how unpredictable the future feels, we will provide vital information so we can all make decisions about our lives, health and security – based on fact, not fiction.',
+        'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.',
+    ],
+    cta: {
+        text: 'Show your support',
+        baseUrl: 'https://support.theguardian.com/contribute'
+    },
+    modulePath,
+});
+
+export const liveblogEpicDesignTest: Test = {
+    name: TestName,
+    expiry: '2021-03-01',
+    campaignId: TestName,
+    isOn: true,
+    locations: [],
+    audience: 1,
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: true,
+    userCohort: 'AllNonSupporters',
+    isLiveBlog: false,
+    hasCountryName: false,
+    variants: [
+        variant(LiveblogEpicDesignTestVariants.control, liveblogEpic.endpointPath),
+        variant(LiveblogEpicDesignTestVariants.yellowHeader, liveblogEpicYellowHeader.endpointPath, 'Support the Guardian'),
+        variant(LiveblogEpicDesignTestVariants.smallHeader,liveblogEpicSmallHeader.endpointPath, 'Support the Guardian'),
+    ],
+    highPriority: false,
+    useLocalViewLog: false,
+};


### PR DESCRIPTION
This adds 2 hardcoded tests because we need different copy in the US. But they're both testing the same thing - the epic design.

Adds new endpoints for the 2 new component modules.
Introduces `ContributionsLiveblogEpicComponent`, so that the variant name can be passed in.

### Control
<img width="617" alt="Screen Shot 2021-01-20 at 10 51 09" src="https://user-images.githubusercontent.com/1513454/105168425-07015980-5b12-11eb-9586-6d56d0f3fdaa.png">

<img width="367" alt="Screen Shot 2021-01-20 at 10 50 51" src="https://user-images.githubusercontent.com/1513454/105168417-04066900-5b12-11eb-828a-5fd1cc426d33.png">

### Variant 1 (`smallHeader`)
<img width="617" alt="Screen Shot 2021-01-20 at 10 51 33" src="https://user-images.githubusercontent.com/1513454/105168494-1c768380-5b12-11eb-8675-258eeb6434d1.png">
<img width="367" alt="Screen Shot 2021-01-20 at 10 50 21" src="https://user-images.githubusercontent.com/1513454/105168470-15e80c00-5b12-11eb-915c-5faef4ecab1f.png">

### Variant 2 (`yellowHeader`)
<img width="621" alt="Screen Shot 2021-01-20 at 10 49 08" src="https://user-images.githubusercontent.com/1513454/105168592-3ca64280-5b12-11eb-9f0a-bc5d9c1cb788.png">
<img width="367" alt="Screen Shot 2021-01-20 at 10 50 06" src="https://user-images.githubusercontent.com/1513454/105168606-40d26000-5b12-11eb-8e2d-c13da9b9ec0e.png">


### US-only copy
<img width="619" alt="Screen Shot 2021-01-20 at 11 36 31" src="https://user-images.githubusercontent.com/1513454/105169701-ca366200-5b13-11eb-95a3-7c51b65e47d9.png">
