### PR TITLE
Turn off non US targeting tests

### DIFF
--- a/src/tests/epicTargetingTest.ts
+++ b/src/tests/epicTargetingTest.ts
@@ -1,33 +1,11 @@
 import { Test } from '../lib/variants';
 import {
     BASE_TEST,
-    EU_ROW_HIGHLY_ENGAGED_VARIANTS,
-    EU_ROW_LESS_ENGAGED_VARIANTS,
     HIGHLY_ENGAGED_ARTICLES_VIEWED_SETTINGS,
     LESS_ENGAGED_ARTICLES_VIEWED_SETTINGS,
-    UK_AUS_HIGHLY_ENGAGED_VARIANTS,
-    UK_AUS_LESS_ENGAGED_VARIANTS,
     US_HIGHLY_ENGAGED_VARIANTS,
     US_LESS_ENGAGED_VARIANTS,
 } from './epicTargetingTestData';
-
-// ---- UK + AUS ---- //
-
-const ukAusHighlyEngaged: Test = {
-    ...BASE_TEST,
-    name: 'EpicTargetingHighlyEngagedTest__UkAus',
-    locations: ['GBPCountries', 'AUDCountries'],
-    variants: UK_AUS_HIGHLY_ENGAGED_VARIANTS,
-    articlesViewedSettings: HIGHLY_ENGAGED_ARTICLES_VIEWED_SETTINGS,
-};
-
-const ukAusLessEngaged: Test = {
-    ...BASE_TEST,
-    name: 'EpicTargetingLessEngagedTest__UkAus',
-    locations: ['GBPCountries', 'AUDCountries'],
-    variants: UK_AUS_LESS_ENGAGED_VARIANTS,
-    articlesViewedSettings: LESS_ENGAGED_ARTICLES_VIEWED_SETTINGS,
-};
 
 // ---- US ---- //
 
@@ -47,29 +25,4 @@ const usLessEngaged: Test = {
     articlesViewedSettings: LESS_ENGAGED_ARTICLES_VIEWED_SETTINGS,
 };
 
-// ---- EU + ROW ---- //
-
-const euRowHighlyEngaged: Test = {
-    ...BASE_TEST,
-    name: 'EpicTargetingHighlyEngagedTest__EuRow',
-    locations: ['EURCountries', 'Canada', 'NZDCountries', 'International'],
-    variants: EU_ROW_HIGHLY_ENGAGED_VARIANTS,
-    articlesViewedSettings: HIGHLY_ENGAGED_ARTICLES_VIEWED_SETTINGS,
-};
-
-const euRowLessEngaged: Test = {
-    ...BASE_TEST,
-    name: 'EpicTargetingLessEngagedTest__EuRow',
-    locations: ['EURCountries', 'Canada', 'NZDCountries', 'International'],
-    variants: EU_ROW_LESS_ENGAGED_VARIANTS,
-    articlesViewedSettings: LESS_ENGAGED_ARTICLES_VIEWED_SETTINGS,
-};
-
-export const tests = [
-    ukAusHighlyEngaged,
-    ukAusLessEngaged,
-    usHighlyEngaged,
-    usLessEngaged,
-    euRowHighlyEngaged,
-    euRowLessEngaged,
-];
+export const tests = [usHighlyEngaged, usLessEngaged];


### PR DESCRIPTION
## What does this change?
We're turning off the non-US targeting tests as they're costing us quite a lot of money to run. This doesn't seem to be the case in the US, so we will leave them on to gather more data.