### PR TITLE
Add policy to allow instance to describe tags

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -168,6 +168,21 @@ Resources:
                         Ref: Stage
         Metadata:
             aws:cdk:path: AlbEc2Stack/role/Resource
+    DescribeEC2Policy:
+        Type: AWS::IAM::Policy
+        Properties:
+            PolicyName: describe-ec2-policy
+            PolicyDocument:
+                Statement:
+                    - Effect: Allow
+                    Resource: "*"
+                    Action:
+                        - ec2:DescribeTags
+                        - ec2:DescribeInstances
+                        - autoscaling:DescribeAutoScalingGroups
+                        - autoscaling:DescribeAutoScalingInstances
+            Roles:
+               - !Ref roleC7B7E775
     ASGInstanceSecurityGroup0525485D:
         Type: AWS::EC2::SecurityGroup
         Properties:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -175,12 +175,12 @@ Resources:
             PolicyDocument:
                 Statement:
                     - Effect: Allow
-                    Resource: "*"
-                    Action:
-                        - ec2:DescribeTags
-                        - ec2:DescribeInstances
-                        - autoscaling:DescribeAutoScalingGroups
-                        - autoscaling:DescribeAutoScalingInstances
+                      Resource: "*"
+                      Action:
+                          - ec2:DescribeTags
+                          - ec2:DescribeInstances
+                          - autoscaling:DescribeAutoScalingGroups
+                          - autoscaling:DescribeAutoScalingInstances
             Roles:
                - !Ref roleC7B7E775
     ASGInstanceSecurityGroup0525485D:


### PR DESCRIPTION
## What does this change?

There's currently a major review of the guardian's security practices under the cyber security programme. One of the projects in this programme is to install a vulnerability scanner called Wazuh in guardian ec2 instances.

This patch enables Wazuh to work by

* Giving permission to the instance to call describe-tags,
   so the agent can identify itself in a human readable way with 
   the wazuh server.


## How to test
Deploy to CODE and see if the wazuh agent successfully identifies itself with the central server 

## How can we measure success?
Wazuh will start reporting vulnerabilities to infosec!

## Have we considered potential risks?
CFN could be wrong and cause downtime.

## Testing

Works in code ✅