### PR TITLE
Fix deploy

### DIFF
--- a/artifact.json
+++ b/artifact.json
@@ -15,7 +15,7 @@
         {
             "action": "dotcom-components",
             "path": "dist",
-            "compress": "zip"
+            "compress": "tar"
         }
     ]
 }

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -260,7 +260,7 @@ Resources:
 
                     aws --region eu-west-1 s3 cp s3://${S3Bucket}/support/${Stage}/${App}/${App}.tar ./
                     mkdir ${App}
-                    tar -xvzf ${App}.tgz --directory ${App}
+                    tar -xvzf ${App}.tar --directory ${App}
 
                     chown -R dotcom-components:support ${App}
 

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -260,7 +260,7 @@ Resources:
 
                     aws --region eu-west-1 s3 cp s3://${S3Bucket}/support/${Stage}/${App}/${App}.tar ./
                     mkdir ${App}
-                    tar -xvzf ${App}.tar --directory ${App}
+                    tar -xvf ${App}.tar --directory ${App}
 
                     chown -R dotcom-components:support ${App}
 

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -274,7 +274,7 @@ Resources:
                     mkdir /var/log/dotcom-components
                     chown -R dotcom-components:support /var/log/dotcom-components
 
-                    /usr/local/node/pm2 start --uid dotcom-components --gid support dist/server.js
+                    /usr/local/node/pm2 start --uid dotcom-components --gid support server.js
 
                     /opt/aws-kinesis-agent/configure-aws-kinesis-agent ${AWS::Region} ${ELKStream} /var/log/dotcom-components/dotcom-components.log
         DependsOn:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -258,7 +258,7 @@ Resources:
                     useradd -r -m -s /usr/bin/nologin -g support dotcom-components
                     cd /home/dotcom-components
 
-                    aws --region eu-west-1 s3 cp s3://${S3Bucket}/support/${Stage}/${App}/${App}.tgz ./
+                    aws --region eu-west-1 s3 cp s3://${S3Bucket}/support/${Stage}/${App}/${App}.tar ./
                     mkdir ${App}
                     tar -xvzf ${App}.tgz --directory ${App}
 


### PR DESCRIPTION
The recent change to node-riffraff-artifact changed the file type, meaning we've been deploying an old build since.