### PR TITLE
Full support for mobile banner copy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,9 @@ module.exports = {
                 args: 'after-used',
             },
         ],
+        // Not compatible with TS + arrow functions - https://github.com/yannickcr/eslint-plugin-react/issues/2353#issuecomment-674792754
+        // TS does the type checking anyway
+        "react/prop-types": "off",
     },
     settings: {
         react: {

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -17,21 +17,21 @@ const closeComponentId = `${bannerId} : close`;
 const ctaComponentId = `${bannerId} : cta`;
 
 const ContributionsBannerBody: React.FC<ContributionsBannerRenderedContent> = ({
-    cleanHighlightedText,
-    cleanMessageText,
-    cleanHeading,
+    highlightedText,
+    messageText,
+    heading,
 }: ContributionsBannerRenderedContent) => (
     <>
-        {cleanHeading && (
+        {heading && (
             <>
-                <span css={styles.heading}>{cleanHeading}</span>{' '}
+                <span css={styles.heading}>{heading}</span>{' '}
             </>
         )}
-        <span css={styles.messageText}>{cleanMessageText}</span>
-        {cleanHighlightedText && (
+        <span css={styles.messageText}>{messageText}</span>
+        {highlightedText && (
             <>
                 {' '}
-                <span css={styles.highlightedText}>{cleanHighlightedText}</span>
+                <span css={styles.highlightedText}>{highlightedText}</span>
             </>
         )}
     </>

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -7,46 +7,69 @@ import { SvgCross, SvgArrowRightStraight } from '@guardian/src-icons';
 import { ThemeProvider } from 'emotion-theming';
 import { Button, LinkButton, buttonReaderRevenueBrandAlt } from '@guardian/src-button';
 import { Hide } from '@guardian/src-layout';
-import contributionsBannerWrapper, { ContributionsBannerProps } from './ContributionsBannerWrapper';
+import contributionsBannerWrapper, {
+    ContributionsBannerProps,
+    ContributionsBannerRenderedContent,
+} from './ContributionsBannerWrapper';
 
 const bannerId = 'contributions-banner';
 const closeComponentId = `${bannerId} : close`;
 const ctaComponentId = `${bannerId} : cta`;
 
-interface ContributionsBannerBodyProps {
-    cleanMessageText: JSX.Element[];
-    cleanMobileMessageText: JSX.Element[] | null;
+const ContributionsBannerBody: React.FC<ContributionsBannerRenderedContent> = ({
+    cleanHighlightedText,
+    cleanMessageText,
+    cleanHeading,
+}: ContributionsBannerRenderedContent) => (
+    <>
+        {cleanHeading && (
+            <>
+                <span css={styles.heading}>{cleanHeading}</span>{' '}
+            </>
+        )}
+        <span css={styles.messageText}>{cleanMessageText}</span>
+        {cleanHighlightedText && (
+            <>
+                {' '}
+                <span css={styles.highlightedText}>{cleanHighlightedText}</span>
+            </>
+        )}
+    </>
+);
+
+interface ContributionsBannerCtaProps {
+    ctaText: string;
+    ctaUrl: string;
+    onContributeClick: () => void;
 }
 
-const ContributionsBannerBody: React.FC<ContributionsBannerBodyProps> = ({
-    cleanMessageText,
-    cleanMobileMessageText,
-}) => {
-    if (cleanMobileMessageText) {
-        return (
-            <>
-                <Hide above="tablet">
-                    <span css={styles.messageText}>{cleanMobileMessageText}</span>
-                </Hide>
-                <Hide below="tablet">
-                    <span css={styles.messageText}>{cleanMessageText}</span>
-                </Hide>
-            </>
-        );
-    } else {
-        return <span css={styles.messageText}>{cleanMessageText}</span>;
-    }
-};
+const ContributionsBannerCta: React.FC<ContributionsBannerCtaProps> = ({
+    ctaText,
+    ctaUrl,
+    onContributeClick,
+}: ContributionsBannerCtaProps) => (
+    <LinkButton
+        data-link-name={ctaComponentId}
+        css={styles.ctaButton}
+        priority="primary"
+        size="small"
+        icon={<SvgArrowRightStraight />}
+        iconSide="right"
+        nudgeIcon={true}
+        onClick={onContributeClick}
+        hideLabel={false}
+        aria-label="Contribute"
+        href={ctaUrl}
+    >
+        {ctaText}
+    </LinkButton>
+);
 
 const ContributionsBanner: React.FC<ContributionsBannerProps> = ({
     onContributeClick,
     onCloseClick,
-    cleanHighlightedText,
-    cleanMessageText,
-    cleanMobileMessageText,
-    cleanHeading,
-    ctaUrl,
-    ctaText,
+    content,
+    mobileContent,
 }: ContributionsBannerProps) => {
     return (
         <>
@@ -59,40 +82,48 @@ const ContributionsBanner: React.FC<ContributionsBannerProps> = ({
                     </div>
                     <div css={styles.copyAndCta}>
                         <div css={styles.copy}>
-                            {cleanHeading && (
+                            {mobileContent ? (
                                 <>
-                                    <span css={styles.heading}>{cleanHeading}</span>{' '}
+                                    <Hide above="tablet">
+                                        {mobileContent && (
+                                            <ContributionsBannerBody {...mobileContent} />
+                                        )}
+                                    </Hide>
+                                    <Hide below="tablet">
+                                        <ContributionsBannerBody {...content} />
+                                    </Hide>
                                 </>
-                            )}
-                            <ContributionsBannerBody
-                                cleanMessageText={cleanMessageText}
-                                cleanMobileMessageText={cleanMobileMessageText}
-                            />
-                            {cleanHighlightedText && (
-                                <>
-                                    {' '}
-                                    <span css={styles.highlightedText}>{cleanHighlightedText}</span>
-                                </>
+                            ) : (
+                                <ContributionsBannerBody {...content} />
                             )}
                         </div>
                         <div css={styles.ctaContainer}>
                             <div css={styles.cta}>
                                 <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
-                                    <LinkButton
-                                        data-link-name={ctaComponentId}
-                                        css={styles.ctaButton}
-                                        priority="primary"
-                                        size="small"
-                                        icon={<SvgArrowRightStraight />}
-                                        iconSide="right"
-                                        nudgeIcon={true}
-                                        onClick={onContributeClick}
-                                        hideLabel={false}
-                                        aria-label="Contribute"
-                                        href={ctaUrl}
-                                    >
-                                        {ctaText}
-                                    </LinkButton>
+                                    {mobileContent ? (
+                                        <>
+                                            <Hide above="tablet">
+                                                <ContributionsBannerCta
+                                                    ctaText={mobileContent.ctaText}
+                                                    ctaUrl={mobileContent.ctaUrl}
+                                                    onContributeClick={onContributeClick}
+                                                />
+                                            </Hide>
+                                            <Hide below="tablet">
+                                                <ContributionsBannerCta
+                                                    ctaText={content.ctaText}
+                                                    ctaUrl={content.ctaUrl}
+                                                    onContributeClick={onContributeClick}
+                                                />
+                                            </Hide>
+                                        </>
+                                    ) : (
+                                        <ContributionsBannerCta
+                                            ctaText={content.ctaText}
+                                            ctaUrl={content.ctaUrl}
+                                            onContributeClick={onContributeClick}
+                                        />
+                                    )}
                                 </ThemeProvider>
                                 <img
                                     src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"

--- a/src/components/modules/banners/contributions/ContributionsBannerMobile.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerMobile.tsx
@@ -6,6 +6,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
 import { ContributionsBannerCta } from './ContributionsBannerCta';
 import { ContributionsBannerCloseButton } from './ContributionsBannerCloseButton';
+import { ContributionsBannerRenderedContent } from './ContributionsBannerWrapper';
 
 const mobileStyles = {
     container: css`
@@ -39,34 +40,26 @@ const mobileStyles = {
 interface ContributionsBannerMobileProps {
     onContributeClick: () => void;
     onCloseClick: () => void;
-    messageText: JSX.Element[];
-    highlightedText: JSX.Element[] | null;
-    heading: JSX.Element[] | null;
-    ctaUrl: string;
-    ctaText: string;
+    content: ContributionsBannerRenderedContent;
 }
 
 export const ContributionsBannerMobile: React.FC<ContributionsBannerMobileProps> = ({
     onContributeClick,
     onCloseClick,
-    highlightedText,
-    messageText,
-    heading,
-    ctaUrl,
-    ctaText,
+    content,
 }: ContributionsBannerMobileProps) => {
     return (
         <div css={mobileStyles.container}>
             <div css={mobileStyles.headingContainer}>
-                <div css={mobileStyles.heading}>{heading}</div>
+                <div css={mobileStyles.heading}>{content.cleanHeading}</div>
                 <ContributionsBannerCloseButton onCloseClick={onCloseClick} />
             </div>
             <div css={[styles.copy, mobileStyles.copy]}>
-                {messageText}
-                {highlightedText && (
+                {content.cleanMessageText}
+                {content.cleanHighlightedText && (
                     <>
                         {' '}
-                        <span css={styles.highlightedText}>{highlightedText}</span>
+                        <span css={styles.highlightedText}>{content.cleanHighlightedText}</span>
                     </>
                 )}
             </div>
@@ -74,8 +67,8 @@ export const ContributionsBannerMobile: React.FC<ContributionsBannerMobileProps>
             <div css={mobileStyles.ctaContainer}>
                 <ContributionsBannerCta
                     onContributeClick={onContributeClick}
-                    ctaText={ctaText}
-                    ctaUrl={ctaUrl}
+                    ctaText={content.ctaText}
+                    ctaUrl={content.ctaUrl}
                     stacked={true}
                 />
             </div>

--- a/src/components/modules/banners/contributions/ContributionsBannerMobile.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerMobile.tsx
@@ -51,15 +51,15 @@ export const ContributionsBannerMobile: React.FC<ContributionsBannerMobileProps>
     return (
         <div css={mobileStyles.container}>
             <div css={mobileStyles.headingContainer}>
-                <div css={mobileStyles.heading}>{content.cleanHeading}</div>
+                <div css={mobileStyles.heading}>{content.heading}</div>
                 <ContributionsBannerCloseButton onCloseClick={onCloseClick} />
             </div>
             <div css={[styles.copy, mobileStyles.copy]}>
-                {content.cleanMessageText}
-                {content.cleanHighlightedText && (
+                {content.messageText}
+                {content.highlightedText && (
                     <>
                         {' '}
-                        <span css={styles.highlightedText}>{content.cleanHighlightedText}</span>
+                        <span css={styles.highlightedText}>{content.highlightedText}</span>
                     </>
                 )}
             </div>

--- a/src/components/modules/banners/contributions/ContributionsBannerWrapper.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerWrapper.tsx
@@ -18,9 +18,9 @@ const closeComponentId = `${bannerId} : close`;
 const ctaComponentId = `${bannerId} : cta`;
 
 export interface ContributionsBannerRenderedContent {
-    cleanHighlightedText: JSX.Element[] | null;
-    cleanMessageText: JSX.Element[];
-    cleanHeading: JSX.Element[] | null;
+    highlightedText: JSX.Element[] | null;
+    messageText: JSX.Element[];
+    heading: JSX.Element[] | null;
     ctaUrl: string;
     ctaText: string;
 }
@@ -88,9 +88,9 @@ const withBannerData = (
         }
 
         return {
-            cleanHighlightedText: highlightedTextWithArticleCount,
-            cleanMessageText: messageTextWithArticleCount,
-            cleanHeading: headingWithArticleCount,
+            highlightedText: highlightedTextWithArticleCount,
+            messageText: messageTextWithArticleCount,
+            heading: headingWithArticleCount,
             ctaUrl,
             ctaText: cta.text,
         };

--- a/src/components/modules/banners/contributions/variantA/ContributionsBannerVariantA.tsx
+++ b/src/components/modules/banners/contributions/variantA/ContributionsBannerVariantA.tsx
@@ -91,14 +91,14 @@ const ContributionsBannerVariantA: React.FC<ContributionsBannerProps> = ({
 }: ContributionsBannerProps) => {
     const BodyAndHeading = () => (
         <div css={variantAStyles.bodyAndHeading}>
-            <div css={variantAStyles.heading}>{content.cleanHeading}</div>
+            <div css={variantAStyles.heading}>{content.heading}</div>
             <div css={variantAStyles.body}>
                 <div css={[styles.copy, variantAStyles.copy]}>
-                    {content.cleanMessageText}
-                    {content.cleanHighlightedText && (
+                    {content.messageText}
+                    {content.highlightedText && (
                         <>
                             {' '}
-                            <span css={styles.highlightedText}>{content.cleanHighlightedText}</span>
+                            <span css={styles.highlightedText}>{content.highlightedText}</span>
                         </>
                     )}
                 </div>

--- a/src/components/modules/banners/contributions/variantA/ContributionsBannerVariantA.tsx
+++ b/src/components/modules/banners/contributions/variantA/ContributionsBannerVariantA.tsx
@@ -86,23 +86,19 @@ const columnCounts = {
 const ContributionsBannerVariantA: React.FC<ContributionsBannerProps> = ({
     onContributeClick,
     onCloseClick,
-    cleanHighlightedText,
-    cleanMessageText,
-    cleanMobileMessageText,
-    cleanHeading,
-    ctaUrl,
-    ctaText,
+    content,
+    mobileContent,
 }: ContributionsBannerProps) => {
     const BodyAndHeading = () => (
         <div css={variantAStyles.bodyAndHeading}>
-            <div css={variantAStyles.heading}>{cleanHeading}</div>
+            <div css={variantAStyles.heading}>{content.cleanHeading}</div>
             <div css={variantAStyles.body}>
                 <div css={[styles.copy, variantAStyles.copy]}>
-                    {cleanMessageText}
-                    {cleanHighlightedText && (
+                    {content.cleanMessageText}
+                    {content.cleanHighlightedText && (
                         <>
                             {' '}
-                            <span css={styles.highlightedText}>{cleanHighlightedText}</span>
+                            <span css={styles.highlightedText}>{content.cleanHighlightedText}</span>
                         </>
                     )}
                 </div>
@@ -116,8 +112,8 @@ const ContributionsBannerVariantA: React.FC<ContributionsBannerProps> = ({
             <div css={variantAStyles.ctaContainer}>
                 <ContributionsBannerCta
                     onContributeClick={onContributeClick}
-                    ctaText={ctaText}
-                    ctaUrl={ctaUrl}
+                    ctaText={content.ctaText}
+                    ctaUrl={content.ctaUrl}
                     stacked={true}
                 />
             </div>
@@ -129,11 +125,7 @@ const ContributionsBannerVariantA: React.FC<ContributionsBannerProps> = ({
             <ContributionsBannerMobile
                 onCloseClick={onCloseClick}
                 onContributeClick={onContributeClick}
-                heading={cleanHeading}
-                messageText={cleanMobileMessageText || cleanMessageText}
-                highlightedText={cleanHighlightedText}
-                ctaUrl={ctaUrl}
-                ctaText={ctaText}
+                content={mobileContent || content}
             />
 
             <Container cssOverrides={variantAStyles.columnsContainer}>

--- a/src/components/modules/banners/contributions/variantB/ContributionsBannerVariantB.tsx
+++ b/src/components/modules/banners/contributions/variantB/ContributionsBannerVariantB.tsx
@@ -81,16 +81,16 @@ const ContributionsBannerVariantB: React.FC<ContributionsBannerProps> = ({
     content,
     mobileContent,
 }: ContributionsBannerProps) => {
-    const Heading = () => <div css={variantBStyles.heading}>{content.cleanHeading}</div>;
+    const Heading = () => <div css={variantBStyles.heading}>{content.heading}</div>;
 
     const BodyAndCta = () => (
         <div css={variantBStyles.bodyAndCta}>
             <div css={[styles.copy, variantBStyles.copy]}>
-                {content.cleanMessageText}
-                {content.cleanHighlightedText && (
+                {content.messageText}
+                {content.highlightedText && (
                     <>
                         {' '}
-                        <span css={styles.highlightedText}>{content.cleanHighlightedText}</span>
+                        <span css={styles.highlightedText}>{content.highlightedText}</span>
                     </>
                 )}
             </div>

--- a/src/components/modules/banners/contributions/variantB/ContributionsBannerVariantB.tsx
+++ b/src/components/modules/banners/contributions/variantB/ContributionsBannerVariantB.tsx
@@ -78,30 +78,26 @@ const columnCounts = {
 const ContributionsBannerVariantB: React.FC<ContributionsBannerProps> = ({
     onContributeClick,
     onCloseClick,
-    cleanHighlightedText,
-    cleanMessageText,
-    cleanMobileMessageText,
-    cleanHeading,
-    ctaUrl,
-    ctaText,
+    content,
+    mobileContent,
 }: ContributionsBannerProps) => {
-    const Heading = () => <div css={variantBStyles.heading}>{cleanHeading}</div>;
+    const Heading = () => <div css={variantBStyles.heading}>{content.cleanHeading}</div>;
 
     const BodyAndCta = () => (
         <div css={variantBStyles.bodyAndCta}>
             <div css={[styles.copy, variantBStyles.copy]}>
-                {cleanMessageText}
-                {cleanHighlightedText && (
+                {content.cleanMessageText}
+                {content.cleanHighlightedText && (
                     <>
                         {' '}
-                        <span css={styles.highlightedText}>{cleanHighlightedText}</span>
+                        <span css={styles.highlightedText}>{content.cleanHighlightedText}</span>
                     </>
                 )}
             </div>
             <ContributionsBannerCta
                 onContributeClick={onContributeClick}
-                ctaText={ctaText}
-                ctaUrl={ctaUrl}
+                ctaText={content.ctaText}
+                ctaUrl={content.ctaUrl}
                 stacked={false}
             />
         </div>
@@ -118,11 +114,7 @@ const ContributionsBannerVariantB: React.FC<ContributionsBannerProps> = ({
             <ContributionsBannerMobile
                 onCloseClick={onCloseClick}
                 onContributeClick={onContributeClick}
-                heading={cleanHeading}
-                messageText={cleanMobileMessageText || cleanMessageText}
-                highlightedText={cleanHighlightedText}
-                ctaUrl={ctaUrl}
-                ctaText={ctaText}
+                content={mobileContent || content}
             />
 
             <Container>

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -241,6 +241,7 @@ const buildBannerData = async (
             isSupporter: !targeting.showSupportMessaging,
             countryCode: targeting.countryCode,
             content: variant.bannerContent,
+            mobileContent: variant.mobileBannerContent,
             numArticles: getArticleViewCountForWeeks(
                 targeting.weeklyArticleHistory,
                 test.articlesViewedSettings?.periodInWeeks,

--- a/src/tests/banners/ChannelBannerTests.ts
+++ b/src/tests/banners/ChannelBannerTests.ts
@@ -35,17 +35,27 @@ export const BannerTemplateProducts: { [key in BannerTemplate]?: OphanProduct[] 
 };
 
 const BannerVariantFromParams = (variant: RawVariantParams): BannerVariant => {
+    const bannerContent = () => {
+        if (variant.bannerContent) {
+            return variant.bannerContent;
+        } else {
+            // legacy model
+            return {
+                messageText: variant.body,
+                heading: variant.heading,
+                highlightedText: variant.highlightedText,
+                cta: variant.cta,
+                secondaryCta: variant.secondaryCta,
+            };
+        }
+    };
+
     return {
         name: variant.name,
         modulePath: BannerPaths[variant.template],
         moduleName: variant.template,
-        bannerContent: {
-            messageText: variant.body,
-            heading: variant.heading,
-            highlightedText: variant.highlightedText,
-            cta: variant.cta,
-            secondaryCta: variant.secondaryCta,
-        },
+        bannerContent: bannerContent(),
+        mobileBannerContent: variant.mobileBannerContent,
         componentType: BannerTemplateComponentTypes[variant.template],
         products: BannerTemplateProducts[variant.template],
     };

--- a/src/tests/banners/ContributionsBannerDesignTest.ts
+++ b/src/tests/banners/ContributionsBannerDesignTest.ts
@@ -40,7 +40,7 @@ const buildVariant = (
     bannerContent: {
         heading,
         messageText: messageText,
-        mobileMessageText: mobileMessageText,  // for backwards-compatibility
+        mobileMessageText: mobileMessageText, // for backwards-compatibility
         highlightedText,
         cta,
     },

--- a/src/tests/banners/ContributionsBannerDesignTest.ts
+++ b/src/tests/banners/ContributionsBannerDesignTest.ts
@@ -39,8 +39,14 @@ const buildVariant = (
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     bannerContent: {
         heading,
-        messageText,
-        mobileMessageText,
+        messageText: messageText,
+        mobileMessageText: mobileMessageText,  // for backwards-compatibility
+        highlightedText,
+        cta,
+    },
+    mobileBannerContent: {
+        heading,
+        messageText: mobileMessageText,
         highlightedText,
         cta,
     },

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -48,7 +48,7 @@ export interface Cta {
 export interface BannerContent {
     heading?: string;
     messageText: string;
-    mobileMessageText?: string;
+    mobileMessageText?: string; // deprecated - use mobileBannerContent instead
     highlightedText?: string;
     cta?: Cta;
     secondaryCta?: Cta;
@@ -66,6 +66,7 @@ export interface BannerVariant {
     modulePath: string;
     moduleName: string;
     bannerContent?: BannerContent;
+    mobileBannerContent?: BannerContent;
     componentType: OphanComponentType;
     products?: OphanProduct[];
 }
@@ -105,6 +106,7 @@ export interface BannerProps {
     tracking: BannerTracking;
     bannerChannel: BannerChannel;
     content?: BannerContent;
+    mobileContent?: BannerContent;
     countryCode?: string;
     isSupporter?: boolean;
     tickerSettings?: TickerSettings;
@@ -116,6 +118,10 @@ export interface BannerProps {
 export interface RawVariantParams {
     name: string;
     template: BannerTemplate;
+    bannerContent: BannerContent;
+    mobileBannerContent?: BannerContent;
+
+    // deprecated - use bannerContent
     body: string;
     heading?: string;
     highlightedText?: string;


### PR DESCRIPTION
Currently we allow banners to have mobile-only copy for the body (aka messageText) only.
This PR makes all mobile content optionally configurable.

### Banner props change
I have left the `mobileMessageText` field in the `BannerContent` type for backwards-compatibility. This is so that cached versions of the banner components can still use it. It should be removed later.
But new versions of the banner components will use a new field for mobile copy. The banner props now contain a `mobileContent` field:
```
    content?: BannerContent;
    mobileContent?: BannerContent;
```

I have changed the following banners to use the new model:
`ContributionsBanner`
`ContributionsBannerVariantA`
`ContributionsBannerVariantB`

I have also refactored the `ContributionsBannerWrapper` (which is used for the above 3 banners) to construct `content` and `mobileContent` data.

### Banner tool model change
The logic that fetches banner test config from the tool now accepts a new model.
For backwards compatibility it still accepts the old model as well.
With the new model, each variant now has `bannerContent` and `mobileBannerContent` fields, which match the model in this repo (see `RawVariantParams`).
The tool will be updated to publish this model after this PR goes live.