### PR TITLE
Minimised state for the puzzles banner

### DIFF
--- a/src/components/ResponsiveImage.tsx
+++ b/src/components/ResponsiveImage.tsx
@@ -12,7 +12,7 @@ type ResponsiveImageProps = {
 };
 
 function createSource(image: Image): ReactElement {
-    return <source media={image.media} srcSet={image.url} />;
+    return <source media={image.media} srcSet={image.url} key={image.url} />;
 }
 
 export const ResponsiveImage: React.FC<ResponsiveImageProps> = ({

--- a/src/components/hooks/useEscapeShortcut.ts
+++ b/src/components/hooks/useEscapeShortcut.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+// Pass a function to run when the user hits the escape key
+// Useful for enabling a keyboard shortcut for dismissing banners
+export function useEscapeShortcut(eventHandler: (event: KeyboardEvent) => void): void {
+    function handleEscapeKeydown(event: KeyboardEvent) {
+        // IE key name is 'Esc', because IE
+        const isEscapeKey = event.key === 'Escape' || event.key === 'Esc';
+        if (isEscapeKey) {
+            eventHandler(event);
+        }
+    }
+
+    useEffect(() => {
+        window.addEventListener('keydown', handleEscapeKeydown);
+
+        return () => window.removeEventListener('keydown', handleEscapeKeydown);
+    }, []);
+}

--- a/src/components/hooks/useTabDetection.ts
+++ b/src/components/hooks/useTabDetection.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+// If a user is hitting the tab key repeatedly, they're probably navigating via keyboard
+// This enables showing a hint message about the dismissal shortcut to keyboard users
+export function useTabDetection(tabThreshold = 5): boolean {
+    const [tabPressCount, setTabPressCount] = useState<number>(0);
+    const [isUserTabbing, setIsUserTabbing] = useState<boolean>(false);
+
+    function handleTabPress(event: KeyboardEvent): void {
+        if (event.key === 'Tab') {
+            setTabPressCount(count => {
+                if (count < tabThreshold) {
+                    return count + 1;
+                }
+                return count;
+            });
+        }
+    }
+
+    useEffect(() => {
+        if (tabPressCount >= tabThreshold) {
+            setIsUserTabbing(true);
+            window.removeEventListener('keydown', handleTabPress);
+        }
+    }, [tabPressCount]);
+
+    useEffect(() => {
+        window.addEventListener('keydown', handleTabPress);
+
+        return () => window.removeEventListener('keydown', handleTabPress);
+    }, []);
+
+    return isUserTabbing;
+}

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -20,6 +20,7 @@ import {
     headingSection,
     hide,
     imageContainer,
+    mobileSquaresContainer,
     minimisedBanner,
     minimisedContentContainer,
     squaresContainer,
@@ -43,7 +44,7 @@ const tabletPackshot = {
 };
 
 export const PuzzlesBanner: React.FC = () => {
-    const [isCollapsed, setIsCollapsed] = useState<boolean>(true);
+    const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
 
     const hideOnCollapse = isCollapsed ? hide : '';
     const hideOnExpand = isCollapsed ? '' : hide;
@@ -67,7 +68,7 @@ export const PuzzlesBanner: React.FC = () => {
     return (
         <CacheProvider value={emotionCache}>
             <section css={[banner, isCollapsed ? minimisedBanner : '']}>
-                <Container>
+                <Container css={hideOnCollapse}>
                     <div css={[bannerContents, hideOnCollapse]}>
                         <div css={[headingSection, hideOnCollapse]}>
                             <h3 css={heading}>
@@ -101,11 +102,13 @@ export const PuzzlesBanner: React.FC = () => {
                         </div>
                     </div>
                 </Container>
+                <div css={[mobileSquaresContainer, hideOnCollapse]}>
+                    <MobileSquares collapseButton={CollapseButton} />
+                </div>
                 <div css={[hideOnExpand, minimisedContentContainer]}>
                     <MinimisedContentSquare collapseButton={CollapseButton} />
                     <MinimisedBorderSquares />
                 </div>
-                <MobileSquares collapseButton={CollapseButton} isCollapsed={isCollapsed} />
             </section>
         </CacheProvider>
     );

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { CacheProvider } from '@emotion/core';
 import createCache from '@emotion/cache';
 import { Container } from '@guardian/src-layout';
@@ -22,9 +22,12 @@ import {
     imageContainer,
     minimisedBanner,
     minimisedContentContainer,
+    minimiseHint,
     squaresContainer,
 } from './puzzlesBannerStyles';
 import { appStore, packshot } from './images';
+import { useEscapeShortcut } from '../../../hooks/useEscapeShortcut';
+import { useTabDetection } from '../../../hooks/useTabDetection';
 
 // A custom Emotion cache to allow us to run a custom prefixer for CSS grid on IE11
 const emotionCache = createCache({
@@ -44,20 +47,13 @@ const tabletPackshot = {
 
 export const PuzzlesBanner: React.FC = () => {
     const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
+    const isKeyboardUser = useTabDetection();
 
     const hideOnCollapse = isCollapsed ? hide : '';
     const hideOnExpand = isCollapsed ? '' : hide;
 
     function collapse() {
         setIsCollapsed(!isCollapsed);
-    }
-
-    function collapseOnEscape(event: KeyboardEvent) {
-        // IE key name is 'Esc', because IE
-        const isEscapeKey = event.key === 'Escape' || event.key === 'Esc';
-        if (isEscapeKey && !isCollapsed) {
-            collapse();
-        }
     }
 
     const CollapseButton = (
@@ -73,11 +69,11 @@ export const PuzzlesBanner: React.FC = () => {
     );
 
     // Enable keyboard users to collapse the banner quickly
-    useEffect(() => {
-        window.addEventListener('keydown', collapseOnEscape);
-
-        return () => window.removeEventListener('keydown', collapseOnEscape);
-    }, []);
+    useEscapeShortcut(() => {
+        if (!isCollapsed) {
+            collapse();
+        }
+    });
 
     return (
         <CacheProvider value={emotionCache}>
@@ -103,6 +99,9 @@ export const PuzzlesBanner: React.FC = () => {
                                     <img src={appStore.google} alt="Get it on Google Play" />
                                 </a>
                             </div>
+                            {isKeyboardUser && (
+                                <p css={minimiseHint}>Hit escape to minimise this banner</p>
+                            )}
                         </div>
                         <div css={[squaresContainer, hideOnCollapse]}>
                             <ContentSquares />

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -20,7 +20,6 @@ import {
     headingSection,
     hide,
     imageContainer,
-    mobileSquaresContainer,
     minimisedBanner,
     minimisedContentContainer,
     squaresContainer,
@@ -117,9 +116,7 @@ export const PuzzlesBanner: React.FC = () => {
                         </div>
                     </div>
                 </Container>
-                <div css={[mobileSquaresContainer, hideOnCollapse]}>
-                    <MobileSquares collapseButton={CollapseButton} />
-                </div>
+                <MobileSquares collapseButton={CollapseButton} cssOverrides={hideOnCollapse} />
                 <div css={[hideOnExpand, minimisedContentContainer]}>
                     <MinimisedContentSquare collapseButton={CollapseButton} />
                     <MinimisedBorderSquares />

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -16,7 +16,7 @@ import {
     collapseButton,
     heading,
     headingSection,
-    hideIfMinimised,
+    hide,
     imageContainer,
     minimisedBanner,
     squaresContainer,
@@ -42,7 +42,8 @@ const tabletPackshot = {
 export const PuzzlesBanner: React.FC = () => {
     const [isCollapsed, setIsCollapsed] = useState<boolean>(true);
 
-    const maybeHidden = isCollapsed ? hideIfMinimised : '';
+    const hideOnCollapse = isCollapsed ? hide : '';
+    const hideOnExpand = isCollapsed ? '' : hide;
 
     function collapse() {
         setIsCollapsed(!isCollapsed);
@@ -64,8 +65,8 @@ export const PuzzlesBanner: React.FC = () => {
         <CacheProvider value={emotionCache}>
             <section css={[banner, isCollapsed ? minimisedBanner : '']}>
                 <Container>
-                    <div css={[bannerContents, maybeHidden]}>
-                        <div css={[headingSection, maybeHidden]}>
+                    <div css={[bannerContents, hideOnCollapse]}>
+                        <div css={[headingSection, hideOnCollapse]}>
                             <h3 css={heading}>
                                 Discover
                                 <br />
@@ -85,7 +86,7 @@ export const PuzzlesBanner: React.FC = () => {
                                 </a>
                             </div>
                         </div>
-                        <div css={[squaresContainer, maybeHidden]}>
+                        <div css={[squaresContainer, hideOnCollapse]}>
                             <ContentSquares />
                             <div css={imageContainer}>
                                 <ResponsiveImage
@@ -96,6 +97,7 @@ export const PuzzlesBanner: React.FC = () => {
                             <TabletDesktopSquares collapseButton={CollapseButton} />
                         </div>
                     </div>
+                    <div css={hideOnExpand}>{CollapseButton}</div>
                 </Container>
                 <MobileSquares collapseButton={CollapseButton} />
             </section>

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -16,7 +16,9 @@ import {
     collapseButton,
     heading,
     headingSection,
+    hideIfMinimised,
     imageContainer,
+    minimisedBanner,
     squaresContainer,
 } from './puzzlesBannerStyles';
 import { appStore, packshot } from './images';
@@ -38,7 +40,9 @@ const tabletPackshot = {
 };
 
 export const PuzzlesBanner: React.FC = () => {
-    const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
+    const [isCollapsed, setIsCollapsed] = useState<boolean>(true);
+
+    const maybeHidden = isCollapsed ? hideIfMinimised : '';
 
     function collapse() {
         setIsCollapsed(!isCollapsed);
@@ -58,10 +62,10 @@ export const PuzzlesBanner: React.FC = () => {
 
     return (
         <CacheProvider value={emotionCache}>
-            <section css={banner}>
+            <section css={[banner, isCollapsed ? minimisedBanner : '']}>
                 <Container>
-                    <div css={bannerContents}>
-                        <div css={headingSection}>
+                    <div css={[bannerContents, maybeHidden]}>
+                        <div css={[headingSection, maybeHidden]}>
                             <h3 css={heading}>
                                 Discover
                                 <br />
@@ -81,7 +85,7 @@ export const PuzzlesBanner: React.FC = () => {
                                 </a>
                             </div>
                         </div>
-                        <div css={squaresContainer}>
+                        <div css={[squaresContainer, maybeHidden]}>
                             <ContentSquares />
                             <div css={imageContainer}>
                                 <ResponsiveImage

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CacheProvider } from '@emotion/core';
 import createCache from '@emotion/cache';
 import { Container } from '@guardian/src-layout';
@@ -53,6 +53,14 @@ export const PuzzlesBanner: React.FC = () => {
         setIsCollapsed(!isCollapsed);
     }
 
+    function collapseOnEscape(event: KeyboardEvent) {
+        // IE key name is 'Esc', because IE
+        const isEscapeKey = event.key === 'Escape' || event.key === 'Esc';
+        if (isEscapeKey && !isCollapsed) {
+            collapse();
+        }
+    }
+
     const CollapseButton = (
         <Button
             size="small"
@@ -64,6 +72,13 @@ export const PuzzlesBanner: React.FC = () => {
             Minimise
         </Button>
     );
+
+    // Enable keyboard users to collapse the banner quickly
+    useEffect(() => {
+        window.addEventListener('keydown', collapseOnEscape);
+
+        return () => window.removeEventListener('keydown', collapseOnEscape);
+    }, []);
 
     return (
         <CacheProvider value={emotionCache}>

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -21,6 +21,7 @@ import {
     hide,
     imageContainer,
     minimisedBanner,
+    minimisedContentContainer,
     squaresContainer,
 } from './puzzlesBannerStyles';
 import { appStore, packshot } from './images';
@@ -100,11 +101,11 @@ export const PuzzlesBanner: React.FC = () => {
                         </div>
                     </div>
                 </Container>
-                <div css={hideOnExpand}>
+                <div css={[hideOnExpand, minimisedContentContainer]}>
                     <MinimisedContentSquare collapseButton={CollapseButton} />
                     <MinimisedBorderSquares />
                 </div>
-                <MobileSquares collapseButton={CollapseButton} />
+                <MobileSquares collapseButton={CollapseButton} isCollapsed={isCollapsed} />
             </section>
         </CacheProvider>
     );

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -9,6 +9,7 @@ import { ResponsiveImage } from '../../../ResponsiveImage';
 import { MobileSquares } from './squares/MobileSquares';
 import { TabletDesktopSquares } from './squares/TabletDesktopSquares';
 import { ContentSquares } from './squares/ContentSquares';
+import { MinimisedContentSquare } from './squares/MinimisedContentSquare';
 import {
     appStoreButtonContainer,
     banner,
@@ -97,8 +98,10 @@ export const PuzzlesBanner: React.FC = () => {
                             <TabletDesktopSquares collapseButton={CollapseButton} />
                         </div>
                     </div>
-                    <div css={hideOnExpand}>{CollapseButton}</div>
                 </Container>
+                <div css={hideOnExpand}>
+                    <MinimisedContentSquare collapseButton={CollapseButton} />
+                </div>
                 <MobileSquares collapseButton={CollapseButton} />
             </section>
         </CacheProvider>

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -10,6 +10,7 @@ import { MobileSquares } from './squares/MobileSquares';
 import { TabletDesktopSquares } from './squares/TabletDesktopSquares';
 import { ContentSquares } from './squares/ContentSquares';
 import { MinimisedContentSquare } from './squares/MinimisedContentSquare';
+import { MinimisedBorderSquares } from './squares/MinimisedBorderSquares';
 import {
     appStoreButtonContainer,
     banner,
@@ -101,6 +102,7 @@ export const PuzzlesBanner: React.FC = () => {
                 </Container>
                 <div css={hideOnExpand}>
                     <MinimisedContentSquare collapseButton={CollapseButton} />
+                    <MinimisedBorderSquares />
                 </div>
                 <MobileSquares collapseButton={CollapseButton} />
             </section>

--- a/src/components/modules/puzzles/puzzlesBanner/images.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/images.ts
@@ -7,9 +7,9 @@ export const appStore = {
 
 export const packshot = {
     desktop:
-        'https://i.guim.co.uk/img/media/8759e22d5a920f73253e73ac593956760b7c58d9/0_0_1224_1076/500.png?width=300&quality=85&s=3e78a054770de9e16024517cd727ed47',
+        'https://i.guim.co.uk/img/media/a03b0d9567d1d8be41094aab096f659effc6b177/0_0_300_264/300.png?width=300&quality=85&s=d144380417be72d29c831e76d1aaf271',
     tablet:
-        'https://i.guim.co.uk/img/media/8759e22d5a920f73253e73ac593956760b7c58d9/0_0_1224_1076/500.png?width=230&quality=85&s=86d3b846ec56cd7662e3cb187b787c49',
+        'https://i.guim.co.uk/img/media/a03b0d9567d1d8be41094aab096f659effc6b177/0_0_300_264/300.png?width=230&quality=85&s=ce06077f0c48df9625dfa23e10207823',
 };
 
 export const qrCode =

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -139,7 +139,7 @@ export const imageContainer = css`
     }
 `;
 
-export const hideIfMinimised = css`
+export const hide = css`
     display: none;
 `;
 

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -64,10 +64,6 @@ export const squaresContainer = css`
     }
 `;
 
-export const mobileSquaresContainer = css`
-    width: 100%;
-`;
-
 export const headingSection = css`
     max-width: 500px;
     margin-right: ${space[6]}px;
@@ -165,7 +161,7 @@ export const minimisedBanner = css`
     right: 0;
     bottom: 0;
     height: 136px;
-    width: max-content;
+    width: auto;
     padding-right: ${space[3]}px;
     transition: width 1s;
 

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -4,6 +4,10 @@ import { headline } from '@guardian/src-foundations/typography/cjs';
 import { neutral, lifestyle } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 
+export const squareBorder = `2px solid ${neutral[0]}`;
+
+export const squareBoxShadow = 'box-shadow: 0px 6px 0px rgba(0, 0, 0, 0.25)';
+
 export const banner = css`
     html {
         box-sizing: border-box;
@@ -17,7 +21,7 @@ export const banner = css`
     width: 100%;
     background-color: ${lifestyle[300]};
     color: ${neutral[100]};
-    border: 2px solid ${neutral[0]};
+    border: ${squareBorder};
 
     ${until.tablet} {
         display: flex;

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -6,7 +6,7 @@ import { space } from '@guardian/src-foundations';
 
 export const squareBorder = `2px solid ${neutral[0]}`;
 
-export const squareBoxShadow = 'box-shadow: 0px 6px 0px rgba(0, 0, 0, 0.25)';
+export const squareBoxShadow = '0px 6px 0px rgba(0, 0, 0, 0.25)';
 
 export const banner = css`
     html {
@@ -152,9 +152,28 @@ export const hide = css`
 `;
 
 export const minimisedBanner = css`
+    border-radius: 2px 0 0 0;
     position: absolute;
     right: 0;
     bottom: 0;
-    height: 174px;
-    width: 260px;
+    height: 136px;
+    width: 146px;
+    padding-right: ${space[3]}px;
+
+    ${from.mobileLandscape} {
+        padding-right: ${space[5]}px;
+        width: 196px;
+        height: 176px;
+    }
+`;
+
+export const minimisedContentContainer = css`
+    position: relative;
+    width: 132px;
+    height: 132px;
+
+    ${from.mobileLandscape} {
+        width: 172px;
+        height: 172px;
+    }
 `;

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -3,6 +3,7 @@ import { between, from, until } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography/cjs';
 import { neutral, lifestyle } from '@guardian/src-foundations/palette';
 import { breakpoints, space } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
 
 export const squareBorder = `2px solid ${neutral[0]}`;
 
@@ -149,6 +150,11 @@ export const imageContainer = css`
 
 export const hide = css`
     display: none;
+`;
+
+export const minimiseHint = css`
+    ${textSans.small()}
+    margin: ${space[1]}px 0;
 `;
 
 function paddingOffsetFor(breakpointWidth: number) {

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -138,3 +138,15 @@ export const imageContainer = css`
         align-items: flex-end;
     }
 `;
+
+export const hideIfMinimised = css`
+    display: none;
+`;
+
+export const minimisedBanner = css`
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    height: 174px;
+    width: 260px;
+`;

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/core';
 import { between, from, until } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography/cjs';
 import { neutral, lifestyle } from '@guardian/src-foundations/palette';
-import { space } from '@guardian/src-foundations';
+import { breakpoints, space } from '@guardian/src-foundations';
 
 export const squareBorder = `2px solid ${neutral[0]}`;
 
@@ -62,6 +62,10 @@ export const squaresContainer = css`
     ${from.desktop} {
         padding-right: 44px;
     }
+`;
+
+export const mobileSquaresContainer = css`
+    width: 100%;
 `;
 
 export const headingSection = css`
@@ -151,19 +155,40 @@ export const hide = css`
     display: none;
 `;
 
+function paddingOffsetFor(breakpointWidth: number) {
+    return `calc((100vw - ${breakpointWidth - space[5]}px) / 2)`;
+}
+
 export const minimisedBanner = css`
     border-radius: 2px 0 0 0;
     position: absolute;
     right: 0;
     bottom: 0;
     height: 136px;
-    width: 146px;
+    width: max-content;
     padding-right: ${space[3]}px;
+    transition: width 1s;
 
     ${from.mobileLandscape} {
         padding-right: ${space[5]}px;
-        width: 196px;
+        /* width: 196px; */
         height: 176px;
+    }
+
+    ${from.tablet} {
+        padding-right: ${paddingOffsetFor(breakpoints.tablet)};
+    }
+
+    ${from.desktop} {
+        padding-right: ${paddingOffsetFor(breakpoints.desktop)};
+    }
+
+    ${from.leftCol} {
+        padding-right: ${paddingOffsetFor(breakpoints.leftCol)};
+    }
+
+    ${from.wide} {
+        padding-right: ${paddingOffsetFor(breakpoints.wide)};
     }
 `;
 

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -194,13 +194,18 @@ export const minimisedBanner = css`
     }
 `;
 
+const minimisedContainerSize = {
+    mobile: 132,
+    tablet: 172,
+};
+
 export const minimisedContentContainer = css`
     position: relative;
-    width: 132px;
-    height: 132px;
+    width: ${minimisedContainerSize.mobile}px;
+    height: ${minimisedContainerSize.mobile}px;
 
     ${from.mobileLandscape} {
-        width: 172px;
-        height: 172px;
+        width: ${minimisedContainerSize.tablet}px;
+        height: ${minimisedContainerSize.tablet}px;
     }
 `;

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -167,10 +167,10 @@ export const minimisedBanner = css`
 
     ${from.mobileLandscape} {
         padding-right: ${space[5]}px;
-        /* width: 196px; */
         height: 176px;
     }
 
+    /* Maintain a right-hand offset that matches the edge of the main container */
     ${from.tablet} {
         padding-right: ${paddingOffsetFor(breakpoints.tablet)};
     }

--- a/src/components/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
@@ -5,6 +5,7 @@ import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { from, until } from '@guardian/src-foundations/mq';
 import { Square } from './Square';
+import { SquareSide } from './SquareSide';
 import { qrCode } from '../images';
 
 function desktopGridPlacement(row: number, column: number) {
@@ -22,38 +23,13 @@ function withIECompatibleGap(rowsOrCols: string[], gap: string) {
     return rowsOrCols.join(` ${gap} `);
 }
 
-const boxShadow = '0px 6px 0px rgba(0, 0, 0, 0.25);';
-const border = `2px solid ${neutral[0]}`;
-
-const contentSquareSide = css`
-    position: relative;
-    background-color: ${neutral[20]};
-    border: ${border};
-    border-top: none;
-    border-right: none;
-    border-radius: 2px 0 0 0;
-    transform: translate(-10px, 2px);
-    height: 100%;
-    box-shadow: ${boxShadow};
-
-    ::before {
-        content: ' ';
-        display: block;
-        width: 6px;
-        background-color: ${neutral[20]};
-        border-top: ${border};
-        height: 100%;
-        transform: translateY(-2px) skewY(-30deg);
-    }
-`;
-
 const contentSquare = css`
     z-index: 2;
     ${headline.xxxsmall({ fontWeight: 'bold' })};
     color: ${neutral[7]};
-    border-bottom: ${border};
+    border-bottom: 2px solid ${neutral[0]};
     padding-top: 0;
-    box-shadow: ${boxShadow};
+    box-shadow: 0px 6px 0px rgba(0, 0, 0, 0.25);
     min-width: ${space[24]}px;
     min-height: ${space[24]}px;
 
@@ -177,7 +153,7 @@ type ContentSquareProps = {
 const ContentSquare: React.FC<ContentSquareProps> = ({ children, cssOverrides = [] }) => {
     return (
         <Square colour="white" cssOverrides={[contentSquare, ...cssOverrides]}>
-            <div css={contentSquareSide}></div>
+            <SquareSide />
             {children}
         </Square>
     );

--- a/src/components/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
@@ -45,6 +45,7 @@ const contentSquare = css`
     min-height: ${squareSizes.mobile.small}px;
 
     p {
+        width: 100%;
         padding: ${space[1]}px;
         padding-left: 0;
         margin: 0;

--- a/src/components/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
@@ -6,6 +6,7 @@ import { space } from '@guardian/src-foundations';
 import { from, until } from '@guardian/src-foundations/mq';
 import { Square } from './Square';
 import { SquareSide } from './SquareSide';
+import { squareBorder, squareBoxShadow } from '../puzzlesBannerStyles';
 import { qrCode } from '../images';
 
 function desktopGridPlacement(row: number, column: number) {
@@ -27,9 +28,9 @@ const contentSquare = css`
     z-index: 2;
     ${headline.xxxsmall({ fontWeight: 'bold' })};
     color: ${neutral[7]};
-    border-bottom: 2px solid ${neutral[0]};
+    border-bottom: ${squareBorder};
     padding-top: 0;
-    box-shadow: 0px 6px 0px rgba(0, 0, 0, 0.25);
+    box-shadow: ${squareBoxShadow};
     min-width: ${space[24]}px;
     min-height: ${space[24]}px;
 

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedBorderSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedBorderSquares.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import { Square } from './Square';
+import { SquareSide } from './SquareSide';
+import { squareBorder, squareBoxShadow } from '../puzzlesBannerStyles';
+
+const container = css`
+    pointer-events: none;
+    position: absolute;
+    width: 170px;
+    height: 170px;
+    bottom: 0;
+    left: 0;
+`;
+
+const squareContainer = css`
+    position: absolute;
+    width: 42px;
+    height: 42px;
+`;
+
+const squareOverrides = css`
+    border-bottom: ${squareBorder};
+    box-shadow: ${squareBoxShadow};
+`;
+
+const bottomLeft = css`
+    bottom: 2px;
+    left: 0;
+    transform: translateX(-100%);
+`;
+
+const topLeft = css`
+    z-index: -1;
+    top: 0;
+    left: 20px;
+    transform: translateY(-30px);
+`;
+
+const topRight = css`
+    top: 0;
+    right: 10px;
+    transform: translateY(-37px);
+`;
+
+export const MinimisedBorderSquares: React.FC = () => {
+    return (
+        <div css={container}>
+            <div css={[squareContainer, bottomLeft]}>
+                <Square colour="white" cssOverrides={squareOverrides}>
+                    <SquareSide small />
+                </Square>
+            </div>
+            <div css={[squareContainer, topLeft]}>
+                <Square colour="pink" cssOverrides={squareOverrides}>
+                    <SquareSide small />
+                </Square>
+            </div>
+            <div css={[squareContainer, topRight]}>
+                <Square colour="grey" cssOverrides={squareOverrides}>
+                    <SquareSide small />
+                </Square>
+            </div>
+        </div>
+    );
+};

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedBorderSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedBorderSquares.tsx
@@ -3,20 +3,31 @@ import { css } from '@emotion/core';
 import { Square } from './Square';
 import { SquareSide } from './SquareSide';
 import { squareBorder, squareBoxShadow } from '../puzzlesBannerStyles';
+import { from } from '@guardian/src-foundations/mq';
+
+const smallSquareSizes = {
+    mobile: 32,
+    tablet: 42,
+};
 
 const container = css`
     pointer-events: none;
     position: absolute;
-    width: 170px;
-    height: 170px;
+    width: 100%;
+    height: 100%;
     bottom: 0;
-    left: 0;
+    right: 0;
 `;
 
 const squareContainer = css`
     position: absolute;
-    width: 42px;
-    height: 42px;
+    width: ${smallSquareSizes.mobile}px;
+    height: ${smallSquareSizes.mobile}px;
+
+    ${from.mobileLandscape} {
+        width: ${smallSquareSizes.tablet}px;
+        height: ${smallSquareSizes.tablet}px;
+    }
 `;
 
 const squareOverrides = css`
@@ -34,13 +45,13 @@ const topLeft = css`
     z-index: -1;
     top: 0;
     left: 20px;
-    transform: translateY(-30px);
+    transform: translateY(-70%);
 `;
 
 const topRight = css`
     top: 0;
     right: 10px;
-    transform: translateY(-37px);
+    transform: translateY(-90%);
 `;
 
 export const MinimisedBorderSquares: React.FC = () => {

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedBorderSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedBorderSquares.tsx
@@ -13,8 +13,8 @@ const smallSquareSizes = {
 const container = css`
     pointer-events: none;
     position: absolute;
-    width: 100%;
-    height: 100%;
+    width: 98%;
+    height: 98%;
     bottom: 0;
     right: 0;
 `;

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
@@ -9,6 +9,7 @@ import { SquareSide } from './SquareSide';
 const squareContainer = css`
     width: 170px;
     height: 170px;
+    transform: translateX(-2px);
 `;
 
 const heading = css`

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
@@ -5,16 +5,23 @@ import { space } from '@guardian/src-foundations';
 // import { from, until } from '@guardian/src-foundations/mq';
 import { Square } from './Square';
 import { SquareSide } from './SquareSide';
+import { from } from '@guardian/src-foundations/mq';
 
 const squareContainer = css`
-    width: 170px;
-    height: 170px;
-    transform: translateX(-2px);
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
 `;
 
 const heading = css`
-    ${headline.small({ fontWeight: 'bold' })};
+    ${headline.xxsmall({ fontWeight: 'bold' })};
     margin: 0;
+
+    ${from.mobileLandscape} {
+        ${headline.small({ fontWeight: 'bold' })}
+    }
 `;
 
 const removeTopBorder = css`
@@ -26,7 +33,11 @@ const content = css`
     flex-direction: column;
     justify-content: space-between;
     padding-right: ${space[2]}px;
-    padding-bottom: ${space[3]}px;
+    padding-bottom: ${space[2]}px;
+
+    ${from.mobileLandscape} {
+        padding-bottom: ${space[3]}px;
+    }
 `;
 
 type MinimisedContentSquareProps = {

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { css } from '@emotion/core';
 import { headline } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
-// import { from, until } from '@guardian/src-foundations/mq';
 import { Square } from './Square';
 import { SquareSide } from './SquareSide';
 import { from } from '@guardian/src-foundations/mq';

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
@@ -32,6 +32,7 @@ const content = css`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    width: 100%;
     padding-right: ${space[2]}px;
     padding-bottom: ${space[2]}px;
 

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import { headline } from '@guardian/src-foundations/typography';
+import { space } from '@guardian/src-foundations';
+// import { from, until } from '@guardian/src-foundations/mq';
+import { Square } from './Square';
+import { SquareSide } from './SquareSide';
+
+const squareContainer = css`
+    width: 170px;
+    height: 170px;
+`;
+
+const heading = css`
+    ${headline.small({ fontWeight: 'bold' })};
+    margin: 0;
+`;
+
+const removeTopBorder = css`
+    border-top: none;
+`;
+
+const content = css`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding-right: ${space[2]}px;
+    padding-bottom: ${space[3]}px;
+`;
+
+type MinimisedContentSquareProps = {
+    collapseButton: React.ReactNode;
+};
+
+export const MinimisedContentSquare: React.FC<MinimisedContentSquareProps> = ({
+    collapseButton,
+}) => {
+    return (
+        <div css={squareContainer}>
+            <Square colour="purple" cssOverrides={removeTopBorder}>
+                <SquareSide />
+                <div css={content}>
+                    <h3 css={heading}>Master every challenge</h3>
+                    {collapseButton}
+                </div>
+            </Square>
+        </div>
+    );
+};

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MobileSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MobileSquares.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from '@emotion/core';
+import { css, SerializedStyles } from '@emotion/core';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 import { Square } from './Square';
@@ -7,7 +7,7 @@ import { collapseButtonContainer } from '../puzzlesBannerStyles';
 
 type MobileSquaresProps = {
     collapseButton: React.ReactNode;
-    isCollapsed: boolean;
+    cssOverrides?: SerializedStyles | string;
 };
 
 const mobileSquareGrid = css`
@@ -35,16 +35,9 @@ const noLeftBorderOnSmallestScreens = css`
     }
 `;
 
-const hide = css`
-    display: none;
-`;
-
-export const MobileSquares: React.FC<MobileSquaresProps> = ({
-    collapseButton,
-    isCollapsed = false,
-}) => {
+export const MobileSquares: React.FC<MobileSquaresProps> = ({ collapseButton, cssOverrides }) => {
     return (
-        <div css={[mobileSquareGrid, isCollapsed ? hide : '']}>
+        <div css={[mobileSquareGrid, cssOverrides]}>
             <Square colour="purple" cssOverrides={firstRow} removeBorder={['right']} />
             <Square colour="pink" removeBorder={['right']} />
             <Square colour="pink" cssOverrides={secondRow} removeBorder={['right']} />

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MobileSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MobileSquares.tsx
@@ -7,6 +7,7 @@ import { collapseButtonContainer } from '../puzzlesBannerStyles';
 
 type MobileSquaresProps = {
     collapseButton: React.ReactNode;
+    isCollapsed: boolean;
 };
 
 const mobileSquareGrid = css`
@@ -34,9 +35,16 @@ const noLeftBorderOnSmallestScreens = css`
     }
 `;
 
-export const MobileSquares: React.FC<MobileSquaresProps> = ({ collapseButton }) => {
+const hide = css`
+    display: none;
+`;
+
+export const MobileSquares: React.FC<MobileSquaresProps> = ({
+    collapseButton,
+    isCollapsed = false,
+}) => {
     return (
-        <div css={mobileSquareGrid}>
+        <div css={[mobileSquareGrid, isCollapsed ? hide : '']}>
             <Square colour="purple" cssOverrides={firstRow} removeBorder={['right']} />
             <Square colour="pink" removeBorder={['right']} />
             <Square colour="pink" cssOverrides={secondRow} removeBorder={['right']} />

--- a/src/components/modules/puzzles/puzzlesBanner/squares/Square.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/Square.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { neutral, lifestyle } from '@guardian/src-foundations/palette';
+import { squareBorder } from '../puzzlesBannerStyles';
 
 type SquareColour = 'white' | 'grey' | 'pink' | 'purple';
 
@@ -14,7 +15,7 @@ type SquareProps = {
 };
 
 const basicSquare = css`
-    border: 2px solid ${neutral[0]};
+    border: ${squareBorder};
     border-bottom: none;
     position: relative;
     width: 100%;

--- a/src/components/modules/puzzles/puzzlesBanner/squares/SquareSide.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/SquareSide.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import { neutral } from '@guardian/src-foundations/palette';
+
+const boxShadow = '0px 6px 0px rgba(0, 0, 0, 0.25);';
+const border = `2px solid ${neutral[0]}`;
+
+const squareSide = css`
+    position: relative;
+    background-color: ${neutral[20]};
+    border: ${border};
+    border-top: none;
+    border-right: none;
+    border-radius: 2px 0 0 0;
+    transform: translate(-10px, 2px);
+    height: 100%;
+    box-shadow: ${boxShadow};
+
+    ::before {
+        content: ' ';
+        display: block;
+        width: 6px;
+        background-color: ${neutral[20]};
+        border-top: ${border};
+        height: 100%;
+        transform: translateY(-2px) skewY(-30deg);
+    }
+`;
+
+export const SquareSide: React.FC = () => {
+    return <div css={squareSide}></div>;
+};

--- a/src/components/modules/puzzles/puzzlesBanner/squares/SquareSide.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/SquareSide.tsx
@@ -1,32 +1,41 @@
 import React from 'react';
 import { css } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
-
-const boxShadow = '0px 6px 0px rgba(0, 0, 0, 0.25);';
-const border = `2px solid ${neutral[0]}`;
+import { squareBorder, squareBoxShadow } from '../puzzlesBannerStyles';
 
 const squareSide = css`
     position: relative;
     background-color: ${neutral[20]};
-    border: ${border};
+    border: ${squareBorder};
     border-top: none;
     border-right: none;
     border-radius: 2px 0 0 0;
     transform: translate(-10px, 2px);
     height: 100%;
-    box-shadow: ${boxShadow};
+    box-shadow: ${squareBoxShadow};
 
     ::before {
         content: ' ';
         display: block;
         width: 6px;
         background-color: ${neutral[20]};
-        border-top: ${border};
+        border-top: ${squareBorder};
         height: 100%;
         transform: translateY(-2px) skewY(-30deg);
     }
 `;
 
-export const SquareSide: React.FC = () => {
-    return <div css={squareSide}></div>;
+const squareSideSmall = css`
+    transform: translate(-7px, 2px);
+    ::before {
+        width: 3px;
+    }
+`;
+
+type SquareSideProps = {
+    small?: boolean;
+};
+
+export const SquareSide: React.FC<SquareSideProps> = ({ small }) => {
+    return <div css={[squareSide, small ? squareSideSmall : '']}></div>;
 };


### PR DESCRIPTION
## What does this change?
This adds the minimised form of the puzzles banner, and the ability to toggle back and forth using the button.

I've also added, experimentally, the facility to minimise the banner by hitting the escape key. The banners end up at the bottom of the tab order on dotcom, so a user relying on the keyboard has to tab through the entire page to reach the minimise button, which is a profoundly annoying experience- and will be even more so on a crossword page as the crosswords have a _lot_ of focusable elements. Currently we aren't doing anything to tell users that this shortcut exists, so this needs some further thought, but this is primarily for testing once we have the banner showing up under the 0% A/B test on dotcom.

## Images

### Mobile

**iPhone SE 2020**
![mobile - iphone se 2020](https://user-images.githubusercontent.com/29146931/110827151-b2ff2f80-828d-11eb-84ec-6d4c9f4c472a.png)

**OnePlus 8**
![mobile - oneplus 8](https://user-images.githubusercontent.com/29146931/110827347-e17d0a80-828d-11eb-8f23-8166bbc23258.png)

### Tablet

**iPad Pro**
![tablet - ipad pro](https://user-images.githubusercontent.com/29146931/110827394-ef329000-828d-11eb-9aca-742b47f1cf48.png)

**Google Nexus 9**
![tablet - google nexus 9](https://user-images.githubusercontent.com/29146931/110827400-f063bd00-828d-11eb-96dc-b9e5304e42f8.png)

### Desktop

**Firefox - 1980px width**
![desktop - firefox](https://user-images.githubusercontent.com/29146931/110827499-096c6e00-828e-11eb-87fe-65811b3f5bce.png)

**IE11 - 1140px width (leftCol breakpoint)**
![desktop - ie11 (leftCol)](https://user-images.githubusercontent.com/29146931/110827552-17ba8a00-828e-11eb-842d-5f11b7570ec6.png)
