### PR TITLE
Remove hasNoZeroArticleCount filter

### DIFF
--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -11,7 +11,6 @@ import {
     withinMaxViews,
     withinArticleViewedSettings,
     userInTest,
-    hasNoZeroArticleCount,
     isNotExpired,
 } from './variants';
 import { EpicTargeting } from '../components/modules/epics/ContributionsEpicTypes';
@@ -646,48 +645,6 @@ describe('withinMaxViews filter', () => {
         const got = filter.test(test, targetingDefault);
 
         expect(got).toBe(true);
-    });
-});
-
-// Avoids selecting a test that uses article count when the value would be zero
-describe('hasNoZeroArticleCount filter', () => {
-    const now = new Date('2010-03-31T12:30:00');
-    it('should pass if no need for article history', () => {
-        const test: Test = {
-            ...testDefault,
-            articlesViewedSettings: undefined,
-        };
-        const filter = hasNoZeroArticleCount(now);
-
-        const got = filter.test(test, targetingDefault);
-
-        expect(got).toBe(true);
-    });
-
-    it('should pass if replacement value is greater than 0', () => {
-        const history = [{ week: 18330, count: 1 }];
-        const targeting: EpicTargeting = {
-            ...targetingDefault,
-            weeklyArticleHistory: history,
-        };
-        const filter = hasNoZeroArticleCount(now);
-
-        const got = filter.test(testDefault, targeting);
-
-        expect(got).toBe(true);
-    });
-
-    it('should fail if replacement value is 0', () => {
-        const history = [{ week: 18330, count: 0 }];
-        const targeting: EpicTargeting = {
-            ...targetingDefault,
-            weeklyArticleHistory: history,
-        };
-        const filter = hasNoZeroArticleCount(now);
-
-        const got = filter.test(testDefault, targeting);
-
-        expect(got).toBe(false);
     });
 });
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -5,7 +5,7 @@ import {
 } from '../components/modules/epics/ContributionsEpicTypes';
 import { shouldThrottle, shouldNotRenderEpic, userIsInTest } from './targeting';
 import { getCountryName, inCountryGroups, CountryGroupId } from './geolocation';
-import { getArticleViewCountForWeeks, historyWithinArticlesViewedSettings } from './history';
+import { historyWithinArticlesViewedSettings } from './history';
 import { isRecentOneOffContributor } from './dates';
 import { ArticlesViewedSettings, WeeklyArticleHistory } from '../types/shared';
 import { getReminderFields, ReminderFields } from './reminderFields';
@@ -247,29 +247,6 @@ export const inCorrectCohort = (userCohorts: UserCohort[]): Filter => ({
     test: (test): boolean => userCohorts.includes(test.userCohort),
 });
 
-// Prevent cases like "...you've read 0 articles...".
-// This could happen when the article history required by the test
-// is different than the date range used by the template itself.
-export const hasNoZeroArticleCount = (now: Date = new Date(), templateWeeks = 52): Filter => ({
-    id: 'hasNoZeroArticleCount',
-    test: (test, targeting): boolean => {
-        const mustHaveHistory =
-            test.articlesViewedSettings && test.articlesViewedSettings.periodInWeeks;
-
-        if (!mustHaveHistory) {
-            return true;
-        }
-
-        const numArticlesInWeeks = getArticleViewCountForWeeks(
-            targeting.weeklyArticleHistory || [],
-            templateWeeks,
-            now,
-        );
-
-        return numArticlesInWeeks > 0;
-    },
-});
-
 export const shouldNotRender = (epicType: EpicType): Filter => ({
     id: 'shouldNotRender',
     test: (_, targeting): boolean => !shouldNotRenderEpic(targeting, epicType),
@@ -339,7 +316,6 @@ export const findTestAndVariant = (
         matchesCountryGroups,
         withinMaxViews(targeting.epicViewLog || []),
         withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
-        hasNoZeroArticleCount(),
         respectArticleCountOptOut,
     ];
 


### PR DESCRIPTION
## What does this change?
Remove hasNoZeroArticleCount filter. This filter seems to have been added to catch inconsitencies between the article views that counted towards test targeting, and those used when actually rendering the component. These are now the same value, so let's remove this filter. 