### PR TITLE
Add reminder tracking

### DIFF
--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -307,28 +307,28 @@ export const ContributionsEpicComponent: (
                 tracking={ophanTracking}
             />
 
-            {!isReminderActive && (
-                <ContributionsEpicButtons
-                    variant={variant}
-                    tracking={tracking}
-                    countryCode={countryCode}
-                    onOpenReminderClick={(): void => {
-                        const buttonCopyAsString = showReminderFields?.reminderCta
-                            .toLowerCase()
-                            .replace(/\s/g, '-');
+            <ContributionsEpicButtons
+                variant={variant}
+                tracking={tracking}
+                countryCode={countryCode}
+                onOpenReminderClick={(): void => {
+                    const buttonCopyAsString = showReminderFields?.reminderCta
+                        .toLowerCase()
+                        .replace(/\s/g, '-');
 
-                        // This callback let's the platform react to the user interaction with the
-                        // 'Remind me' button
-                        if (onReminderOpen) {
-                            onReminderOpen({
-                                buttonCopyAsString,
-                            } as OnReminderOpen);
-                        }
+                    // This callback let's the platform react to the user interaction with the
+                    // 'Remind me' button
+                    if (onReminderOpen) {
+                        onReminderOpen({
+                            buttonCopyAsString,
+                        } as OnReminderOpen);
+                    }
 
-                        setIsReminderActive(true);
-                    }}
-                />
-            )}
+                    setIsReminderActive(true);
+                }}
+                submitComponentEvent={submitComponentEvent}
+                isReminderActive={isReminderActive}
+            />
 
             {isReminderActive && showReminderFields && (
                 <ContributionsEpicReminder
@@ -336,6 +336,7 @@ export const ContributionsEpicComponent: (
                     reminderPeriod={showReminderFields.reminderPeriod}
                     reminderLabel={showReminderFields.reminderLabel}
                     onCloseReminderClick={(): void => setIsReminderActive(false)}
+                    submitComponentEvent={submitComponentEvent}
                 />
             )}
         </section>

--- a/src/components/modules/epics/ContributionsEpicReminder.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminder.tsx
@@ -5,6 +5,11 @@ import { OneOffSignupRequest } from '../../../api/supportRemindersApi';
 import { ContributionsEpicReminderSignedIn } from './ContributionsEpicReminderSignedIn';
 import { ContributionsEpicReminderSignedOut } from './ContributionsEpicReminderSignedOut';
 import { addContributionReminderCookie } from './utils/reminders';
+import { OphanComponentEvent } from '../../../types/OphanTypes';
+import {
+    OPHAN_COMPONENT_EVENT_REMINDER_CLOSE,
+    OPHAN_COMPONENT_EVENT_REMINDER_SET,
+} from './utils/ophan';
 
 // --- Types --- //
 
@@ -13,6 +18,7 @@ export interface ContributionsEpicReminderProps {
     reminderPeriod: string;
     reminderLabel: string;
     onCloseReminderClick: () => void;
+    submitComponentEvent?: (event: OphanComponentEvent) => void;
 }
 
 export enum ReminderStatus {
@@ -37,10 +43,15 @@ export const ContributionsEpicReminder: React.FC<ContributionsEpicReminderProps>
     reminderLabel,
     reminderPeriod,
     onCloseReminderClick,
+    submitComponentEvent,
 }: ContributionsEpicReminderProps) => {
     const [reminderStatus, setReminderStatus] = useState<ReminderStatus>(ReminderStatus.Editing);
 
     const setReminder = (emailAddress: string): void => {
+        if (submitComponentEvent) {
+            submitComponentEvent(OPHAN_COMPONENT_EVENT_REMINDER_SET);
+        }
+
         const reminderSignupData: OneOffSignupRequest = {
             email: emailAddress,
             reminderPeriod,
@@ -68,19 +79,26 @@ export const ContributionsEpicReminder: React.FC<ContributionsEpicReminderProps>
             .catch(() => setReminderStatus(ReminderStatus.Error));
     };
 
+    const closeReminder = () => {
+        if (submitComponentEvent) {
+            submitComponentEvent(OPHAN_COMPONENT_EVENT_REMINDER_CLOSE);
+        }
+        onCloseReminderClick();
+    };
+
     return initialEmailAddress ? (
         <ContributionsEpicReminderSignedIn
             reminderLabel={reminderLabel}
             reminderStatus={reminderStatus}
             onSetReminderClick={() => setReminder(initialEmailAddress)}
-            onCloseReminderClick={onCloseReminderClick}
+            onCloseReminderClick={closeReminder}
         />
     ) : (
         <ContributionsEpicReminderSignedOut
             reminderLabel={reminderLabel}
             reminderStatus={reminderStatus}
             onSetReminderClick={setReminder}
-            onCloseReminderClick={onCloseReminderClick}
+            onCloseReminderClick={closeReminder}
         />
     );
 };

--- a/src/components/modules/epics/utils/ophan.ts
+++ b/src/components/modules/epics/utils/ophan.ts
@@ -1,0 +1,38 @@
+import { OphanComponentEvent } from '../../../../types/OphanTypes';
+
+const OPHAN_COMPONENT_ID_REMINDER_VIEW = 'contributions-epic-reminder-view';
+const OPHAN_COMPONENT_ID_REMINDER_OPEN = 'contributions-epic-reminder-open';
+const OPHAN_COMPONENT_ID_REMINDER_SET = 'contributions-epic-reminder-set';
+const OPHAN_COMPONENT_ID_REMINDER_CLOSE = 'contributions-epic-reminder-close';
+
+export const OPHAN_COMPONENT_EVENT_REMINDER_VIEW: OphanComponentEvent = {
+    component: {
+        componentType: 'ACQUISITIONS_EPIC',
+        id: OPHAN_COMPONENT_ID_REMINDER_VIEW,
+    },
+    action: 'VIEW',
+};
+
+export const OPHAN_COMPONENT_EVENT_REMINDER_OPEN: OphanComponentEvent = {
+    component: {
+        componentType: 'ACQUISITIONS_EPIC',
+        id: OPHAN_COMPONENT_ID_REMINDER_OPEN,
+    },
+    action: 'CLICK',
+};
+
+export const OPHAN_COMPONENT_EVENT_REMINDER_SET: OphanComponentEvent = {
+    component: {
+        componentType: 'ACQUISITIONS_EPIC',
+        id: OPHAN_COMPONENT_ID_REMINDER_SET,
+    },
+    action: 'CLICK',
+};
+
+export const OPHAN_COMPONENT_EVENT_REMINDER_CLOSE: OphanComponentEvent = {
+    component: {
+        componentType: 'ACQUISITIONS_EPIC',
+        id: OPHAN_COMPONENT_ID_REMINDER_CLOSE,
+    },
+    action: 'CLICK',
+};


### PR DESCRIPTION
## What does this change?
Add tracking the the epic reminder. This is primarily so we can work out a "conversion rate" for the component.

[Trello card](https://trello.com/c/QcMhp9hO/2591-adding-tracking-events-to-epic-reminders)