### PR TITLE
add payment method icons below cta

### DIFF
--- a/src/components/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.tsx
@@ -62,12 +62,18 @@ const textContainer = css`
     }
 `;
 
+const paymentMethods = css`
+    display: block;
+    max-height: 1.25rem;
+    margin-top: ${space[2]}px;
+`;
+
 const cta: SerializedStyles = css`
     color: ${neutral[7]};
     background-color: ${brandAlt[400]};
 
     &:hover {
-        background-color: ${brandAlt[200]};
+        background-color: ${brandAlt[300]};
     }
 `;
 
@@ -144,9 +150,16 @@ const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
         countryCode,
     );
     return (
-        <LinkButton css={cta} priority="primary" href={url}>
+        <div>
+            <LinkButton css={cta} priority="primary" href={url}>
             {text || DEFAULT_CTA_TEXT}
-        </LinkButton>
+            </LinkButton>
+            <img
+                src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+                alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                css={paymentMethods}
+            />
+        </div>
     );
 };
 

--- a/src/components/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.tsx
@@ -14,6 +14,7 @@ import { EpicTracking } from './ContributionsEpicTypes';
 import { Variant } from '../../../lib/variants';
 import { replaceArticleCount } from '../../../lib/replaceArticleCount';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
+import { LiveblogEpicCardIconsTestVariants } from '../../../tests/liveblogEpicCardIconsTest';
 
 const container: SerializedStyles = css`
     padding: 6px 10px 28px 10px;
@@ -64,8 +65,7 @@ const textContainer = css`
 
 const paymentMethods = css`
     display: block;
-    max-height: 1.25rem;
-    margin-top: ${space[2]}px;
+    height: 28px;
 `;
 
 const cta: SerializedStyles = css`
@@ -74,6 +74,20 @@ const cta: SerializedStyles = css`
 
     &:hover {
         background-color: ${brandAlt[300]};
+    }
+`;
+
+const ctaContainer: SerializedStyles = css`
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    *:first-child {
+        margin-right: 25px;
+    }
+
+    > * {
+        margin-top: 6px;
+        margin-bottom: 6px;
     }
 `;
 
@@ -136,6 +150,7 @@ interface LiveblogEpicCtaProps {
     baseUrl?: string;
     countryCode?: string;
     tracking: EpicTracking;
+    cardIconsTestVariant: LiveblogEpicCardIconsTestVariants;
 }
 
 const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
@@ -143,6 +158,7 @@ const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
     baseUrl,
     tracking,
     countryCode,
+    cardIconsTestVariant,
 }: LiveblogEpicCtaProps) => {
     const url = addRegionIdAndTrackingParamsToSupportUrl(
         baseUrl || DEFAULT_CTA_BASE_URL,
@@ -150,15 +166,17 @@ const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
         countryCode,
     );
     return (
-        <div>
+        <div css={ctaContainer}>
             <LinkButton css={cta} priority="primary" href={url}>
-            {text || DEFAULT_CTA_TEXT}
+                {text || DEFAULT_CTA_TEXT}
             </LinkButton>
-            <img
-                src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
-                alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-                css={paymentMethods}
-            />
+            {cardIconsTestVariant === LiveblogEpicCardIconsTestVariants.variant && (
+                <img
+                    src="https://uploads.guim.co.uk/2021/02/04/liveblog-epic-cards.png"
+                    alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                    css={paymentMethods}
+                />
+            )}
         </div>
     );
 };
@@ -170,7 +188,9 @@ interface LiveblogEpicProps {
     numArticles: number;
 }
 
-export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
+export const ContributionsLiveblogEpicComponent: (
+    cardIconsTestVariant: LiveblogEpicCardIconsTestVariants,
+) => React.FC<LiveblogEpicProps> = cardIconsTestVariant => ({
     variant,
     countryCode,
     numArticles,
@@ -198,8 +218,13 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
                     text={variant.cta?.text}
                     baseUrl={variant.cta?.baseUrl}
                     tracking={tracking}
+                    cardIconsTestVariant={cardIconsTestVariant}
                 />
             </section>
         </>
     );
 };
+
+export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ContributionsLiveblogEpicComponent(
+    LiveblogEpicCardIconsTestVariants.control,
+);

--- a/src/components/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.tsx
@@ -64,7 +64,6 @@ const textContainer = css`
 `;
 
 const paymentMethods = css`
-    display: block;
     height: 28px;
 `;
 

--- a/src/components/modules/epics/ContributionsLiveblogEpicWithCardIcons.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpicWithCardIcons.tsx
@@ -1,0 +1,7 @@
+import { EpicProps } from './ContributionsEpic';
+import { LiveblogEpicCardIconsTestVariants } from '../../../tests/liveblogEpicCardIconsTest';
+import { ContributionsLiveblogEpicComponent } from './ContributionsLiveblogEpic';
+
+export const ContributionsLiveblogEpic: React.FC<EpicProps> = ContributionsLiveblogEpicComponent(
+    LiveblogEpicCardIconsTestVariants.variant,
+);

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -31,6 +31,11 @@ export const liveblogEpic: ModuleInfo = getDefaultModuleInfo(
     'epics/ContributionsLiveblogEpic',
 );
 
+export const liveblogCardIconsEpic: ModuleInfo = getDefaultModuleInfo(
+    'liveblog-epic-card-icons',
+    'epics/ContributionsLiveblogEpicWithCardIcons',
+);
+
 export const contributionsBanner: ModuleInfo = getDefaultModuleInfo(
     'contributions-banner',
     'banners/contributions/ContributionsBanner',
@@ -56,6 +61,7 @@ export const moduleInfos: ModuleInfo[] = [
     epicACAbove,
     epicACInline,
     liveblogEpic,
+    liveblogCardIconsEpic,
     contributionsBanner,
     digiSubs,
     guardianWeekly,

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -44,8 +44,8 @@ import { getAmpExperimentData } from './tests/amp/ampEpicTests';
 import { OphanComponentEvent } from './types/OphanTypes';
 import { logger } from './utils/logging';
 import {
-    liveblogEpicDesignTestGlobal,
-    liveblogEpicDesignTestUS,
+    liveblogEpicCardIconsTestGlobal,
+    liveblogEpicCardIconsTestUS,
 } from './tests/liveblogEpicCardIconsTest';
 
 const app = express();
@@ -128,7 +128,7 @@ const getForceableArticleEpicTests = async (): Promise<Test[]> => {
 
 const getLiveblogEpicTests = async (): Promise<Test[]> => {
     const configuredTests = await fetchConfiguredLiveblogEpicTestsCached();
-    return [liveblogEpicDesignTestUS, liveblogEpicDesignTestGlobal, ...configuredTests.tests];
+    return [liveblogEpicCardIconsTestUS, liveblogEpicCardIconsTestGlobal, ...configuredTests.tests];
 };
 
 const buildEpicData = async (

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -43,6 +43,10 @@ import { getAmpVariantAssignments } from './lib/ampVariantAssignments';
 import { getAmpExperimentData } from './tests/amp/ampEpicTests';
 import { OphanComponentEvent } from './types/OphanTypes';
 import { logger } from './utils/logging';
+import {
+    liveblogEpicDesignTestGlobal,
+    liveblogEpicDesignTestUS,
+} from './tests/liveblogEpicCardIconsTest';
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -124,7 +128,7 @@ const getForceableArticleEpicTests = async (): Promise<Test[]> => {
 
 const getLiveblogEpicTests = async (): Promise<Test[]> => {
     const configuredTests = await fetchConfiguredLiveblogEpicTestsCached();
-    return configuredTests.tests;
+    return [liveblogEpicDesignTestUS, liveblogEpicDesignTestGlobal, ...configuredTests.tests];
 };
 
 const buildEpicData = async (

--- a/src/tests/liveblogEpicCardIconsTest.ts
+++ b/src/tests/liveblogEpicCardIconsTest.ts
@@ -1,0 +1,73 @@
+import { Test, Variant } from '../lib/variants';
+import { CountryGroupId } from '../lib/geolocation';
+import { liveblogCardIconsEpic, liveblogEpic } from '../modules';
+
+export enum LiveblogEpicCardIconsTestVariants {
+    control = 'control',
+    variant = 'variant',
+}
+
+const globalParagraphs = [
+    'In these extraordinary times, the Guardian’s editorial independence has never been more important. Because no one sets our agenda, or edits our editor, we can keep delivering high-impact, trustworthy journalism each and every day. Free from commercial or political influence, we can report fearlessly on world events and challenge those in power.',
+    'We believe everyone deserves equal access to accurate news and calm explanation. Your support enables us to keep our journalism open for all. No matter how unpredictable the future feels, we will provide vital information so we can all make decisions about our lives, health and security – based on fact, not fiction.',
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.',
+];
+
+const USParagraphs = [
+    'Since you’re here, we have a small favour to ask. Millions are flocking to the Guardian for independent, quality news every day. As the new year begins, we’re asking you to consider a gift to help fund our journalism.',
+    'We believe everyone deserves to access information that’s grounded in science and truth. That’s why we made a different choice: to keep our reporting open for all readers, regardless of where they live or what they can afford to pay.',
+    'If you’ve enjoyed our live updates and in-depth coverage, support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.',
+];
+
+const variant = (name: string, modulePath: string, paragraphs: string[]): Variant => ({
+    name,
+    heading: 'Support the Guardian',
+    paragraphs,
+    cta: {
+        text: 'Show your support',
+        baseUrl: 'https://support.theguardian.com/contribute',
+    },
+    modulePath,
+});
+
+const liveblogEpicCardIconsTest = (
+    name: string,
+    paragraphs: string[],
+    locations: CountryGroupId[],
+): Test => ({
+    name: name,
+    expiry: '2021-03-01',
+    campaignId: name,
+    isOn: true,
+    locations,
+    audience: 1,
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: true,
+    userCohort: 'AllNonSupporters',
+    isLiveBlog: false,
+    hasCountryName: false,
+    variants: [
+        variant(LiveblogEpicCardIconsTestVariants.control, liveblogEpic.endpointPath, paragraphs),
+        variant(
+            LiveblogEpicCardIconsTestVariants.variant,
+            liveblogCardIconsEpic.endpointPath,
+            paragraphs,
+        ),
+    ],
+    highPriority: false,
+    useLocalViewLog: false,
+});
+
+export const liveblogEpicDesignTestGlobal: Test = liveblogEpicCardIconsTest(
+    '2020-01-20-LiveblogEpicDesignTest__Global',
+    globalParagraphs,
+    ['GBPCountries', 'AUDCountries', 'EURCountries', 'International', 'NZDCountries', 'Canada'],
+);
+export const liveblogEpicDesignTestUS: Test = liveblogEpicCardIconsTest(
+    '2020-01-20-LiveblogEpicDesignTest__US',
+    USParagraphs,
+    ['UnitedStates'],
+);

--- a/src/tests/liveblogEpicCardIconsTest.ts
+++ b/src/tests/liveblogEpicCardIconsTest.ts
@@ -61,13 +61,13 @@ const liveblogEpicCardIconsTest = (
     useLocalViewLog: false,
 });
 
-export const liveblogEpicDesignTestGlobal: Test = liveblogEpicCardIconsTest(
-    '2020-01-20-LiveblogEpicDesignTest__Global',
+export const liveblogEpicCardIconsTestGlobal: Test = liveblogEpicCardIconsTest(
+    '2020-01-20-LiveblogEpicCardIconsTest__Global',
     globalParagraphs,
     ['GBPCountries', 'AUDCountries', 'EURCountries', 'International', 'NZDCountries', 'Canada'],
 );
-export const liveblogEpicDesignTestUS: Test = liveblogEpicCardIconsTest(
-    '2020-01-20-LiveblogEpicDesignTest__US',
+export const liveblogEpicCardIconsTestUS: Test = liveblogEpicCardIconsTest(
+    '2020-01-20-LiveblogEpicCardIconsTest__US',
     USParagraphs,
     ['UnitedStates'],
 );

--- a/src/tests/liveblogEpicCardIconsTest.ts
+++ b/src/tests/liveblogEpicCardIconsTest.ts
@@ -62,12 +62,12 @@ const liveblogEpicCardIconsTest = (
 });
 
 export const liveblogEpicCardIconsTestGlobal: Test = liveblogEpicCardIconsTest(
-    '2020-01-20-LiveblogEpicCardIconsTest__Global',
+    '2021-02-05-LiveblogEpicCardIconsTest__Global',
     globalParagraphs,
     ['GBPCountries', 'AUDCountries', 'EURCountries', 'International', 'NZDCountries', 'Canada'],
 );
 export const liveblogEpicCardIconsTestUS: Test = liveblogEpicCardIconsTest(
-    '2020-01-20-LiveblogEpicCardIconsTest__US',
+    '2021-02-05-LiveblogEpicCardIconsTest__US',
     USParagraphs,
     ['UnitedStates'],
 );


### PR DESCRIPTION
AB testing the card icon image. Implemented as separate modules.
Test name: `2021-02-05-LiveblogEpicCardIconsTest`

### Control
<img width="623" alt="Screen Shot 2021-02-04 at 16 28 15" src="https://user-images.githubusercontent.com/1513454/106923460-ffdb6d80-6705-11eb-9992-6c50780af08b.png">

### Variant mobile
<img width="318" alt="Screen Shot 2021-02-04 at 16 11 05" src="https://user-images.githubusercontent.com/1513454/106923331-da4e6400-6705-11eb-9a72-b216a62adec9.png">

### Variant desktop
<img width="623" alt="Screen Shot 2021-02-04 at 16 28 45" src="https://user-images.githubusercontent.com/1513454/106923535-12ee3d80-6706-11eb-973a-e6f08104ae07.png">

