### PR TITLE
Remove AUDCountries from hardcoded tests

### DIFF
--- a/src/tests/banners/ContributionsBannerDesignTest.ts
+++ b/src/tests/banners/ContributionsBannerDesignTest.ts
@@ -50,6 +50,15 @@ export const ContributionsBannerDesignTestAC: BannerTest = {
     name: '2021-02-16_ContributionsBannerDesignTest__AC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
+    // We've removed AUDCountries intentionally to allow testing from the tool
+    locations: [
+        'GBPCountries',
+        'EURCountries',
+        'International',
+        'NZDCountries',
+        'Canada',
+        'UnitedStates',
+    ],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => true,
     minPageViews: 2,
@@ -86,6 +95,15 @@ export const ContributionsBannerDesignTestNoAC: BannerTest = {
     name: '2021-02-16_ContributionsBannerDesignTest__NoAC',
     bannerChannel: 'contributions',
     testAudience: 'AllNonSupporters',
+    // We've removed AUDCountries intentionally to allow testing from the tool
+    locations: [
+        'GBPCountries',
+        'EURCountries',
+        'International',
+        'NZDCountries',
+        'Canada',
+        'UnitedStates',
+    ],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (targeting: BannerTargeting, pageTracking: BannerPageTracking) => true,
     minPageViews: 2,

--- a/src/tests/liveblogEpicCardIconsTest.ts
+++ b/src/tests/liveblogEpicCardIconsTest.ts
@@ -64,7 +64,8 @@ const liveblogEpicCardIconsTest = (
 export const liveblogEpicCardIconsTestGlobal: Test = liveblogEpicCardIconsTest(
     '2021-02-05-LiveblogEpicCardIconsTest__Global',
     globalParagraphs,
-    ['GBPCountries', 'AUDCountries', 'EURCountries', 'International', 'NZDCountries', 'Canada'],
+    // We've removed AUDCountries intentionally to allow testing from the tool
+    ['GBPCountries', 'EURCountries', 'International', 'NZDCountries', 'Canada'],
 );
 export const liveblogEpicCardIconsTestUS: Test = liveblogEpicCardIconsTest(
     '2021-02-05-LiveblogEpicCardIconsTest__US',


### PR DESCRIPTION
## What does this change?
Remove AUDCountries from hardcoded tests from hardcoded tests to allow for testing in the tool in response to the FB situation in AU.