### PR TITLE
Fix issue with app store buttons not being clickable on mobile

### DIFF
--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -86,6 +86,9 @@ export const heading = css`
 export const appStoreButtonContainer = css`
     display: flex;
     flex-direction: column;
+    z-index: 2;
+    position: relative;
+    align-items: flex-start;
 
     a {
         margin-bottom: ${space[2]}px;


### PR DESCRIPTION
## What does this change?
This bumps up the z-index of the app store links in the puzzles banner to fix an issue where they were not interactive at mobile breakpoints due to element overlap.
