### PR TITLE
Set cacheControl and surrogateControl on modules in S3

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -7,8 +7,8 @@ deployments:
         parameters:
             bucket: gu-contributions-public
             prefixStack: false
-            cacheControl: no-cache
-            surrogateControl: max-age=3600
+            cacheControl: max-age=120
+            surrogateControl: max-age=300
 
     dotcom-components-cloudformation:
         type: cloud-formation

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,6 +8,7 @@ deployments:
             bucket: gu-contributions-public
             prefixStack: false
             cacheControl: no-cache
+            surrogateControl: max-age=3600
 
     dotcom-components-cloudformation:
         type: cloud-formation


### PR DESCRIPTION
We'll soon be serving modules from S3.
This change aligns the caching headers with what we currently have [here](https://github.com/guardian/support-dotcom-components/blob/main/src/server.tsx#L386)

riff-raff change [here](https://github.com/guardian/riff-raff/pull/619)

![Screen Shot 2021-03-24 at 13 15 08](https://user-images.githubusercontent.com/1513454/112316404-fc467a80-8ca2-11eb-8a1d-2df190e2feef.png)
