### PR TITLE
Add tracking to puzzles banner

### DIFF
--- a/src/components/hooks/useEscapeShortcut.ts
+++ b/src/components/hooks/useEscapeShortcut.ts
@@ -2,7 +2,10 @@ import { useEffect } from 'react';
 
 // Pass a function to run when the user hits the escape key
 // Useful for enabling a keyboard shortcut for dismissing banners
-export function useEscapeShortcut(eventHandler: (event: KeyboardEvent) => void): void {
+export function useEscapeShortcut(
+    eventHandler: (event: KeyboardEvent) => void,
+    deps: React.DependencyList = [],
+): void {
     function handleEscapeKeydown(event: KeyboardEvent) {
         // IE key name is 'Esc', because IE
         const isEscapeKey = event.key === 'Escape' || event.key === 'Esc';
@@ -15,5 +18,5 @@ export function useEscapeShortcut(eventHandler: (event: KeyboardEvent) => void):
         window.addEventListener('keydown', handleEscapeKeydown);
 
         return () => window.removeEventListener('keydown', handleEscapeKeydown);
-    }, []);
+    }, deps);
 }

--- a/src/components/modules/puzzles/localStorage.ts
+++ b/src/components/modules/puzzles/localStorage.ts
@@ -1,0 +1,20 @@
+export const setBannerState = (isMinimised: boolean): void => {
+    localStorage.setItem(
+        'gu.prefs.isPuzzlesBannerMinimised',
+        JSON.stringify({
+            value: isMinimised,
+        }),
+    );
+};
+
+export const getBannerState = (): boolean => {
+    const savedState = localStorage.getItem('gu.prefs.isPuzzlesBannerMinimised');
+    if (savedState) {
+        try {
+            return JSON.parse(savedState)?.value ?? false;
+        } catch (error) {
+            return false;
+        }
+    }
+    return false;
+};

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.stories.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.stories.tsx
@@ -23,7 +23,7 @@ const tracking: BannerTracking = {
 export const defaultStory = (): ReactElement => {
     return (
         <StorybookWrapper>
-            <PuzzlesBanner tracking={tracking} />
+            <PuzzlesBanner tracking={tracking} submitComponentEvent={console.log} />
         </StorybookWrapper>
     );
 };

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.stories.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.stories.tsx
@@ -1,16 +1,29 @@
 import React, { ReactElement } from 'react';
 import { PuzzlesBanner } from './PuzzlesBanner';
 import { StorybookWrapper, BannerWrapper } from '../../../../utils/StorybookWrapper';
+import { BannerTracking } from '../../../../types/BannerTypes';
 
 export default {
     component: PuzzlesBanner,
     title: 'Puzzles/PuzzlesBanner',
 };
 
+const tracking: BannerTracking = {
+    ophanPageId: 'kbluzw2csbf83eabettt',
+    platformId: 'GUARDIAN_WEB',
+    clientName: 'dcr',
+    referrerUrl: 'http://localhost:3030/Article',
+    abTestName: 'GuardianPuzzlesBanner',
+    abTestVariant: 'control',
+    campaignCode: '',
+    componentType: 'ACQUISITIONS_PUZZLES_BANNER',
+    products: ['PUZZLES_APP'],
+};
+
 export const defaultStory = (): ReactElement => {
     return (
         <StorybookWrapper>
-            <PuzzlesBanner />
+            <PuzzlesBanner tracking={tracking} />
         </StorybookWrapper>
     );
 };

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.stories.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.stories.tsx
@@ -16,8 +16,7 @@ const tracking: BannerTracking = {
     abTestName: 'GuardianPuzzlesBanner',
     abTestVariant: 'control',
     campaignCode: '',
-    componentType: 'ACQUISITIONS_PUZZLES_BANNER',
-    products: ['PUZZLES_APP'],
+    componentType: 'ACQUISITIONS_OTHER',
 };
 
 export const defaultStory = (): ReactElement => {

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -6,7 +6,7 @@ import { Button } from '@guardian/src-button';
 import { SvgArrowDownStraight, SvgArrowUpStraight } from '@guardian/src-icons';
 import {
     createClickEventFromTracking,
-    createViewEvenetFromTracking,
+    createViewEventFromTracking,
 } from '../../../../lib/tracking';
 import { PuzzlesBannerProps } from '../../../../types/BannerTypes';
 import { gridPrefixerPlugin } from '../../../../utils/gridPrefixerPlugin';
@@ -92,7 +92,7 @@ export const PuzzlesBanner: React.FC<PuzzlesBannerProps> = ({ tracking, submitCo
     }
 
     function onBannerView(bannerState: BannerState) {
-        const componentViewEvent = createViewEvenetFromTracking(
+        const componentViewEvent = createViewEventFromTracking(
             tracking,
             bannerStateComponentIds[bannerState],
         );

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -157,7 +157,7 @@ export const PuzzlesBanner: React.FC<PuzzlesBannerProps> = ({ tracking, submitCo
                             </h3>
                             <div css={appStoreButtonContainer}>
                                 <a
-                                    href="http://"
+                                    href="https://apps.apple.com/app/apple-store/id1487780661?pt=304191&ct=Puzzles_Banner&mt=8"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     onClick={handleAppStoreClickFor('apple')}
@@ -168,7 +168,7 @@ export const PuzzlesBanner: React.FC<PuzzlesBannerProps> = ({ tracking, submitCo
                                     />
                                 </a>
                                 <a
-                                    href="http://"
+                                    href="https://play.google.com/store/apps/details?id=uk.co.guardian.puzzles&referrer=utm_source%3Dtheguardian.com%26utm_medium%3Dpuzzle_banner%26utm_campaign%3DUS2020"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     onClick={handleAppStoreClickFor('google')}

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -135,7 +135,7 @@ export const PuzzlesBanner: React.FC<PuzzlesBannerProps> = ({ tracking, submitCo
         if (!isMinimised) {
             minimise();
         }
-    });
+    }, [isMinimised]);
 
     useEffect(() => {
         const bannerLoadState: BannerState = isMinimised ? 'minimised' : 'expanded';

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -100,7 +100,7 @@ export const appStoreButtonContainer = css`
     }
 `;
 
-export const collapseButtonContainer = css`
+export const minimiseButtonContainer = css`
     & > * {
         padding: ${space[2]}px;
         justify-content: flex-end;
@@ -111,7 +111,7 @@ export const collapseButtonContainer = css`
     }
 `;
 
-export const collapseButton = css`
+export const minimiseButton = css`
     border: none;
     background-color: ${neutral[97]};
     color: ${neutral[7]};

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MinimisedContentSquare.tsx
@@ -41,11 +41,11 @@ const content = css`
 `;
 
 type MinimisedContentSquareProps = {
-    collapseButton: React.ReactNode;
+    minimiseButton: React.ReactNode;
 };
 
 export const MinimisedContentSquare: React.FC<MinimisedContentSquareProps> = ({
-    collapseButton,
+    minimiseButton,
 }) => {
     return (
         <div css={squareContainer}>
@@ -53,7 +53,7 @@ export const MinimisedContentSquare: React.FC<MinimisedContentSquareProps> = ({
                 <SquareSide />
                 <div css={content}>
                     <h3 css={heading}>Master every challenge</h3>
-                    {collapseButton}
+                    {minimiseButton}
                 </div>
             </Square>
         </div>

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MobileSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MobileSquares.tsx
@@ -3,10 +3,10 @@ import { css, SerializedStyles } from '@emotion/core';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 import { Square } from './Square';
-import { collapseButtonContainer } from '../puzzlesBannerStyles';
+import { minimiseButtonContainer } from '../puzzlesBannerStyles';
 
 type MobileSquaresProps = {
-    collapseButton: React.ReactNode;
+    minimiseButton: React.ReactNode;
     cssOverrides?: SerializedStyles | string;
 };
 
@@ -35,7 +35,7 @@ const noLeftBorderOnSmallestScreens = css`
     }
 `;
 
-export const MobileSquares: React.FC<MobileSquaresProps> = ({ collapseButton, cssOverrides }) => {
+export const MobileSquares: React.FC<MobileSquaresProps> = ({ minimiseButton, cssOverrides }) => {
     return (
         <div css={[mobileSquareGrid, cssOverrides]}>
             <Square colour="purple" cssOverrides={firstRow} removeBorder={['right']} />
@@ -50,8 +50,8 @@ export const MobileSquares: React.FC<MobileSquaresProps> = ({ collapseButton, cs
             />
             <Square colour="grey" removeBorder={['right']} />
             <Square colour="pink" removeBorder={['right']} />
-            <Square colour="purple" removeBorder={['right']} cssOverrides={collapseButtonContainer}>
-                {collapseButton}
+            <Square colour="purple" removeBorder={['right']} cssOverrides={minimiseButtonContainer}>
+                {minimiseButton}
             </Square>
         </div>
     );

--- a/src/components/modules/puzzles/puzzlesBanner/squares/TabletDesktopSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/TabletDesktopSquares.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { css } from '@emotion/core';
 import { from, until } from '@guardian/src-foundations/mq';
 import { Square } from './Square';
-import { collapseButtonContainer } from '../puzzlesBannerStyles';
+import { minimiseButtonContainer } from '../puzzlesBannerStyles';
 
 type TabletDesktopSquaresProps = {
-    collapseButton: React.ReactNode;
+    minimiseButton: React.ReactNode;
 };
 
 const backgroundSquaresGrid = css`
@@ -41,7 +41,7 @@ function gridPlacement(row: number, column: number) {
     `;
 }
 
-export const TabletDesktopSquares: React.FC<TabletDesktopSquaresProps> = ({ collapseButton }) => {
+export const TabletDesktopSquares: React.FC<TabletDesktopSquaresProps> = ({ minimiseButton }) => {
     return (
         <div css={backgroundSquaresGrid}>
             <Square
@@ -59,9 +59,9 @@ export const TabletDesktopSquares: React.FC<TabletDesktopSquaresProps> = ({ coll
             <Square colour="pink" removeBorder={['right']} cssOverrides={gridPlacement(2, 2)} />
             <Square
                 colour="purple"
-                cssOverrides={[collapseButtonContainer, nudgeSquareRight, gridPlacement(2, 3)]}
+                cssOverrides={[minimiseButtonContainer, nudgeSquareRight, gridPlacement(2, 3)]}
             >
-                {collapseButton}
+                {minimiseButton}
             </Square>
         </div>
     );

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -87,7 +87,7 @@ export const createClickEventFromTracking = (
     };
 };
 
-export const createViewEvenetFromTracking = (
+export const createViewEventFromTracking = (
     tracking: BannerTracking,
     componentId: string,
 ): OphanComponentEvent => {

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -86,3 +86,24 @@ export const createClickEventFromTracking = (
         action: 'CLICK',
     };
 };
+
+export const createViewEvenetFromTracking = (
+    tracking: BannerTracking,
+    componentId: string,
+): OphanComponentEvent => {
+    const { abTestName, abTestVariant, componentType, products = [], campaignCode } = tracking;
+
+    return {
+        component: {
+            componentType,
+            products,
+            campaignCode,
+            id: componentId,
+        },
+        abTest: {
+            name: abTestName,
+            variant: abTestVariant,
+        },
+        action: 'VIEW',
+    };
+};

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -621,12 +621,24 @@ app.get(
 );
 
 app.post('/puzzles', async (req: express.Request, res: express.Response) => {
+    const { tracking } = req.body;
+    // Exclude AB test & campaign properties that relate to the admin console; we don't care about them for puzzles
+    const puzzlesTracking: Partial<BannerTestTracking> = {
+        componentType: 'ACQUISITIONS_PUZZLES_BANNER',
+        products: ['PUZZLES_APP'],
+    };
+
     const response = {
         data: {
             module: {
                 url: `${baseUrl(req)}/puzzles-banner.js`,
                 name: 'PuzzlesBanner',
-                props: {},
+                props: {
+                    tracking: {
+                        ...tracking,
+                        ...puzzlesTracking,
+                    },
+                },
             },
             meta: {},
         },

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -624,8 +624,7 @@ app.post('/puzzles', async (req: express.Request, res: express.Response) => {
     const { tracking } = req.body;
     // Exclude AB test & campaign properties that relate to the admin console; we don't care about them for puzzles
     const puzzlesTracking: Partial<BannerTestTracking> = {
-        componentType: 'ACQUISITIONS_PUZZLES_BANNER',
-        products: ['PUZZLES_APP'],
+        componentType: 'ACQUISITIONS_OTHER',
     };
 
     const response = {

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -115,6 +115,10 @@ export interface BannerProps {
     hasOptedOutOfArticleCount?: boolean;
 }
 
+export interface PuzzlesBannerProps extends Partial<BannerProps> {
+    tracking: BannerTracking;
+}
+
 export interface RawVariantParams {
     name: string;
     template: BannerTemplate;

--- a/src/types/OphanTypes.ts
+++ b/src/types/OphanTypes.ts
@@ -2,14 +2,16 @@ export type OphanProduct =
     | 'CONTRIBUTION'
     | 'MEMBERSHIP_SUPPORTER'
     | 'DIGITAL_SUBSCRIPTION'
-    | 'PRINT_SUBSCRIPTION';
+    | 'PRINT_SUBSCRIPTION'
+    | 'PUZZLES_APP';
 
 export type OphanAction = 'CLICK' | 'VIEW';
 
 export type OphanComponentType =
     | 'ACQUISITIONS_EPIC'
     | 'ACQUISITIONS_ENGAGEMENT_BANNER'
-    | 'ACQUISITIONS_SUBSCRIPTIONS_BANNER';
+    | 'ACQUISITIONS_SUBSCRIPTIONS_BANNER'
+    | 'ACQUISITIONS_PUZZLES_BANNER';
 
 export type OphanComponent = {
     componentType: OphanComponentType;

--- a/src/types/OphanTypes.ts
+++ b/src/types/OphanTypes.ts
@@ -2,8 +2,7 @@ export type OphanProduct =
     | 'CONTRIBUTION'
     | 'MEMBERSHIP_SUPPORTER'
     | 'DIGITAL_SUBSCRIPTION'
-    | 'PRINT_SUBSCRIPTION'
-    | 'PUZZLES_APP';
+    | 'PRINT_SUBSCRIPTION';
 
 export type OphanAction = 'CLICK' | 'VIEW';
 
@@ -11,7 +10,7 @@ export type OphanComponentType =
     | 'ACQUISITIONS_EPIC'
     | 'ACQUISITIONS_ENGAGEMENT_BANNER'
     | 'ACQUISITIONS_SUBSCRIPTIONS_BANNER'
-    | 'ACQUISITIONS_PUZZLES_BANNER';
+    | 'ACQUISITIONS_OTHER';
 
 export type OphanComponent = {
     componentType: OphanComponentType;


### PR DESCRIPTION
## What does this change?
This adds Ophan tracking to the puzzles banner for the following events:

- Load (includes the expanded/minimised state)
- Banner expanded or minimised
- App store link clicked

This also adds the proper links to the Apple and Google app stores, code to save the banner state into local storage (so once minimised it will stay minimised on the next page load, or vice-versa), and makes the naming of variables and props relating to expanded/minimised state consistent.
