### PR TITLE
Update epic secondary cta model

### DIFF
--- a/src/components/modules/epics/ContributionsEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpic.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { ContributionsEpic, EpicProps } from './ContributionsEpic';
-import { TickerCountType, TickerEndType } from '../../../lib/variants';
+import { SecondaryCtaType, TickerCountType, TickerEndType } from '../../../lib/variants';
 import { props } from './utils/storybook';
 import { from } from '@guardian/src-foundations/mq';
 import { css } from '@emotion/core';
@@ -54,7 +54,9 @@ export const WithReminder = Template.bind({});
 WithReminder.args = {
     variant: {
         ...props.variant,
-        secondaryCta: undefined,
+        secondaryCta: {
+            type: SecondaryCtaType.ContributionsReminder,
+        },
         showReminderFields: {
             reminderCta: 'Remind me in May',
             reminderPeriod: '2020-05-01',
@@ -68,7 +70,9 @@ WithPrefilledReminder.args = {
     email: 'example@guardian.co.uk',
     variant: {
         ...props.variant,
-        secondaryCta: undefined,
+        secondaryCta: {
+            type: SecondaryCtaType.ContributionsReminder,
+        },
         showReminderFields: {
             reminderCta: 'Remind me in May',
             reminderPeriod: '2020-05-01',

--- a/src/components/modules/epics/ContributionsEpicButtons.tsx
+++ b/src/components/modules/epics/ContributionsEpicButtons.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 import { Button } from './Button';
 import { EpicTracking } from './ContributionsEpicTypes';
-import { Cta, Variant } from '../../../lib/variants';
+import { Cta, SecondaryCtaType, Variant } from '../../../lib/variants';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
 import { getCookie } from '../../../lib/cookies';
 import { OphanComponentEvent } from '../../../types/OphanTypes';
@@ -129,13 +129,16 @@ export const ContributionsEpicButtons = ({
                 <>
                     <PrimaryCtaButton cta={cta} tracking={tracking} countryCode={countryCode} />
 
-                    {secondaryCta && secondaryCta.baseUrl && secondaryCta.text ? (
+                    {secondaryCta?.type === SecondaryCtaType.Custom &&
+                    secondaryCta.cta.baseUrl &&
+                    secondaryCta.cta.text ? (
                         <SecondaryCtaButton
-                            cta={secondaryCta}
+                            cta={secondaryCta.cta}
                             tracking={tracking}
                             countryCode={countryCode}
                         />
                     ) : (
+                        secondaryCta?.type === SecondaryCtaType.ContributionsReminder &&
                         showReminderFields &&
                         !hasSetReminder && (
                             <div css={buttonMargins}>

--- a/src/components/modules/epics/utils/storybook.ts
+++ b/src/components/modules/epics/utils/storybook.ts
@@ -1,6 +1,6 @@
 import { EpicTestTracking, EpicPageTracking, EpicTracking } from '../ContributionsEpicTypes';
 import { EpicProps } from '../ContributionsEpic';
-import { Variant } from '../../../../lib/variants';
+import { SecondaryCtaType, Variant } from '../../../../lib/variants';
 
 const variant: Variant = {
     name: 'control',
@@ -18,9 +18,12 @@ const variant: Variant = {
         baseUrl: 'https://support.theguardian.com/contribute',
     },
     secondaryCta: {
-        text: 'Read our pledge',
-        baseUrl:
-            'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?INTCMP=pledge_Jan_2020',
+        type: SecondaryCtaType.Custom,
+        cta: {
+            text: 'Read our pledge',
+            baseUrl:
+                'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?INTCMP=pledge_Jan_2020',
+        },
     },
 };
 

--- a/src/lib/fetchTickerData.ts
+++ b/src/lib/fetchTickerData.ts
@@ -56,18 +56,15 @@ export const addTickerDataToSettings = (tickerSettings: TickerSettings): Promise
         tickerData: tickerData,
     }));
 
-export const addTickerDataToVariant = (variant: Variant): Promise<Variant> => {
+export const getTickerSettings = (variant: Variant): Promise<TickerSettings | undefined> => {
     if (variant.tickerSettings) {
         const tickerSettings = variant.tickerSettings;
 
         return fetchTickerDataCached(tickerSettings).then((tickerData: TickerData) => ({
-            ...variant,
-            tickerSettings: {
-                ...tickerSettings,
-                tickerData,
-            },
+            ...tickerSettings,
+            tickerData,
         }));
     } else {
-        return Promise.resolve(variant);
+        return Promise.resolve(undefined);
     }
 };

--- a/src/lib/reminderFields.ts
+++ b/src/lib/reminderFields.ts
@@ -1,3 +1,6 @@
+import { EpicTargeting } from '../components/modules/epics/ContributionsEpicTypes';
+import { getUserCohorts, Variant } from './variants';
+
 export interface ReminderFields {
     reminderCta: string;
     reminderLabel: string;
@@ -26,6 +29,16 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-export const getReminderFields = (reminderFields?: ReminderFields): ReminderFields => {
-    return !!reminderFields ? reminderFields : buildReminderFields();
+export const getReminderFields = (
+    variant: Variant,
+    targeting: EpicTargeting,
+): ReminderFields | undefined => {
+    const userCohorts = getUserCohorts(targeting);
+    const isSupporter = userCohorts.includes('AllExistingSupporters');
+
+    if (isSupporter) {
+        return undefined;
+    }
+
+    return !!variant.showReminderFields ? variant.showReminderFields : buildReminderFields();
 };

--- a/src/lib/variants.test.ts
+++ b/src/lib/variants.test.ts
@@ -12,6 +12,7 @@ import {
     withinArticleViewedSettings,
     userInTest,
     isNotExpired,
+    SecondaryCtaType,
 } from './variants';
 import { EpicTargeting } from '../components/modules/epics/ContributionsEpicTypes';
 import { withNowAs } from '../utils/withNowAs';
@@ -49,9 +50,12 @@ const testDefault: Test = {
                 baseUrl: 'https://support.theguardian.com/contribute',
             },
             secondaryCta: {
-                text: 'Read our pledge',
-                baseUrl:
-                    'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?INTCMP=pledge_Jan_2020',
+                type: SecondaryCtaType.Custom,
+                cta: {
+                    text: 'Read our pledge',
+                    baseUrl:
+                        'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?INTCMP=pledge_Jan_2020',
+                },
             },
         },
     ],

--- a/src/tests/epicTargetingTestData.ts
+++ b/src/tests/epicTargetingTestData.ts
@@ -1,5 +1,5 @@
 import { epic } from '../modules';
-import { Cta, MaxViews, Test, Variant } from '../lib/variants';
+import { Cta, MaxViews, SecondaryCta, SecondaryCtaType, Test, Variant } from '../lib/variants';
 import { ArticlesViewedSettings } from '../types/shared';
 
 // ---- MaxViews ---- //
@@ -74,11 +74,16 @@ const CTA: Cta = {
     baseUrl: 'https://support.theguardian.com/contribute',
 };
 
+const SECONDARY_CTA: SecondaryCta = {
+    type: SecondaryCtaType.ContributionsReminder,
+};
+
 // ---- Variants ---- //
 
 const BASE_VARIANT = {
     modulePathBuilder: epic.endpointPathBuilder,
     cta: CTA,
+    secondaryCta: SECONDARY_CTA,
 };
 
 function getVariants(


### PR DESCRIPTION
## What does this change?
Update epic secondary cta model. The updated model is now explicit about the type of secondary cta: custom, contributions reminder, or none. 

The matching tooling change is here: https://github.com/guardian/support-admin-console/pull/202