### PR TITLE
Update reminders for signed in users

### DIFF
--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -17,10 +17,8 @@ import { EpicSeparateArticleCountTestVariants } from '../../../tests/epicArticle
 import { ContributionsEpicArticleCountAbove } from './ContributionsEpicArticleCountAbove';
 import { ContributionsEpicArticleCountInline } from './ContributionsEpicArticleCountInline';
 
-// Spacing values below are multiples of 4.
-// See https://www.theguardian.design/2a1e5182b/p/449bd5
 const wrapperStyles = css`
-    padding: ${space[1]}px ${space[1]}px ${space[3]}px;
+    padding: ${space[1]}px ${space[2]}px ${space[3]}px;
     border-top: 1px solid ${palette.brandAlt[400]};
     background-color: ${palette.neutral[97]};
 

--- a/src/components/modules/epics/ContributionsEpicReminder.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.stories.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { css } from '@emotion/core';
+import { from } from '@guardian/src-foundations/mq';
+import { palette } from '@guardian/src-foundations';
+import {
+    ContributionsEpicReminder,
+    ContributionsEpicReminderProps,
+} from './ContributionsEpicReminder';
+
+const containerStyles = css`
+    margin: 3em auto;
+    padding: 0 10px;
+    max-width: 620px;
+
+    ${from.mobileLandscape} {
+        padding: 0 20px;
+    }
+`;
+
+const backgroundStyles = css`
+    background-color: ${palette.neutral[97]};
+`;
+
+export const EpicDecorator = (Story: Story): JSX.Element => (
+    <div css={containerStyles}>
+        <div css={backgroundStyles}>
+            <Story />
+        </div>
+    </div>
+);
+
+export default {
+    component: ContributionsEpicReminder,
+    title: 'Epics/ContributionsEpicReminder',
+    args: {
+        reminderPeriod: '2021-05-01',
+        reminderLabel: 'May',
+    },
+    decorators: [EpicDecorator],
+    excludeStories: /.*Decorator$/,
+} as Meta;
+
+const Template: Story<ContributionsEpicReminderProps> = (props: ContributionsEpicReminderProps) => (
+    <ContributionsEpicReminder {...props} />
+);
+
+export const SignedIn = Template.bind({});
+SignedIn.args = {
+    initialEmailAddress: 'test.user@guardian.co.uk',
+};
+
+export const SignedOut = Template.bind({});

--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -1,26 +1,10 @@
 // --- Imports --- //
 
 import React, { useState } from 'react';
-import { addCookie } from '../../../lib/cookies';
 import { OneOffSignupRequest } from '../../../api/supportRemindersApi';
 import { ContributionsEpicReminderSignedIn } from './ContributionsEpicReminderSignedIn';
 import { ContributionsEpicReminderSignedOut } from './ContributionsEpicReminderSignedOut';
-
-// --- Utils --- //
-
-const dateDiff = (start: Date, end: Date): number => {
-    const twentyFourHours = 86400000;
-    return Math.round((end.valueOf() - start.valueOf()) / twentyFourHours);
-};
-
-const addContributionReminderCookie = (reminderDateString: string): void => {
-    const today = new Date();
-    const reminderDate = new Date(Date.parse(reminderDateString));
-
-    addCookie('gu_epic_contribution_reminder', '1', dateDiff(today, reminderDate));
-};
-
-const createOneOffReminderEndpoint = 'https://support.theguardian.com/reminders/create/one-off';
+import { addContributionReminderCookie } from './utils/reminders';
 
 // --- Types --- //
 
@@ -38,9 +22,15 @@ export enum ReminderStatus {
     Completed = 'Completed',
 }
 
+// --- Consts --- //
+
+const CREATE_ONE_OFF_REMINDER_ENDPOINT = 'https://support.theguardian.com/reminders/create/one-off';
+
 const REMINDER_PLATFORM = 'WEB';
 const REMINDER_COMPONENT = 'EPIC';
 const REMINDER_STAGE = 'PRE';
+
+// --- Components --- //
 
 export const ContributionsEpicReminder: React.FC<ContributionsEpicReminderProps> = ({
     initialEmailAddress,
@@ -60,7 +50,7 @@ export const ContributionsEpicReminder: React.FC<ContributionsEpicReminderProps>
         };
 
         setReminderStatus(ReminderStatus.Submitting);
-        fetch(createOneOffReminderEndpoint, {
+        fetch(CREATE_ONE_OFF_REMINDER_ENDPOINT, {
             body: JSON.stringify(reminderSignupData),
             method: 'POST',
             headers: {

--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -1,122 +1,12 @@
 // --- Imports --- //
 
 import React, { useState } from 'react';
-import { css, SerializedStyles } from '@emotion/core';
-import { headline, textSans, body } from '@guardian/src-foundations/typography';
-import { palette, space } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
-import { Lines } from '../../Lines';
-import { TextInput } from '@guardian/src-text-input';
-import { Button } from '@guardian/src-button';
-import { SvgArrowRightStraight, SvgCross } from '@guardian/src-icons';
 import { addCookie } from '../../../lib/cookies';
 import { OneOffSignupRequest } from '../../../api/supportRemindersApi';
 import { ContributionsEpicReminderSignedIn } from './ContributionsEpicReminderSignedIn';
-
-// --- Styles --- //
-
-const rootStyles = css`
-    position: relative;
-
-    * {
-        box-sizing: border-box;
-    }
-`;
-
-const closeButtonStyles = css`
-    width: 30px;
-    height: 30px;
-    cursor: pointer;
-    position: absolute;
-    top: 20px;
-    right: 0;
-    background: none;
-    border: none;
-    padding: 0;
-`;
-
-const lineWrapperStyles = css`
-    margin: ${space[3]}px auto;
-`;
-
-const containerStyles = css`
-    padding: 0 ${space[1]}px;
-`;
-
-const remindHeading = css`
-    ${headline.xxsmall({ fontWeight: 'bold' })};
-    margin: 0 ${space[5]}px ${space[2]}px 0;
-`;
-
-const successTextStyles = css`
-    margin: 0 auto ${space[2]}px;
-    ${body.medium()};
-`;
-
-const linkStyles = css`
-    color: ${palette.neutral[7]};
-`;
-
-const formWrapper = css`
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-
-    ${from.tablet} {
-        flex-direction: row;
-        align-items: flex-end;
-        justify-content: flex-start;
-    }
-`;
-
-const inputWrapper = css`
-    width: 100%;
-    margin-bottom: ${space[2]}px;
-    flex-grow: 1;
-
-    ${from.tablet} {
-        width: auto;
-        margin-right: ${space[2]}px;
-        margin-bottom: 0;
-    }
-`;
-
-const formTextStyles = css`
-    ${textSans.small()};
-    font-style: italic;
-    margin-top: ${space[1]}px;
-`;
-
-const errorTextStyles = css`
-    ${textSans.small({ fontWeight: 'bold' })};
-    color: ${palette.error[400]};
-    font-style: italic;
-    margin-top: ${space[1]}px;
-    margin-bottom: 0;
-`;
-
-const getCustomSubmitStyles = (isDisabled: boolean): SerializedStyles | undefined => {
-    if (isDisabled) {
-        // Unfortunately these overrides need !important as otherwise they'll lose
-        // the specificity war against the default Source styles.
-        return css`
-            pointer-events: none;
-            color: ${palette.neutral[60]} !important;
-            background-color: ${palette.neutral[93]} !important;
-            border: 1px solid ${palette.neutral[86]} !important;
-        `;
-    }
-
-    return undefined;
-};
+import { ContributionsEpicReminderSignedOut } from './ContributionsEpicReminderSignedOut';
 
 // --- Utils --- //
-
-const isValidEmail = (email: string): boolean => {
-    const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    return re.test(String(email).toLowerCase());
-};
 
 const dateDiff = (start: Date, end: Date): number => {
     const twentyFourHours = 86400000;
@@ -129,15 +19,6 @@ const addContributionReminderCookie = (reminderDateString: string): void => {
 
     addCookie('gu_epic_contribution_reminder', '1', dateDiff(today, reminderDate));
 };
-
-const PREPOSITION_REGEX = /^(on|in)/;
-
-const containsPreposition = (text: string): boolean => PREPOSITION_REGEX.test(text);
-
-const addPreposition = (text: string): string => 'in ' + text;
-
-const ensureHasPreposition = (text: string): string =>
-    containsPreposition(text) ? text : addPreposition(text);
 
 const createOneOffReminderEndpoint = 'https://support.theguardian.com/reminders/create/one-off';
 
@@ -207,154 +88,9 @@ export const ContributionsEpicReminder: React.FC<ContributionsEpicReminderProps>
     ) : (
         <ContributionsEpicReminderSignedOut
             reminderLabel={reminderLabel}
-            reminderPeriod={reminderPeriod}
+            reminderStatus={reminderStatus}
+            onSetReminderClick={setReminder}
             onCloseReminderClick={onCloseReminderClick}
         />
-    );
-};
-
-interface ContributionsEpicReminderSignedOutProps {
-    reminderLabel: string;
-    reminderPeriod: string;
-    onCloseReminderClick: () => void;
-}
-
-export const ContributionsEpicReminderSignedOut: React.FC<ContributionsEpicReminderSignedOutProps> = ({
-    reminderLabel,
-    reminderPeriod,
-    onCloseReminderClick,
-}: ContributionsEpicReminderProps) => {
-    const [isDirty, setIsDirty] = useState(false);
-    const [isSubmittingState, setIsSubmittingState] = useState(false);
-    const [isErrorState, setIsErrorState] = useState(false);
-    const [isSuccessState, setIsSuccessState] = useState(false);
-    const [emailAddress, setEmailAddress] = useState('');
-
-    const isEmpty = emailAddress.trim().length === 0;
-    const isValid = isValidEmail(emailAddress);
-
-    const reminderSignupData: OneOffSignupRequest = {
-        email: emailAddress,
-        reminderPeriod,
-        reminderPlatform: REMINDER_PLATFORM,
-        reminderComponent: REMINDER_COMPONENT,
-        reminderStage: REMINDER_STAGE,
-    };
-    const submitForm = (): Promise<Response> => {
-        return fetch(createOneOffReminderEndpoint, {
-            body: JSON.stringify(reminderSignupData),
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-        });
-    };
-
-    let inputError;
-    if (isDirty && isEmpty) {
-        inputError = 'Please enter your email address';
-    } else if (isDirty && !isValid) {
-        inputError = 'Please enter a valid email address';
-    }
-
-    const reminderDateWithPreposition = ensureHasPreposition(reminderLabel);
-
-    return (
-        <div css={rootStyles}>
-            <button css={closeButtonStyles} onClick={(): void => onCloseReminderClick()}>
-                <SvgCross />
-            </button>
-
-            <div css={lineWrapperStyles}>
-                <Lines />
-            </div>
-
-            <div css={containerStyles}>
-                <form
-                    onSubmit={(e): void => {
-                        if (isValid) {
-                            setIsSubmittingState(true);
-                            submitForm()
-                                .then(response => {
-                                    if (!response.ok) {
-                                        throw Error(response.statusText);
-                                    }
-                                    addContributionReminderCookie(reminderPeriod);
-                                    setIsSuccessState(true);
-                                })
-                                .catch((): void => setIsErrorState(true))
-                                .finally((): void => setIsSubmittingState(false));
-                        }
-                        setIsDirty(true);
-                        e.preventDefault();
-                    }}
-                >
-                    {!isSuccessState && (
-                        <>
-                            <h4 css={remindHeading}>Remind me {reminderDateWithPreposition}</h4>
-                            <div css={formWrapper}>
-                                <div css={inputWrapper}>
-                                    <TextInput
-                                        label="Email address"
-                                        error={inputError}
-                                        value={emailAddress}
-                                        onChange={(e): void =>
-                                            setEmailAddress(e.currentTarget.value)
-                                        }
-                                    />
-                                </div>
-                                <Button
-                                    iconSide="right"
-                                    icon={<SvgArrowRightStraight />}
-                                    type="submit"
-                                    disabled={isSubmittingState}
-                                    css={getCustomSubmitStyles(isSubmittingState)}
-                                >
-                                    Set a reminder
-                                </Button>
-                            </div>
-                        </>
-                    )}
-
-                    {isErrorState && (
-                        <p css={errorTextStyles}>
-                            Sorry we couldn&apos;t set a reminder for you this time. Please try
-                            again later.
-                        </p>
-                    )}
-                </form>
-
-                {!isSuccessState && (
-                    <p css={formTextStyles}>
-                        We will send you a maximum of two emails {reminderDateWithPreposition}. To
-                        find out what personal data we collect and how we use it, view our{' '}
-                        <a
-                            css={linkStyles}
-                            href="https://www.theguardian.com/help/privacy-policy"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            Privacy Policy
-                        </a>
-                        .
-                    </p>
-                )}
-
-                {isSuccessState && (
-                    <>
-                        <h4 css={remindHeading}>Thank you! Your reminder is set.</h4>
-                        <p css={successTextStyles}>
-                            We will be in touch to invite you to contribute. Look out for a message
-                            in your inbox {reminderDateWithPreposition}. If you have any questions
-                            about contributing, please{' '}
-                            <a href="mailto:contribution.support@theguardian.com" css={linkStyles}>
-                                contact us
-                            </a>
-                            .
-                        </p>
-                    </>
-                )}
-            </div>
-        </div>
     );
 };

--- a/src/components/modules/epics/ContributionsEpicReminderSignedIn.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedIn.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { css } from '@emotion/core';
+import { from } from '@guardian/src-foundations/mq';
+import {
+    ContributionsEpicReminderSignedIn,
+    ContributionsEpicReminderSignedInProps,
+} from './ContributionsEpicReminderSignedIn';
+
+const epicContainerStyles = css`
+    margin: 3em auto;
+    padding: 0 10px;
+    max-width: 620px;
+
+    ${from.mobileLandscape} {
+        padding: 0 20px;
+    }
+`;
+
+export default {
+    component: ContributionsEpicReminderSignedIn,
+    title: 'Epics/ContributionsEpicReminderSignedIn',
+    args: {
+        reminderLabel: 'May',
+        reminderStatus: 'EDITING',
+    },
+    decorators: [
+        Story => (
+            <div css={epicContainerStyles}>
+                <Story />
+            </div>
+        ),
+    ],
+} as Meta;
+
+const Template: Story<ContributionsEpicReminderSignedInProps> = (
+    props: ContributionsEpicReminderSignedInProps,
+) => <ContributionsEpicReminderSignedIn {...props} />;
+
+export const Default = Template.bind({});

--- a/src/components/modules/epics/ContributionsEpicReminderSignedIn.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedIn.stories.tsx
@@ -1,36 +1,20 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { css } from '@emotion/core';
-import { from } from '@guardian/src-foundations/mq';
 import {
     ContributionsEpicReminderSignedIn,
     ContributionsEpicReminderSignedInProps,
 } from './ContributionsEpicReminderSignedIn';
-
-const epicContainerStyles = css`
-    margin: 3em auto;
-    padding: 0 10px;
-    max-width: 620px;
-
-    ${from.mobileLandscape} {
-        padding: 0 20px;
-    }
-`;
+import { ReminderStatus } from './ContributionsEpicReminder';
+import { EpicDecorator } from './ContributionsEpicReminder.stories';
 
 export default {
     component: ContributionsEpicReminderSignedIn,
     title: 'Epics/ContributionsEpicReminderSignedIn',
     args: {
         reminderLabel: 'May',
-        reminderStatus: 'EDITING',
+        reminderStatus: ReminderStatus.Editing,
     },
-    decorators: [
-        Story => (
-            <div css={epicContainerStyles}>
-                <Story />
-            </div>
-        ),
-    ],
+    decorators: [EpicDecorator],
 } as Meta;
 
 const Template: Story<ContributionsEpicReminderSignedInProps> = (
@@ -38,3 +22,18 @@ const Template: Story<ContributionsEpicReminderSignedInProps> = (
 ) => <ContributionsEpicReminderSignedIn {...props} />;
 
 export const Default = Template.bind({});
+
+export const Submitting = Template.bind({});
+Submitting.args = {
+    reminderStatus: ReminderStatus.Submitting,
+};
+
+export const Completed = Template.bind({});
+Completed.args = {
+    reminderStatus: ReminderStatus.Completed,
+};
+
+export const Error = Template.bind({});
+Error.args = {
+    reminderStatus: ReminderStatus.Error,
+};

--- a/src/components/modules/epics/ContributionsEpicReminderSignedIn.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedIn.tsx
@@ -22,6 +22,11 @@ const rootStyles = css`
     * {
         box-sizing: border-box;
     }
+
+    p {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
 `;
 
 const lineWrapperStyles = css`
@@ -46,7 +51,7 @@ const errorTextStyles = css`
     ${textSans.small({ fontWeight: 'bold' })};
     color: ${palette.error[400]};
     font-style: italic;
-    margin-top: ${space[1]}px;
+    margin-top: ${space[2]}px !important;
     margin-bottom: 0;
 `;
 
@@ -62,7 +67,6 @@ const closeButtonContainerStyles = css`
 `;
 
 const bodyCopyStyles = css`
-    margin-top: ${space[1]}px;
     ${body.medium()}
 
     ${from.tablet} {
@@ -73,12 +77,14 @@ const bodyCopyStyles = css`
 const infoCopyStyles = css`
     ${textSans.small()};
     font-style: italic;
+    margin-top: ${space[2]}px !important;
 `;
 
 const ctaContainerStyles = css`
     display: flex;
     flex-direction: row;
     align-items: center;
+    margin-top: ${space[4]}px;
 
     & > * + * {
         margin-left: ${space[6]}px;

--- a/src/components/modules/epics/ContributionsEpicReminderSignedIn.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedIn.tsx
@@ -10,6 +10,7 @@ import { Button } from '@guardian/src-button';
 import { Hide } from '@guardian/src-layout';
 import { SvgCheckmark, SvgCross } from '@guardian/src-icons';
 import { ReminderStatus } from './ContributionsEpicReminder';
+import { ensureHasPreposition } from './utils/reminders';
 
 // --- Styles --- //
 
@@ -83,17 +84,6 @@ const ctaContainerStyles = css`
         margin-left: ${space[6]}px;
     }
 `;
-
-// --- Utils --- //
-
-const PREPOSITION_REGEX = /^(on|in)/;
-
-const containsPreposition = (text: string): boolean => PREPOSITION_REGEX.test(text);
-
-const addPreposition = (text: string): string => 'in ' + text;
-
-const ensureHasPreposition = (text: string): string =>
-    containsPreposition(text) ? text : addPreposition(text);
 
 // --- Types --- //
 

--- a/src/components/modules/epics/ContributionsEpicReminderSignedIn.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedIn.tsx
@@ -9,6 +9,7 @@ import { Lines } from '../../Lines';
 import { Button } from '@guardian/src-button';
 import { Hide } from '@guardian/src-layout';
 import { SvgCheckmark, SvgCross } from '@guardian/src-icons';
+import { ReminderStatus } from './ContributionsEpicReminder';
 
 // --- Styles --- //
 
@@ -95,7 +96,6 @@ const ensureHasPreposition = (text: string): string =>
     containsPreposition(text) ? text : addPreposition(text);
 
 // --- Types --- //
-type ReminderStatus = 'EDITING' | 'SUBMITTING' | 'ERROR' | 'COMPLETED';
 
 export interface ContributionsEpicReminderSignedInProps {
     reminderLabel: string;
@@ -132,7 +132,7 @@ export const ContributionsEpicReminderSignedIn: React.FC<ContributionsEpicRemind
                 <Lines />
             </div>
 
-            {reminderStatus === 'COMPLETED' ? (
+            {reminderStatus === ReminderStatus.Completed ? (
                 <>
                     <h4 css={remindHeading}>Thank you! Your reminder is set.</h4>
                     <p css={successTextStyles}>
@@ -157,7 +157,7 @@ export const ContributionsEpicReminderSignedIn: React.FC<ContributionsEpicRemind
                             <Hide above="tablet">
                                 <Button
                                     onClick={onSetReminderClick}
-                                    disabled={reminderStatus === 'SUBMITTING'}
+                                    disabled={reminderStatus === ReminderStatus.Submitting}
                                 >
                                     Set a reminder
                                 </Button>
@@ -168,7 +168,7 @@ export const ContributionsEpicReminderSignedIn: React.FC<ContributionsEpicRemind
                                     onClick={onSetReminderClick}
                                     icon={<SvgCheckmark />}
                                     iconSide="left"
-                                    disabled={reminderStatus === 'SUBMITTING'}
+                                    disabled={reminderStatus === ReminderStatus.Submitting}
                                 >
                                     Set a reminder
                                 </Button>
@@ -180,7 +180,7 @@ export const ContributionsEpicReminderSignedIn: React.FC<ContributionsEpicRemind
                         </Button>
                     </div>
 
-                    {reminderStatus === 'ERROR' && (
+                    {reminderStatus === ReminderStatus.Error && (
                         <p css={errorTextStyles}>
                             Sorry we couldn&apos;t set a reminder for you this time. Please try
                             again later.

--- a/src/components/modules/epics/ContributionsEpicReminderSignedIn.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedIn.tsx
@@ -1,0 +1,207 @@
+// --- Imports --- //
+
+import React from 'react';
+import { css } from '@emotion/core';
+import { headline, textSans, body } from '@guardian/src-foundations/typography';
+import { palette, space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { Lines } from '../../Lines';
+import { Button } from '@guardian/src-button';
+import { Hide } from '@guardian/src-layout';
+import { SvgCheckmark, SvgCross } from '@guardian/src-icons';
+
+// --- Styles --- //
+
+const rootStyles = css`
+    position: relative;
+
+    background-color: ${palette.neutral[97]};
+
+    * {
+        box-sizing: border-box;
+    }
+`;
+
+const lineWrapperStyles = css`
+    margin: ${space[3]}px auto;
+`;
+
+const remindHeading = css`
+    ${headline.xxsmall({ fontWeight: 'bold' })};
+    margin: 0 ${space[5]}px ${space[2]}px 0;
+`;
+
+const successTextStyles = css`
+    margin: 0 auto ${space[2]}px;
+    ${body.medium()};
+`;
+
+const linkStyles = css`
+    color: ${palette.neutral[7]};
+`;
+
+const errorTextStyles = css`
+    ${textSans.small({ fontWeight: 'bold' })};
+    color: ${palette.error[400]};
+    font-style: italic;
+    margin-top: ${space[1]}px;
+    margin-bottom: 0;
+`;
+
+const closeButtonContainerStyles = css`
+    display: none;
+    position: absolute;
+    top: 20px;
+    right: 0;
+
+    ${from.tablet} {
+        display: block;
+    }
+`;
+
+const bodyCopyStyles = css`
+    margin-top: ${space[1]}px;
+    ${body.medium()}
+
+    ${from.tablet} {
+        margin-right: ${space[9]}px;
+    }
+`;
+
+const infoCopyStyles = css`
+    ${textSans.small()};
+    font-style: italic;
+`;
+
+const ctaContainerStyles = css`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    & > * + * {
+        margin-left: ${space[6]}px;
+    }
+`;
+
+// --- Utils --- //
+
+const PREPOSITION_REGEX = /^(on|in)/;
+
+const containsPreposition = (text: string): boolean => PREPOSITION_REGEX.test(text);
+
+const addPreposition = (text: string): string => 'in ' + text;
+
+const ensureHasPreposition = (text: string): string =>
+    containsPreposition(text) ? text : addPreposition(text);
+
+// --- Types --- //
+type ReminderStatus = 'EDITING' | 'SUBMITTING' | 'ERROR' | 'COMPLETED';
+
+export interface ContributionsEpicReminderSignedInProps {
+    reminderLabel: string;
+    reminderStatus: ReminderStatus;
+    onSetReminderClick: () => void;
+    onCloseReminderClick: () => void;
+}
+
+// --- Components --- //
+
+export const ContributionsEpicReminderSignedIn: React.FC<ContributionsEpicReminderSignedInProps> = ({
+    reminderLabel,
+    reminderStatus,
+    onSetReminderClick,
+    onCloseReminderClick,
+}: ContributionsEpicReminderSignedInProps) => {
+    const reminderDateWithPreposition = ensureHasPreposition(reminderLabel);
+
+    return (
+        <div css={rootStyles}>
+            <div css={closeButtonContainerStyles}>
+                <Button
+                    onClick={onCloseReminderClick}
+                    icon={<SvgCross />}
+                    priority="subdued"
+                    size="small"
+                    hideLabel
+                >
+                    Close
+                </Button>
+            </div>
+
+            <div css={lineWrapperStyles}>
+                <Lines />
+            </div>
+
+            {reminderStatus === 'COMPLETED' ? (
+                <>
+                    <h4 css={remindHeading}>Thank you! Your reminder is set.</h4>
+                    <p css={successTextStyles}>
+                        We will be in touch to invite you to contribute. Look out for a message in
+                        your inbox {reminderDateWithPreposition}. If you have any questions about
+                        contributing, please{' '}
+                        <a href="mailto:contribution.support@theguardian.com" css={linkStyles}>
+                            contact us
+                        </a>
+                        .
+                    </p>
+                </>
+            ) : (
+                <>
+                    <p css={bodyCopyStyles}>
+                        Show your support for the Guardian at a later date. To make this easier, set
+                        a reminder and we’ll email you {reminderDateWithPreposition}.
+                    </p>
+
+                    <div css={ctaContainerStyles}>
+                        <div>
+                            <Hide above="tablet">
+                                <Button
+                                    onClick={onSetReminderClick}
+                                    disabled={reminderStatus === 'SUBMITTING'}
+                                >
+                                    Set a reminder
+                                </Button>
+                            </Hide>
+
+                            <Hide below="tablet">
+                                <Button
+                                    onClick={onSetReminderClick}
+                                    icon={<SvgCheckmark />}
+                                    iconSide="left"
+                                    disabled={reminderStatus === 'SUBMITTING'}
+                                >
+                                    Set a reminder
+                                </Button>
+                            </Hide>
+                        </div>
+
+                        <Button onClick={onCloseReminderClick} priority="subdued">
+                            Not now
+                        </Button>
+                    </div>
+
+                    {reminderStatus === 'ERROR' && (
+                        <p css={errorTextStyles}>
+                            Sorry we couldn&apos;t set a reminder for you this time. Please try
+                            again later.
+                        </p>
+                    )}
+
+                    <p css={infoCopyStyles}>
+                        We will send you a maximum of two emails {reminderDateWithPreposition}. To
+                        find out what personal data we collect and how we use it, view our{' '}
+                        <a
+                            css={linkStyles}
+                            href="https://www.theguardian.com/help/privacy-policy"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Privacy Policy
+                        </a>
+                        .
+                    </p>
+                </>
+            )}
+        </div>
+    );
+};

--- a/src/components/modules/epics/ContributionsEpicReminderSignedOut.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedOut.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import {
+    ContributionsEpicReminderSignedOut,
+    ContributionsEpicReminderSignedOutProps,
+} from './ContributionsEpicReminderSignedOut';
+import { ReminderStatus } from './ContributionsEpicReminder';
+import { EpicDecorator } from './ContributionsEpicReminder.stories';
+
+export default {
+    component: ContributionsEpicReminderSignedOut,
+    title: 'Epics/ContributionsEpicReminderSignedOut',
+    args: {
+        reminderLabel: 'May',
+        reminderStatus: ReminderStatus.Editing,
+    },
+    decorators: [EpicDecorator],
+} as Meta;
+
+const Template: Story<ContributionsEpicReminderSignedOutProps> = (
+    props: ContributionsEpicReminderSignedOutProps,
+) => <ContributionsEpicReminderSignedOut {...props} />;
+
+export const Default = Template.bind({});
+
+export const Submitting = Template.bind({});
+Submitting.args = {
+    reminderStatus: ReminderStatus.Submitting,
+};
+
+export const Completed = Template.bind({});
+Completed.args = {
+    reminderStatus: ReminderStatus.Completed,
+};
+
+export const Error = Template.bind({});
+Error.args = {
+    reminderStatus: ReminderStatus.Error,
+};

--- a/src/components/modules/epics/ContributionsEpicReminderSignedOut.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedOut.tsx
@@ -10,6 +10,7 @@ import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';
 import { SvgArrowRightStraight, SvgCross } from '@guardian/src-icons';
 import { ReminderStatus } from './ContributionsEpicReminder';
+import { ensureHasPreposition, isValidEmail } from './utils/reminders';
 
 // --- Styles --- //
 
@@ -108,22 +109,6 @@ const getCustomSubmitStyles = (isDisabled: boolean): SerializedStyles | undefine
 
     return undefined;
 };
-
-// --- Utils --- //
-
-const isValidEmail = (email: string): boolean => {
-    const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    return re.test(String(email).toLowerCase());
-};
-
-const PREPOSITION_REGEX = /^(on|in)/;
-
-const containsPreposition = (text: string): boolean => PREPOSITION_REGEX.test(text);
-
-const addPreposition = (text: string): string => 'in ' + text;
-
-const ensureHasPreposition = (text: string): string =>
-    containsPreposition(text) ? text : addPreposition(text);
 
 // --- Types --- //
 

--- a/src/components/modules/epics/ContributionsEpicReminderSignedOut.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedOut.tsx
@@ -1,0 +1,256 @@
+// --- Imports --- //
+
+import React, { useState } from 'react';
+import { css, SerializedStyles } from '@emotion/core';
+import { headline, textSans, body } from '@guardian/src-foundations/typography';
+import { palette, space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { Lines } from '../../Lines';
+import { TextInput } from '@guardian/src-text-input';
+import { Button } from '@guardian/src-button';
+import { SvgArrowRightStraight, SvgCross } from '@guardian/src-icons';
+import { ReminderStatus } from './ContributionsEpicReminder';
+
+// --- Styles --- //
+
+const rootStyles = css`
+    position: relative;
+
+    * {
+        box-sizing: border-box;
+    }
+`;
+
+const closeButtonStyles = css`
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+    position: absolute;
+    top: 20px;
+    right: 0;
+    background: none;
+    border: none;
+    padding: 0;
+`;
+
+const lineWrapperStyles = css`
+    margin: ${space[3]}px auto;
+`;
+
+const containerStyles = css`
+    padding: 0 ${space[1]}px;
+`;
+
+const remindHeading = css`
+    ${headline.xxsmall({ fontWeight: 'bold' })};
+    margin: 0 ${space[5]}px ${space[2]}px 0;
+`;
+
+const successTextStyles = css`
+    margin: 0 auto ${space[2]}px;
+    ${body.medium()};
+`;
+
+const linkStyles = css`
+    color: ${palette.neutral[7]};
+`;
+
+const formWrapper = css`
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    ${from.tablet} {
+        flex-direction: row;
+        align-items: flex-end;
+        justify-content: flex-start;
+    }
+`;
+
+const inputWrapper = css`
+    width: 100%;
+    margin-bottom: ${space[2]}px;
+    flex-grow: 1;
+
+    ${from.tablet} {
+        width: auto;
+        margin-right: ${space[2]}px;
+        margin-bottom: 0;
+    }
+`;
+
+const formTextStyles = css`
+    ${textSans.small()};
+    font-style: italic;
+    margin-top: ${space[1]}px;
+`;
+
+const errorTextStyles = css`
+    ${textSans.small({ fontWeight: 'bold' })};
+    color: ${palette.error[400]};
+    font-style: italic;
+    margin-top: ${space[1]}px;
+    margin-bottom: 0;
+`;
+
+const getCustomSubmitStyles = (isDisabled: boolean): SerializedStyles | undefined => {
+    if (isDisabled) {
+        // Unfortunately these overrides need !important as otherwise they'll lose
+        // the specificity war against the default Source styles.
+        return css`
+            pointer-events: none;
+            color: ${palette.neutral[60]} !important;
+            background-color: ${palette.neutral[93]} !important;
+            border: 1px solid ${palette.neutral[86]} !important;
+        `;
+    }
+
+    return undefined;
+};
+
+// --- Utils --- //
+
+const isValidEmail = (email: string): boolean => {
+    const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return re.test(String(email).toLowerCase());
+};
+
+const PREPOSITION_REGEX = /^(on|in)/;
+
+const containsPreposition = (text: string): boolean => PREPOSITION_REGEX.test(text);
+
+const addPreposition = (text: string): string => 'in ' + text;
+
+const ensureHasPreposition = (text: string): string =>
+    containsPreposition(text) ? text : addPreposition(text);
+
+// --- Types --- //
+
+export interface ContributionsEpicReminderSignedOutProps {
+    reminderLabel: string;
+    reminderStatus: ReminderStatus;
+    onSetReminderClick: (email: string) => void;
+    onCloseReminderClick: () => void;
+}
+
+// --- Components --- //
+
+export const ContributionsEpicReminderSignedOut: React.FC<ContributionsEpicReminderSignedOutProps> = ({
+    reminderLabel,
+    reminderStatus,
+    onSetReminderClick,
+    onCloseReminderClick,
+}: ContributionsEpicReminderSignedOutProps) => {
+    const [isDirty, setIsDirty] = useState(false);
+    const [emailAddress, setEmailAddress] = useState('');
+
+    const updateEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setEmailAddress(e.target.value);
+        if (isDirty) {
+            setIsDirty(false);
+        }
+    };
+
+    const isEmpty = emailAddress.trim().length === 0;
+    const isValid = isValidEmail(emailAddress);
+
+    let inputError;
+    if (isDirty && isEmpty) {
+        inputError = 'Please enter your email address';
+    } else if (isDirty && !isValid) {
+        inputError = 'Please enter a valid email address';
+    }
+
+    const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (isValid) {
+            onSetReminderClick(emailAddress);
+        } else {
+            setIsDirty(true);
+        }
+    };
+
+    const reminderDateWithPreposition = ensureHasPreposition(reminderLabel);
+
+    return (
+        <div css={rootStyles}>
+            <button css={closeButtonStyles} onClick={(): void => onCloseReminderClick()}>
+                <SvgCross />
+            </button>
+
+            <div css={lineWrapperStyles}>
+                <Lines />
+            </div>
+
+            <div css={containerStyles}>
+                <form onSubmit={onSubmit}>
+                    {reminderStatus !== ReminderStatus.Completed && (
+                        <>
+                            <h4 css={remindHeading}>Remind me {reminderDateWithPreposition}</h4>
+                            <div css={formWrapper}>
+                                <div css={inputWrapper}>
+                                    <TextInput
+                                        label="Email address"
+                                        error={inputError}
+                                        value={emailAddress}
+                                        onChange={updateEmail}
+                                    />
+                                </div>
+                                <Button
+                                    iconSide="right"
+                                    icon={<SvgArrowRightStraight />}
+                                    type="submit"
+                                    disabled={reminderStatus === ReminderStatus.Submitting}
+                                    css={getCustomSubmitStyles(
+                                        reminderStatus === ReminderStatus.Submitting,
+                                    )}
+                                >
+                                    Set a reminder
+                                </Button>
+                            </div>
+                        </>
+                    )}
+
+                    {reminderStatus === ReminderStatus.Error && (
+                        <p css={errorTextStyles}>
+                            Sorry we couldn&apos;t set a reminder for you this time. Please try
+                            again later.
+                        </p>
+                    )}
+                </form>
+
+                {reminderStatus !== ReminderStatus.Completed && (
+                    <p css={formTextStyles}>
+                        We will send you a maximum of two emails {reminderDateWithPreposition}. To
+                        find out what personal data we collect and how we use it, view our{' '}
+                        <a
+                            css={linkStyles}
+                            href="https://www.theguardian.com/help/privacy-policy"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Privacy Policy
+                        </a>
+                        .
+                    </p>
+                )}
+
+                {reminderStatus === ReminderStatus.Completed && (
+                    <>
+                        <h4 css={remindHeading}>Thank you! Your reminder is set.</h4>
+                        <p css={successTextStyles}>
+                            We will be in touch to invite you to contribute. Look out for a message
+                            in your inbox {reminderDateWithPreposition}. If you have any questions
+                            about contributing, please{' '}
+                            <a href="mailto:contribution.support@theguardian.com" css={linkStyles}>
+                                contact us
+                            </a>
+                            .
+                        </p>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/src/components/modules/epics/utils/reminders.ts
+++ b/src/components/modules/epics/utils/reminders.ts
@@ -1,0 +1,27 @@
+import { addCookie } from '../../../../lib/cookies';
+
+const dateDiff = (start: Date, end: Date): number => {
+    const twentyFourHours = 86400000;
+    return Math.round((end.valueOf() - start.valueOf()) / twentyFourHours);
+};
+
+export const addContributionReminderCookie = (reminderDateString: string): void => {
+    const today = new Date();
+    const reminderDate = new Date(Date.parse(reminderDateString));
+
+    addCookie('gu_epic_contribution_reminder', '1', dateDiff(today, reminderDate));
+};
+
+const PREPOSITION_REGEX = /^(on|in)/;
+
+const containsPreposition = (text: string): boolean => PREPOSITION_REGEX.test(text);
+
+const addPreposition = (text: string): string => 'in ' + text;
+
+export const ensureHasPreposition = (text: string): string =>
+    containsPreposition(text) ? text : addPreposition(text);
+
+export const isValidEmail = (email: string): boolean => {
+    const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return re.test(String(email).toLowerCase());
+};


### PR DESCRIPTION
## What does this change?
Update the `ContributionsEpicReminder` for signed in users. I decided to spend a little bit extra time on this to refactor the original component too. In the process I think I've stumbled across quite a nice pattern that helped out with building the components too. We now have a top level `ContributionsEpicReminder` which doesn't do a whole lot in it's JSX (just returns either the signed in or signed out component) but is responsible for passing the `reminderStatus` (e.g submitting/error) into the signed in/out component. By having this status as a prop, it makes it really easy to build/test the component in storybook - want to see the submitting (loading) state? just create a story with the status set to loading ! Before I was just submitting and relying on slow internet to see it 🙈

## Images
**mobile**
<img width="447" alt="Screenshot 2021-03-23 at 14 21 59" src="https://user-images.githubusercontent.com/17720442/112162011-8fb87680-8be3-11eb-817b-96cfd610bb53.png">

**tablet+**
<img width="807" alt="Screenshot 2021-03-23 at 14 47 16" src="https://user-images.githubusercontent.com/17720442/112165743-ebd0ca00-8be6-11eb-98c2-c35813b1db5c.png">

