### PR TITLE
hide reminders for supporters

### DIFF
--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -121,6 +121,24 @@ describe('findTestAndVariant', () => {
 
         expect(got.result).toBe(undefined);
     });
+
+    it('should not return showReminderFields if user is a supporter', () => {
+        const testWithoutArticlesViewedSettings: Test = {
+            ...testDefault,
+            articlesViewedSettings: undefined,
+            userCohort: 'AllExistingSupporters',
+        };
+        const tests = [testWithoutArticlesViewedSettings];
+        const targeting: EpicTargeting = {
+            ...targetingDefault,
+            showSupportMessaging: false,
+        };
+        const epicType = 'ARTICLE';
+
+        const got = findTestAndVariant(tests, targeting, epicType);
+
+        expect(got?.result?.variant.showReminderFields).toBe(undefined);
+    });
 });
 
 describe('getUserCohort', () => {

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -306,6 +306,9 @@ export const findTestAndVariant = (
 ): Result => {
     const debug: Debug = {};
 
+    const userCohorts = getUserCohorts(targeting);
+    const isSupporter = userCohorts.includes('AllExistingSupporters');
+
     // Also need to include canRun of individual variants (only relevant for
     // manually configured tests).
     // https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js#L378
@@ -315,7 +318,7 @@ export const findTestAndVariant = (
         isNotExpired(),
         hasSectionOrTags,
         userInTest(targeting.mvtId || 1),
-        inCorrectCohort(getUserCohorts(targeting)),
+        inCorrectCohort(userCohorts),
         excludeSection,
         excludeTags,
         hasCountryCode,
@@ -351,9 +354,14 @@ export const findTestAndVariant = (
 
     if (test) {
         const variant = selectVariant(test, targeting.mvtId || 1);
+        // Never show reminder feature to supporters
+        const showReminderFields = isSupporter
+            ? undefined
+            : getReminderFields(variant.showReminderFields);
+
         const variantWithReminder: Variant = {
             ...variant,
-            showReminderFields: getReminderFields(variant.showReminderFields),
+            showReminderFields,
         };
 
         return {


### PR DESCRIPTION
this is for the 'thank you' epic, where we would like to include a cta but not a reminder signup

As a supporter and with no reminder signup cookie:
![Screen Shot 2021-02-26 at 11 51 00](https://user-images.githubusercontent.com/1513454/109296850-eb802180-7828-11eb-861a-e8601bb8ab8e.png)
