### PR TITLE
Update to new reminders API

### DIFF
--- a/src/components/modules/epics/ContributionsEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpic.stories.tsx
@@ -29,9 +29,9 @@ WithReminder.args = {
         ...props.variant,
         secondaryCta: undefined,
         showReminderFields: {
-            reminderCTA: 'Remind me in May',
-            reminderDate: '2020-05-18T09:30:00',
-            reminderDateAsString: 'May',
+            reminderCta: 'Remind me in May',
+            reminderPeriod: '2020-05-01',
+            reminderLabel: 'May',
         },
     },
 };

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -265,7 +265,7 @@ export const ContributionsEpicComponent: (
                     tracking={tracking}
                     countryCode={countryCode}
                     onOpenReminderClick={(): void => {
-                        const buttonCopyAsString = showReminderFields?.reminderCTA
+                        const buttonCopyAsString = showReminderFields?.reminderCta
                             .toLowerCase()
                             .replace(/\s/g, '-');
 
@@ -284,9 +284,8 @@ export const ContributionsEpicComponent: (
 
             {isReminderActive && showReminderFields && (
                 <ContributionsEpicReminder
-                    reminderCTA={showReminderFields.reminderCTA}
-                    reminderDate={showReminderFields.reminderDate}
-                    reminderDateAsString={showReminderFields.reminderDateAsString}
+                    reminderPeriod={showReminderFields.reminderPeriod}
+                    reminderLabel={showReminderFields.reminderLabel}
                     onCloseReminderClick={(): void => setIsReminderActive(false)}
                 />
             )}

--- a/src/components/modules/epics/ContributionsEpicButtons.tsx
+++ b/src/components/modules/epics/ContributionsEpicButtons.tsx
@@ -112,7 +112,7 @@ export const ContributionsEpicButtons = ({
                 showReminderFields && (
                     <div css={buttonMargins}>
                         <Button onClickAction={onOpenReminderClick} isTertiary>
-                            {showReminderFields.reminderCTA}
+                            {showReminderFields.reminderCta}
                         </Button>
                     </div>
                 )

--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -3,7 +3,6 @@ import { css, SerializedStyles } from '@emotion/core';
 import { headline, textSans, body } from '@guardian/src-foundations/typography';
 import { palette, space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { ReminderFields } from '../../../lib/reminderFields';
 import { Lines } from '../../Lines';
 import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';
@@ -111,15 +110,16 @@ const isValidEmail = (email: string): boolean => {
     return re.test(String(email).toLowerCase());
 };
 
-interface Props extends ReminderFields {
+interface ContributionsEpicReminderProps {
+    reminderPeriod: string;
+    reminderLabel: string;
     // eslint-disable-next-line @typescript-eslint/ban-types
     onCloseReminderClick: Function;
 }
 
-type ReminderPayload = {
-    email: string;
-    reminderDate: string;
-};
+const REMINDER_PLATFORM = 'WEB';
+const REMINDER_COMPONENT = 'EPIC';
+const REMINDER_STAGE = 'PRE';
 
 const dateDiff = (start: Date, end: Date): number => {
     const twentyFourHours = 86400000;
@@ -133,22 +133,7 @@ const addContributionReminderCookie = (reminderDateString: string): void => {
     addCookie('gu_epic_contribution_reminder', '1', dateDiff(today, reminderDate));
 };
 
-const contributionsReminderUrl =
-    'https://contribution-reminders.support.guardianapis.com/remind-me';
-
-const submitForm = ({ email, reminderDate }: ReminderPayload): Promise<Response> => {
-    return fetch(contributionsReminderUrl, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-            email,
-            reminderDate,
-            isPreContribution: true,
-        }),
-    });
-};
+const createOneOffReminderEndpoint = 'https://support.theguardian.com/reminders/create/one-off';
 
 const PREPOSITION_REGEX = /^(on|in)/;
 
@@ -159,11 +144,11 @@ const addPreposition = (text: string): string => 'in ' + text;
 const ensureHasPreposition = (text: string): string =>
     containsPreposition(text) ? text : addPreposition(text);
 
-export const ContributionsEpicReminder: React.FC<Props> = ({
-    reminderDate,
-    reminderDateAsString,
+export const ContributionsEpicReminder: React.FC<ContributionsEpicReminderProps> = ({
+    reminderLabel,
+    reminderPeriod,
     onCloseReminderClick,
-}: Props) => {
+}: ContributionsEpicReminderProps) => {
     const [isDirty, setIsDirty] = useState(false);
     const [isSubmittingState, setIsSubmittingState] = useState(false);
     const [isErrorState, setIsErrorState] = useState(false);
@@ -173,6 +158,22 @@ export const ContributionsEpicReminder: React.FC<Props> = ({
     const isEmpty = emailAddress.trim().length === 0;
     const isValid = isValidEmail(emailAddress);
 
+    const submitForm = (): Promise<Response> => {
+        return fetch(createOneOffReminderEndpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                email: emailAddress,
+                reminderPeriod,
+                reminderPlatform: REMINDER_PLATFORM,
+                reminderComponent: REMINDER_COMPONENT,
+                reminderStage: REMINDER_STAGE,
+            }),
+        });
+    };
+
     let inputError;
     if (isDirty && isEmpty) {
         inputError = 'Please enter your email address';
@@ -180,7 +181,7 @@ export const ContributionsEpicReminder: React.FC<Props> = ({
         inputError = 'Please enter a valid email address';
     }
 
-    const reminderDateWithPreposition = ensureHasPreposition(reminderDateAsString);
+    const reminderDateWithPreposition = ensureHasPreposition(reminderLabel);
 
     return (
         <div css={rootStyles}>
@@ -196,24 +197,13 @@ export const ContributionsEpicReminder: React.FC<Props> = ({
                 <form
                     onSubmit={(e): void => {
                         if (isValid) {
-                            const formValues: ReminderPayload = {
-                                email: emailAddress,
-                                reminderDate: reminderDate,
-                            };
                             setIsSubmittingState(true);
-                            submitForm(formValues)
+                            submitForm()
                                 .then(response => {
                                     if (!response.ok) {
                                         throw Error(response.statusText);
                                     }
-                                    return response;
-                                })
-                                .then(response => response.json())
-                                .then(json => {
-                                    if (json !== 'OK') {
-                                        throw Error('Server error');
-                                    }
-                                    addContributionReminderCookie(reminderDate);
+                                    addContributionReminderCookie(reminderPeriod);
                                     setIsSuccessState(true);
                                 })
                                 .catch((): void => setIsErrorState(true))

--- a/src/lib/reminderFields.test.ts
+++ b/src/lib/reminderFields.test.ts
@@ -2,12 +2,12 @@ import { buildReminderFields } from './reminderFields';
 
 describe('buildReminderFields', () => {
     it('should set date to the next calendar month if the current date is BEFORE the 20th', () => {
-        const novemberNineteenth = new Date('2020-11-19 00:00:00');
+        const novemberNineteenth = new Date('2020-11-19');
 
         const expected = {
-            reminderCTA: `Remind me in December`,
-            reminderDate: `2020-12-19 00:00:00`,
-            reminderDateAsString: `December 2020`,
+            reminderCta: `Remind me in December`,
+            reminderPeriod: `2020-12-01`,
+            reminderLabel: `December 2020`,
         };
         const actual = buildReminderFields(novemberNineteenth);
 
@@ -15,12 +15,12 @@ describe('buildReminderFields', () => {
     });
 
     it('should set date to the next + 1 calendar month if the current date is the 20th', () => {
-        const novemberTwentieth = new Date('2020-11-20 00:00:00');
+        const novemberTwentieth = new Date('2020-11-20');
 
         const expected = {
-            reminderCTA: `Remind me in January`,
-            reminderDate: `2021-01-19 00:00:00`,
-            reminderDateAsString: `January 2021`,
+            reminderCta: `Remind me in January`,
+            reminderPeriod: `2021-01-01`,
+            reminderLabel: `January 2021`,
         };
         const actual = buildReminderFields(novemberTwentieth);
 
@@ -28,12 +28,12 @@ describe('buildReminderFields', () => {
     });
 
     it('should set date to the next + 1 calendar month if the current date is AFTER the 20th', () => {
-        const novemberTwentyFirst = new Date('2020-11-21 00:00:00');
+        const novemberTwentyFirst = new Date('2020-11-21');
 
         const expected = {
-            reminderCTA: `Remind me in January`,
-            reminderDate: `2021-01-19 00:00:00`,
-            reminderDateAsString: `January 2021`,
+            reminderCta: `Remind me in January`,
+            reminderPeriod: `2021-01-01`,
+            reminderLabel: `January 2021`,
         };
         const actual = buildReminderFields(novemberTwentyFirst);
 

--- a/src/lib/reminderFields.ts
+++ b/src/lib/reminderFields.ts
@@ -1,7 +1,7 @@
 export interface ReminderFields {
-    reminderCTA: string;
-    reminderDate: string;
-    reminderDateAsString: string;
+    reminderCta: string;
+    reminderLabel: string;
+    reminderPeriod: string;
 }
 
 const getReminderDate = (date: Date): Date => {
@@ -20,9 +20,9 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     const year = reminderDate.getFullYear();
 
     return {
-        reminderCTA: `Remind me in ${monthName}`,
-        reminderDate: `${year}-${paddedMonth}-19 00:00:00`,
-        reminderDateAsString: `${monthName} ${year}`,
+        reminderCta: `Remind me in ${monthName}`,
+        reminderPeriod: `${year}-${paddedMonth}-01`,
+        reminderLabel: `${monthName} ${year}`,
     };
 };
 


### PR DESCRIPTION
## What does this change?
Update Epic reminder to use new reminders API ([trello card](https://trello.com/c/P2olSwqR/2486-reminders-architecture-v2))

## Images

### request
<img width="473" alt="Screenshot 2021-02-12 at 13 52 08" src="https://user-images.githubusercontent.com/17720442/107777237-78f84780-6d3a-11eb-90d5-34ba372a9510.png">

### cloudwatch
<img width="473" alt="Screenshot 2021-02-12 at 13 53 35" src="https://user-images.githubusercontent.com/17720442/107777243-7a297480-6d3a-11eb-9bfa-4096ab9406ab.png">
