### PR TITLE
Use modules from S3, with versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,23 @@ $ yarn generate-schema
 ### SSH access
 To ssh onto an instance use:
 `ssm ssh --profile <aws profile> -x --ssm-tunnel -i <instance ID>`
+
+## Module versions
+
+We use versioning on the modules for backwards-incompatible upgrades. For example when we need to upgrade the emotion dependency, which the platforms (DCR+frontend) must also have.
+
+Module versions are not tied to main branch builds. We release new versions infrequently. These versions represent a contract between the platforms and dotcom-components.
+
+The latest version is defined in [modules.ts](src/modules.ts).
+
+Version history is documented in [module-versions.md](/module-versions.md).
+
+Modules are uploaded to an S3 bucket during the riff-raff deploy. Fastly routes requests to `/modules/...` to this bucket. In this bucket the paths contain the version.
+
+E.g. a client request to:
+
+`<our-domain>/modules/v1/banners/contributions/ContributionsBanner.js`
+
+is routed to:
+
+`<s3-bucket-domain>/PROD/dotcom-components-modules-upload/v1/banners/contributions/ContributionsBanner.js` 

--- a/module-versions.md
+++ b/module-versions.md
@@ -1,0 +1,3 @@
+## v1
+- Source v2
+- Emotion v10

--- a/src/api/contributionsApi.testData.ts
+++ b/src/api/contributionsApi.testData.ts
@@ -60,7 +60,7 @@ export const configuredTests: EpicTests = {
                         text: 'Support The Guardian',
                         baseUrl: 'https://support.theguardian.com/contribute',
                     },
-                    modulePath: version => `${version}/epic.js`,
+                    modulePathBuilder: version => `${version}/epic.js`,
                 },
             ],
             highPriority: false,

--- a/src/api/contributionsApi.testData.ts
+++ b/src/api/contributionsApi.testData.ts
@@ -60,7 +60,7 @@ export const configuredTests: EpicTests = {
                         text: 'Support The Guardian',
                         baseUrl: 'https://support.theguardian.com/contribute',
                     },
-                    modulePath: 'epic.js',
+                    modulePath: version => `${version}/epic.js`,
                 },
             ],
             highPriority: false,

--- a/src/components/modules/epics/ContributionsEpicTypes.ts
+++ b/src/components/modules/epics/ContributionsEpicTypes.ts
@@ -59,6 +59,7 @@ export type EpicTargeting = {
     showSupportMessaging: boolean;
     isRecurringContributor: boolean;
     lastOneOffContributionDate?: number; // Platform to send undefined or a timestamp date
+    modulesVersion?: string;
 };
 
 export type EpicPayload = {

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -61,7 +61,7 @@ export interface Variant {
     footer?: string;
     backgroundImageUrl?: string;
     showReminderFields?: ReminderFields;
-    modulePath?: (version?: string) => string;
+    modulePathBuilder?: (version?: string) => string;
 }
 
 interface ControlProportionSettings {

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -61,7 +61,7 @@ export interface Variant {
     footer?: string;
     backgroundImageUrl?: string;
     showReminderFields?: ReminderFields;
-    modulePath?: string;
+    modulePath?: (version?: string) => string;
 }
 
 interface ControlProportionSettings {

--- a/src/modules.test.ts
+++ b/src/modules.test.ts
@@ -8,9 +8,8 @@ describe('getDefaultModuleInfo', () => {
             name: 'my-banner',
             srcPath: 'src/components/modules/banners/myBanner/MyBanner.tsx',
             distPath: 'dist/modules/banners/myBanner/MyBanner.js',
-            endpointPath: 'my-banner.js',
+            endpointPath: 'modules/banners/myBanner/MyBanner.js',
             devServerPath: '/../dist/modules/banners/myBanner/MyBanner.js',
-            prodServerPath: '/modules/banners/myBanner/MyBanner.js',
         };
 
         const moduleInfo = getDefaultModuleInfo(name, path);
@@ -20,6 +19,5 @@ describe('getDefaultModuleInfo', () => {
         expect(moduleInfo.distPath).toEqual(expectedModuleInfo.distPath);
         expect(moduleInfo.endpointPath).toEqual(expectedModuleInfo.endpointPath);
         expect(moduleInfo.devServerPath).toEqual(expectedModuleInfo.devServerPath);
-        expect(moduleInfo.prodServerPath).toEqual(expectedModuleInfo.prodServerPath);
     });
 });

--- a/src/modules.test.ts
+++ b/src/modules.test.ts
@@ -1,4 +1,4 @@
-import { getDefaultModuleInfo, ModuleInfo } from './modules';
+import { getDefaultModuleInfo } from './modules';
 
 describe('getDefaultModuleInfo', () => {
     it('should create the expected paths', () => {
@@ -7,9 +7,9 @@ describe('getDefaultModuleInfo', () => {
         const expectedModuleInfo = {
             name: 'my-banner',
             srcPath: 'src/components/modules/banners/myBanner/MyBanner.tsx',
-            distPath: 'dist/modules/banners/myBanner/MyBanner.js',
+            distPath: 'dist/modules/v1/banners/myBanner/MyBanner.js',
             endpointPath: 'modules/v1/banners/myBanner/MyBanner.js',
-            devServerPath: '/../dist/modules/banners/myBanner/MyBanner.js',
+            devServerPath: '/../dist/modules/v1/banners/myBanner/MyBanner.js',
         };
 
         const moduleInfo = getDefaultModuleInfo(name, path);

--- a/src/modules.test.ts
+++ b/src/modules.test.ts
@@ -17,7 +17,7 @@ describe('getDefaultModuleInfo', () => {
         expect(moduleInfo.name).toEqual(expectedModuleInfo.name);
         expect(moduleInfo.srcPath).toEqual(expectedModuleInfo.srcPath);
         expect(moduleInfo.distPath).toEqual(expectedModuleInfo.distPath);
-        expect(moduleInfo.endpointPath('v1')).toEqual(expectedModuleInfo.endpointPath);
+        expect(moduleInfo.endpointPathBuilder('v1')).toEqual(expectedModuleInfo.endpointPath);
         expect(moduleInfo.devServerPath).toEqual(expectedModuleInfo.devServerPath);
     });
 });

--- a/src/modules.test.ts
+++ b/src/modules.test.ts
@@ -4,11 +4,11 @@ describe('getDefaultModuleInfo', () => {
     it('should create the expected paths', () => {
         const name = 'my-banner';
         const path = 'banners/myBanner/MyBanner';
-        const expectedModuleInfo: ModuleInfo = {
+        const expectedModuleInfo = {
             name: 'my-banner',
             srcPath: 'src/components/modules/banners/myBanner/MyBanner.tsx',
             distPath: 'dist/modules/banners/myBanner/MyBanner.js',
-            endpointPath: 'modules/banners/myBanner/MyBanner.js',
+            endpointPath: 'modules/v1/banners/myBanner/MyBanner.js',
             devServerPath: '/../dist/modules/banners/myBanner/MyBanner.js',
         };
 
@@ -17,7 +17,7 @@ describe('getDefaultModuleInfo', () => {
         expect(moduleInfo.name).toEqual(expectedModuleInfo.name);
         expect(moduleInfo.srcPath).toEqual(expectedModuleInfo.srcPath);
         expect(moduleInfo.distPath).toEqual(expectedModuleInfo.distPath);
-        expect(moduleInfo.endpointPath).toEqual(expectedModuleInfo.endpointPath);
+        expect(moduleInfo.endpointPath('v1')).toEqual(expectedModuleInfo.endpointPath);
         expect(moduleInfo.devServerPath).toEqual(expectedModuleInfo.devServerPath);
     });
 });

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -9,11 +9,11 @@ export interface ModuleInfo {
 
 export const getDefaultModuleInfo = (name: string, path: string): ModuleInfo => ({
     name: name,
-    srcPath: `src/components/modules/${path}.tsx`,
-    distPath: `dist/modules/${path}.js`,
-    endpointPath: `${name}.js`,
-    devServerPath: `/../dist/modules/${path}.js`,
-    prodServerPath: `/modules/${path}.js`,
+    srcPath: `src/components/modules/${path}.tsx`,  // where the source lives
+    distPath: `dist/modules/${path}.js`,            // where to put the built module
+    endpointPath: `/modules/${path}.js`,            // path used by the client
+    devServerPath: `/../dist/modules/${path}.js`,   // the location on disk in DEV
+    prodServerPath: `/modules/${path}.js`,          // the location on disk in PROD/CODE
 });
 
 export const epic: ModuleInfo = getDefaultModuleInfo('epic', 'epics/ContributionsEpic');

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,17 +1,20 @@
+const MODULES_VERSION = 'v1';
+
 export interface ModuleInfo {
     name: string;
     srcPath: string; // where the source lives
     distPath: string; // where to put the built module
-    endpointPath: string; // path used by the client
+
+    endpointPath: (version?: string) => string; // path used by the client
     devServerPath: string; // local path of the modules, so we can serve them when running locally
 }
 
 export const getDefaultModuleInfo = (name: string, path: string): ModuleInfo => ({
     name: name,
     srcPath: `src/components/modules/${path}.tsx`,
-    distPath: `dist/modules/${path}.js`,
-    endpointPath: `modules/${path}.js`,
-    devServerPath: `/../dist/modules/${path}.js`,
+    distPath: `dist/modules/${MODULES_VERSION}/${path}.js`,
+    endpointPath: (version: string = MODULES_VERSION) => `modules/${version}/${path}.js`,
+    devServerPath: `/../dist/modules/${MODULES_VERSION}/${path}.js`,
 });
 
 export const epic: ModuleInfo = getDefaultModuleInfo('epic', 'epics/ContributionsEpic');

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,11 +1,10 @@
-const MODULES_VERSION = 'v1';
+const MODULES_VERSION = 'v1'; // The latest version of the modules
 
 export interface ModuleInfo {
     name: string;
     srcPath: string; // where the source lives
     distPath: string; // where to put the built module
-
-    endpointPath: (version?: string) => string; // path used by the client
+    endpointPathBuilder: (version?: string) => string; // path used by the client
     devServerPath: string; // local path of the modules, so we can serve them when running locally
 }
 
@@ -13,7 +12,7 @@ export const getDefaultModuleInfo = (name: string, path: string): ModuleInfo => 
     name: name,
     srcPath: `src/components/modules/${path}.tsx`,
     distPath: `dist/modules/${MODULES_VERSION}/${path}.js`,
-    endpointPath: (version: string = MODULES_VERSION) => `modules/${version}/${path}.js`,
+    endpointPathBuilder: (version: string = MODULES_VERSION) => `modules/${version}/${path}.js`,
     devServerPath: `/../dist/modules/${MODULES_VERSION}/${path}.js`,
 });
 

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,19 +1,17 @@
 export interface ModuleInfo {
     name: string;
-    srcPath: string;
-    distPath: string;
-    endpointPath: string;
-    devServerPath: string;
-    prodServerPath: string;
+    srcPath: string; // where the source lives
+    distPath: string; // where to put the built module
+    endpointPath: string; // path used by the client
+    devServerPath: string; // local path of the modules, so we can serve them when running locally
 }
 
 export const getDefaultModuleInfo = (name: string, path: string): ModuleInfo => ({
     name: name,
-    srcPath: `src/components/modules/${path}.tsx`,  // where the source lives
-    distPath: `dist/modules/${path}.js`,            // where to put the built module
-    endpointPath: `/modules/${path}.js`,            // path used by the client
-    devServerPath: `/../dist/modules/${path}.js`,   // the location on disk in DEV
-    prodServerPath: `/modules/${path}.js`,          // the location on disk in PROD/CODE
+    srcPath: `src/components/modules/${path}.tsx`,
+    distPath: `dist/modules/${path}.js`,
+    endpointPath: `modules/${path}.js`,
+    devServerPath: `/../dist/modules/${path}.js`,
 });
 
 export const epic: ModuleInfo = getDefaultModuleInfo('epic', 'epics/ContributionsEpic');

--- a/src/schemas/bannerPayload.schema.json
+++ b/src/schemas/bannerPayload.schema.json
@@ -68,6 +68,9 @@
                             "week"
                         ]
                     }
+                },
+                "modulesVersion": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/src/schemas/epicPayload.schema.json
+++ b/src/schemas/epicPayload.schema.json
@@ -101,6 +101,9 @@
                 },
                 "lastOneOffContributionDate": {
                     "type": "number"
+                },
+                "modulesVersion": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -191,7 +191,7 @@ const buildEpicData = async (
         countryCode: targeting.countryCode,
     };
 
-    const modulePath =
+    const modulePathBuilder: (version?: string) => string =
         variantWithTickerData.modulePath ||
         (type === 'ARTICLE' ? epicModule.endpointPath : liveblogEpicModule.endpointPath);
 
@@ -200,7 +200,7 @@ const buildEpicData = async (
             variant: variantWithTickerData,
             meta: testTracking,
             module: {
-                url: `${baseUrl}/${modulePath}`,
+                url: `${baseUrl}/${modulePathBuilder(targeting.modulesVersion)}`,
                 props,
             },
         },
@@ -398,7 +398,7 @@ const setComponentCacheHeaders = (res: express.Response): void => {
 // ES module endpoints
 const createEndpointForModule = (moduleInfo: ModuleInfo): void => {
     app.get(
-        `/${moduleInfo.endpointPath}`,
+        `/${moduleInfo.endpointPath()}`,
         async (req: express.Request, res: express.Response, next: express.NextFunction) => {
             try {
                 const module = await fs.promises.readFile(__dirname + moduleInfo.devServerPath);

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -192,8 +192,10 @@ const buildEpicData = async (
     };
 
     const modulePathBuilder: (version?: string) => string =
-        variantWithTickerData.modulePath ||
-        (type === 'ARTICLE' ? epicModule.endpointPath : liveblogEpicModule.endpointPath);
+        variantWithTickerData.modulePathBuilder ||
+        (type === 'ARTICLE'
+            ? epicModule.endpointPathBuilder
+            : liveblogEpicModule.endpointPathBuilder);
 
     return {
         data: {
@@ -398,7 +400,7 @@ const setComponentCacheHeaders = (res: express.Response): void => {
 // ES module endpoints
 const createEndpointForModule = (moduleInfo: ModuleInfo): void => {
     app.get(
-        `/${moduleInfo.endpointPath()}`,
+        `/${moduleInfo.endpointPathBuilder()}`,
         async (req: express.Request, res: express.Response, next: express.NextFunction) => {
             try {
                 const module = await fs.promises.readFile(__dirname + moduleInfo.devServerPath);

--- a/src/tests/banners/ChannelBannerTests.ts
+++ b/src/tests/banners/ChannelBannerTests.ts
@@ -17,7 +17,7 @@ const BannerChannelFiles: { [key in BannerChannel]: string } = {
     subscriptions: 'banner-tests2.json',
 };
 
-export const BannerPaths: { [key in BannerTemplate]: string } = {
+export const BannerPaths: { [key in BannerTemplate]: (version?: string) => string } = {
     [BannerTemplate.ContributionsBanner]: contributionsBanner.endpointPath,
     [BannerTemplate.DigitalSubscriptionsBanner]: digiSubs.endpointPath,
     [BannerTemplate.GuardianWeeklyBanner]: guardianWeekly.endpointPath,

--- a/src/tests/banners/ChannelBannerTests.ts
+++ b/src/tests/banners/ChannelBannerTests.ts
@@ -18,9 +18,9 @@ const BannerChannelFiles: { [key in BannerChannel]: string } = {
 };
 
 export const BannerPaths: { [key in BannerTemplate]: (version?: string) => string } = {
-    [BannerTemplate.ContributionsBanner]: contributionsBanner.endpointPath,
-    [BannerTemplate.DigitalSubscriptionsBanner]: digiSubs.endpointPath,
-    [BannerTemplate.GuardianWeeklyBanner]: guardianWeekly.endpointPath,
+    [BannerTemplate.ContributionsBanner]: contributionsBanner.endpointPathBuilder,
+    [BannerTemplate.DigitalSubscriptionsBanner]: digiSubs.endpointPathBuilder,
+    [BannerTemplate.GuardianWeeklyBanner]: guardianWeekly.endpointPathBuilder,
 };
 
 export const BannerTemplateComponentTypes: { [key in BannerTemplate]: OphanComponentType } = {
@@ -52,7 +52,7 @@ const BannerVariantFromParams = (variant: RawVariantParams): BannerVariant => {
 
     return {
         name: variant.name,
-        modulePath: BannerPaths[variant.template],
+        modulePathBuilder: BannerPaths[variant.template],
         moduleName: variant.template,
         bannerContent: bannerContent(),
         mobileBannerContent: variant.mobileBannerContent,

--- a/src/tests/banners/DefaultContributionsBannerTest.ts
+++ b/src/tests/banners/DefaultContributionsBannerTest.ts
@@ -12,7 +12,7 @@ export const DefaultContributionsBanner: BannerTest = {
     variants: [
         {
             name: 'control',
-            modulePath: contributionsBanner.endpointPath,
+            modulePathBuilder: contributionsBanner.endpointPathBuilder,
             moduleName: 'ContributionsBanner',
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             bannerContent: DefaultBannerContent,

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -59,7 +59,7 @@ describe('selectBannerTest', () => {
             variants: [
                 {
                     name: 'variant',
-                    modulePath: contributionsBanner.endpointPath,
+                    modulePath: contributionsBanner.endpointPathBuilder,
                     moduleName: 'ContributionsBanner',
                     bannerContent: {
                         messageText: 'body',
@@ -181,7 +181,7 @@ describe('selectBannerTest', () => {
             variants: [
                 {
                     name: 'variant',
-                    modulePath: digiSubs.endpointPath,
+                    modulePath: digiSubs.endpointPathBuilder,
                     moduleName: 'DigitalSubscriptionsBanner',
                     bannerContent: {
                         messageText: 'body',

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -59,7 +59,7 @@ describe('selectBannerTest', () => {
             variants: [
                 {
                     name: 'variant',
-                    modulePath: contributionsBanner.endpointPathBuilder,
+                    modulePathBuilder: contributionsBanner.endpointPathBuilder,
                     moduleName: 'ContributionsBanner',
                     bannerContent: {
                         messageText: 'body',
@@ -181,7 +181,7 @@ describe('selectBannerTest', () => {
             variants: [
                 {
                     name: 'variant',
-                    modulePath: digiSubs.endpointPathBuilder,
+                    modulePathBuilder: digiSubs.endpointPathBuilder,
                     moduleName: 'DigitalSubscriptionsBanner',
                     bannerContent: {
                         messageText: 'body',

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -59,7 +59,7 @@ describe('selectBannerTest', () => {
             variants: [
                 {
                     name: 'variant',
-                    modulePath: contributionsBanner.endpointPath(),
+                    modulePath: contributionsBanner.endpointPath,
                     moduleName: 'ContributionsBanner',
                     bannerContent: {
                         messageText: 'body',
@@ -181,7 +181,7 @@ describe('selectBannerTest', () => {
             variants: [
                 {
                     name: 'variant',
-                    modulePath: digiSubs.endpointPath(),
+                    modulePath: digiSubs.endpointPath,
                     moduleName: 'DigitalSubscriptionsBanner',
                     bannerContent: {
                         messageText: 'body',

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -59,7 +59,7 @@ describe('selectBannerTest', () => {
             variants: [
                 {
                     name: 'variant',
-                    modulePath: contributionsBanner.endpointPath,
+                    modulePath: contributionsBanner.endpointPath(),
                     moduleName: 'ContributionsBanner',
                     bannerContent: {
                         messageText: 'body',
@@ -181,7 +181,7 @@ describe('selectBannerTest', () => {
             variants: [
                 {
                     name: 'variant',
-                    modulePath: digiSubs.endpointPath,
+                    modulePath: digiSubs.endpointPath(),
                     moduleName: 'DigitalSubscriptionsBanner',
                     bannerContent: {
                         messageText: 'body',

--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -92,7 +92,7 @@ const getForcedVariant = (
         return {
             test,
             variant,
-            moduleUrl: `${baseUrl}/${variant.modulePath(targeting.modulesVersion)}`,
+            moduleUrl: `${baseUrl}/${variant.modulePathBuilder(targeting.modulesVersion)}`,
             moduleName: variant.moduleName,
         };
     }
@@ -135,7 +135,7 @@ export const selectBannerTest = async (
             const bannerTestSelection = {
                 test,
                 variant,
-                moduleUrl: `${baseUrl}/${variant.modulePath(targeting.modulesVersion)}`,
+                moduleUrl: `${baseUrl}/${variant.modulePathBuilder(targeting.modulesVersion)}`,
                 moduleName: variant.moduleName,
             };
 

--- a/src/tests/banners/bannerSelection.tsx
+++ b/src/tests/banners/bannerSelection.tsx
@@ -79,6 +79,7 @@ const getForcedVariant = (
     forcedTestVariant: TestVariant,
     tests: BannerTest[],
     baseUrl: string,
+    targeting: BannerTargeting,
 ): BannerTestSelection | null => {
     const test = tests.find(
         test => test.name.toLowerCase() === forcedTestVariant.testName.toLowerCase(),
@@ -91,7 +92,7 @@ const getForcedVariant = (
         return {
             test,
             variant,
-            moduleUrl: `${baseUrl}/${variant.modulePath}`,
+            moduleUrl: `${baseUrl}/${variant.modulePath(targeting.modulesVersion)}`,
             moduleName: variant.moduleName,
         };
     }
@@ -110,7 +111,7 @@ export const selectBannerTest = async (
     const tests = await getTests();
 
     if (forcedTestVariant) {
-        return Promise.resolve(getForcedVariant(forcedTestVariant, tests, baseUrl));
+        return Promise.resolve(getForcedVariant(forcedTestVariant, tests, baseUrl, targeting));
     }
 
     for (const test of tests) {
@@ -134,7 +135,7 @@ export const selectBannerTest = async (
             const bannerTestSelection = {
                 test,
                 variant,
-                moduleUrl: `${baseUrl}/${variant.modulePath}`,
+                moduleUrl: `${baseUrl}/${variant.modulePath(targeting.modulesVersion)}`,
                 moduleName: variant.moduleName,
             };
 

--- a/src/tests/epicArticleCountTest.ts
+++ b/src/tests/epicArticleCountTest.ts
@@ -58,7 +58,7 @@ export const epicSeparateArticleCountTest: Test = {
             highlightedText,
             name: EpicSeparateArticleCountTestVariants.control,
             cta,
-            modulePath: epic.endpointPath,
+            modulePathBuilder: epic.endpointPathBuilder,
         },
         {
             heading: heading,
@@ -66,7 +66,7 @@ export const epicSeparateArticleCountTest: Test = {
             highlightedText,
             name: EpicSeparateArticleCountTestVariants.above,
             cta,
-            modulePath: epicACAbove.endpointPath,
+            modulePathBuilder: epicACAbove.endpointPathBuilder,
         },
         {
             heading: heading,
@@ -74,7 +74,7 @@ export const epicSeparateArticleCountTest: Test = {
             highlightedText,
             name: EpicSeparateArticleCountTestVariants.inline,
             cta,
-            modulePath: epicACInline.endpointPath,
+            modulePathBuilder: epicACInline.endpointPathBuilder,
         },
     ],
     highPriority: true,

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -64,7 +64,7 @@ export enum BannerTemplate {
 export interface BannerVariant {
     name: string;
     tickerSettings?: TickerSettings;
-    modulePath: (version?: string) => string;
+    modulePathBuilder: (version?: string) => string;
     moduleName: string;
     bannerContent?: BannerContent;
     mobileBannerContent?: BannerContent;

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -16,6 +16,7 @@ export type BannerTargeting = {
     countryCode: string;
     weeklyArticleHistory?: WeeklyArticleHistory;
     hasOptedOutOfArticleCount: boolean;
+    modulesVersion?: string;
 };
 
 export type BannerTestTracking = {
@@ -63,7 +64,7 @@ export enum BannerTemplate {
 export interface BannerVariant {
     name: string;
     tickerSettings?: TickerSettings;
-    modulePath: string;
+    modulePath: (version?: string) => string;
     moduleName: string;
     bannerContent?: BannerContent;
     mobileBannerContent?: BannerContent;


### PR DESCRIPTION
### Serving modules from S3
The modules are already uploaded to a public S3 bucket during the deploy, but are not currently used.
Fastly routes requests to `/modules/...` to this bucket.

This PR makes use of the S3 modules in CODE + PROD by telling the client to fetch them from `/modules/...`.
Locally, the modules are still served by the node server.

This required a bit of extra fastly configuration, to set the `Access-Control-Allow-Origin` header on responses from this s3 bucket.

### Versioning
This PR also introduces versioning.
A version applies to all modules. We will release a new modules version infrequently, for example for a backwards-incompatible upgrade of emotion.
The client can optionally send a `modulesVersion` string in its request. If this is present then we use it to build the url of the module. This means clients can request older versions which still live in S3.

In CODE, requests are made to e.g. /modules/epics/ContributionsEpic.js, which fastly routes to s3:
![Screen Shot 2021-03-25 at 14 57 14](https://user-images.githubusercontent.com/1513454/112493829-6b42d280-8d7a-11eb-8923-6caed677123a.png)


In DEV (locally), requests are served by the server:
![Screen Shot 2021-03-25 at 14 14 45](https://user-images.githubusercontent.com/1513454/112490574-63cdfa00-8d77-11eb-9e3b-11aa3d9c6748.png)

