### PR TITLE
Tweak mobile contributions banner styles

### DIFF
--- a/src/components/modules/banners/contributions/ContributionsBannerCommonStyles.ts
+++ b/src/components/modules/banners/contributions/ContributionsBannerCommonStyles.ts
@@ -8,18 +8,15 @@ export const commonStyles = {
         max-width: 40rem;
         display: block;
         padding-bottom: 0;
-        ${body.medium()};
+        ${body.medium({ lineHeight: 'loose' })};
         ${until.tablet} {
-            font-size: 17px;
-            line-height: 1.125rem;
-
             strong {
                 font-weight: 800;
             }
         }
         ${from.tablet} {
             strong {
-                ${body.medium({ fontWeight: 'bold' })};
+                ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
             }
         }
         &::selection {
@@ -37,9 +34,8 @@ export const commonStyles = {
     highlightedText: css`
         background-color: ${neutral[100]};
         padding: 0.15rem 0.15rem;
-        ${body.medium({ fontWeight: 'bold' })};
+        ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
         ${until.tablet} {
-            font-size: 17px;
             font-weight: 800;
         }
         &::selection {

--- a/src/components/modules/banners/contributions/ContributionsBannerCta.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerCta.tsx
@@ -21,9 +21,12 @@ const styles = {
         }
     `,
     paymentMethods: css`
-        margin-left: ${space[4]}px;
         display: block;
         max-height: 1.25rem;
+
+        ${from.tablet} {
+            margin-left: ${space[4]}px;
+        }
     `,
 };
 


### PR DESCRIPTION
## What does this change?
Small tweaks the the mobile contributions banner. We've increased the line height, and aligned the payment icons with the left edge of the CTA for mobile.

## Images
<img width="332" alt="Screenshot 2021-03-23 at 09 17 19" src="https://user-images.githubusercontent.com/17720442/112123940-b5c92100-8bb9-11eb-8f4a-726f70dfd7b4.png">

