### PR TITLE
Mock getAmpExperimentData in test

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -15,6 +15,7 @@ jest.mock('./api/contributionsApi', () => {
         fetchConfiguredEpicTests: jest
             .fn()
             .mockImplementation(() => Promise.resolve(configuredTests)),
+        getAmpExperimentData: jest.fn().mockImplementation(() => Promise.resolve({})),
     };
 });
 


### PR DESCRIPTION
Currently when the server.tsx test runs it logs:
`Error: Failed to make initial request for ampEpicTests`
It doesn't cause the test to fail.

This change silences it by mocking the function that makes the request