### PR TITLE
Basic set up for the new puzzles banner component

### DIFF
--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
 
 export const PuzzlesBanner: React.FC = () => {
-    return (
-        <div>
-            Get the Guardian puzzles app
-        </div>
-    )
-}
+    return <div>Get the Guardian puzzles app</div>;
+};

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export const PuzzlesBanner: React.FC = () => {
+    return (
+        <div>
+            Get the Guardian puzzles app
+        </div>
+    )
+}

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -61,6 +61,11 @@ export const guardianWeekly: ModuleInfo = getDefaultModuleInfo(
     'banners/guardianWeekly/GuardianWeeklyBanner',
 );
 
+export const puzzlesBanner: ModuleInfo = getDefaultModuleInfo(
+    'puzzles-banner',
+    'puzzles/puzzlesBanner/PuzzlesBanner',
+);
+
 export const moduleInfos: ModuleInfo[] = [
     epic,
     epicACAbove,
@@ -72,4 +77,5 @@ export const moduleInfos: ModuleInfo[] = [
     contributionsBannerVariantB,
     digiSubs,
     guardianWeekly,
+    puzzlesBanner,
 ];

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -619,6 +619,20 @@ app.get(
     },
 );
 
+app.post('/puzzles', async (req: express.Request, res: express.Response) => {
+    const response = {
+        data: {
+            module: {
+                url: `${baseUrl(req)}/puzzles-banner.js`,
+                name: 'PuzzlesBanner',
+                props: {},
+            },
+            meta: {},
+        },
+    };
+    res.send(response);
+});
+
 app.use(errorHandlingMiddleware);
 
 const PORT = process.env.PORT || 3030;


### PR DESCRIPTION
## What does this change?
This adds a basic route and component with build process for the new puzzles banner component.

We're setting this up separately from the existing banner architecture because the puzzles banner is significantly different in appearance and behaviour- it has a very different copy structure and acts as a persistent part of the page rather than a dismissible banner.