### PR TITLE
Article count design test round 2

### DIFF
--- a/src/components/modules/epics/ContributionsEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpic.stories.tsx
@@ -3,11 +3,38 @@ import { Story, Meta } from '@storybook/react';
 import { ContributionsEpic, EpicProps } from './ContributionsEpic';
 import { TickerCountType, TickerEndType } from '../../../lib/variants';
 import { props } from './utils/storybook';
+import { from } from '@guardian/src-foundations/mq';
+import { css } from '@emotion/core';
+import { palette } from '@guardian/src-foundations';
+
+const containerStyles = css`
+    margin: 3em auto;
+    padding: 0 10px;
+    max-width: 620px;
+
+    ${from.mobileLandscape} {
+        padding: 0 20px;
+    }
+`;
+
+const backgroundStyles = css`
+    background-color: ${palette.neutral[97]};
+`;
+
+export const EpicDecorator = (Story: Story): JSX.Element => (
+    <div css={containerStyles}>
+        <div css={backgroundStyles}>
+            <Story />
+        </div>
+    </div>
+);
 
 export default {
     component: ContributionsEpic,
     title: 'Epics/Contributions',
     args: props,
+    decorators: [EpicDecorator],
+    excludeStories: /.*Decorator$/,
 } as Meta;
 
 const Template: Story<EpicProps> = (props: EpicProps) => <ContributionsEpic {...props} />;

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -80,6 +80,10 @@ const imageStyles = css`
     object-fit: cover;
 `;
 
+const articleCountAboveContainerStyles = css`
+    margin-bottom: ${space[4]}px;
+`;
+
 export type EpicProps = {
     variant: Variant;
     tracking: EpicTracking;
@@ -181,12 +185,7 @@ const EpicBody: React.FC<BodyProps> = ({
                 );
 
                 if (acVariant === EpicSeparateArticleCountTestVariants.inline && idx === 1) {
-                    return (
-                        <ContributionsEpicArticleCountInline
-                            numArticles={numArticles}
-                            paragraphElement={paragraphElement}
-                        />
-                    );
+                    return <ContributionsEpicArticleCountInline numArticles={numArticles} />;
                 }
                 return paragraphElement;
             })}
@@ -228,7 +227,9 @@ export const ContributionsEpicComponent: (
     return (
         <section css={wrapperStyles}>
             {acVariant === EpicSeparateArticleCountTestVariants.above && (
-                <ContributionsEpicArticleCountAbove numArticles={numArticles} />
+                <div css={articleCountAboveContainerStyles}>
+                    <ContributionsEpicArticleCountAbove numArticles={numArticles} />
+                </div>
             )}
 
             {tickerSettings && tickerSettings.tickerData && (

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -16,6 +16,8 @@ import { replaceArticleCount } from '../../../lib/replaceArticleCount';
 import { EpicSeparateArticleCountTestVariants } from '../../../tests/epicArticleCountTest';
 import { ContributionsEpicArticleCountAbove } from './ContributionsEpicArticleCountAbove';
 import { ContributionsEpicArticleCountInline } from './ContributionsEpicArticleCountInline';
+import { OphanComponentEvent } from '../../../types/OphanTypes';
+import { OphanTracking } from '../shared/ArticleCountOptOut';
 
 const wrapperStyles = css`
     padding: ${space[1]}px ${space[2]}px ${space[3]}px;
@@ -98,12 +100,14 @@ export type EpicProps = {
     // eslint-disable-next-line @typescript-eslint/ban-types
     onReminderOpen?: Function;
     email?: string;
+    submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
 };
 
 type HighlightedProps = {
     highlightedText: string;
     countryCode?: string;
     numArticles: number;
+    tracking?: OphanTracking;
 };
 
 type BodyProps = {
@@ -112,6 +116,7 @@ type BodyProps = {
     countryCode?: string;
     numArticles: number;
     acVariant: EpicSeparateArticleCountTestVariants;
+    tracking?: OphanTracking;
 };
 
 interface OnReminderOpen {
@@ -121,18 +126,24 @@ interface OnReminderOpen {
 interface EpicHeaderProps {
     text: string;
     numArticles: number;
+    tracking?: OphanTracking;
 }
 
-const EpicHeader: React.FC<EpicHeaderProps> = ({ text, numArticles }: EpicHeaderProps) => {
-    const elements = replaceArticleCount(text, numArticles, 'epic');
+const EpicHeader: React.FC<EpicHeaderProps> = ({
+    text,
+    numArticles,
+    tracking,
+}: EpicHeaderProps) => {
+    const elements = replaceArticleCount(text, numArticles, 'epic', tracking);
     return <h2 css={headingStyles}>{elements}</h2>;
 };
 
 const Highlighted: React.FC<HighlightedProps> = ({
     highlightedText,
     numArticles,
+    tracking,
 }: HighlightedProps) => {
-    const elements = replaceArticleCount(highlightedText, numArticles, 'epic');
+    const elements = replaceArticleCount(highlightedText, numArticles, 'epic', tracking);
 
     return (
         <strong css={highlightWrapperStyles}>
@@ -146,14 +157,16 @@ interface EpicBodyParagraphProps {
     paragraph: string;
     numArticles: number;
     highlighted: JSX.Element | null;
+    tracking?: OphanTracking;
 }
 
 const EpicBodyParagraph: React.FC<EpicBodyParagraphProps> = ({
     paragraph,
     numArticles,
     highlighted,
+    tracking,
 }: EpicBodyParagraphProps) => {
-    const elements = replaceArticleCount(paragraph, numArticles, 'epic');
+    const elements = replaceArticleCount(paragraph, numArticles, 'epic', tracking);
 
     return (
         <p css={bodyStyles}>
@@ -169,6 +182,7 @@ const EpicBody: React.FC<BodyProps> = ({
     paragraphs,
     highlightedText,
     acVariant,
+    tracking,
 }: BodyProps) => {
     return (
         <>
@@ -187,6 +201,7 @@ const EpicBody: React.FC<BodyProps> = ({
                                 />
                             ) : null
                         }
+                        tracking={tracking}
                     />
                 );
 
@@ -194,7 +209,10 @@ const EpicBody: React.FC<BodyProps> = ({
                     return (
                         <div>
                             <div css={articleCountInlineContainerStyles}>
-                                <ContributionsEpicArticleCountInline numArticles={numArticles} />
+                                <ContributionsEpicArticleCountInline
+                                    numArticles={numArticles}
+                                    tracking={tracking}
+                                />
                             </div>
                             {paragraphElement}
                         </div>
@@ -215,6 +233,7 @@ export const ContributionsEpicComponent: (
     numArticles,
     onReminderOpen,
     email,
+    submitComponentEvent,
 }: EpicProps) => {
     const [isReminderActive, setIsReminderActive] = useState(false);
     const { backgroundImageUrl, showReminderFields, tickerSettings } = variant;
@@ -237,11 +256,19 @@ export const ContributionsEpicComponent: (
         return null; // quick exit if something goes wrong. Ideally we'd throw and caller would catch/log but TODO that separately
     }
 
+    const ophanTracking: OphanTracking | undefined = submitComponentEvent && {
+        submitComponentEvent,
+        componentType: 'ACQUISITIONS_EPIC',
+    };
+
     return (
         <section css={wrapperStyles}>
             {acVariant === EpicSeparateArticleCountTestVariants.above && (
                 <div css={articleCountAboveContainerStyles}>
-                    <ContributionsEpicArticleCountAbove numArticles={numArticles} />
+                    <ContributionsEpicArticleCountAbove
+                        numArticles={numArticles}
+                        tracking={ophanTracking}
+                    />
                 </div>
             )}
 
@@ -263,7 +290,13 @@ export const ContributionsEpicComponent: (
                 </div>
             )}
 
-            {cleanHeading && <EpicHeader text={cleanHeading} numArticles={numArticles} />}
+            {cleanHeading && (
+                <EpicHeader
+                    text={cleanHeading}
+                    numArticles={numArticles}
+                    tracking={ophanTracking}
+                />
+            )}
 
             <EpicBody
                 paragraphs={cleanParagraphs}
@@ -271,6 +304,7 @@ export const ContributionsEpicComponent: (
                 countryCode={countryCode}
                 numArticles={numArticles}
                 acVariant={acVariant}
+                tracking={ophanTracking}
             />
 
             {!isReminderActive && (

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -84,6 +84,12 @@ const articleCountAboveContainerStyles = css`
     margin-bottom: ${space[4]}px;
 `;
 
+const articleCountInlineContainerStyles = css`
+    float: left;
+    margin-top: 6px;
+    margin-right: ${space[4]}px;
+`;
+
 export type EpicProps = {
     variant: Variant;
     tracking: EpicTracking;
@@ -185,7 +191,14 @@ const EpicBody: React.FC<BodyProps> = ({
                 );
 
                 if (acVariant === EpicSeparateArticleCountTestVariants.inline && idx === 1) {
-                    return <ContributionsEpicArticleCountInline numArticles={numArticles} />;
+                    return (
+                        <div>
+                            <div css={articleCountInlineContainerStyles}>
+                                <ContributionsEpicArticleCountInline numArticles={numArticles} />
+                            </div>
+                            {paragraphElement}
+                        </div>
+                    );
                 }
                 return paragraphElement;
             })}

--- a/src/components/modules/epics/ContributionsEpicArticleCountAbove.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicArticleCountAbove.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { EpicDecorator } from './ContributionsEpic.stories';
+import { ContributionsEpicArticleCountAbove, Props } from './ContributionsEpicArticleCountAbove';
+
+export default {
+    component: ContributionsEpicArticleCountAbove,
+    title: 'Epics/ContributionsEpicArticleCountAbove',
+    args: {
+        numArticles: 989,
+    },
+    decorators: [EpicDecorator],
+} as Meta;
+
+const Template: Story<Props> = (props: Props) => <ContributionsEpicArticleCountAbove {...props} />;
+
+export const Default = Template.bind({});

--- a/src/components/modules/epics/ContributionsEpicArticleCountAbove.tsx
+++ b/src/components/modules/epics/ContributionsEpicArticleCountAbove.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/core';
 import { ArticleCountOptOut, OphanTracking } from '../shared/ArticleCountOptOut';
 
 const containerStyles = css`
-    ${body.medium()};
+    ${body.medium({ fontWeight: 'bold' })};
     font-style: italic;
 `;
 

--- a/src/components/modules/epics/ContributionsEpicArticleCountAbove.tsx
+++ b/src/components/modules/epics/ContributionsEpicArticleCountAbove.tsx
@@ -1,30 +1,35 @@
 import React from 'react';
-import { textSans } from '@guardian/src-foundations/typography';
+import { body } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
 import { css } from '@emotion/core';
-import { replaceArticleCount } from '../../../lib/replaceArticleCount';
+import { ArticleCountOptOut } from '../shared/ArticleCountOptOut';
 
-const containerStyle = css`
-    margin: 12px 0 10px 0;
+const containerStyles = css`
+    ${body.medium()};
+    font-style: italic;
 `;
 
-const contentStyle = css`
-    ${textSans.medium()};
-    background-color: ${palette.neutral[100]};
-    padding: 4px;
+const optOutContainer = css`
+    color: ${palette.opinion[400]};
 `;
 
-const message = 'You’ve read %%ARTICLE_COUNT%% articles this year';
-
-interface Props {
+export interface Props {
     numArticles: number;
 }
 
 export const ContributionsEpicArticleCountAbove: React.FC<Props> = ({ numArticles }: Props) => {
     if (numArticles >= 5) {
         return (
-            <div css={containerStyle}>
-                <span css={contentStyle}>{replaceArticleCount(message, numArticles, 'epic')}</span>
+            <div css={containerStyles}>
+                You&apos;ve read{' '}
+                <span css={optOutContainer}>
+                    <ArticleCountOptOut
+                        numArticles={numArticles}
+                        nextWord=" articles"
+                        type="epic"
+                    />
+                </span>{' '}
+                in the last year
             </div>
         );
     }

--- a/src/components/modules/epics/ContributionsEpicArticleCountAbove.tsx
+++ b/src/components/modules/epics/ContributionsEpicArticleCountAbove.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { body } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
 import { css } from '@emotion/core';
-import { ArticleCountOptOut } from '../shared/ArticleCountOptOut';
+import { ArticleCountOptOut, OphanTracking } from '../shared/ArticleCountOptOut';
 
 const containerStyles = css`
     ${body.medium()};
@@ -15,9 +15,13 @@ const optOutContainer = css`
 
 export interface Props {
     numArticles: number;
+    tracking?: OphanTracking;
 }
 
-export const ContributionsEpicArticleCountAbove: React.FC<Props> = ({ numArticles }: Props) => {
+export const ContributionsEpicArticleCountAbove: React.FC<Props> = ({
+    numArticles,
+    tracking,
+}: Props) => {
     if (numArticles >= 5) {
         return (
             <div css={containerStyles}>
@@ -27,6 +31,7 @@ export const ContributionsEpicArticleCountAbove: React.FC<Props> = ({ numArticle
                         numArticles={numArticles}
                         nextWord=" articles"
                         type="epic"
+                        tracking={tracking}
                     />
                 </span>{' '}
                 in the last year

--- a/src/components/modules/epics/ContributionsEpicArticleCountInline.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicArticleCountInline.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { EpicDecorator } from './ContributionsEpic.stories';
+import { ContributionsEpicArticleCountInline, Props } from './ContributionsEpicArticleCountInline';
+
+export default {
+    component: ContributionsEpicArticleCountInline,
+    title: 'Epics/ContributionsEpicArticleCountInline',
+    args: {
+        numArticles: 989,
+    },
+    decorators: [EpicDecorator],
+} as Meta;
+
+const Template: Story<Props> = (props: Props) => <ContributionsEpicArticleCountInline {...props} />;
+
+export const Default = Template.bind({});

--- a/src/components/modules/epics/ContributionsEpicArticleCountInline.tsx
+++ b/src/components/modules/epics/ContributionsEpicArticleCountInline.tsx
@@ -3,6 +3,7 @@ import { body, headline } from '@guardian/src-foundations/typography';
 import { css } from '@emotion/core';
 import { palette } from '@guardian/src-foundations';
 import { ArticleCountOptOut } from '../shared/ArticleCountOptOut2';
+import { OphanTracking } from '../shared/ArticleCountOptOut';
 
 const containerStyles = css`
     width: max-content;
@@ -21,16 +22,20 @@ const articleCountStyles = css`
 
 export interface Props {
     numArticles: number;
+    tracking?: OphanTracking;
 }
 
-export const ContributionsEpicArticleCountInline: React.FC<Props> = ({ numArticles }: Props) => {
+export const ContributionsEpicArticleCountInline: React.FC<Props> = ({
+    numArticles,
+    tracking,
+}: Props) => {
     if (numArticles >= 5) {
         return (
             <div css={containerStyles}>
                 <div>You&apos;ve read</div>
                 <div css={articleCountStyles}>{numArticles}</div>
                 <div>
-                    <ArticleCountOptOut text="articles" type="epic" /> in
+                    <ArticleCountOptOut text="articles" type="epic" tracking={tracking} /> in
                 </div>
                 <div>the last year</div>
             </div>

--- a/src/components/modules/epics/ContributionsEpicArticleCountInline.tsx
+++ b/src/components/modules/epics/ContributionsEpicArticleCountInline.tsx
@@ -7,7 +7,9 @@ import { OphanTracking } from '../shared/ArticleCountOptOut';
 
 const containerStyles = css`
     width: max-content;
-    padding: 8px;
+    box-sizing: border-box;
+    height: 139px;
+    padding: 4px 8px;
     border: 1px solid black;
     border-left: none;
 
@@ -16,7 +18,9 @@ const containerStyles = css`
 
 const articleCountStyles = css`
     ${headline.xlarge({ fontWeight: 'bold' })};
+    margin-top: -7px;
     font-size: 58px;
+    line-height: 1;
     color: ${palette.opinion[500]};
 `;
 

--- a/src/components/modules/epics/ContributionsEpicArticleCountInline.tsx
+++ b/src/components/modules/epics/ContributionsEpicArticleCountInline.tsx
@@ -1,34 +1,38 @@
 import React from 'react';
-import { textSans } from '@guardian/src-foundations/typography';
-import { palette } from '@guardian/src-foundations';
+import { body, headline } from '@guardian/src-foundations/typography';
 import { css } from '@emotion/core';
-import { replaceArticleCount } from '../../../lib/replaceArticleCount';
+import { palette } from '@guardian/src-foundations';
+import { ArticleCountOptOut } from '../shared/ArticleCountOptOut2';
 
-const contentStyle = css`
-    float: left;
-    width: 40%;
-    ${textSans.medium()};
-    background-color: ${palette.neutral[100]};
+const containerStyles = css`
+    width: max-content;
     padding: 8px;
-    margin-right: 10px;
+    border: 1px solid black;
+    border-left: none;
+
+    ${body.medium({ fontWeight: 'bold' })};
 `;
 
-const message = 'You’ve read %%ARTICLE_COUNT%% articles this year';
+const articleCountStyles = css`
+    ${headline.xlarge({ fontWeight: 'bold' })};
+    font-size: 58px;
+    color: ${palette.opinion[500]};
+`;
 
-interface Props {
+export interface Props {
     numArticles: number;
-    paragraphElement: JSX.Element;
 }
 
-export const ContributionsEpicArticleCountInline: React.FC<Props> = ({
-    numArticles,
-    paragraphElement,
-}: Props) => {
+export const ContributionsEpicArticleCountInline: React.FC<Props> = ({ numArticles }: Props) => {
     if (numArticles >= 5) {
         return (
-            <div>
-                <div css={contentStyle}>{replaceArticleCount(message, numArticles, 'epic')}</div>
-                {paragraphElement}
+            <div css={containerStyles}>
+                <div>You&apos;ve read</div>
+                <div css={articleCountStyles}>{numArticles}</div>
+                <div>
+                    <ArticleCountOptOut text="articles" type="epic" /> in
+                </div>
+                <div>the last year</div>
             </div>
         );
     }

--- a/src/components/modules/epics/ContributionsEpicReminder.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.stories.tsx
@@ -1,34 +1,10 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { css } from '@emotion/core';
-import { from } from '@guardian/src-foundations/mq';
-import { palette } from '@guardian/src-foundations';
 import {
     ContributionsEpicReminder,
     ContributionsEpicReminderProps,
 } from './ContributionsEpicReminder';
-
-const containerStyles = css`
-    margin: 3em auto;
-    padding: 0 10px;
-    max-width: 620px;
-
-    ${from.mobileLandscape} {
-        padding: 0 20px;
-    }
-`;
-
-const backgroundStyles = css`
-    background-color: ${palette.neutral[97]};
-`;
-
-export const EpicDecorator = (Story: Story): JSX.Element => (
-    <div css={containerStyles}>
-        <div css={backgroundStyles}>
-            <Story />
-        </div>
-    </div>
-);
+import { EpicDecorator } from './ContributionsEpic.stories';
 
 export default {
     component: ContributionsEpicReminder,
@@ -38,7 +14,6 @@ export default {
         reminderLabel: 'May',
     },
     decorators: [EpicDecorator],
-    excludeStories: /.*Decorator$/,
 } as Meta;
 
 const Template: Story<ContributionsEpicReminderProps> = (props: ContributionsEpicReminderProps) => (

--- a/src/components/modules/epics/ContributionsEpicReminderSignedIn.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedIn.stories.tsx
@@ -5,7 +5,7 @@ import {
     ContributionsEpicReminderSignedInProps,
 } from './ContributionsEpicReminderSignedIn';
 import { ReminderStatus } from './ContributionsEpicReminder';
-import { EpicDecorator } from './ContributionsEpicReminder.stories';
+import { EpicDecorator } from './ContributionsEpic.stories';
 
 export default {
     component: ContributionsEpicReminderSignedIn,

--- a/src/components/modules/epics/ContributionsEpicReminderSignedOut.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedOut.stories.tsx
@@ -5,7 +5,7 @@ import {
     ContributionsEpicReminderSignedOutProps,
 } from './ContributionsEpicReminderSignedOut';
 import { ReminderStatus } from './ContributionsEpicReminder';
-import { EpicDecorator } from './ContributionsEpicReminder.stories';
+import { EpicDecorator } from './ContributionsEpic.stories';
 
 export default {
     component: ContributionsEpicReminderSignedOut,

--- a/src/components/modules/epics/ContributionsEpicWithArticleCountAbove.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicWithArticleCountAbove.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { ContributionsEpic } from './ContributionsEpicWithArticleCountAbove';
+import { EpicProps } from './ContributionsEpic';
+import { props } from './utils/storybook';
+import { EpicDecorator } from './ContributionsEpic.stories';
+
+export default {
+    component: ContributionsEpic,
+    title: 'Epics/ContributionsWithArticleCountAbove',
+    args: { ...props, numArticles: 989 },
+    decorators: [EpicDecorator],
+} as Meta;
+
+const Template: Story<EpicProps> = (props: EpicProps) => <ContributionsEpic {...props} />;
+
+export const Default = Template.bind({});

--- a/src/components/modules/epics/ContributionsEpicWithArticleCountInline.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicWithArticleCountInline.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { ContributionsEpic } from './ContributionsEpicWithArticleCountInline';
+import { EpicProps } from './ContributionsEpic';
+import { props } from './utils/storybook';
+import { EpicDecorator } from './ContributionsEpic.stories';
+
+export default {
+    component: ContributionsEpic,
+    title: 'Epics/ContributionsWithArticleCountInline',
+    args: { ...props, numArticles: 989 },
+    decorators: [EpicDecorator],
+} as Meta;
+
+const Template: Story<EpicProps> = (props: EpicProps) => <ContributionsEpic {...props} />;
+
+export const Default = Template.bind({});

--- a/src/components/modules/shared/ArticleCountOptOut.tsx
+++ b/src/components/modules/shared/ArticleCountOptOut.tsx
@@ -30,10 +30,11 @@ const articleCountButton = css`
     border: none;
     padding: 0;
     cursor: pointer;
-    text-decoration: underline;
+    border-bottom: 1px solid;
     font-family: inherit;
     font-size: inherit;
     font-weight: inherit;
+    font-style: inherit;
     color: inherit;
     &:focus {
         outline: none !important;

--- a/src/components/modules/shared/ArticleCountOptOut.tsx
+++ b/src/components/modules/shared/ArticleCountOptOut.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
@@ -10,7 +10,9 @@ import {
     ophanComponentEventOptOutClose,
     ophanComponentEventOptOutConfirm,
     ophanComponentEventOptOutOpen,
+    ophanComponentEventOptOutView,
 } from './helpers/ophan';
+import { useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 
 const ARTICLE_COUNT_OPT_OUT_COOKIE = {
     name: 'gu_article_count_opt_out',
@@ -96,6 +98,19 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
 }: ArticleCountOptOutProps) => {
     const [isOpen, setIsOpen] = useState(false);
     const [hasOptedOut, setHasOptedOut] = useState(false);
+    const [hasBeenSeen, setNode] = useHasBeenSeen(
+        {
+            rootMargin: '-18px',
+            threshold: 0,
+        },
+        true,
+    );
+
+    useEffect(() => {
+        if (hasBeenSeen && tracking) {
+            tracking.submitComponentEvent(ophanComponentEventOptOutView(tracking.componentType));
+        }
+    }, [hasBeenSeen]);
 
     const addArticleCountOptOutCookie = (): void =>
         addCookie(
@@ -132,7 +147,7 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
     const onToggle = (): void => (isOpen ? onClose() : onOpen());
 
     return (
-        <div css={optOutContainer(type)}>
+        <div ref={setNode} css={optOutContainer(type)}>
             <button css={articleCountButton} onClick={onToggle}>
                 {`${numArticles}${nextWord ? nextWord : ''}`}
             </button>

--- a/src/components/modules/shared/ArticleCountOptOut2.tsx
+++ b/src/components/modules/shared/ArticleCountOptOut2.tsx
@@ -1,0 +1,126 @@
+// --- NB --- //
+// This is a temporary component whilst we're running an article count
+// A/B test. The aim is to deprecate this type of opt out in favour of
+// one with better UX.
+import React, { useState } from 'react';
+import { css, SerializedStyles } from '@emotion/core';
+import { space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { addCookie } from '../../../lib/cookies';
+
+import { ArticleCountOptOutOverlay } from './ArticleCountOptOutOverlay';
+
+const ARTICLE_COUNT_OPT_OUT_COOKIE = {
+    name: 'gu_article_count_opt_out',
+    daysToLive: 90,
+};
+
+const DAILY_ARTICLE_COUNT_STORAGE_KEY = 'gu.history.dailyArticleCount';
+const WEEKLY_ARTICLE_COUNT_STORAGE_KEY = 'gu.history.weeklyArticleCount';
+
+export type ArticleCountOptOutType = 'epic' | 'banner' | 'global-eoy-banner';
+const isBanner = (type: ArticleCountOptOutType): boolean =>
+    type === 'banner' || type === 'global-eoy-banner';
+
+const optOutContainer = (type: ArticleCountOptOutType): SerializedStyles => css`
+    display: inline-block;
+
+    ${from.tablet} {
+        ${!isBanner(type) ? 'position: relative;' : ''}
+`;
+
+const articleCountButton = css`
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    border-bottom: 1px solid;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    font-style: inherit;
+    color: inherit;
+    &:focus {
+        outline: none !important;
+    }
+`;
+
+const overlayContainer = (type: ArticleCountOptOutType): SerializedStyles => css`
+    position: absolute;
+    z-index: 100;
+    ${isBanner(type)
+        ? css`
+              top: 0px;
+              left: 0px;
+          `
+        : css`
+              left: ${space[4]}px;
+              right: ${space[4]}px;
+              ${isBanner(type) ? 'bottom: 21px;' : ''}
+          `}
+    display: block;
+
+    ${from.tablet} {
+        ${isBanner(type)
+            ? css`
+                  top: 10px;
+                  left: 10px;
+                  width: 450px;
+              `
+            : css`
+                  width: 400px;
+                  left: 0;
+              `}
+    }
+`;
+
+export interface ArticleCountOptOutProps {
+    text: string;
+    type: ArticleCountOptOutType;
+}
+
+export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
+    text,
+    type,
+}: ArticleCountOptOutProps) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [hasOptedOut, setHasOptedOut] = useState(false);
+
+    const addArticleCountOptOutCookie = (): void =>
+        addCookie(
+            ARTICLE_COUNT_OPT_OUT_COOKIE.name,
+            new Date().getTime().toString(),
+            ARTICLE_COUNT_OPT_OUT_COOKIE.daysToLive,
+        );
+
+    const removeArticleCountFromLocalStorage = (): void => {
+        window.localStorage.removeItem(DAILY_ARTICLE_COUNT_STORAGE_KEY);
+        window.localStorage.removeItem(WEEKLY_ARTICLE_COUNT_STORAGE_KEY);
+    };
+
+    const onOptOut = (): void => {
+        addArticleCountOptOutCookie();
+        removeArticleCountFromLocalStorage();
+        setHasOptedOut(true);
+    };
+
+    const onClose = (): void => setIsOpen(false);
+
+    return (
+        <div css={optOutContainer(type)}>
+            <button css={articleCountButton} onClick={(): void => setIsOpen(!isOpen)}>
+                {text}
+            </button>
+            {isOpen && (
+                <div css={overlayContainer(type)}>
+                    <ArticleCountOptOutOverlay
+                        type={type}
+                        hasOptedOut={hasOptedOut}
+                        onOptOut={onOptOut}
+                        onClose={onClose}
+                    />
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/components/modules/shared/ArticleCountOptOut2.tsx
+++ b/src/components/modules/shared/ArticleCountOptOut2.tsx
@@ -9,6 +9,12 @@ import { from } from '@guardian/src-foundations/mq';
 import { addCookie } from '../../../lib/cookies';
 
 import { ArticleCountOptOutOverlay } from './ArticleCountOptOutOverlay';
+import { OphanComponentEvent, OphanComponentType } from '../../../types/OphanTypes';
+import {
+    ophanComponentEventOptOutClose,
+    ophanComponentEventOptOutConfirm,
+    ophanComponentEventOptOutOpen,
+} from './helpers/ophan';
 
 const ARTICLE_COUNT_OPT_OUT_COOKIE = {
     name: 'gu_article_count_opt_out',
@@ -74,14 +80,21 @@ const overlayContainer = (type: ArticleCountOptOutType): SerializedStyles => css
     }
 `;
 
+interface OphanTracking {
+    componentType: OphanComponentType;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+}
+
 export interface ArticleCountOptOutProps {
     text: string;
     type: ArticleCountOptOutType;
+    tracking?: OphanTracking;
 }
 
 export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
     text,
     type,
+    tracking,
 }: ArticleCountOptOutProps) => {
     const [isOpen, setIsOpen] = useState(false);
     const [hasOptedOut, setHasOptedOut] = useState(false);
@@ -102,13 +115,27 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
         addArticleCountOptOutCookie();
         removeArticleCountFromLocalStorage();
         setHasOptedOut(true);
+        tracking &&
+            tracking.submitComponentEvent(ophanComponentEventOptOutConfirm(tracking.componentType));
     };
 
-    const onClose = (): void => setIsOpen(false);
+    const onOpen = (): void => {
+        setIsOpen(true);
+        tracking &&
+            tracking.submitComponentEvent(ophanComponentEventOptOutOpen(tracking.componentType));
+    };
+
+    const onClose = (): void => {
+        setIsOpen(false);
+        tracking &&
+            tracking.submitComponentEvent(ophanComponentEventOptOutClose(tracking.componentType));
+    };
+
+    const onToggle = (): void => (isOpen ? onClose() : onOpen());
 
     return (
         <div css={optOutContainer(type)}>
-            <button css={articleCountButton} onClick={(): void => setIsOpen(!isOpen)}>
+            <button css={articleCountButton} onClick={onToggle}>
                 {text}
             </button>
             {isOpen && (

--- a/src/components/modules/shared/ArticleCountOptOut2.tsx
+++ b/src/components/modules/shared/ArticleCountOptOut2.tsx
@@ -2,7 +2,7 @@
 // This is a temporary component whilst we're running an article count
 // A/B test. The aim is to deprecate this type of opt out in favour of
 // one with better UX.
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
@@ -14,7 +14,9 @@ import {
     ophanComponentEventOptOutClose,
     ophanComponentEventOptOutConfirm,
     ophanComponentEventOptOutOpen,
+    ophanComponentEventOptOutView,
 } from './helpers/ophan';
+import { useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 
 const ARTICLE_COUNT_OPT_OUT_COOKIE = {
     name: 'gu_article_count_opt_out',
@@ -98,6 +100,19 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
 }: ArticleCountOptOutProps) => {
     const [isOpen, setIsOpen] = useState(false);
     const [hasOptedOut, setHasOptedOut] = useState(false);
+    const [hasBeenSeen, setNode] = useHasBeenSeen(
+        {
+            rootMargin: '-18px',
+            threshold: 0,
+        },
+        true,
+    );
+
+    useEffect(() => {
+        if (hasBeenSeen && tracking) {
+            tracking.submitComponentEvent(ophanComponentEventOptOutView(tracking.componentType));
+        }
+    }, [hasBeenSeen]);
 
     const addArticleCountOptOutCookie = (): void =>
         addCookie(
@@ -134,7 +149,7 @@ export const ArticleCountOptOut: React.FC<ArticleCountOptOutProps> = ({
     const onToggle = (): void => (isOpen ? onClose() : onOpen());
 
     return (
-        <div css={optOutContainer(type)}>
+        <div ref={setNode} css={optOutContainer(type)}>
             <button css={articleCountButton} onClick={onToggle}>
                 {text}
             </button>

--- a/src/components/modules/shared/helpers/ophan.ts
+++ b/src/components/modules/shared/helpers/ophan.ts
@@ -1,0 +1,35 @@
+import { OphanComponentEvent, OphanComponentType } from '../../../../types/OphanTypes';
+
+const OPHAN_COMPONENT_ID_OPT_OUT_OPEN = 'article-count-opt-out-open';
+const OPHAN_COMPONENT_ID_OPT_OUT_CLOSE = 'article-count-opt-out-close';
+const OPHAN_COMPONENT_ID_OPT_OUT_CONFIRM = 'article-count-opt-out-confirm';
+
+export const ophanComponentEventOptOutOpen = (
+    componentType: OphanComponentType,
+): OphanComponentEvent => ({
+    component: {
+        componentType,
+        id: OPHAN_COMPONENT_ID_OPT_OUT_OPEN,
+    },
+    action: 'CLICK',
+});
+
+export const ophanComponentEventOptOutClose = (
+    componentType: OphanComponentType,
+): OphanComponentEvent => ({
+    component: {
+        componentType,
+        id: OPHAN_COMPONENT_ID_OPT_OUT_CLOSE,
+    },
+    action: 'CLICK',
+});
+
+export const ophanComponentEventOptOutConfirm = (
+    componentType: OphanComponentType,
+): OphanComponentEvent => ({
+    component: {
+        componentType,
+        id: OPHAN_COMPONENT_ID_OPT_OUT_CONFIRM,
+    },
+    action: 'CLICK',
+});

--- a/src/components/modules/shared/helpers/ophan.ts
+++ b/src/components/modules/shared/helpers/ophan.ts
@@ -1,8 +1,19 @@
 import { OphanComponentEvent, OphanComponentType } from '../../../../types/OphanTypes';
 
+const OPHAN_COMPONENT_ID_OPT_OUT_VIEW = 'article-count-opt-out-view';
 const OPHAN_COMPONENT_ID_OPT_OUT_OPEN = 'article-count-opt-out-open';
 const OPHAN_COMPONENT_ID_OPT_OUT_CLOSE = 'article-count-opt-out-close';
 const OPHAN_COMPONENT_ID_OPT_OUT_CONFIRM = 'article-count-opt-out-confirm';
+
+export const ophanComponentEventOptOutView = (
+    componentType: OphanComponentType,
+): OphanComponentEvent => ({
+    component: {
+        componentType,
+        id: OPHAN_COMPONENT_ID_OPT_OUT_VIEW,
+    },
+    action: 'VIEW',
+});
 
 export const ophanComponentEventOptOutOpen = (
     componentType: OphanComponentType,

--- a/src/lib/replaceArticleCount.tsx
+++ b/src/lib/replaceArticleCount.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { ArticleCountOptOut } from '../components/modules/shared/ArticleCountOptOut';
+import { ArticleCountOptOut, OphanTracking } from '../components/modules/shared/ArticleCountOptOut';
 import { ArticleCountOptOutType } from '../components/modules/shared/ArticleCountOptOut';
 
 export const replaceArticleCount = (
     text: string,
     numArticles: number,
     articleCountOptOutType: ArticleCountOptOutType,
+    tracking?: OphanTracking,
 ): Array<JSX.Element> => {
     const nextWords: Array<string | null> = [];
     const subbedText = text.replace(/%%ARTICLE_COUNT%%( \w+)?/g, (_, nextWord) => {
@@ -22,6 +23,7 @@ export const replaceArticleCount = (
                 numArticles={numArticles}
                 nextWord={nextWords[i] as string}
                 type={articleCountOptOutType}
+                tracking={tracking}
             />,
         );
     }

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -50,6 +50,10 @@ import { getAmpExperimentData } from './tests/amp/ampEpicTests';
 import { OphanComponentEvent } from './types/OphanTypes';
 import { logger } from './utils/logging';
 import { OneOffSignupRequest, setOneOffReminderEndpoint } from './api/supportRemindersApi';
+import {
+    epicSeparateArticleCountTestEuRow,
+    epicSeparateArticleCountTestUkAus,
+} from './tests/epicArticleCountTest';
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -118,7 +122,12 @@ const getArticleEpicTests = async (mvtId: number): Promise<Test[]> => {
     const regular = await fetchConfiguredArticleEpicTestsCached();
     const hardCoded = await getAllHardcodedTests();
 
-    return [...regular.tests, ...hardCoded];
+    return [
+        epicSeparateArticleCountTestUkAus,
+        epicSeparateArticleCountTestEuRow,
+        ...regular.tests,
+        ...hardCoded,
+    ];
 };
 
 const getForceableArticleEpicTests = async (): Promise<Test[]> => {
@@ -126,7 +135,13 @@ const getForceableArticleEpicTests = async (): Promise<Test[]> => {
     const hardCoded = await getAllHardcodedTests();
     const holdback = await fetchConfiguredArticleEpicHoldbackTestsCached();
 
-    return [...regular.tests, ...hardCoded, ...holdback.tests];
+    return [
+        epicSeparateArticleCountTestUkAus,
+        epicSeparateArticleCountTestEuRow,
+        ...regular.tests,
+        ...hardCoded,
+        ...holdback.tests,
+    ];
 };
 
 const getLiveblogEpicTests = async (): Promise<Test[]> => {

--- a/src/tests/epicArticleCountTest.ts
+++ b/src/tests/epicArticleCountTest.ts
@@ -69,7 +69,7 @@ export const epicSeparateArticleCountTestEuRow: Test = {
     name: 'EpicSeparateArticleCountTestR2__EU_ROW',
     campaignId: 'EpicSeparateArticleCountTest',
     isOn: true,
-    locations: ['EURCountries', 'International'],
+    locations: ['EURCountries', 'NZDCountries', 'Canada', 'International'],
     audience: 1,
     tagIds: [],
     sections: [],

--- a/src/tests/epicArticleCountTest.ts
+++ b/src/tests/epicArticleCountTest.ts
@@ -1,5 +1,13 @@
-import { Cta, Test } from '../lib/variants';
+import { Test } from '../lib/variants';
 import { epic, epicACAbove, epicACInline } from '../modules';
+import {
+    CTA,
+    EU_ROW_CONTROL_PARAGRAPHS,
+    EU_ROW_VARIANTS_PARAGRAPHS,
+    HIGHLIGHTED_TEXT,
+    UK_AUS_CONTROL_PARAGRAPHS,
+    UK_AUS_VARIANTS_PARAGRAPHS,
+} from './epicArticleCountTestData';
 
 export enum EpicSeparateArticleCountTestVariants {
     control = 'control',
@@ -7,36 +15,11 @@ export enum EpicSeparateArticleCountTestVariants {
     inline = 'inline',
 }
 
-const cta: Cta = {
-    text: 'Support The Guardian',
-    baseUrl: 'https://support.theguardian.com/contribute',
-};
-
-const heading = 'Since you’re here...';
-const controlFirstParagraph =
-    '… and it’s nearly the end of the year, we have a small favour to ask. You’ve read %%ARTICLE_COUNT%% articles this year. And you’re not alone; millions have turned to the Guardian for vital, independent, quality journalism throughout a turbulent and challenging 2020. Readers in 180 countries around the world, including %%COUNTRY_NAME%%, now support us financially. Will you join them?';
-const variantFirstParagraph =
-    '… and it’s nearly the end of the year, we have a small favour to ask. Millions have turned to the Guardian for vital, independent, quality journalism throughout a turbulent and challenging 2020. Readers in 180 countries around the world, including %%COUNTRY_NAME%%, now support us financially. Will you join them?';
-
-const paragraphs = (firstParagraph: string): string[] => [
-    firstParagraph,
-    'We believe everyone deserves access to information that’s grounded in science and truth, and analysis rooted in authority and integrity. That’s why we made a different choice: to keep our reporting open for all readers, regardless of where they live or what they can afford to pay. This means more people can be better informed, united, and inspired to take meaningful action.',
-    'In these perilous times, a truth-seeking global news organisation like the Guardian is essential. We have no shareholders or billionaire owner, meaning our journalism is free from commercial and political influence – this makes us different. When it’s never been more important, our independence allows us to investigate fearlessly, and challenge those in power.',
-    'In this unprecedented year of intersecting crises, we have done just that, with revealing journalism that had real-world impact: the inept handling of the Covid-19 crisis, the Black Lives Matter protests, and the tumultuous US election.',
-    'We have enhanced our reputation for urgent, powerful reporting on the climate emergency, and moved to practice what we preach, rejecting advertising from fossil fuel companies, divesting from oil and gas companies and setting a course to achieve net zero emissions by 2030.',
-    'If there were ever a time to join us, it is now. Your funding powers our journalism, it protects our independence, and ensures we can remain open for all. You can support us through these challenging economic times and enable real-world impact.',
-    'Every contribution, however big or small, makes a real difference for our future.',
-];
-
-const highlightedText =
-    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.';
-
-export const epicSeparateArticleCountTest: Test = {
-    name: 'EpicSeparateArticleCountTest',
-    expiry: '2021-05-01',
+export const epicSeparateArticleCountTestUkAus: Test = {
+    name: 'EpicSeparateArticleCountTestR2__UK_AUS',
     campaignId: 'EpicSeparateArticleCountTest',
     isOn: true,
-    locations: ['GBPCountries', 'EURCountries', 'International', 'Canada', 'NZDCountries'],
+    locations: ['GBPCountries', 'AUDCountries'],
     audience: 1,
     tagIds: [],
     sections: [],
@@ -53,28 +36,75 @@ export const epicSeparateArticleCountTest: Test = {
     hasCountryName: true,
     variants: [
         {
-            heading: heading,
-            paragraphs: paragraphs(controlFirstParagraph),
-            highlightedText,
             name: EpicSeparateArticleCountTestVariants.control,
-            cta,
             modulePathBuilder: epic.endpointPathBuilder,
+            paragraphs: UK_AUS_CONTROL_PARAGRAPHS,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
         },
         {
-            heading: heading,
-            paragraphs: paragraphs(variantFirstParagraph),
-            highlightedText,
             name: EpicSeparateArticleCountTestVariants.above,
-            cta,
             modulePathBuilder: epicACAbove.endpointPathBuilder,
+            paragraphs: UK_AUS_VARIANTS_PARAGRAPHS,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
         },
         {
-            heading: heading,
-            paragraphs: paragraphs(variantFirstParagraph),
-            highlightedText,
             name: EpicSeparateArticleCountTestVariants.inline,
-            cta,
             modulePathBuilder: epicACInline.endpointPathBuilder,
+            paragraphs: UK_AUS_VARIANTS_PARAGRAPHS,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
+        },
+    ],
+    highPriority: true,
+    useLocalViewLog: true,
+    articlesViewedSettings: {
+        minViews: 5,
+        periodInWeeks: 52,
+    },
+};
+
+export const epicSeparateArticleCountTestEuRow: Test = {
+    name: 'EpicSeparateArticleCountTestR2__EU_ROW',
+    campaignId: 'EpicSeparateArticleCountTest',
+    isOn: true,
+    locations: ['EURCountries', 'International'],
+    audience: 1,
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: false,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
+    userCohort: 'AllNonSupporters',
+    isLiveBlog: false,
+    hasCountryName: true,
+    variants: [
+        {
+            name: EpicSeparateArticleCountTestVariants.control,
+            modulePathBuilder: epic.endpointPathBuilder,
+            paragraphs: EU_ROW_CONTROL_PARAGRAPHS,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
+        },
+        {
+            name: EpicSeparateArticleCountTestVariants.above,
+            modulePathBuilder: epicACAbove.endpointPathBuilder,
+            paragraphs: EU_ROW_VARIANTS_PARAGRAPHS,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
+        },
+        {
+            name: EpicSeparateArticleCountTestVariants.inline,
+            modulePathBuilder: epicACInline.endpointPathBuilder,
+            paragraphs: EU_ROW_VARIANTS_PARAGRAPHS,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
         },
     ],
     highPriority: true,

--- a/src/tests/epicArticleCountTestData.ts
+++ b/src/tests/epicArticleCountTestData.ts
@@ -1,0 +1,36 @@
+import { Cta } from '../lib/variants';
+
+const SHARED_PARAGRAPHS = [
+    'With your help, we will continue to provide high-impact reporting that can counter misinformation and offer an authoritative, trustworthy source of news for everyone. With no shareholders or billionaire owner, we set our own agenda and provide truth-seeking journalism that’s free from commercial and political influence. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+    'Unlike many others, we have maintained our choice: to keep Guardian journalism open for all readers, regardless of where they live or what they can afford to pay. We do this because we believe in information equality, where everyone deserves to read accurate news and thoughtful analysis. Greater numbers of people are staying well-informed on world events, and being inspired to take meaningful action.',
+    "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+    'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+];
+
+export const UK_AUS_CONTROL_PARAGRAPHS = [
+    '… we have a small favour to ask. You’ve read %%ARTICLE_COUNT%% articles in the last year. And you’re not alone; through these turbulent and challenging times, millions rely on the Guardian for independent journalism that stands for truth and integrity. Readers chose to support us financially more than 1.5 million times in 2020, joining existing supporters in 180 countries.',
+    ...SHARED_PARAGRAPHS,
+];
+
+export const UK_AUS_VARIANTS_PARAGRAPHS = [
+    '… we have a small favour to ask. Through these turbulent and challenging times, millions rely on the Guardian for independent journalism that stands for truth and integrity. Readers chose to support us financially more than 1.5 million times in 2020, joining existing supporters in 180 countries.',
+    ...SHARED_PARAGRAPHS,
+];
+
+export const EU_ROW_CONTROL_PARAGRAPHS = [
+    '… as you join us today from %%COUNTRY_NAME%%, we have a small favour to ask. You’ve read %%ARTICLE_COUNT%% articles in the last year. And you’re not alone; through these turbulent and challenging times, millions rely on the Guardian for independent journalism that stands for truth and integrity. Readers chose to support us financially more than 1.5 million times in 2020, joining existing supporters in 180 countries.',
+    ...SHARED_PARAGRAPHS,
+];
+
+export const EU_ROW_VARIANTS_PARAGRAPHS = [
+    '… as you join us today from %%COUNTRY_NAME%%, we have a small favour to ask. Through these turbulent and challenging times, millions rely on the Guardian for independent journalism that stands for truth and integrity. Readers chose to support us financially more than 1.5 million times in 2020, joining existing supporters in 180 countries.',
+    ...SHARED_PARAGRAPHS,
+];
+
+export const HIGHLIGHTED_TEXT =
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.';
+
+export const CTA: Cta = {
+    text: 'Support The Guardian',
+    baseUrl: 'https://support.theguardian.com/contribute',
+};


### PR DESCRIPTION
## What does this change?
Adds a second round of article count design tests. Additionally, we want to track how many users opt out of article counts. To do this the platform now passes in a `submitComponentEvent` function as a prop, much like for the banners. This requires https://github.com/guardian/dotcom-rendering/pull/2747 to be merged. I was thinking we wouldn't bother implementing this in frontend as so few (if any?) articles are rendered by frontend.

## How to test
UK/AUS
- force-epic=EpicSeparateArticleCountTestR2__UK_AUS:control
- force-epic=EpicSeparateArticleCountTestR2__UK_AUS:above
- force-epic=EpicSeparateArticleCountTestR2__UK_AUS:inline

EU/ROW
- force-epic=EpicSeparateArticleCountTestR2__EU_ROW:control
- force-epic=EpicSeparateArticleCountTestR2__EU_ROW:above
- force-epic=EpicSeparateArticleCountTestR2__EU_ROW:inline

## Images

#### control
<img width="752" alt="Screenshot 2021-03-26 at 15 06 01" src="https://user-images.githubusercontent.com/17720442/112652685-921a0b00-8e45-11eb-8188-25f8b51b5025.png">

#### above
<img width="752" alt="Screenshot 2021-03-26 at 15 06 56" src="https://user-images.githubusercontent.com/17720442/112652701-97775580-8e45-11eb-93bd-baccb60634de.png">

#### inline
<img width="752" alt="Screenshot 2021-03-26 at 15 07 22" src="https://user-images.githubusercontent.com/17720442/112652714-9b0adc80-8e45-11eb-9bb8-c5d94f40df3f.png">

