### PR TITLE
Puzzles pre-launch fixes

### DIFF
--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -183,7 +183,7 @@ export const PuzzlesBanner: React.FC<PuzzlesBannerProps> = ({ tracking, submitCo
                                 </p>
                             )}
                         </div>
-                        <div css={[squaresContainer]}>
+                        <div css={[squaresContainer, hideOnMinimise]}>
                             <ContentSquares />
                             <div css={imageContainer}>
                                 <ResponsiveImage

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -183,7 +183,7 @@ export const PuzzlesBanner: React.FC<PuzzlesBannerProps> = ({ tracking, submitCo
                                 </p>
                             )}
                         </div>
-                        <div css={[squaresContainer, hideOnMinimise]}>
+                        <div css={[squaresContainer]}>
                             <ContentSquares />
                             <div css={imageContainer}>
                                 <ResponsiveImage

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -3,7 +3,8 @@ import { CacheProvider } from '@emotion/core';
 import createCache from '@emotion/cache';
 import { Container } from '@guardian/src-layout';
 import { Button } from '@guardian/src-button';
-import { SvgArrowDownStraight, SvgArrowUpStraight } from '@guardian/src-icons';
+import { Link } from '@guardian/src-link';
+import { SvgArrowDownStraight, SvgArrowUpStraight, SvgInfo } from '@guardian/src-icons';
 import {
     createClickEventFromTracking,
     createViewEventFromTracking,
@@ -156,7 +157,7 @@ export const PuzzlesBanner: React.FC<PuzzlesBannerProps> = ({ tracking, submitCo
                                 Puzzles&nbsp;App
                             </h3>
                             <div css={appStoreButtonContainer}>
-                                <a
+                                <Link
                                     href="https://apps.apple.com/app/apple-store/id1487780661?pt=304191&ct=Puzzles_Banner&mt=8"
                                     target="_blank"
                                     rel="noopener noreferrer"
@@ -166,18 +167,20 @@ export const PuzzlesBanner: React.FC<PuzzlesBannerProps> = ({ tracking, submitCo
                                         src={appStore.apple}
                                         alt="Download on the Apple App Store"
                                     />
-                                </a>
-                                <a
+                                </Link>
+                                <Link
                                     href="https://play.google.com/store/apps/details?id=uk.co.guardian.puzzles&referrer=utm_source%3Dtheguardian.com%26utm_medium%3Dpuzzle_banner%26utm_campaign%3DUS2020"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     onClick={handleAppStoreClickFor('google')}
                                 >
                                     <img src={appStore.google} alt="Get it on Google Play" />
-                                </a>
+                                </Link>
                             </div>
                             {isKeyboardUser && (
-                                <p css={minimiseHint}>Hit escape to minimise this banner</p>
+                                <p css={minimiseHint}>
+                                    <SvgInfo /> You can minimise this banner using the escape key
+                                </p>
                             )}
                         </div>
                         <div css={[squaresContainer, hideOnMinimise]}>

--- a/src/components/modules/puzzles/puzzlesBanner/images.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/images.ts
@@ -7,9 +7,9 @@ export const appStore = {
 
 export const packshot = {
     desktop:
-        'https://i.guim.co.uk/img/media/a03b0d9567d1d8be41094aab096f659effc6b177/0_0_300_264/300.png?width=300&quality=85&s=d144380417be72d29c831e76d1aaf271',
+        'https://i.guim.co.uk/img/media/a54e8dd806f47578b7cf7238a54211fa5ea53cd4/0_0_300_264/300.png?width=300&quality=85&s=6f51d251a3fb56ee02283e631e10cc52',
     tablet:
-        'https://i.guim.co.uk/img/media/a03b0d9567d1d8be41094aab096f659effc6b177/0_0_300_264/300.png?width=230&quality=85&s=ce06077f0c48df9625dfa23e10207823',
+        'https://i.guim.co.uk/img/media/a54e8dd806f47578b7cf7238a54211fa5ea53cd4/0_0_300_264/300.png?width=230&quality=85&s=86c526a051f0ca237011b4ffb89f9b55',
 };
 
 export const qrCode =

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -153,15 +153,19 @@ export const hide = css`
 `;
 
 export const minimiseHint = css`
+    ${until.desktop} {
+        display: none;
+    }
+
     ${textSans.small()}
     margin: ${space[1]}px 0;
-    display: flex;
-    align-items: center;
 
     svg {
+        position: relative;
+        top: 0.25em;
+        height: 1.25em;
         margin-right: ${space[1]}px;
         fill: currentColor;
-        height: 1.25em;
     }
 `;
 

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -155,6 +155,14 @@ export const hide = css`
 export const minimiseHint = css`
     ${textSans.small()}
     margin: ${space[1]}px 0;
+    display: flex;
+    align-items: center;
+
+    svg {
+        margin-right: ${space[1]}px;
+        fill: currentColor;
+        height: 1.25em;
+    }
 `;
 
 function paddingOffsetFor(breakpointWidth: number) {

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -166,7 +166,7 @@ export const minimiseHint = css`
 `;
 
 function paddingOffsetFor(breakpointWidth: number) {
-    return `calc((100vw - ${breakpointWidth - space[5]}px) / 2)`;
+    return `calc((100vw - ${breakpointWidth - space[9]}px) / 2)`;
 }
 
 export const minimisedBanner = css`

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -176,16 +176,16 @@ export const minimisedBanner = css`
     bottom: 0;
     height: 136px;
     width: auto;
-    padding-right: ${space[3]}px;
+    border-right: none;
     transition: width 1s;
 
     ${from.mobileLandscape} {
-        padding-right: ${space[5]}px;
         height: 176px;
     }
 
     /* Maintain a right-hand offset that matches the edge of the main container */
     ${from.tablet} {
+        border-right: ${squareBorder};
         padding-right: ${paddingOffsetFor(breakpoints.tablet)};
     }
 

--- a/src/components/modules/puzzles/puzzlesBanner/squares/TabletDesktopSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/TabletDesktopSquares.tsx
@@ -30,7 +30,7 @@ const backgroundSquaresGrid = css`
 
 const nudgeSquareRight = css`
     ${from.desktop} {
-        transform: translateX(25%);
+        transform: translateX(44px);
     }
 `;
 


### PR DESCRIPTION
## What does this change?
This addresses a number of small remaining issues before launch:

- Changes the side padding of the minimised state of the banner below the tablet breakpoint, and fixes a slight visual shift of the button position when switching between the expanded and minimised state at tablet and desktop breakpoints.
- Updates to a higher resolution version of the packshot
- Switches app store links to use the `<Link>` component from Source, for better focus styling
- Improves the accessibility hint shown to users navigating with a keyboard

## Images

**Mobile view, minimised**
![Screenshot_2021-03-31 Storybook](https://user-images.githubusercontent.com/29146931/113181348-8f565600-9249-11eb-8e78-b0723eb9a027.png)

**Keyboard shortcut hint on desktop**
![Screenshot_2021-03-31 Storybook(1)](https://user-images.githubusercontent.com/29146931/113181423-a7c67080-9249-11eb-81a7-b31266bad765.png)

