### PR TITLE
Remove snyk check from branches

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,6 +1,5 @@
 # This action runs every day at 6 AM and on every push
 # If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
-# Otherwise it will run snyk test
 name: Snyk
 
 on:
@@ -16,6 +15,7 @@ jobs:
       SNYK_COMMAND: test
     steps:
       - name: Checkout branch
+        if: github.ref == 'refs/heads/main'
         uses: actions/checkout@v2
 
       - name: Set command to monitor

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,9 +15,6 @@ jobs:
     env:
       SNYK_COMMAND: test
     steps:
-      - name: Checkout branch
-        uses: actions/checkout@v2
-
       - name: Set command to monitor
         if: github.ref == 'refs/heads/main'
         run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,11 +15,15 @@ jobs:
     env:
       SNYK_COMMAND: test
     steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
       - name: Set command to monitor
         if: github.ref == 'refs/heads/main'
         run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
 
       - name: Run Snyk to check for vulnerabilities
+        if: github.ref == 'refs/heads/main'
         uses: snyk/actions/node@0.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
The snyk error on every PR is unhelpful because:
1. we have a snyk rota for addressing these issues
2. we very rarely add new dependencies