### PR TITLE
fix reminder url

### DIFF
--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -8,7 +8,7 @@ import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';
 import { SvgArrowRightStraight, SvgCross } from '@guardian/src-icons';
 import { addCookie } from '../../../lib/cookies';
-import { OneOffSignupRequest, setOneOffReminderEndpoint } from '../../../api/supportRemindersApi';
+import { OneOffSignupRequest } from '../../../api/supportRemindersApi';
 
 const rootStyles = css`
     position: relative;

--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -143,6 +143,8 @@ const addPreposition = (text: string): string => 'in ' + text;
 const ensureHasPreposition = (text: string): string =>
     containsPreposition(text) ? text : addPreposition(text);
 
+const createOneOffReminderEndpoint = 'https://support.theguardian.com/reminders/create/one-off';
+
 export const ContributionsEpicReminder: React.FC<ContributionsEpicReminderProps> = ({
     reminderLabel,
     reminderPeriod,
@@ -165,7 +167,7 @@ export const ContributionsEpicReminder: React.FC<ContributionsEpicReminderProps>
         reminderStage: REMINDER_STAGE,
     };
     const submitForm = (): Promise<Response> => {
-        return fetch(setOneOffReminderEndpoint(), {
+        return fetch(createOneOffReminderEndpoint, {
             body: JSON.stringify(reminderSignupData),
             method: 'POST',
             headers: {


### PR DESCRIPTION
the logic for setting the url in the epic module broke here: https://github.com/guardian/support-dotcom-components/pull/381/files#diff-469af771aea54851d95ec44ef73613ac45100f0a2e151d76312fd97a6dd83212R168
This is because `isProd` only works server-side.

Quick fix for now is to hardcode it to the PROD url
We can worry about CODE later