### PR TITLE
Reprioritise design test

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -123,9 +123,9 @@ const getArticleEpicTests = async (mvtId: number): Promise<Test[]> => {
     const hardCoded = await getAllHardcodedTests();
 
     return [
-        ...regular.tests,
         epicSeparateArticleCountTestUkAus,
         epicSeparateArticleCountTestEuRow,
+        ...regular.tests,
         ...hardCoded,
     ];
 };
@@ -136,9 +136,9 @@ const getForceableArticleEpicTests = async (): Promise<Test[]> => {
     const holdback = await fetchConfiguredArticleEpicHoldbackTestsCached();
 
     return [
-        ...regular.tests,
         epicSeparateArticleCountTestUkAus,
         epicSeparateArticleCountTestEuRow,
+        ...regular.tests,
         ...hardCoded,
         ...holdback.tests,
     ];


### PR DESCRIPTION
## What does this change?
After chatting with Jessie + Minna we've decided to reprioritse the design test over the weekend.

We also quickly chatted about a potential solution that would allow for us to quickly prioritise specific epics tests. Perhaps we could include hardcoded tests in the tool somehow? You wouldn't be able to edit them, but you would be able to move them around in the priority list like the other tests. Perhaps a dev would create the test in SDC and then create a "hardcoded" test (a new type of epic test) that references the name they gave it. 