### PR TITLE
Fix issues with the puzzles banner on small screens

### DIFF
--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -67,6 +67,10 @@ export const squaresContainer = css`
         right: 0;
     }
 
+    ${until.mobileMedium} {
+        bottom: 40px;
+    }
+
     ${from.desktop} {
         padding-right: 44px;
     }

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -93,7 +93,7 @@ export const heading = css`
 export const appStoreButtonContainer = css`
     display: flex;
     flex-direction: column;
-    z-index: 2;
+    z-index: 3;
     position: relative;
     align-items: flex-start;
 

--- a/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
+++ b/src/components/modules/puzzles/puzzlesBanner/puzzlesBannerStyles.ts
@@ -81,6 +81,10 @@ export const heading = css`
     ${headline.large({ fontWeight: 'bold' })};
     margin: 0 0 ${space[6]}px;
 
+    ${until.mobileMedium} {
+        ${headline.medium({ fontWeight: 'bold' })}
+    }
+
     ${between.tablet.and.desktop} {
         ${headline.small({ fontWeight: 'bold' })}
     }

--- a/src/components/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
@@ -57,7 +57,7 @@ const contentSquare = css`
         margin-left: -4px;
 
         ${from.mobileMedium} {
-            margin-left: --2px;
+            margin-left: -2px;
         }
     }
 

--- a/src/components/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
@@ -26,6 +26,7 @@ function withIECompatibleGap(rowsOrCols: string[], gap: string) {
 
 const squareSizes = {
     mobile: {
+        xsmall: 84,
         small: space[24],
         medium: 120,
         large: 152,
@@ -41,15 +42,28 @@ const contentSquare = css`
     border-bottom: ${squareBorder};
     padding-top: 0;
     box-shadow: ${squareBoxShadow};
-    min-width: ${squareSizes.mobile.small}px;
-    min-height: ${squareSizes.mobile.small}px;
+    min-width: ${squareSizes.mobile.xsmall}px;
+    min-height: ${squareSizes.mobile.xsmall}px;
+
+    ${until.mobileMedium} {
+        font-size: 15px;
+    }
 
     p {
         width: 100%;
         padding: ${space[1]}px;
         padding-left: 0;
         margin: 0;
-        margin-left: -2px;
+        margin-left: -4px;
+
+        ${from.mobileMedium} {
+            margin-left: --2px;
+        }
+    }
+
+    ${from.mobileMedium} {
+        min-width: ${squareSizes.mobile.small}px;
+        min-height: ${squareSizes.mobile.small}px;
     }
 
     ${from.tablet} {
@@ -71,6 +85,11 @@ const bottomLeftOnMobile = css`
         width: ${squareSizes.mobile.medium}px;
         height: ${squareSizes.mobile.medium}px;
     }
+
+    ${until.mobileMedium} {
+        width: ${squareSizes.mobile.small}px;
+        height: ${squareSizes.mobile.small}px;
+    }
 `;
 
 const bottomRightOnMobile = css`
@@ -79,6 +98,11 @@ const bottomRightOnMobile = css`
         grid-column: 3;
         width: ${squareSizes.mobile.large}px;
         height: ${squareSizes.mobile.large}px;
+    }
+
+    ${until.mobileMedium} {
+        width: ${squareSizes.mobile.medium}px;
+        height: ${squareSizes.mobile.medium}px;
     }
 `;
 

--- a/src/components/modules/puzzles/puzzlesBanner/squares/MobileSquares.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/squares/MobileSquares.tsx
@@ -14,11 +14,15 @@ const mobileSquareGrid = css`
     ${from.tablet} {
         display: none;
     }
-    margin-top: -${space[12]}px;
+
+    margin-top: -72px;
     width: 100%;
     max-width: 374px;
     display: grid;
     grid-template-columns: repeat(4, 1fr);
+    ${from.mobileMedium} {
+        margin-top: -${space[12]}px;
+    }
 `;
 
 const firstRow = css`


### PR DESCRIPTION
## What does this change?
This introduces a number of small tweaks to the puzzles banner below the mobileMedium breakpoint to make sure it's still readable and can be minimised on smaller devices.

## How to test
This branch is currently deployed on CODE.

## Images

Taken with iPhone SE

**Before**
![Screenshot 2021-04-14 at 13 01 57](https://user-images.githubusercontent.com/29146931/114707616-57a7dd80-9d22-11eb-8a8a-eec374366b67.png)

**After**
![Screenshot 2021-04-14 at 13 00 22](https://user-images.githubusercontent.com/29146931/114707668-642c3600-9d22-11eb-8448-0084b4b11c00.png)

