### PR TITLE
Add article count functionality to banner heading

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
@@ -28,10 +28,10 @@ const tracking: BannerTracking = {
 
 export const defaultStory = (): ReactElement => {
     const content: BannerContent = {
-        heading: text('heading', "You've read %%ARTICLE_COUNT%% articles in the last year."),
+        heading: text('heading', "You've read %%ARTICLE_COUNT%% articles in the last year"),
         messageText: text(
             'messageText',
-            "You've read %%ARTICLE_COUNT%% articles in the last year. Subscribe to enjoy our journalism <strong>without ads</strong>, as well as Premium access to <strong>our Live and Editions apps</strong>.",
+            "And you're not alone. Millions have turned to the Guardian for vital, independent journalism in the last year. Reader funding powers our reporting. It protects our independence and ensures we can remain open for all. With <strong>a digital subscription starting from £5.99 a month</strong>, you can enjoy the richest, ad-free Guardian experience via our award-winning apps.",
         ),
     };
 

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
@@ -28,7 +28,7 @@ const tracking: BannerTracking = {
 
 export const defaultStory = (): ReactElement => {
     const content: BannerContent = {
-        heading: text('heading', 'Start a digital subscription today'),
+        heading: text('heading', "You've read %%ARTICLE_COUNT%% articles in the last year."),
         messageText: text(
             'messageText',
             "You've read %%ARTICLE_COUNT%% articles in the last year. Subscribe to enjoy our journalism <strong>without ads</strong>, as well as Premium access to <strong>our Live and Editions apps</strong>.",

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -128,7 +128,9 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                 <section css={banner} data-target={bannerId}>
                     <div css={contentContainer}>
                         <div css={topLeftComponent}>
-                            <h3 css={heading}>{content?.heading}</h3>
+                            <h3 css={heading}>
+                                {replaceArticleCount(content?.heading || '', numArticles, 'banner')}
+                            </h3>
                             <p css={messageText}>
                                 {replaceArticleCount(
                                     content?.messageText || '',

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -84,15 +84,13 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     const mobileImg = getMobileImg(countryCode);
     const baseImg = getBaseImg(countryCode);
 
-    const cleanHeadingText =
-        content.heading && containsNonArticleCountPlaceholder(content.heading, countryCode)
-            ? fallbackHeading
-            : content.heading;
+    const cleanHeadingText = containsNonArticleCountPlaceholder(content?.heading || '')
+        ? fallbackHeading
+        : content?.heading || '';
 
-    const cleanMessageText =
-        content.messageText && containsNonArticleCountPlaceholder(content.messageText, countryCode)
-            ? fallbackMessageText
-            : content.messageText;
+    const cleanMessageText = containsNonArticleCountPlaceholder(content?.messageText || '')
+        ? fallbackMessageText
+        : content?.messageText || '';
 
     const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
         evt.preventDefault();

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -67,6 +67,10 @@ const getBaseImg = (countryCode: string | undefined): Img => ({
     media: '(min-width: 740px)',
 });
 
+const fallbackHeading = 'Start a digital subscription today';
+const fallbackMessageText =
+    'Millions have turned to the Guardian for vital, independent journalism in the last year. Reader funding powers our reporting. It protects our independence and ensures we can remain open for all. With <strong>a digital subscription starting from £5.99 a month</strong>, you can enjoy the richest, ad-free Guardian experience via our award-winning apps.';
+
 export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     bannerChannel,
     content,
@@ -82,12 +86,12 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
 
     const cleanHeadingText =
         content.heading && containsNonArticleCountPlaceholder(content.heading, countryCode)
-            ? 'Start a digital subscription today'
+            ? fallbackHeading
             : content.heading;
 
     const cleanMessageText =
         content.messageText && containsNonArticleCountPlaceholder(content.messageText, countryCode)
-            ? 'Millions have turned to the Guardian for vital, independent journalism in the last year. Reader funding powers our reporting. It protects our independence and ensures we can remain open for all. With <strong>a digital subscription starting from £5.99 a month</strong>, you can enjoy the richest, ad-free Guardian experience via our award-winning apps.'
+            ? fallbackMessageText
             : content.messageText;
 
     const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -32,6 +32,7 @@ import { BannerProps } from '../../../../types/BannerTypes';
 import { setChannelClosedTimestamp } from '../localStorage';
 import { ResponsiveImage } from '../../../ResponsiveImage';
 import { replaceArticleCount } from '../../../../lib/replaceArticleCount';
+import { containsNonArticleCountPlaceholder } from '../../../../lib/placeholders';
 
 const subscriptionUrl = 'https://support.theguardian.com/subscribe/digital';
 const signInUrl =
@@ -78,6 +79,16 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
 
     const mobileImg = getMobileImg(countryCode);
     const baseImg = getBaseImg(countryCode);
+
+    const cleanHeadingText =
+        content.heading && containsNonArticleCountPlaceholder(content.heading, countryCode)
+            ? 'Start a digital subscription today'
+            : content.heading;
+
+    const cleanMessageText =
+        content.messageText && containsNonArticleCountPlaceholder(content.messageText, countryCode)
+            ? 'Millions have turned to the Guardian for vital, independent journalism in the last year. Reader funding powers our reporting. It protects our independence and ensures we can remain open for all. With <strong>a digital subscription starting from £5.99 a month</strong>, you can enjoy the richest, ad-free Guardian experience via our award-winning apps.'
+            : content.messageText;
 
     const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
         evt.preventDefault();
@@ -129,14 +140,10 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                     <div css={contentContainer}>
                         <div css={topLeftComponent}>
                             <h3 css={heading}>
-                                {replaceArticleCount(content?.heading || '', numArticles, 'banner')}
+                                {replaceArticleCount(cleanHeadingText || '', numArticles, 'banner')}
                             </h3>
                             <p css={messageText}>
-                                {replaceArticleCount(
-                                    content?.messageText || '',
-                                    numArticles,
-                                    'banner',
-                                )}
+                                {replaceArticleCount(cleanMessageText || '', numArticles, 'banner')}
                             </p>
                             <a css={linkStyle} onClick={onSubscribeClick}>
                                 <div data-link-name={ctaComponentId} css={becomeASubscriberButton}>


### PR DESCRIPTION
## What does this change?
This is a small change to make the `%%ARTICLE_COUNT%%` variable available in the digital subscriptions banner heading as well as in the banner body text. This was missed in a previous PR: https://github.com/guardian/support-dotcom-components/pull/366

## How to test
Put this branch on code and use the [code version of the banner tool](https://support.code.dev-gutools.co.uk/banner-tests2) to update the text.

## How can we measure success?
The `%%ARTICLE_COUNT%%` variable is available in the digital subscriptions banner heading.

## Have we considered potential risks?
This is a very small change, incorporating code that is already live (implemented by the Contributions team).

## Images
<img width="1198" alt="Screen Shot 2021-02-23 at 15 04 21" src="https://user-images.githubusercontent.com/16781258/108862798-7c1bef00-75e8-11eb-9fed-cbb8f470dda5.png">

<img width="1200" alt="Screen Shot 2021-02-23 at 15 04 33" src="https://user-images.githubusercontent.com/16781258/108862841-83db9380-75e8-11eb-803e-7f0e8305fef0.png">

