### PR TITLE
Prevent passing an empty A/B test object in tracking

### DIFF
--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -71,6 +71,13 @@ export const createClickEventFromTracking = (
     componentId: string,
 ): OphanComponentEvent => {
     const { abTestName, abTestVariant, componentType, products = [], campaignCode } = tracking;
+    const abTest =
+        abTestName && abTestVariant
+            ? {
+                  name: abTestName,
+                  variant: abTestVariant,
+              }
+            : null;
 
     return {
         component: {
@@ -79,10 +86,7 @@ export const createClickEventFromTracking = (
             campaignCode,
             id: componentId,
         },
-        abTest: {
-            name: abTestName,
-            variant: abTestVariant,
-        },
+        ...(abTest ? { abTest } : {}),
         action: 'CLICK',
     };
 };
@@ -92,6 +96,13 @@ export const createViewEventFromTracking = (
     componentId: string,
 ): OphanComponentEvent => {
     const { abTestName, abTestVariant, componentType, products = [], campaignCode } = tracking;
+    const abTest =
+        abTestName && abTestVariant
+            ? {
+                  name: abTestName,
+                  variant: abTestVariant,
+              }
+            : null;
 
     return {
         component: {
@@ -100,10 +111,7 @@ export const createViewEventFromTracking = (
             campaignCode,
             id: componentId,
         },
-        abTest: {
-            name: abTestName,
-            variant: abTestVariant,
-        },
+        ...(abTest ? { abTest } : {}),
         action: 'VIEW',
     };
 };

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -1,7 +1,7 @@
 import { EpicTracking } from '../components/modules/epics/ContributionsEpicTypes';
 import { Test, Variant } from '../lib/variants';
 import { BannerTest, BannerVariant, BannerTracking } from '../types/BannerTypes';
-import { OphanComponentEvent } from '../types/OphanTypes';
+import { OphanAction, OphanComponentEvent } from '../types/OphanTypes';
 import { addRegionIdToSupportUrl } from './geolocation';
 
 type LinkParams = {
@@ -66,52 +66,30 @@ export const buildBannerCampaignCode = (test: BannerTest, variant: BannerVariant
 export const buildAmpEpicCampaignCode = (testName: string, variantName: string): string =>
     `AMP__${testName}__${variantName}`;
 
-export const createClickEventFromTracking = (
-    tracking: BannerTracking,
-    componentId: string,
-): OphanComponentEvent => {
-    const { abTestName, abTestVariant, componentType, products = [], campaignCode } = tracking;
-    const abTest =
-        abTestName && abTestVariant
-            ? {
-                  name: abTestName,
-                  variant: abTestVariant,
-              }
-            : null;
+const createEventFromTracking = (action: OphanAction) => {
+    return (tracking: BannerTracking, componentId: string): OphanComponentEvent => {
+        const { abTestName, abTestVariant, componentType, products = [], campaignCode } = tracking;
+        const abTest =
+            abTestName && abTestVariant
+                ? {
+                      name: abTestName,
+                      variant: abTestVariant,
+                  }
+                : null;
 
-    return {
-        component: {
-            componentType,
-            products,
-            campaignCode,
-            id: componentId,
-        },
-        ...(abTest ? { abTest } : {}),
-        action: 'CLICK',
+        return {
+            component: {
+                componentType,
+                products,
+                campaignCode,
+                id: componentId,
+            },
+            ...(abTest ? { abTest } : {}),
+            action,
+        };
     };
 };
 
-export const createViewEventFromTracking = (
-    tracking: BannerTracking,
-    componentId: string,
-): OphanComponentEvent => {
-    const { abTestName, abTestVariant, componentType, products = [], campaignCode } = tracking;
-    const abTest =
-        abTestName && abTestVariant
-            ? {
-                  name: abTestName,
-                  variant: abTestVariant,
-              }
-            : null;
+export const createClickEventFromTracking = createEventFromTracking('CLICK');
 
-    return {
-        component: {
-            componentType,
-            products,
-            campaignCode,
-            id: componentId,
-        },
-        ...(abTest ? { abTest } : {}),
-        action: 'VIEW',
-    };
-};
+export const createViewEventFromTracking = createEventFromTracking('VIEW');


### PR DESCRIPTION
## What does this change?
This updates the tracking event creation functions to not include an `abTest` field when no test name and variant have been passed, as this may be causing issues with Ophan tracking for the puzzles banner.
