### PR TITLE
Update highlighted text copy in US targeting test 

### DIFF
--- a/src/tests/epicTargetingTestData.ts
+++ b/src/tests/epicTargetingTestData.ts
@@ -66,6 +66,9 @@ const EU_ROW_LESS_ENGAGED_PARAGRAPHS = [
 const HIGHLIGHTED_TEXT =
     'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.';
 
+const US_HIGHLIGHTED_TEXT =
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.';
+
 const CTA: Cta = {
     text: 'Support The Guardian',
     baseUrl: 'https://support.theguardian.com/contribute',
@@ -75,15 +78,19 @@ const CTA: Cta = {
 
 const BASE_VARIANT = {
     modulePathBuilder: epic.endpointPathBuilder,
-    highlightedText: HIGHLIGHTED_TEXT,
     cta: CTA,
 };
 
-function getVariants(paragraphs: string[], kind: 'HIGHLY_ENGAGED' | 'LESS_ENGAGED'): Variant[] {
+function getVariants(
+    paragraphs: string[],
+    kind: 'HIGHLY_ENGAGED' | 'LESS_ENGAGED',
+    highlightedText: string = HIGHLIGHTED_TEXT,
+): Variant[] {
     const control = {
         ...BASE_VARIANT,
         name: 'control',
         paragraphs,
+        highlightedText,
         maxViews: CONTROL_MAX_VIEWS,
     };
 
@@ -117,8 +124,13 @@ export const UK_AUS_LESS_ENGAGED_VARIANTS = getVariants(
 export const US_HIGHLY_ENGAGED_VARIANTS = getVariants(
     US_HIGHLY_ENGAGED_PARAGRAPHS,
     'HIGHLY_ENGAGED',
+    US_HIGHLIGHTED_TEXT,
 );
-export const US_LESS_ENGAGED_VARIANTS = getVariants(US_LESS_ENGAGED_PARAGRAPHS, 'LESS_ENGAGED');
+export const US_LESS_ENGAGED_VARIANTS = getVariants(
+    US_LESS_ENGAGED_PARAGRAPHS,
+    'LESS_ENGAGED',
+    US_HIGHLIGHTED_TEXT,
+);
 
 export const EU_ROW_HIGHLY_ENGAGED_VARIANTS = getVariants(
     EU_ROW_HIGHLY_ENGAGED_PARAGRAPHS,


### PR DESCRIPTION
## What does this change?
Update highlighted text copy in US targeting test as this new line of copy hasn't performed as well in the US.

## Images

### US
<img width="589" alt="Screenshot 2021-04-14 at 08 30 03" src="https://user-images.githubusercontent.com/17720442/114671437-0553c600-9cfc-11eb-8fc7-5a7d6bbfae48.png">

### None US (specifically UK/AUS)

<img width="589" alt="Screenshot 2021-04-14 at 08 29 36" src="https://user-images.githubusercontent.com/17720442/114671454-097fe380-9cfc-11eb-96b1-43985898f6da.png">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
