### PR TITLE
Send signed in/out data on epic reminder view event

### DIFF
--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -328,6 +328,7 @@ export const ContributionsEpicComponent: (
                 }}
                 submitComponentEvent={submitComponentEvent}
                 isReminderActive={isReminderActive}
+                isSignedIn={Boolean(email)}
             />
 
             {isReminderActive && showReminderFields && (

--- a/src/components/modules/epics/ContributionsEpicButtons.tsx
+++ b/src/components/modules/epics/ContributionsEpicButtons.tsx
@@ -7,10 +7,7 @@ import { Cta, Variant } from '../../../lib/variants';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
 import { getCookie } from '../../../lib/cookies';
 import { OphanComponentEvent } from '../../../types/OphanTypes';
-import {
-    OPHAN_COMPONENT_EVENT_REMINDER_OPEN,
-    OPHAN_COMPONENT_EVENT_REMINDER_VIEW,
-} from './utils/ophan';
+import { getReminderViewEvent, OPHAN_COMPONENT_EVENT_REMINDER_OPEN } from './utils/ophan';
 import { useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 
 const buttonWrapperStyles = css`
@@ -92,6 +89,7 @@ interface ContributionsEpicButtonsProps {
     onOpenReminderClick: () => void;
     submitComponentEvent?: (event: OphanComponentEvent) => void;
     isReminderActive: boolean;
+    isSignedIn: boolean;
 }
 
 export const ContributionsEpicButtons = ({
@@ -101,6 +99,7 @@ export const ContributionsEpicButtons = ({
     onOpenReminderClick,
     submitComponentEvent,
     isReminderActive,
+    isSignedIn,
 }: ContributionsEpicButtonsProps): JSX.Element | null => {
     const [hasBeenSeen, setNode] = useHasBeenSeen({}, true);
 
@@ -113,7 +112,7 @@ export const ContributionsEpicButtons = ({
 
     useEffect(() => {
         if (hasBeenSeen && submitComponentEvent && showReminderFields && !hasSetReminder) {
-            submitComponentEvent(OPHAN_COMPONENT_EVENT_REMINDER_VIEW);
+            submitComponentEvent(getReminderViewEvent(isSignedIn));
         }
     }, [hasBeenSeen]);
 

--- a/src/components/modules/epics/utils/ophan.ts
+++ b/src/components/modules/epics/utils/ophan.ts
@@ -5,13 +5,14 @@ const OPHAN_COMPONENT_ID_REMINDER_OPEN = 'contributions-epic-reminder-open';
 const OPHAN_COMPONENT_ID_REMINDER_SET = 'contributions-epic-reminder-set';
 const OPHAN_COMPONENT_ID_REMINDER_CLOSE = 'contributions-epic-reminder-close';
 
-export const OPHAN_COMPONENT_EVENT_REMINDER_VIEW: OphanComponentEvent = {
+export const getReminderViewEvent = (isSignedIn: boolean): OphanComponentEvent => ({
     component: {
         componentType: 'ACQUISITIONS_EPIC',
         id: OPHAN_COMPONENT_ID_REMINDER_VIEW,
     },
     action: 'VIEW',
-};
+    value: isSignedIn.toString(),
+});
 
 export const OPHAN_COMPONENT_EVENT_REMINDER_OPEN: OphanComponentEvent = {
     component: {


### PR DESCRIPTION
## What does this change?
Along with recording a reminder view, we also want to know if a user is signed in/out. Now we send that data in the `value` field of the view component event. 