### PR TITLE
Reduce CLS caused by the G200 banner

### DIFF
--- a/src/components/modules/banners/g200/components/G200BannerImage.tsx
+++ b/src/components/modules/banners/g200/components/G200BannerImage.tsx
@@ -3,14 +3,24 @@ import { css } from '@emotion/core';
 import { from } from '@guardian/src-foundations/mq';
 
 const containerStyles = css`
-    img {
-        display: block;
-        width: 100%;
-        object-fit: cover;
+    position: relative;
+    height: 0;
+    overflow: hidden;
+    padding-bottom: 38.83%;
 
-        ${from.tablet} {
-            margin-bottom: 0;
-        }
+    ${from.tablet} {
+        padding-bottom: 79.5%;
+    }
+
+    img {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        object-fit: cover;
     }
 `;
 


### PR DESCRIPTION
## What does this change?
Reduce CLS caused by the G200 banner. The issue is that the images don't have specified width and height, meaning the browser can't allocate space for the image before it's loaded leading to large layout shift when it pops in (especially on mobile, where the design also suffers without the image). 

Unfortunately, as we're using a `picture` element to switch select a different image for mobile (both of which have different aspect ratios) we can't just set the `width` and `height` attributes on the image tag. We could use two separate image tags, and hide/show them at different breakpoints, but that means a users browser will download both images, even if only one is required (maybe we think this is actually the best solution?). 

I've tried to maintain the `picture` element, and used a bit of a css hack to [set the aspect ratio of the container](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/#:~:text=working%20around%20the%20problem). This seems to have removed the layout shift. However, I think it may now look bad on browsers that don't support the `picture` element. They will fall back to the mobile image, but with the desktop aspect ratio. I will try and test on browserstack to see how the banner looks in ie11.

## Images

<img width="385" alt="Screenshot 2021-05-07 at 12 45 54" src="https://user-images.githubusercontent.com/17720442/117445287-6bfe8500-af32-11eb-8cfe-531188b0c0b4.png">
<img width="994" alt="Screenshot 2021-05-07 at 12 46 07" src="https://user-images.githubusercontent.com/17720442/117445359-7c166480-af32-11eb-976f-4e55c70920c9.png">
