### PR TITLE
Refactor contribs banner

### DIFF
--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -1,50 +1,41 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import {
-    addRegionIdAndTrackingParamsToSupportUrl,
-    createClickEventFromTracking,
-} from '../../../../lib/tracking';
-import { setChannelClosedTimestamp } from '../localStorage';
-import React, { useState } from 'react';
-import { BannerProps } from '../../../../types/BannerTypes';
+import React from 'react';
 import { styles } from './ContributionsBannerStyles';
-import {
-    containsNonArticleCountPlaceholder,
-    replaceNonArticleCountPlaceholders,
-} from '../../../../lib/placeholders';
 import { SvgRoundel } from '@guardian/src-brand';
 import { SvgCross, SvgArrowRightStraight } from '@guardian/src-icons';
 import { ThemeProvider } from 'emotion-theming';
 import { Button, LinkButton, buttonReaderRevenueBrandAlt } from '@guardian/src-button';
 import { replaceArticleCount } from '../../../../lib/replaceArticleCount';
 import { Hide } from '@guardian/src-layout/components/hide/hide';
+import contributionsBannerWrapper, { ContributionsBannerProps } from './ContributionsBannerWrapper';
 
 const bannerId = 'contributions-banner';
 const closeComponentId = `${bannerId} : close`;
 const ctaComponentId = `${bannerId} : cta`;
 
 interface ContributionsBannerBodyProps {
-    messageText: string;
-    mobileMessageText: string;
+    cleanMessageText: string;
+    cleanMobileMessageText?: string;
     numArticles: number;
 }
 
 const ContributionsBannerBody: React.FC<ContributionsBannerBodyProps> = ({
-    messageText,
-    mobileMessageText,
+    cleanMessageText,
+    cleanMobileMessageText,
     numArticles,
 }) => {
-    if (mobileMessageText) {
+    if (cleanMobileMessageText) {
         return (
             <>
                 <Hide above="phablet">
                     <span css={styles.messageText}>
-                        {replaceArticleCount(mobileMessageText, numArticles, 'banner')}
+                        {replaceArticleCount(cleanMobileMessageText, numArticles, 'banner')}
                     </span>
                 </Hide>
                 <Hide below="phablet">
                     <span css={styles.messageText}>
-                        {replaceArticleCount(messageText, numArticles, 'banner')}
+                        {replaceArticleCount(cleanMessageText, numArticles, 'banner')}
                     </span>
                 </Hide>
             </>
@@ -52,165 +43,114 @@ const ContributionsBannerBody: React.FC<ContributionsBannerBodyProps> = ({
     } else {
         return (
             <span css={styles.messageText}>
-                {replaceArticleCount(messageText, numArticles, 'banner')}
+                {replaceArticleCount(cleanMessageText, numArticles, 'banner')}
             </span>
         );
     }
 };
 
-export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) => {
-    const [showBanner, setShowBanner] = useState(true);
-    const { content, countryCode } = props;
-    const numArticles = props.numArticles || 0;
-
-    const onContributeClick = (): void => {
-        const componentClickEvent = createClickEventFromTracking(props.tracking, ctaComponentId);
-        if (props.submitComponentEvent) {
-            props.submitComponentEvent(componentClickEvent);
-        }
-    };
-
-    const onCloseClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
-        evt.preventDefault();
-        const componentClickEvent = createClickEventFromTracking(props.tracking, closeComponentId);
-        if (props.submitComponentEvent) {
-            props.submitComponentEvent(componentClickEvent);
-        }
-        setShowBanner(false);
-        setChannelClosedTimestamp(props.bannerChannel);
-    };
-
-    if (content && countryCode && showBanner) {
-        const cleanHighlightedText =
-            content.highlightedText &&
-            replaceNonArticleCountPlaceholders(content.highlightedText, countryCode).trim();
-
-        const cleanMessageText = replaceNonArticleCountPlaceholders(
-            content.messageText,
-            countryCode,
-        ).trim();
-
-        const cleanMobileMessageText = replaceNonArticleCountPlaceholders(
-            content.mobileMessageText,
-            countryCode,
-        ).trim();
-
-        const cleanHeading = replaceNonArticleCountPlaceholders(
-            content.heading,
-            countryCode,
-        ).trim();
-
-        const copyHasPlaceholder =
-            containsNonArticleCountPlaceholder(cleanMessageText) ||
-            (!!cleanMobileMessageText &&
-                containsNonArticleCountPlaceholder(cleanMobileMessageText)) ||
-            (!!cleanHighlightedText && containsNonArticleCountPlaceholder(cleanHighlightedText)) ||
-            (!!cleanHeading && containsNonArticleCountPlaceholder(cleanHeading));
-
-        if (!copyHasPlaceholder) {
-            return (
-                <>
-                    <div css={styles.bannerContainer}>
-                        <div css={styles.banner}>
-                            <div css={styles.leftRoundel}>
-                                <div css={styles.roundelContainer}>
-                                    <SvgRoundel />
-                                </div>
-                            </div>
-                            <div css={styles.copyAndCta}>
-                                <div css={styles.copy}>
-                                    {cleanHeading && (
-                                        <>
-                                            <span css={styles.heading}>
-                                                {replaceArticleCount(
-                                                    cleanHeading,
-                                                    numArticles,
-                                                    'banner',
-                                                )}
-                                            </span>{' '}
-                                        </>
-                                    )}
-                                    <ContributionsBannerBody
-                                        messageText={cleanMessageText}
-                                        mobileMessageText={cleanMobileMessageText}
-                                        numArticles={numArticles}
-                                    />
-                                    {cleanHighlightedText && (
-                                        <>
-                                            {' '}
-                                            <span css={styles.highlightedText}>
-                                                {replaceArticleCount(
-                                                    cleanHighlightedText,
-                                                    numArticles,
-                                                    'banner',
-                                                )}
-                                            </span>
-                                        </>
-                                    )}
-                                </div>
-                                {content.cta && (
-                                    <div css={styles.ctaContainer}>
-                                        <div css={styles.cta}>
-                                            <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
-                                                <LinkButton
-                                                    data-link-name={ctaComponentId}
-                                                    css={styles.ctaButton}
-                                                    priority="primary"
-                                                    size="small"
-                                                    icon={<SvgArrowRightStraight />}
-                                                    iconSide="right"
-                                                    nudgeIcon={true}
-                                                    onClick={onContributeClick}
-                                                    hideLabel={false}
-                                                    aria-label="Contribute"
-                                                    href={addRegionIdAndTrackingParamsToSupportUrl(
-                                                        content.cta.baseUrl,
-                                                        props.tracking,
-                                                        props.countryCode,
-                                                    )}
-                                                >
-                                                    {content.cta.text}
-                                                </LinkButton>
-                                            </ThemeProvider>
-                                            <img
-                                                src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
-                                                alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-                                                css={styles.paymentMethods}
-                                            />
-                                        </div>
-                                    </div>
-                                )}
-                            </div>
-                            <div css={styles.rightButtons}>
-                                <div css={styles.rightRoundel}>
-                                    <div css={styles.roundelContainer}>
-                                        <SvgRoundel />
-                                    </div>
-                                </div>
-                                <div css={styles.closeButtonContainer}>
-                                    <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
-                                        <Button
-                                            aria-label="Close"
-                                            data-link-name={closeComponentId}
-                                            priority="tertiary"
-                                            size="small"
-                                            icon={<SvgCross />}
-                                            nudgeIcon={false}
-                                            onClick={onCloseClick}
-                                            hideLabel={true}
-                                            iconSide="left"
-                                        />
-                                    </ThemeProvider>
-                                </div>
+const ContributionsBanner: React.FC<ContributionsBannerProps> = ({
+    onContributeClick,
+    onCloseClick,
+    cleanHighlightedText,
+    cleanMessageText,
+    cleanMobileMessageText,
+    cleanHeading,
+    ctaUrl,
+    ctaText,
+    numArticles = 0,
+}: ContributionsBannerProps) => {
+    return (
+        <>
+            <div css={styles.bannerContainer}>
+                <div css={styles.banner}>
+                    <div css={styles.leftRoundel}>
+                        <div css={styles.roundelContainer}>
+                            <SvgRoundel />
+                        </div>
+                    </div>
+                    <div css={styles.copyAndCta}>
+                        <div css={styles.copy}>
+                            {cleanHeading && (
+                                <>
+                                    <span css={styles.heading}>
+                                        {replaceArticleCount(cleanHeading, numArticles, 'banner')}
+                                    </span>{' '}
+                                </>
+                            )}
+                            <ContributionsBannerBody
+                                cleanMessageText={cleanMessageText}
+                                cleanMobileMessageText={cleanMobileMessageText}
+                                numArticles={numArticles}
+                            />
+                            {cleanHighlightedText && (
+                                <>
+                                    {' '}
+                                    <span css={styles.highlightedText}>
+                                        {replaceArticleCount(
+                                            cleanHighlightedText,
+                                            numArticles,
+                                            'banner',
+                                        )}
+                                    </span>
+                                </>
+                            )}
+                        </div>
+                        <div css={styles.ctaContainer}>
+                            <div css={styles.cta}>
+                                <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
+                                    <LinkButton
+                                        data-link-name={ctaComponentId}
+                                        css={styles.ctaButton}
+                                        priority="primary"
+                                        size="small"
+                                        icon={<SvgArrowRightStraight />}
+                                        iconSide="right"
+                                        nudgeIcon={true}
+                                        onClick={onContributeClick}
+                                        hideLabel={false}
+                                        aria-label="Contribute"
+                                        href={ctaUrl}
+                                    >
+                                        {ctaText}
+                                    </LinkButton>
+                                </ThemeProvider>
+                                <img
+                                    src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+                                    alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                                    css={styles.paymentMethods}
+                                />
                             </div>
                         </div>
                     </div>
-                </>
-            );
-        } else {
-            console.log('Banner copy contains placeholders, abandoning.');
-        }
-    }
-
-    return null;
+                    <div css={styles.rightButtons}>
+                        <div css={styles.rightRoundel}>
+                            <div css={styles.roundelContainer}>
+                                <SvgRoundel />
+                            </div>
+                        </div>
+                        <div css={styles.closeButtonContainer}>
+                            <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
+                                <Button
+                                    aria-label="Close"
+                                    data-link-name={closeComponentId}
+                                    priority="tertiary"
+                                    size="small"
+                                    icon={<SvgCross />}
+                                    nudgeIcon={false}
+                                    onClick={onCloseClick}
+                                    hideLabel={true}
+                                    iconSide="left"
+                                />
+                            </ThemeProvider>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
 };
+
+const wrapped = contributionsBannerWrapper(ContributionsBanner);
+
+export { wrapped as ContributionsBanner };

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -7,7 +7,7 @@ import { SvgCross, SvgArrowRightStraight } from '@guardian/src-icons';
 import { ThemeProvider } from 'emotion-theming';
 import { Button, LinkButton, buttonReaderRevenueBrandAlt } from '@guardian/src-button';
 import { replaceArticleCount } from '../../../../lib/replaceArticleCount';
-import { Hide } from '@guardian/src-layout/components/hide/hide';
+import { Hide } from '@guardian/src-layout';
 import contributionsBannerWrapper, { ContributionsBannerProps } from './ContributionsBannerWrapper';
 
 const bannerId = 'contributions-banner';

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -17,10 +17,46 @@ import { SvgCross, SvgArrowRightStraight } from '@guardian/src-icons';
 import { ThemeProvider } from 'emotion-theming';
 import { Button, LinkButton, buttonReaderRevenueBrandAlt } from '@guardian/src-button';
 import { replaceArticleCount } from '../../../../lib/replaceArticleCount';
+import { Hide } from '@guardian/src-layout/components/hide/hide';
 
 const bannerId = 'contributions-banner';
 const closeComponentId = `${bannerId} : close`;
 const ctaComponentId = `${bannerId} : cta`;
+
+interface ContributionsBannerBodyProps {
+    messageText: string;
+    mobileMessageText: string;
+    numArticles: number;
+}
+
+const ContributionsBannerBody: React.FC<ContributionsBannerBodyProps> = ({
+    messageText,
+    mobileMessageText,
+    numArticles,
+}) => {
+    if (mobileMessageText) {
+        return (
+            <>
+                <Hide above="phablet">
+                    <span css={styles.messageText}>
+                        {replaceArticleCount(mobileMessageText, numArticles, 'banner')}
+                    </span>
+                </Hide>
+                <Hide below="phablet">
+                    <span css={styles.messageText}>
+                        {replaceArticleCount(messageText, numArticles, 'banner')}
+                    </span>
+                </Hide>
+            </>
+        );
+    } else {
+        return (
+            <span css={styles.messageText}>
+                {replaceArticleCount(messageText, numArticles, 'banner')}
+            </span>
+        );
+    }
+};
 
 export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) => {
     const [showBanner, setShowBanner] = useState(true);
@@ -54,6 +90,11 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
             countryCode,
         ).trim();
 
+        const cleanMobileMessageText = replaceNonArticleCountPlaceholders(
+            content.mobileMessageText,
+            countryCode,
+        ).trim();
+
         const cleanHeading = replaceNonArticleCountPlaceholders(
             content.heading,
             countryCode,
@@ -61,6 +102,8 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
 
         const copyHasPlaceholder =
             containsNonArticleCountPlaceholder(cleanMessageText) ||
+            (!!cleanMobileMessageText &&
+                containsNonArticleCountPlaceholder(cleanMobileMessageText)) ||
             (!!cleanHighlightedText && containsNonArticleCountPlaceholder(cleanHighlightedText)) ||
             (!!cleanHeading && containsNonArticleCountPlaceholder(cleanHeading));
 
@@ -87,13 +130,11 @@ export const ContributionsBanner: React.FC<BannerProps> = (props: BannerProps) =
                                             </span>{' '}
                                         </>
                                     )}
-                                    <span css={styles.messageText}>
-                                        {replaceArticleCount(
-                                            cleanMessageText,
-                                            numArticles,
-                                            'banner',
-                                        )}
-                                    </span>
+                                    <ContributionsBannerBody
+                                        messageText={cleanMessageText}
+                                        mobileMessageText={cleanMobileMessageText}
+                                        numArticles={numArticles}
+                                    />
                                     {cleanHighlightedText && (
                                         <>
                                             {' '}

--- a/src/components/modules/banners/contributions/ContributionsBannerWrapper.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerWrapper.tsx
@@ -1,0 +1,119 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import {
+    addRegionIdAndTrackingParamsToSupportUrl,
+    createClickEventFromTracking,
+} from '../../../../lib/tracking';
+import React from 'react';
+import { BannerProps } from '../../../../types/BannerTypes';
+import {
+    containsNonArticleCountPlaceholder,
+    replaceNonArticleCountPlaceholders,
+} from '../../../../lib/placeholders';
+import withCloseable, { CloseableBannerProps } from '../hocs/withCloseable';
+
+const bannerId = 'contributions-banner';
+const closeComponentId = `${bannerId} : close`;
+const ctaComponentId = `${bannerId} : cta`;
+
+export interface ContributionsBannerProps {
+    onContributeClick: () => void;
+    onCloseClick: () => void;
+    cleanHighlightedText?: string;
+    cleanMessageText: string;
+    cleanMobileMessageText?: string;
+    cleanHeading?: string;
+    ctaUrl: string;
+    ctaText: string;
+    numArticles?: number;
+}
+
+const withBannerData = (
+    Banner: React.FC<ContributionsBannerProps>,
+): React.FC<CloseableBannerProps> => bannerProps => {
+    const {
+        tracking,
+        submitComponentEvent,
+        onClose,
+        content,
+        countryCode,
+        numArticles,
+    } = bannerProps;
+
+    const onContributeClick = (): void => {
+        const componentClickEvent = createClickEventFromTracking(
+            bannerProps.tracking,
+            ctaComponentId,
+        );
+        if (submitComponentEvent) {
+            submitComponentEvent(componentClickEvent);
+        }
+    };
+
+    const onCloseClick = (): void => {
+        const componentClickEvent = createClickEventFromTracking(tracking, closeComponentId);
+        if (submitComponentEvent) {
+            submitComponentEvent(componentClickEvent);
+        }
+        onClose();
+    };
+
+    if (content && countryCode && content.cta) {
+        const ctaUrl = addRegionIdAndTrackingParamsToSupportUrl(
+            content.cta.baseUrl,
+            tracking,
+            countryCode,
+        );
+
+        const cleanHighlightedText =
+            content.highlightedText &&
+            replaceNonArticleCountPlaceholders(content.highlightedText, countryCode).trim();
+
+        const cleanMessageText = replaceNonArticleCountPlaceholders(
+            content.messageText,
+            countryCode,
+        ).trim();
+
+        const cleanMobileMessageText = replaceNonArticleCountPlaceholders(
+            content.mobileMessageText,
+            countryCode,
+        ).trim();
+
+        const cleanHeading = replaceNonArticleCountPlaceholders(
+            content.heading,
+            countryCode,
+        ).trim();
+
+        const copyHasPlaceholder =
+            containsNonArticleCountPlaceholder(cleanMessageText) ||
+            (!!cleanMobileMessageText &&
+                containsNonArticleCountPlaceholder(cleanMobileMessageText)) ||
+            (!!cleanHighlightedText && containsNonArticleCountPlaceholder(cleanHighlightedText)) ||
+            (!!cleanHeading && containsNonArticleCountPlaceholder(cleanHeading));
+
+        if (!copyHasPlaceholder) {
+            const props: ContributionsBannerProps = {
+                onContributeClick,
+                onCloseClick,
+                cleanHighlightedText,
+                cleanMessageText,
+                cleanMobileMessageText,
+                cleanHeading,
+                ctaUrl,
+                ctaText: content.cta.text,
+                numArticles,
+            };
+            return <Banner {...props} />;
+        } else {
+            console.log('Banner copy contains placeholders, abandoning.');
+        }
+    }
+
+    return null;
+};
+
+const contributionsBannerWrapper = (
+    Banner: React.FC<ContributionsBannerProps>,
+): React.FC<BannerProps> => withCloseable(withBannerData(Banner), 'contributions');
+
+export default contributionsBannerWrapper;

--- a/src/components/modules/banners/utils/storybook.ts
+++ b/src/components/modules/banners/utils/storybook.ts
@@ -15,6 +15,8 @@ export const tracking: BannerTracking = {
 export const content: BannerContent = {
     messageText:
         '<strong> We chose a different approach. Will you support it?</strong> Unlike many news organisations, we made a choice to keep our journalism open for all. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart. Every contribution, however big or small, is so valuable – it is essential in protecting our editorial independence.',
+    mobileMessageText:
+        'With 2021 offering new hope, we commit to another year of independent journalism.',
     highlightedText: ' Support the Guardian today from as little as %%CURRENCY_SYMBOL%%1.',
     cta: {
         baseUrl: 'https://support.theguardian.com/contribute',


### PR DESCRIPTION
The only functional change here is to make the ContributionsBanner use `mobileMessageText` if it's set.

The other change is to add a wrapper for contributions banners.
This is because we're going to be testing designs and I want to avoid duplicating common logic.

So:
- `ContributionsBanner` is still the default yellow banner component, but with the logic moved out.
- `contributionsBannerWrapper` uses the existing `withClosable` wrapper, and passes just the necessary props into the actual banner component.