### PR TITLE
Add targeting test

### DIFF
--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -587,7 +587,6 @@ describe('withinMaxViews filter', () => {
         { date: new Date('2019-07-21T10:24:00').valueOf(), testId: 'example-1' },
         { date: new Date('2019-08-11T10:24:00').valueOf(), testId: 'example-1' },
     ];
-
     const now = new Date('2019-08-17T10:24:00');
     const filter = withinMaxViews(viewLog, now);
 

--- a/src/payloads.ts
+++ b/src/payloads.ts
@@ -27,6 +27,7 @@ import { selectBannerTest } from './tests/banners/bannerSelection';
 import { getCachedTests } from './tests/banners/bannerTests';
 import { bannerDeployCaches } from './tests/banners/bannerDeployCache';
 import { epic as epicModule, liveblogEpic as liveblogEpicModule, puzzlesBanner } from './modules';
+import { tests as epicTargetingTests } from './tests/epicTargetingTest';
 
 interface EpicDataResponse {
     data?: {
@@ -91,7 +92,7 @@ const getArticleEpicTests = async (mvtId: number): Promise<Test[]> => {
     const regular = await fetchConfiguredArticleEpicTestsCached();
     const hardCoded = await getAllHardcodedTests();
 
-    return [...regular.tests, ...hardCoded];
+    return [...epicTargetingTests, ...regular.tests, ...hardCoded];
 };
 
 const getForceableArticleEpicTests = async (): Promise<Test[]> => {
@@ -99,7 +100,7 @@ const getForceableArticleEpicTests = async (): Promise<Test[]> => {
     const hardCoded = await getAllHardcodedTests();
     const holdback = await fetchConfiguredArticleEpicHoldbackTestsCached();
 
-    return [...regular.tests, ...hardCoded, ...holdback.tests];
+    return [...epicTargetingTests, ...regular.tests, ...hardCoded, ...holdback.tests];
 };
 
 const getLiveblogEpicTests = async (): Promise<Test[]> => {

--- a/src/tests/epicTargetingTest.ts
+++ b/src/tests/epicTargetingTest.ts
@@ -1,0 +1,75 @@
+import { Test } from '../lib/variants';
+import {
+    BASE_TEST,
+    EU_ROW_HIGHLY_ENGAGED_VARIANTS,
+    EU_ROW_LESS_ENGAGED_VARIANTS,
+    HIGHLY_ENGAGED_ARTICLES_VIEWED_SETTINGS,
+    LESS_ENGAGED_ARTICLES_VIEWED_SETTINGS,
+    UK_AUS_HIGHLY_ENGAGED_VARIANTS,
+    UK_AUS_LESS_ENGAGED_VARIANTS,
+    US_HIGHLY_ENGAGED_VARIANTS,
+    US_LESS_ENGAGED_VARIANTS,
+} from './epicTargetingTestData';
+
+// ---- UK + AUS ---- //
+
+const ukAusHighlyEngaged: Test = {
+    ...BASE_TEST,
+    name: 'EpicTargetingHighlyEngagedTest__UkAus',
+    locations: ['GBPCountries', 'AUDCountries'],
+    variants: UK_AUS_HIGHLY_ENGAGED_VARIANTS,
+    articlesViewedSettings: HIGHLY_ENGAGED_ARTICLES_VIEWED_SETTINGS,
+};
+
+const ukAusLessEngaged: Test = {
+    ...BASE_TEST,
+    name: 'EpicTargetingLessEngagedTest__UkAus',
+    locations: ['GBPCountries', 'AUDCountries'],
+    variants: UK_AUS_LESS_ENGAGED_VARIANTS,
+    articlesViewedSettings: LESS_ENGAGED_ARTICLES_VIEWED_SETTINGS,
+};
+
+// ---- US ---- //
+
+const usHighlyEngaged: Test = {
+    ...BASE_TEST,
+    name: 'EpicTargetingHighlyEngagedTest__Us',
+    locations: ['UnitedStates'],
+    variants: US_HIGHLY_ENGAGED_VARIANTS,
+    articlesViewedSettings: HIGHLY_ENGAGED_ARTICLES_VIEWED_SETTINGS,
+};
+
+const usLessEngaged: Test = {
+    ...BASE_TEST,
+    name: 'EpicTargetingLessEngagedTest__Us',
+    locations: ['UnitedStates'],
+    variants: US_LESS_ENGAGED_VARIANTS,
+    articlesViewedSettings: LESS_ENGAGED_ARTICLES_VIEWED_SETTINGS,
+};
+
+// ---- EU + ROW ---- //
+
+const euRowHighlyEngaged: Test = {
+    ...BASE_TEST,
+    name: 'EpicTargetingHighlyEngagedTest__EuRow',
+    locations: ['EURCountries', 'Canada', 'NZDCountries', 'International'],
+    variants: EU_ROW_HIGHLY_ENGAGED_VARIANTS,
+    articlesViewedSettings: HIGHLY_ENGAGED_ARTICLES_VIEWED_SETTINGS,
+};
+
+const euRowLessEngaged: Test = {
+    ...BASE_TEST,
+    name: 'EpicTargetingLessEngagedTest__EuRow',
+    locations: ['EURCountries', 'Canada', 'NZDCountries', 'International'],
+    variants: EU_ROW_LESS_ENGAGED_VARIANTS,
+    articlesViewedSettings: LESS_ENGAGED_ARTICLES_VIEWED_SETTINGS,
+};
+
+export const tests = [
+    ukAusHighlyEngaged,
+    ukAusLessEngaged,
+    usHighlyEngaged,
+    usLessEngaged,
+    euRowHighlyEngaged,
+    euRowLessEngaged,
+];

--- a/src/tests/epicTargetingTestData.ts
+++ b/src/tests/epicTargetingTestData.ts
@@ -1,0 +1,161 @@
+import { epic } from '../modules';
+import { Cta, MaxViews, Test, Variant } from '../lib/variants';
+import { ArticlesViewedSettings } from '../types/shared';
+
+// ---- MaxViews ---- //
+
+const CONTROL_MAX_VIEWS: MaxViews = {
+    maxViewsCount: 4,
+    maxViewsDays: 30,
+    minDaysBetweenViews: 0,
+};
+
+const ASK6_MAX_VIEWS: MaxViews = {
+    maxViewsCount: 6,
+    maxViewsDays: 30,
+    minDaysBetweenViews: 0,
+};
+
+const ASK2_MAX_VIEWS: MaxViews = {
+    maxViewsCount: 2,
+    maxViewsDays: 30,
+    minDaysBetweenViews: 0,
+};
+
+// ---- Paragraphs ---- //
+
+const SHARED_PARAGRAPHS = [
+    'With your help, we will continue to provide high-impact reporting that can counter misinformation and offer an authoritative, trustworthy source of news for everyone. With no shareholders or billionaire owner, we set our own agenda and provide truth-seeking journalism that’s free from commercial and political influence. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+    'Unlike many others, we have maintained our choice: to keep Guardian journalism open for all readers, regardless of where they live or what they can afford to pay. We do this because we believe in information equality, where everyone deserves to read accurate news and thoughtful analysis. Greater numbers of people are staying well-informed on world events, and being inspired to take meaningful action.',
+    "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+    'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+];
+
+const UK_AUS_HIGHLY_ENGAGED_PARAGRAPHS = [
+    '... we have a small favour to ask. You’ve read %%ARTICLE_COUNT%% articles in the last year. And you’re not alone; through these turbulent and challenging times, millions rely on the Guardian for independent journalism that stands for truth and integrity. Readers chose to support us financially more than 1.5 million times in 2020, joining existing supporters in 180 countries.',
+    ...SHARED_PARAGRAPHS,
+];
+
+const UK_AUS_LESS_ENGAGED_PARAGRAPHS = [
+    '... we have a small favour to ask. Through these turbulent and challenging times, millions rely on the Guardian for independent journalism that stands for truth and integrity. Readers chose to support us financially more than 1.5 million times in 2020, joining existing supporters in 180 countries.',
+    ...SHARED_PARAGRAPHS,
+];
+
+const US_HIGHLY_ENGAGED_PARAGRAPHS = [
+    '... we have a small favour to ask.  You’ve read %%ARTICLE_COUNT%% articles in the last year. And you’re not alone; through these turbulent and challenging times, millions rely on the Guardian for independent journalism that stands for truth and integrity. Readers chose to support us financially more than 1.5 million times in 2020, joining existing supporters in 180 countries.',
+    ...SHARED_PARAGRAPHS,
+];
+
+const US_LESS_ENGAGED_PARAGRAPHS = [
+    '... we have a small favour to ask. Across the US and around the world, millions rely on the Guardian for independent journalism that stands for truth and integrity. The Guardian has no shareholders or billionaire owner to please, and we invest every penny we earn back into our journalism. Readers chose to support us financially more than 1.5 million times in 2020, joining existing supporters in 180 countries.',
+    ...SHARED_PARAGRAPHS,
+];
+
+const EU_ROW_HIGHLY_ENGAGED_PARAGRAPHS = [
+    '… as you join us today from %%COUNTRY_NAME%%, we have a small favour to ask. You’ve read %%ARTICLE_COUNT%% articles in the last year. And you’re not alone; through these turbulent and challenging times, millions rely on the Guardian for independent journalism that stands for truth and integrity. Readers chose to support us financially more than 1.5 million times in 2020, joining existing supporters in 180 countries.',
+    ...SHARED_PARAGRAPHS,
+];
+
+const EU_ROW_LESS_ENGAGED_PARAGRAPHS = [
+    '... as you join us today from %%COUNTRY_NAME%%, we have a small favour to ask. Through these turbulent and challenging times, millions rely on the Guardian for independent journalism that stands for truth and integrity. Readers chose to support us financially more than 1.5 million times in 2020, joining existing supporters in 180 countries.',
+    ...SHARED_PARAGRAPHS,
+];
+
+// ---- Other variant fields ---- //
+
+const HIGHLIGHTED_TEXT =
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.';
+
+const CTA: Cta = {
+    text: 'Support The Guardian',
+    baseUrl: 'https://support.theguardian.com/contribute',
+};
+
+// ---- Variants ---- //
+
+const BASE_VARIANT = {
+    modulePathBuilder: epic.endpointPathBuilder,
+    highlightedText: HIGHLIGHTED_TEXT,
+    cta: CTA,
+};
+
+function getVariants(paragraphs: string[], kind: 'HIGHLY_ENGAGED' | 'LESS_ENGAGED'): Variant[] {
+    const control = {
+        ...BASE_VARIANT,
+        name: 'control',
+        paragraphs,
+        maxViews: CONTROL_MAX_VIEWS,
+    };
+
+    const variant =
+        kind === 'HIGHLY_ENGAGED'
+            ? {
+                  ...BASE_VARIANT,
+                  name: 'ask6',
+                  paragraphs,
+                  maxViews: ASK6_MAX_VIEWS,
+              }
+            : {
+                  ...BASE_VARIANT,
+                  name: 'ask2',
+                  paragraphs,
+                  maxViews: ASK2_MAX_VIEWS,
+              };
+
+    return [control, variant];
+}
+
+export const UK_AUS_HIGHLY_ENGAGED_VARIANTS = getVariants(
+    UK_AUS_HIGHLY_ENGAGED_PARAGRAPHS,
+    'HIGHLY_ENGAGED',
+);
+export const UK_AUS_LESS_ENGAGED_VARIANTS = getVariants(
+    UK_AUS_LESS_ENGAGED_PARAGRAPHS,
+    'LESS_ENGAGED',
+);
+
+export const US_HIGHLY_ENGAGED_VARIANTS = getVariants(
+    US_HIGHLY_ENGAGED_PARAGRAPHS,
+    'HIGHLY_ENGAGED',
+);
+export const US_LESS_ENGAGED_VARIANTS = getVariants(US_LESS_ENGAGED_PARAGRAPHS, 'LESS_ENGAGED');
+
+export const EU_ROW_HIGHLY_ENGAGED_VARIANTS = getVariants(
+    EU_ROW_HIGHLY_ENGAGED_PARAGRAPHS,
+    'HIGHLY_ENGAGED',
+);
+export const EU_ROW_LESS_ENGAGED_VARIANTS = getVariants(
+    EU_ROW_LESS_ENGAGED_PARAGRAPHS,
+    'LESS_ENGAGED',
+);
+
+// ---- Articles viewed settings ---- //
+
+export const HIGHLY_ENGAGED_ARTICLES_VIEWED_SETTINGS: ArticlesViewedSettings = {
+    minViews: 5,
+    periodInWeeks: 52,
+};
+
+export const LESS_ENGAGED_ARTICLES_VIEWED_SETTINGS: ArticlesViewedSettings = {
+    minViews: 0,
+    maxViews: 5,
+    periodInWeeks: 52,
+};
+
+// ---- Tests ---- //
+
+export const BASE_TEST: Omit<Test, 'name' | 'locations' | 'variants'> = {
+    campaignId: '',
+    isOn: true,
+    audience: 1,
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: true,
+    userCohort: 'AllNonSupporters',
+    isLiveBlog: false,
+    hasCountryName: false,
+    highPriority: true,
+    useLocalViewLog: true,
+};


### PR DESCRIPTION
## What does this change?
Add a special hardcoded tests that will compare different targeting strategies. Specifically, for 'highly engaged' users (>5 article count) we're testing ask4 vs ask6, and for 'less engaged' users (<5 article count) we're testing ask4 vs ask2.

Note: Users that have **opted out** of article count, won't be placed in either highly or less engaged tests. This is because the `respectArticleCountOptOut` filters out any test with `articlesViewedSettings`.
## Images

### UK + AUS

**>5 articles**
<img width="640" alt="Screenshot 2021-04-13 at 10 26 13" src="https://user-images.githubusercontent.com/17720442/114531064-74b9af00-9c43-11eb-9863-a3c13bfb285e.png">

**<5 articles**
<img width="640" alt="Screenshot 2021-04-13 at 10 48 18" src="https://user-images.githubusercontent.com/17720442/114533559-e98de880-9c45-11eb-87d4-53271aef043a.png">

### US

**>5 articles**
<img width="640" alt="Screenshot 2021-04-13 at 10 40 59" src="https://user-images.githubusercontent.com/17720442/114532789-1988bc00-9c45-11eb-8cdb-8811862facb2.png">

**<5 articles**
<img width="640" alt="Screenshot 2021-04-13 at 10 26 56" src="https://user-images.githubusercontent.com/17720442/114531089-7aaf9000-9c43-11eb-8c68-288f69897384.png">

### EU + ROW

**>5 articles**
<img width="640" alt="Screenshot 2021-04-13 at 10 27 35" src="https://user-images.githubusercontent.com/17720442/114531118-80a57100-9c43-11eb-9864-4afa559ba058.png">

**<5 articles**
<img width="640" alt="Screenshot 2021-04-13 at 10 49 05" src="https://user-images.githubusercontent.com/17720442/114533620-fd394f00-9c45-11eb-9b2f-8f870a469ef5.png">