### PR TITLE
Upgrade subs banners to use Source buttons, links and layout components

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -110,7 +110,6 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
         }
-        window.location.href = signInUrl;
     };
 
     const onCloseClick = (): void => {
@@ -177,6 +176,7 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                     Already a subscriber?{' '}
                                     <ThemeProvider theme={linkBrand}>
                                         <Link
+                                            href={signInUrl}
                                             data-link-name={signInComponentId}
                                             onClick={onSignInClick}
                                             subdued

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -6,24 +6,25 @@ import {
 } from '../../../../lib/tracking';
 import React, { useState } from 'react';
 import { ThemeProvider } from 'emotion-theming';
+import { Container, Columns, Column, Inline } from '@guardian/src-layout';
 import { Button, LinkButton, buttonBrand, buttonReaderRevenue } from '@guardian/src-button';
 import { Link, linkBrand } from '@guardian/src-link';
 import { SvgGuardianLogo } from '@guardian/src-brand';
 import { SvgCross } from '@guardian/src-icons';
 import {
     banner,
-    contentContainer,
+    columns,
     topLeftComponent,
+    bottomRightComponent,
     heading,
     messageText,
     siteMessage,
-    bottomRightComponent,
+    packShotContainer,
     packShot,
     iconPanel,
     logoContainer,
-    packShotContainer,
     closeButton,
-    notNowButton,
+    closeButtonContainer,
 } from './digitalSubscriptionsBannerStyles';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setChannelClosedTimestamp } from '../localStorage';
@@ -94,16 +95,14 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
         ? fallbackMessageText
         : content?.messageText || '';
 
-    const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
-        evt.preventDefault();
+    const onSubscribeClick = (): void => {
         const componentClickEvent = createClickEventFromTracking(tracking, ctaComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
         }
     };
 
-    const onSignInClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
-        evt.preventDefault();
+    const onSignInClick = (): void => {
         const componentClickEvent = createClickEventFromTracking(tracking, signInComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
@@ -135,75 +134,89 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
         <>
             {showBanner ? (
                 <section css={banner} data-target={bannerId}>
-                    <div css={contentContainer}>
-                        <div css={topLeftComponent}>
-                            <h3 css={heading}>
-                                {replaceArticleCount(cleanHeadingText || '', numArticles, 'banner')}
-                            </h3>
-                            <p css={messageText}>
-                                {replaceArticleCount(cleanMessageText || '', numArticles, 'banner')}
-                            </p>
-                            <ThemeProvider theme={buttonReaderRevenue}>
-                                <LinkButton
-                                    href={subscriptionUrlWithTracking}
-                                    onClick={onSubscribeClick}
-                                >
-                                    {content?.cta || 'Subscribe'}
-                                </LinkButton>
-                            </ThemeProvider>
-                            <ThemeProvider theme={buttonBrand}>
-                                <Button
-                                    cssOverrides={notNowButton}
-                                    priority="subdued"
-                                    data-link-name={notNowComponentId}
-                                    onClick={onNotNowClick}
-                                >
-                                    Not now
-                                </Button>
-                            </ThemeProvider>
-                            <div css={siteMessage}>
-                                Already a subscriber?{' '}
-                                <ThemeProvider theme={linkBrand}>
-                                    <Link
-                                        data-link-name={signInComponentId}
-                                        onClick={onSignInClick}
-                                        subdued
-                                    >
-                                        Sign in
-                                    </Link>{' '}
-                                </ThemeProvider>
-                                to not see this again
-                            </div>
-                        </div>
-                        <div css={bottomRightComponent}>
-                            <div css={packShotContainer}>
-                                <div css={packShot}>
-                                    <ResponsiveImage
-                                        images={[mobileImg, baseImg]}
-                                        baseImage={baseImg}
-                                    />
+                    <Container>
+                        <Columns cssOverrides={columns} collapseBelow="tablet">
+                            <Column cssOverrides={topLeftComponent} width={7 / 12}>
+                                <h3 css={heading}>
+                                    {replaceArticleCount(
+                                        cleanHeadingText || '',
+                                        numArticles,
+                                        'banner',
+                                    )}
+                                </h3>
+                                <p css={messageText}>
+                                    {replaceArticleCount(
+                                        cleanMessageText || '',
+                                        numArticles,
+                                        'banner',
+                                    )}
+                                </p>
+                                <Inline space={3}>
+                                    <ThemeProvider theme={buttonReaderRevenue}>
+                                        <LinkButton
+                                            href={subscriptionUrlWithTracking}
+                                            onClick={onSubscribeClick}
+                                        >
+                                            {content?.cta || 'Subscribe'}
+                                        </LinkButton>
+                                    </ThemeProvider>
+                                    <ThemeProvider theme={buttonBrand}>
+                                        <Button
+                                            // cssOverrides={notNowButton}
+                                            priority="subdued"
+                                            data-link-name={notNowComponentId}
+                                            onClick={onNotNowClick}
+                                        >
+                                            Not now
+                                        </Button>
+                                    </ThemeProvider>
+                                </Inline>
+                                <div css={siteMessage}>
+                                    Already a subscriber?{' '}
+                                    <ThemeProvider theme={linkBrand}>
+                                        <Link
+                                            data-link-name={signInComponentId}
+                                            onClick={onSignInClick}
+                                            subdued
+                                        >
+                                            Sign in
+                                        </Link>{' '}
+                                    </ThemeProvider>
+                                    to not see this again
                                 </div>
-                            </div>
-                            <div css={iconPanel}>
-                                <ThemeProvider theme={buttonBrand}>
-                                    <Button
-                                        size="small"
-                                        cssOverrides={closeButton}
-                                        priority="tertiary"
-                                        onClick={onCloseClick}
-                                        data-link-name={closeComponentId}
-                                        icon={<SvgCross />}
-                                        hideLabel
-                                    >
-                                        Close
-                                    </Button>
-                                </ThemeProvider>
-                                <div css={logoContainer}>
-                                    <SvgGuardianLogo />
+                            </Column>
+                            <Column cssOverrides={bottomRightComponent}>
+                                <div css={packShotContainer}>
+                                    <div css={packShot}>
+                                        <ResponsiveImage
+                                            images={[mobileImg, baseImg]}
+                                            baseImage={baseImg}
+                                        />
+                                    </div>
                                 </div>
-                            </div>
-                        </div>
-                    </div>
+                            </Column>
+                            <Column width={1 / 12} cssOverrides={closeButtonContainer}>
+                                <div css={iconPanel}>
+                                    <ThemeProvider theme={buttonBrand}>
+                                        <Button
+                                            size="small"
+                                            cssOverrides={closeButton}
+                                            priority="tertiary"
+                                            onClick={onCloseClick}
+                                            data-link-name={closeComponentId}
+                                            icon={<SvgCross />}
+                                            hideLabel
+                                        >
+                                            Close
+                                        </Button>
+                                    </ThemeProvider>
+                                    <div css={logoContainer}>
+                                        <SvgGuardianLogo />
+                                    </div>
+                                </div>
+                            </Column>
+                        </Columns>
+                    </Container>
                 </section>
             ) : null}
         </>

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -26,6 +26,7 @@ import {
     closeButton,
     closeButtonContainer,
 } from './digitalSubscriptionsBannerStyles';
+import { useEscapeShortcut } from '../../../hooks/useEscapeShortcut';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setChannelClosedTimestamp } from '../localStorage';
 import { ResponsiveImage } from '../../../ResponsiveImage';
@@ -112,8 +113,7 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
         window.location.href = signInUrl;
     };
 
-    const onCloseClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
-        evt.preventDefault();
+    const onCloseClick = (): void => {
         const componentClickEvent = createClickEventFromTracking(tracking, closeComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
@@ -122,8 +122,7 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
         setChannelClosedTimestamp(bannerChannel);
     };
 
-    const onNotNowClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
-        evt.preventDefault();
+    const onNotNowClick = (): void => {
         const componentClickEvent = createClickEventFromTracking(tracking, notNowComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
@@ -131,6 +130,8 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
         setShowBanner(false);
         setChannelClosedTimestamp(bannerChannel);
     };
+
+    useEscapeShortcut(onCloseClick, []);
 
     return (
         <>
@@ -164,7 +165,6 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                     </ThemeProvider>
                                     <ThemeProvider theme={buttonBrand}>
                                         <Button
-                                            // cssOverrides={notNowButton}
                                             priority="subdued"
                                             data-link-name={notNowComponentId}
                                             onClick={onNotNowClick}

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -68,6 +68,8 @@ const getBaseImg = (countryCode: string | undefined): Img => ({
 const fallbackHeading = 'Start a digital subscription today';
 const fallbackMessageText =
     'Millions have turned to the Guardian for vital, independent journalism in the last year. Reader funding powers our reporting. It protects our independence and ensures we can remain open for all. With <strong>a digital subscription starting from £5.99 a month</strong>, you can enjoy the richest, ad-free Guardian experience via our award-winning apps.';
+const fallbackCta = 'Subscribe';
+const fallbackSecondaryCta = 'Not now';
 
 export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
     bannerChannel,
@@ -157,7 +159,7 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                             href={subscriptionUrlWithTracking}
                                             onClick={onSubscribeClick}
                                         >
-                                            {content?.cta || 'Subscribe'}
+                                            {content?.cta?.text || fallbackCta}
                                         </LinkButton>
                                     </ThemeProvider>
                                     <ThemeProvider theme={buttonBrand}>
@@ -167,7 +169,7 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                             data-link-name={notNowComponentId}
                                             onClick={onNotNowClick}
                                         >
-                                            Not now
+                                            {content?.secondaryCta?.text || fallbackSecondaryCta}
                                         </Button>
                                     </ThemeProvider>
                                 </Inline>

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -5,6 +5,9 @@ import {
     createClickEventFromTracking,
 } from '../../../../lib/tracking';
 import React, { useState } from 'react';
+import { ThemeProvider } from 'emotion-theming';
+import { Button, LinkButton, buttonBrand, buttonReaderRevenue } from '@guardian/src-button';
+import { Link, linkBrand } from '@guardian/src-link';
 import { SvgGuardianLogo } from '@guardian/src-brand';
 import { SvgCross } from '@guardian/src-icons';
 import {
@@ -13,20 +16,14 @@ import {
     topLeftComponent,
     heading,
     messageText,
-    buttonTextDesktop,
-    buttonTextTablet,
-    buttonTextMobile,
     siteMessage,
     bottomRightComponent,
     packShot,
     iconPanel,
-    closeButton,
     logoContainer,
-    notNowButton,
-    becomeASubscriberButton,
-    linkStyle,
-    signInLink,
     packShotContainer,
+    closeButton,
+    notNowButton,
 } from './digitalSubscriptionsBannerStyles';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setChannelClosedTimestamp } from '../localStorage';
@@ -83,6 +80,11 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
 
     const mobileImg = getMobileImg(countryCode);
     const baseImg = getBaseImg(countryCode);
+    const subscriptionUrlWithTracking = addRegionIdAndTrackingParamsToSupportUrl(
+        subscriptionUrl,
+        tracking,
+        countryCode,
+    );
 
     const cleanHeadingText = containsNonArticleCountPlaceholder(content?.heading || '')
         ? fallbackHeading
@@ -94,16 +96,10 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
 
     const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
         evt.preventDefault();
-        const subscriptionUrlWithTracking = addRegionIdAndTrackingParamsToSupportUrl(
-            subscriptionUrl,
-            tracking,
-            countryCode,
-        );
         const componentClickEvent = createClickEventFromTracking(tracking, ctaComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
         }
-        window.location.href = subscriptionUrlWithTracking;
     };
 
     const onSignInClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
@@ -147,29 +143,35 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                             <p css={messageText}>
                                 {replaceArticleCount(cleanMessageText || '', numArticles, 'banner')}
                             </p>
-                            <a css={linkStyle} onClick={onSubscribeClick}>
-                                <div data-link-name={ctaComponentId} css={becomeASubscriberButton}>
-                                    <span css={buttonTextDesktop}>Become a digital subscriber</span>
-                                    <span css={buttonTextTablet}>Become a subscriber</span>
-                                    <span css={buttonTextMobile}>Subscribe now</span>
-                                </div>
-                            </a>
-                            <button
-                                css={notNowButton}
-                                data-link-name={notNowComponentId}
-                                onClick={onNotNowClick}
-                            >
-                                Not now
-                            </button>
+                            <ThemeProvider theme={buttonReaderRevenue}>
+                                <LinkButton
+                                    href={subscriptionUrlWithTracking}
+                                    onClick={onSubscribeClick}
+                                >
+                                    {content?.cta || 'Subscribe'}
+                                </LinkButton>
+                            </ThemeProvider>
+                            <ThemeProvider theme={buttonBrand}>
+                                <Button
+                                    cssOverrides={notNowButton}
+                                    priority="subdued"
+                                    data-link-name={notNowComponentId}
+                                    onClick={onNotNowClick}
+                                >
+                                    Not now
+                                </Button>
+                            </ThemeProvider>
                             <div css={siteMessage}>
                                 Already a subscriber?{' '}
-                                <a
-                                    css={signInLink}
-                                    data-link-name={signInComponentId}
-                                    onClick={onSignInClick}
-                                >
-                                    Sign in
-                                </a>{' '}
+                                <ThemeProvider theme={linkBrand}>
+                                    <Link
+                                        data-link-name={signInComponentId}
+                                        onClick={onSignInClick}
+                                        subdued
+                                    >
+                                        Sign in
+                                    </Link>{' '}
+                                </ThemeProvider>
                                 to not see this again
                             </div>
                         </div>
@@ -183,14 +185,19 @@ export const DigitalSubscriptionsBanner: React.FC<BannerProps> = ({
                                 </div>
                             </div>
                             <div css={iconPanel}>
-                                <button
-                                    onClick={onCloseClick}
-                                    css={closeButton}
-                                    data-link-name={closeComponentId}
-                                    aria-label="Close"
-                                >
-                                    <SvgCross />
-                                </button>
+                                <ThemeProvider theme={buttonBrand}>
+                                    <Button
+                                        size="small"
+                                        cssOverrides={closeButton}
+                                        priority="tertiary"
+                                        onClick={onCloseClick}
+                                        data-link-name={closeComponentId}
+                                        icon={<SvgCross />}
+                                        hideLabel
+                                    >
+                                        Close
+                                    </Button>
+                                </ThemeProvider>
                                 <div css={logoContainer}>
                                     <SvgGuardianLogo />
                                 </div>

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -1,11 +1,11 @@
 import { css } from '@emotion/core';
 import { body, headline, textSans } from '@guardian/src-foundations/typography/cjs';
-import { neutral, text } from '@guardian/src-foundations/palette';
+import { neutral } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
 const mainBannerBackground = '#005689';
-const closeButtonWidthHeight = 35;
+const closeButtonWidthHeight = 40;
 
 // Phablet and lower
 const mobilePackShotWidth = 400;
@@ -34,38 +34,23 @@ export const banner = css`
     color: ${neutral[100]};
 `;
 
-export const contentContainer = css`
-    display: flex;
-    flex-direction: column;
+export const columns = css`
     position: relative;
-    margin: 0 auto;
-    width: 100%;
-    max-width: 980px;
-
-    ${from.tablet} {
-        flex-direction: row;
-    }
-    ${from.leftCol} {
-        max-width: 1140px;
-    }
-    ${from.wide} {
-        max-width: 1300px;
-    }
 `;
 
 export const topLeftComponent = css`
     flex-grow: 1;
-    padding: ${space[4]}px;
+    padding: ${space[4]}px 0;
     ${until.tablet} {
         padding-bottom: 0;
     }
     ${from.tablet} {
         max-width: 60%;
-        padding-right: 0;
     }
-    ${from.leftCol} {
-        padding-left: 0;
-    }
+`;
+
+export const bottomRightComponent = css`
+    margin-bottom: 0;
 `;
 
 export const heading = css`
@@ -111,50 +96,6 @@ export const messageText = css`
     ${from.desktop} {
         font-size: 20px;
         margin: ${space[3]}px 0 ${space[9]}px;
-        max-width: 44rem;
-    }
-
-    ${from.leftCol} {
-        max-width: 39rem;
-    }
-
-    ${from.wide} {
-        max-width: 44rem;
-    }
-`;
-
-export const linkStyle = css`
-    text-decoration: none;
-    :visited {
-        color: ${text.primary};
-    }
-`;
-
-export const notNowButton = css`
-    margin-left: ${space[3]}px;
-`;
-
-export const buttonTextDesktop = css`
-    display: none;
-    ${from.desktop} {
-        display: block;
-    }
-`;
-
-export const buttonTextTablet = css`
-    display: none;
-    ${from.tablet} {
-        display: block;
-    }
-    ${from.desktop} {
-        display: none;
-    }
-`;
-
-export const buttonTextMobile = css`
-    display: block;
-    ${from.tablet} {
-        display: none;
     }
 `;
 
@@ -169,44 +110,16 @@ export const siteMessage = css`
     }
 `;
 
-export const bottomRightComponent = css`
-    display: flex;
-    justify-content: center;
-    flex-grow: 2;
-
-    ${from.tablet} {
-        align-self: flex-end;
-        min-width: 45%;
-        margin-top: -220px;
-        padding-right: ${space[4]}px;
-    }
-
-    ${from.desktop} {
-        height: 100%;
-        justify-content: flex-end;
-        margin-top: 0;
-    }
-
-    ${from.leftCol} {
-        padding-right: 0;
-        justify-content: space-between;
-    }
-`;
-
 export const packShotContainer = css`
     flex: 1;
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
-    margin: 0 ${space[4]}px;
     max-width: ${mobilePackShotWidth}px;
+    height: 100%;
 
     ${from.tablet} {
         max-width: ${packShotWidth}px;
-    }
-
-    ${from.wide} {
-        margin-top: ${space[4]}px;
     }
 `;
 
@@ -218,6 +131,7 @@ export const packShot = css`
     padding-bottom: ${(mobilePackShotHeight / mobilePackShotWidth) * mobileImageWidthPercentage}%;
     width: ${mobileImageWidthPercentage}%;
     margin: 0 auto;
+    height: 100%;
 
     ${from.tablet} {
         padding-bottom: ${(packShotHeight / packShotWidth) * imageWidthPercentage}%;
@@ -268,7 +182,14 @@ export const logoContainer = css`
 export const closeButton = css`
     ${until.desktop} {
         position: absolute;
-        top: 10px;
-        right: 10px;
+        top: ${space[4]}px;
+        right: 0;
+    }
+`;
+
+export const closeButtonContainer = css`
+    ${until.desktop} {
+        width: 0;
+        margin: 0;
     }
 `;

--- a/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
+++ b/src/components/modules/banners/digitalSubscriptions/digitalSubscriptionsBannerStyles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/core';
 import { body, headline, textSans } from '@guardian/src-foundations/typography/cjs';
-import { neutral, brandAlt, text } from '@guardian/src-foundations/palette';
+import { neutral, text } from '@guardian/src-foundations/palette';
 import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
@@ -130,29 +130,8 @@ export const linkStyle = css`
     }
 `;
 
-export const becomeASubscriberButton = css`
-    cursor: pointer;
-    display: inline-block;
-    border-radius: 1.875rem;
-    background-color: ${brandAlt[400]};
-    padding: ${space[2]}px ${space[6]}px;
-    color: ${text.primary};
-    ${textSans.medium()};
-    font-weight: bold;
-`;
-
 export const notNowButton = css`
-    ${textSans.medium()};
     margin-left: ${space[3]}px;
-    font-weight: bold;
-    color: ${text.ctaPrimary};
-    border: 0;
-    border-radius: 0.25rem;
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    outline: inherit;
 `;
 
 export const buttonTextDesktop = css`
@@ -287,35 +266,9 @@ export const logoContainer = css`
 `;
 
 export const closeButton = css`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-    border: 1px solid ${neutral[100]};
-    border-radius: 50%;
-    outline: none;
-    background: transparent;
-    cursor: pointer;
-    width: ${closeButtonWidthHeight};
-    height: ${closeButtonWidthHeight};
-    svg {
-        width: 25px;
-        height: 25px;
-        fill: ${neutral[100]};
-        transition: background-color 0.5s ease;
-        border-radius: 50%;
-    }
-    :hover {
-        cursor: pointer;
-        background-color: rgba(237, 237, 237, 0.5);
-    }
     ${until.desktop} {
         position: absolute;
         top: 10px;
         right: 10px;
     }
-`;
-
-export const signInLink = css`
-    cursor: pointer;
 `;

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -7,20 +7,15 @@ import { SvgRoundel } from '@guardian/src-brand';
 import { SvgCross } from '@guardian/src-icons';
 import {
     banner,
-    contentContainer,
+    columns,
     topLeftComponent,
     heading,
-    iconAndCloseAlign,
     iconAndClosePosition,
     logoContainer,
     paragraph,
     siteMessage,
     bottomRightComponent,
     packShotContainer,
-    packShotTablet,
-    packShotMobileAndDesktop,
-    linkStyle,
-    signInLink,
 } from './guardianWeeklyBannerStyles';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setChannelClosedTimestamp } from '../localStorage';
@@ -28,6 +23,7 @@ import {
     addRegionIdAndTrackingParamsToSupportUrl,
     createClickEventFromTracking,
 } from '../../../../lib/tracking';
+import { ResponsiveImage } from '../../../ResponsiveImage';
 
 const subscriptionUrl = 'https://support.theguardian.com/subscribe/weekly';
 const signInUrl =
@@ -43,6 +39,28 @@ const mobileAndDesktopImg =
 
 const tabletImage =
     'https://i.guim.co.uk/img/media/a213adf3f68f788b3f9434a1e88787fce1fa10bd/322_0_2430_1632/500.png?quality=85&s=70749c1c97ffaac614c1e357d3e7f616';
+
+// Responsive image props
+const baseImg = {
+    url: mobileAndDesktopImg,
+    media: '(min-width: 980px)',
+    alt: 'The Guardian Weekly magazine',
+};
+
+const images = [
+    {
+        url: mobileAndDesktopImg,
+        media: '(max-width: 739px)',
+    },
+    {
+        url: tabletImage,
+        media: '(min-width: 740px) and (max-width: 979px)',
+    },
+    baseImg,
+];
+
+const defaultCta = 'Subscribe';
+const defaultSecondaryCta = 'Not now';
 
 type ButtonPropTypes = {
     onClick: (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
@@ -89,8 +107,7 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
         }
     };
 
-    const onCloseClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
-        evt.preventDefault();
+    const onCloseClick = (): void => {
         const componentClickEvent = createClickEventFromTracking(tracking, closeComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
@@ -99,8 +116,7 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
         setChannelClosedTimestamp(bannerChannel);
     };
 
-    const onNotNowClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
-        evt.preventDefault();
+    const onNotNowClick = (): void => {
         const componentClickEvent = createClickEventFromTracking(tracking, notNowComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
@@ -113,20 +129,19 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
         <>
             {showBanner ? (
                 <section css={banner} data-target={bannerId}>
-                    <Container css={contentContainer}>
-                        <Columns collapseBelow="tablet">
-                            <Column width={6 / 12} css={topLeftComponent}>
+                    <Container>
+                        <Columns cssOverrides={columns} collapseBelow="tablet">
+                            <Column width={5 / 12} css={topLeftComponent}>
                                 <h3 css={heading}>{content?.heading}</h3>
                                 <p css={paragraph}>{content?.messageText}</p>
-                                <Inline space={1}>
+                                <Inline space={3}>
                                     <ThemeProvider theme={buttonReaderRevenue}>
                                         <LinkButton
                                             data-link-name={ctaComponentId}
-                                            css={linkStyle}
                                             onClick={onSubscribeClick}
                                             href={subscriptionUrlWithTracking}
                                         >
-                                            {content?.cta?.text || 'Subscribe'}
+                                            {content?.cta?.text || defaultCta}
                                         </LinkButton>
                                     </ThemeProvider>
                                     <Button
@@ -134,17 +149,15 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                                         data-link-name={notNowComponentId}
                                         onClick={onNotNowClick}
                                     >
-                                        Not now
+                                        {content?.secondaryCta?.text || defaultSecondaryCta}
                                     </Button>
                                 </Inline>
                                 <div css={siteMessage}>
                                     Already a subscriber?{' '}
                                     <Link
-                                        css={signInLink}
                                         data-link-name={signInComponentId}
                                         onClick={onSignInClick}
                                         href={signInUrl}
-                                        priority="secondary"
                                         subdued
                                     >
                                         Sign in
@@ -152,26 +165,19 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
                                     to not see this again
                                 </div>
                             </Column>
-                            <Column width={5 / 12} css={bottomRightComponent}>
+                            <Column cssOverrides={bottomRightComponent}>
                                 <div css={packShotContainer}>
-                                    <img css={packShotTablet} src={tabletImage} alt="" />
-                                    <img
-                                        css={packShotMobileAndDesktop}
-                                        src={mobileAndDesktopImg}
-                                        alt=""
-                                    />
+                                    <ResponsiveImage images={images} baseImage={baseImg} />
                                 </div>
                             </Column>
-                            <Column width={1 / 12}>
-                                <div css={iconAndClosePosition}>
-                                    <div css={iconAndCloseAlign}>
-                                        <div css={logoContainer}>
-                                            <SvgRoundel />
-                                        </div>
-                                        <CloseButton onClick={onCloseClick} />
+                            <div css={iconAndClosePosition}>
+                                <Inline space={1}>
+                                    <div css={logoContainer}>
+                                        <SvgRoundel />
                                     </div>
-                                </div>
-                            </Column>
+                                    <CloseButton onClick={onCloseClick} />
+                                </Inline>
+                            </div>
                         </Columns>
                     </Container>
                 </section>

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -1,4 +1,8 @@
 import React, { useState, ReactElement } from 'react';
+import { ThemeProvider } from 'emotion-theming';
+import { Container, Columns, Column, Inline } from '@guardian/src-layout';
+import { Button, LinkButton, buttonReaderRevenue } from '@guardian/src-button';
+import { Link } from '@guardian/src-link';
 import { SvgRoundel } from '@guardian/src-brand';
 import { SvgCross } from '@guardian/src-icons';
 import {
@@ -9,17 +13,12 @@ import {
     iconAndCloseAlign,
     iconAndClosePosition,
     logoContainer,
-    closeButton,
     paragraph,
-    buttonTextDesktop,
-    buttonTextMobileTablet,
     siteMessage,
     bottomRightComponent,
     packShotContainer,
     packShotTablet,
     packShotMobileAndDesktop,
-    notNowButton,
-    becomeASubscriberButton,
     linkStyle,
     signInLink,
 } from './guardianWeeklyBannerStyles';
@@ -50,14 +49,16 @@ type ButtonPropTypes = {
 };
 
 const CloseButton = (props: ButtonPropTypes): ReactElement => (
-    <button
+    <Button
         data-link-name={closeComponentId}
-        css={closeButton}
         onClick={props.onClick}
-        aria-label="Close"
+        icon={<SvgCross />}
+        size="small"
+        priority="tertiary"
+        hideLabel
     >
-        <SvgCross />
-    </button>
+        Close
+    </Button>
 );
 
 export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
@@ -68,28 +69,24 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
     countryCode,
 }: BannerProps) => {
     const [showBanner, setShowBanner] = useState(true);
+    const subscriptionUrlWithTracking = addRegionIdAndTrackingParamsToSupportUrl(
+        content?.cta?.baseUrl || subscriptionUrl,
+        tracking,
+        countryCode,
+    );
 
-    const onSubscribeClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
-        evt.preventDefault();
-        const subscriptionUrlWithTracking = addRegionIdAndTrackingParamsToSupportUrl(
-            subscriptionUrl,
-            tracking,
-            countryCode,
-        );
+    const onSubscribeClick = (): void => {
         const componentClickEvent = createClickEventFromTracking(tracking, ctaComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
         }
-        window.location.href = subscriptionUrlWithTracking;
     };
 
-    const onSignInClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
-        evt.preventDefault();
+    const onSignInClick = (): void => {
         const componentClickEvent = createClickEventFromTracking(tracking, signInComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);
         }
-        window.location.href = signInUrl;
     };
 
     const onCloseClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
@@ -116,60 +113,67 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
         <>
             {showBanner ? (
                 <section css={banner} data-target={bannerId}>
-                    <div css={contentContainer}>
-                        <div css={iconAndClosePosition}>
-                            <div css={iconAndCloseAlign}>
-                                <div css={logoContainer}>
-                                    <SvgRoundel />
+                    <Container css={contentContainer}>
+                        <Columns collapseBelow="tablet">
+                            <Column width={6 / 12} css={topLeftComponent}>
+                                <h3 css={heading}>{content?.heading}</h3>
+                                <p css={paragraph}>{content?.messageText}</p>
+                                <Inline space={1}>
+                                    <ThemeProvider theme={buttonReaderRevenue}>
+                                        <LinkButton
+                                            data-link-name={ctaComponentId}
+                                            css={linkStyle}
+                                            onClick={onSubscribeClick}
+                                            href={subscriptionUrlWithTracking}
+                                        >
+                                            {content?.cta?.text || 'Subscribe'}
+                                        </LinkButton>
+                                    </ThemeProvider>
+                                    <Button
+                                        priority="subdued"
+                                        data-link-name={notNowComponentId}
+                                        onClick={onNotNowClick}
+                                    >
+                                        Not now
+                                    </Button>
+                                </Inline>
+                                <div css={siteMessage}>
+                                    Already a subscriber?{' '}
+                                    <Link
+                                        css={signInLink}
+                                        data-link-name={signInComponentId}
+                                        onClick={onSignInClick}
+                                        href={signInUrl}
+                                        priority="secondary"
+                                        subdued
+                                    >
+                                        Sign in
+                                    </Link>{' '}
+                                    to not see this again
                                 </div>
-                                <CloseButton onClick={onCloseClick} />
-                            </div>
-                        </div>
-                        <div css={topLeftComponent}>
-                            <h3 css={heading}>{content?.heading}</h3>
-                            <p css={paragraph}>{content?.messageText}</p>
-                            <a
-                                data-link-name={ctaComponentId}
-                                css={linkStyle}
-                                onClick={onSubscribeClick}
-                            >
-                                <div css={becomeASubscriberButton}>
-                                    <span css={buttonTextDesktop}>
-                                        Become a Guardian Weekly subscriber
-                                    </span>
-                                    <span css={buttonTextMobileTablet}>Subscribe now</span>
+                            </Column>
+                            <Column width={5 / 12} css={bottomRightComponent}>
+                                <div css={packShotContainer}>
+                                    <img css={packShotTablet} src={tabletImage} alt="" />
+                                    <img
+                                        css={packShotMobileAndDesktop}
+                                        src={mobileAndDesktopImg}
+                                        alt=""
+                                    />
                                 </div>
-                            </a>
-                            <button
-                                data-link-name={notNowComponentId}
-                                css={notNowButton}
-                                onClick={onNotNowClick}
-                            >
-                                Not now
-                            </button>
-                            <div css={siteMessage}>
-                                Already a subscriber?{' '}
-                                <a
-                                    css={signInLink}
-                                    data-link-name={signInComponentId}
-                                    onClick={onSignInClick}
-                                >
-                                    Sign in
-                                </a>{' '}
-                                to not see this again
-                            </div>
-                        </div>
-                        <div css={bottomRightComponent}>
-                            <div css={packShotContainer}>
-                                <img css={packShotTablet} src={tabletImage} alt="" />
-                                <img
-                                    css={packShotMobileAndDesktop}
-                                    src={mobileAndDesktopImg}
-                                    alt=""
-                                />
-                            </div>
-                        </div>
-                    </div>
+                            </Column>
+                            <Column width={1 / 12}>
+                                <div css={iconAndClosePosition}>
+                                    <div css={iconAndCloseAlign}>
+                                        <div css={logoContainer}>
+                                            <SvgRoundel />
+                                        </div>
+                                        <CloseButton onClick={onCloseClick} />
+                                    </div>
+                                </div>
+                            </Column>
+                        </Columns>
+                    </Container>
                 </section>
             ) : null}
         </>

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -17,6 +17,7 @@ import {
     bottomRightComponent,
     packShotContainer,
 } from './guardianWeeklyBannerStyles';
+import { useEscapeShortcut } from '../../../hooks/useEscapeShortcut';
 import { BannerProps } from '../../../../types/BannerTypes';
 import { setChannelClosedTimestamp } from '../localStorage';
 import {
@@ -124,6 +125,8 @@ export const GuardianWeeklyBanner: React.FC<BannerProps> = ({
         setShowBanner(false);
         setChannelClosedTimestamp(bannerChannel);
     };
+
+    useEscapeShortcut(onCloseClick, []);
 
     return (
         <>

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -1,11 +1,11 @@
 import { css } from '@emotion/core';
 import { body, headline, textSans } from '@guardian/src-foundations/typography/cjs';
-import { neutral, text, brandAlt } from '@guardian/src-foundations/palette';
-import { from } from '@guardian/src-foundations/mq';
+import { neutral, text } from '@guardian/src-foundations/palette';
+import { between, from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
+import { height } from '@guardian/src-foundations/size';
 
 const mainBannerBackground = '#66c2e9';
-const closeButtonWidthHeight = 35;
 
 export const banner = css`
     html {
@@ -22,48 +22,28 @@ export const banner = css`
     width: 100%;
     background-color: ${mainBannerBackground};
     color: ${neutral[7]};
+    position: relative;
+
+    a,
+    button {
+        color: inherit;
+    }
 `;
 
-export const contentContainer = css`
-    display: flex;
-    flex-direction: column;
+export const columns = css`
     position: relative;
-    margin: 0 auto;
-    width: 100%;
-    max-width: 980px;
 
-    ${from.tablet} {
-        flex-direction: row;
-    }
-    ${from.leftCol} {
-        max-width: 1140px;
-    }
-    ${from.wide} {
-        max-width: 1300px;
+    ${between.tablet.and.desktop} {
+        position: static;
     }
 `;
 
 export const topLeftComponent = css`
-    width: 100%;
-    padding: ${space[2]}px ${space[3]}px 0 ${space[3]}px;
-    display: relative;
+    padding-top: ${space[2]}px;
 
-    button {
-        margin-left: ${space[3]}px;
-    }
-    ${from.tablet} {
-        padding: ${space[2]}px ${space[4]}px 0 ${space[4]}px;
-        width: 50%;
-    }
-    ${from.desktop} {
-        width: 43%;
-    }
-    ${from.leftCol} {
-        width: 47%;
-    }
-
-    @media screen and (min-width: 1400px) {
-        padding-left: 0;
+    ${between.tablet.and.desktop} {
+        /* TODO: When we upgrade Source we can ditch this in favour of the responsive column width prop */
+        width: calc((100% + 20px) * 0.4 - 20px);
     }
 `;
 
@@ -90,7 +70,7 @@ export const heading = css`
     }
 
     ${from.leftCol} {
-        max-width: 80%;
+        max-width: 90%;
     }
 `;
 
@@ -100,66 +80,9 @@ export const paragraph = css`
     margin: ${space[2]}px 0 ${space[6]}px;
     max-width: 100%;
 
-    ${from.mobileLandscape} {
-        max-width: 80%;
-    }
-
-    ${from.tablet} {
-        max-width: 100%;
-    }
-
     ${from.desktop} {
         font-size: 20px;
     }
-
-    ${from.leftCol} {
-        max-width: 90%;
-    }
-`;
-
-export const buttonTextDesktop = css`
-    display: none;
-    ${from.leftCol} {
-        display: block;
-    }
-`;
-
-export const buttonTextMobileTablet = css`
-    display: block;
-    ${from.leftCol} {
-        display: none;
-    }
-`;
-
-export const linkStyle = css`
-    cursor: pointer;
-    text-decoration: none;
-    :visited {
-        color: ${text.primary};
-    }
-`;
-
-export const becomeASubscriberButton = css`
-    display: inline-block;
-    border-radius: 1.875rem;
-    background-color: ${brandAlt[400]};
-    padding: ${space[2]}px ${space[6]}px;
-    color: ${text.primary};
-    ${textSans.medium()};
-    font-weight: bold;
-`;
-
-export const notNowButton = css`
-    ${textSans.medium()};
-    font-weight: bold;
-    color: ${text.primary};
-    border: 0;
-    border-radius: 0.25rem;
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    outline: inherit;
 `;
 
 export const siteMessage = css`
@@ -174,32 +97,10 @@ export const siteMessage = css`
 `;
 
 export const bottomRightComponent = css`
-    max-height: 215px;
-    overflow: hidden;
-    margin-top: -25px;
-    ${from.mobileMedium} {
-        max-height: 280px;
-        margin-top: -15px;
-    }
-    ${from.tablet} {
-        display: flex;
-        align-items: flex-end;
-        margin-top: 0;
-        max-width: 60%;
-        max-height: 100%;
-    }
-    ${from.desktop} {
-        align-items: center;
-        max-width: 60%;
-        margin-top: 0;
-        max-height: 100%;
-    }
-    ${from.leftCol} {
-        padding-right: 0;
-    }
-    ${from.wide} {
-        width: 45%;
-    }
+    margin-bottom: 0;
+    display: flex;
+    justify-content: flex-end;
+    align-items: flex-end;
 `;
 
 export const packShotContainer = css`
@@ -207,109 +108,70 @@ export const packShotContainer = css`
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
+    align-items: flex-end;
     margin: 0;
-    max-width: 100%;
+    padding-top: ${space[2]}px;
+    min-height: 170px;
+    height: 100%;
+    width: 100%;
+
+    ${between.tablet.and.desktop} {
+        position: static;
+    }
 
     ${from.desktop} {
         flex-direction: row;
         align-self: flex-end;
+        padding-top: ${height.ctaSmall + space[1]}px;
     }
 
     ${from.wide} {
-        margin-top: ${space[4]}px;
-    }
-`;
-
-export const packShotMobileAndDesktop = css`
-    display: block;
-    width: 90%;
-    margin: 0 auto;
-
-    img {
-        position: absolute;
-        bottom: 0;
-        max-width: 100%;
-        max-height: 100%;
+        padding-top: ${space[4]}px;
     }
 
-    ${from.mobileMedium} {
-        width: 95%;
-        margin-top: ${space[2]}px;
-    }
-
-    ${from.phablet} {
-        width: 90%;
-        margin-top: ${space[4]}px;
-    }
-
-    ${from.tablet} {
-        display: none;
-    }
-
-    ${from.desktop} {
-        display: block;
-        width: 93%;
-    }
-
-    ${from.leftCol} {
-        width: 110%;
-        margin: 0;
-    }
-
-    ${from.leftCol} {
+    picture {
+        display: flex;
         width: 100%;
-        margin: 0;
-    }
-`;
-
-export const packShotTablet = css`
-    display: none;
-
-    ${from.tablet} {
-        display: block;
-        width: 100%;
-        margin: 0;
+        height: 100%;
+        justify-content: flex-end;
+        align-items: flex-end;
+        ${between.tablet.and.desktop} {
+            position: absolute;
+            right: 0;
+            bottom: 0;
+        }
     }
 
     img {
-        position: absolute;
-        bottom: 0;
-        right: 0;
         max-width: 100%;
-        max-height: 100%;
-    }
-
-    ${from.desktop} {
-        display: none;
+        height: 100%;
     }
 `;
 
 export const iconAndClosePosition = css`
-    display: block;
-    position: absolute;
-    top: 10px;
-    right: 10px;
-
-    ${from.leftCol} {
-        right: ${space[4]}px;
-    }
-
-    @media screen and (min-width: 1400px) {
-        right: 0;
-    }
-`;
-
-export const iconAndCloseAlign = css`
-    display: inline-flex;
+    display: flex;
     justify-content: flex-end;
+    padding-top: ${space[2]}px;
+    min-width: ${height.ctaMedium * 2}px;
+
+    ${until.leftCol} {
+        position: absolute;
+        top: 0;
+        right: 0;
+        margin: 0;
+    }
+
+    ${between.tablet.and.desktop} {
+        padding-right: ${space[2]}px;
+    }
 `;
 
 export const logoContainer = css`
     display: none;
     ${from.mobileMedium} {
         display: block;
-        width: ${closeButtonWidthHeight}px;
-        height: ${closeButtonWidthHeight}px;
+        width: ${height.ctaSmall}px;
+        height: ${height.ctaSmall}px;
         svg {
             width: 100%;
         }
@@ -317,37 +179,4 @@ export const logoContainer = css`
     ${from.leftCol} {
         margin-left: ${space[3]}px;
     }
-`;
-
-export const closeButton = css`
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-    border: 1px solid ${text.primary};
-    border-radius: 50%;
-    outline: none;
-    background: transparent;
-    cursor: pointer;
-    width: ${closeButtonWidthHeight}px;
-    height: ${closeButtonWidthHeight}px;
-    svg {
-        width: 25px;
-        height: 25px;
-        fill: ${text.primary};
-        transition: background-color 0.5s ease;
-        border-radius: 50%;
-    }
-    :hover {
-        cursor: pointer;
-        background-color: rgba(237, 237, 237, 0.5);
-    }
-    margin-left: ${space[1]}px;
-    ${from.mobileLandscape} {
-        margin-left: ${space[2]}px;
-    }
-`;
-
-export const signInLink = css`
-    cursor: pointer;
 `;

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -50,18 +50,16 @@ export const topLeftComponent = css`
 export const heading = css`
     ${headline.xsmall({ fontWeight: 'bold' })};
     margin: 0;
-    max-width: 80%;
+    /* Headline should never overflow the close button (plus logo) */
+    max-width: calc(100% - ${height.ctaSmall + space[1]}px);
 
-    ${from.mobileLandscape} {
-        max-width: 70%;
+    ${from.mobileMedium} {
+        ${headline.small({ fontWeight: 'bold' })};
+        max-width: calc(100% - ${height.ctaSmall * 2 + space[2]}px);
     }
 
     ${from.phablet} {
         max-width: 100%;
-    }
-
-    ${from.mobileMedium} {
-        ${headline.small({ fontWeight: 'bold' })};
     }
 
     ${from.desktop} {
@@ -70,7 +68,7 @@ export const heading = css`
     }
 
     ${from.leftCol} {
-        max-width: 90%;
+        max-width: 80%;
     }
 `;
 


### PR DESCRIPTION
## What does this change?
This overhauls the digital subscription and Guardian Weekly banners to make better use of Source components. It also switches to using props provided from the banner tooling for the CTA text and links, and adds the ability to dismiss the banner using the escape key in the same manner as the puzzles banner.

## How to test
This branch is currently on CODE.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
