### PR TITLE
Tweak contribution banner styles

### DIFF
--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -52,10 +52,11 @@ const styles = {
         display: flex;
         flex-direction: column;
         height: 100%;
-        margin-top: 8px;
+        box-sizing: border-box;
+        padding-top: 8px;
+        padding-bottom: 16px;
     `,
     ctaContainer: css`
-        margin-bottom: 16px;
         display: flex;
         justify-content: flex-end;
     `,

--- a/src/components/modules/banners/contributions/ContributionsBannerCommonStyles.ts
+++ b/src/components/modules/banners/contributions/ContributionsBannerCommonStyles.ts
@@ -10,7 +10,7 @@ export const commonStyles = {
         padding-bottom: 0;
         ${body.medium()};
         ${until.tablet} {
-            font-size: 0.875rem;
+            font-size: 17px;
             line-height: 1.125rem;
 
             strong {
@@ -39,7 +39,7 @@ export const commonStyles = {
         padding: 0.15rem 0.15rem;
         ${body.medium({ fontWeight: 'bold' })};
         ${until.tablet} {
-            font-size: 0.875rem;
+            font-size: 17px;
             font-weight: 800;
         }
         &::selection {

--- a/src/components/modules/banners/contributions/ContributionsBannerCta.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerCta.tsx
@@ -5,6 +5,7 @@ import { SvgArrowRightStraight } from '@guardian/src-icons';
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { from } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
 
 const styles = {
     ctaButton: (stacked: boolean): SerializedStyles => css`
@@ -20,6 +21,7 @@ const styles = {
         }
     `,
     paymentMethods: css`
+        margin-left: ${space[4]}px;
         display: block;
         max-height: 1.25rem;
     `,


### PR DESCRIPTION
## What does this change?
Make some tweaks to the contributions banner styles as per [this card](https://trello.com/c/TZcrf9qL/2569-contributions-banner-design-tweaks).

## Images
17px body copy on mobile
<img width="342" alt="Screenshot 2021-03-19 at 11 54 51" src="https://user-images.githubusercontent.com/17720442/111776967-8ad58900-88aa-11eb-968d-6bb47e5718a8.png">

align card icons with CTA text + body copy
<img width="1311" alt="Screenshot 2021-03-19 at 11 55 35" src="https://user-images.githubusercontent.com/17720442/111776973-8d37e300-88aa-11eb-8b96-f1d0e767dd18.png">

