### PR TITLE
use a more sensible name for the instances

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -284,7 +284,11 @@ Resources:
                         Ref: App
                 -   Key: Name
                     PropagateAtLaunch: true
-                    Value: AlbEc2Stack/ASG
+                    Value: !Join
+                      - '-'
+                      - - !Ref Stack
+                        - !Ref Stage
+                        - !Ref App
                 -   Key: Stack
                     PropagateAtLaunch: true
                     Value:


### PR DESCRIPTION
at the moment
![image](https://user-images.githubusercontent.com/7304387/108747552-76b19c80-7535-11eb-86ec-91e21e0f67c8.png)
we want them to be clearer what they are, in the same was as most of the other apps are now
