### PR TITLE
Fix contributions banner secondary CTA

### DIFF
--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -3,11 +3,13 @@ import contributionsBannerWrapper, { ContributionsBannerProps } from './Contribu
 import { Container, Columns, Column } from '@guardian/src-layout';
 import { commonStyles } from './ContributionsBannerCommonStyles';
 import { css } from '@emotion/core';
+import { space } from '@guardian/src-foundations';
 import { between, from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
 import { brandAlt, neutral } from '@guardian/src-foundations';
 import { ContributionsBannerMobile } from './ContributionsBannerMobile';
 import { ContributionsBannerCta } from './ContributionsBannerCta';
+import { ContributionsBannerSecondaryCta } from './ContributionsBannerSecondaryCta';
 import { ContributionsBannerCloseButton } from './ContributionsBannerCloseButton';
 
 const styles = {
@@ -51,16 +53,17 @@ const styles = {
     buttonsContainer: css`
         display: flex;
         flex-direction: column;
+        align-items: flex-end;
         height: 100%;
         box-sizing: border-box;
         padding-top: 8px;
         padding-bottom: 16px;
     `,
-    ctaContainer: css`
-        display: flex;
-        justify-content: flex-end;
+    ctasContainer: css`
+        & > * + * {
+            margin-top: ${space[3]}px;
+        }
     `,
-
     tabletAndDesktop: css`
         display: none;
         ${between.tablet.and.leftCol} {
@@ -117,26 +120,25 @@ const ContributionsBanner: React.FC<ContributionsBannerProps> = ({
     const buttons = (
         <div css={styles.buttonsContainer}>
             <ContributionsBannerCloseButton onCloseClick={onCloseClick} />
-            {content.primaryCta && (
-                <div css={styles.ctaContainer}>
+
+            <div css={styles.ctasContainer}>
+                {content.primaryCta && (
                     <ContributionsBannerCta
                         onContributeClick={onContributeClick}
                         ctaText={content.primaryCta.ctaText}
                         ctaUrl={content.primaryCta.ctaUrl}
                         stacked={true}
                     />
-                </div>
-            )}
-            {content.secondaryCta && (
-                <div css={styles.ctaContainer}>
-                    <ContributionsBannerCta
-                        onContributeClick={onSecondaryCtaClick}
+                )}
+
+                {content.secondaryCta && (
+                    <ContributionsBannerSecondaryCta
+                        onCtaClick={onSecondaryCtaClick}
                         ctaText={content.secondaryCta.ctaText}
                         ctaUrl={content.secondaryCta.ctaUrl}
-                        stacked={true}
                     />
-                </div>
-            )}
+                )}
+            </div>
         </div>
     );
 
@@ -145,6 +147,7 @@ const ContributionsBanner: React.FC<ContributionsBannerProps> = ({
             <ContributionsBannerMobile
                 onCloseClick={onCloseClick}
                 onContributeClick={onContributeClick}
+                onSecondaryCtaClick={onSecondaryCtaClick}
                 content={mobileContent || content}
             />
 

--- a/src/components/modules/banners/contributions/ContributionsBannerCta.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerCta.tsx
@@ -11,15 +11,6 @@ const styles = {
     ctaButton: (stacked: boolean): SerializedStyles => css`
         ${stacked ? 'margin-bottom: 0.5rem' : 'margin-right: 14px'};
     `,
-    cta: (stacked: boolean): SerializedStyles => css`
-        display: flex;
-        flex-direction: ${stacked ? 'column' : 'row'};
-        align-items: ${stacked ? 'flex-start' : 'center'};
-        ${from.tablet} {
-            width: auto;
-            justify-content: flex-start;
-        }
-    `,
     paymentMethods: css`
         display: block;
         max-height: 1.25rem;
@@ -44,7 +35,7 @@ export const ContributionsBannerCta: React.FC<ContributionsBannerCtaProps> = ({
     stacked,
 }: ContributionsBannerCtaProps) => {
     return (
-        <div css={styles.cta(stacked)}>
+        <div>
             <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
                 <LinkButton
                     data-link-name="contributions-banner : cta"

--- a/src/components/modules/banners/contributions/ContributionsBannerMobile.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerMobile.tsx
@@ -3,8 +3,10 @@ import { commonStyles } from './ContributionsBannerCommonStyles';
 import { css } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 import { ContributionsBannerCta } from './ContributionsBannerCta';
+import { ContributionsBannerSecondaryCta } from './ContributionsBannerSecondaryCta';
 import { ContributionsBannerCloseButton } from './ContributionsBannerCloseButton';
 import { ContributionsBannerRenderedContent } from './ContributionsBannerWrapper';
 
@@ -14,6 +16,7 @@ const styles = {
             display: none;
         }
         margin: 0 12px;
+        padding-bottom: 20px;
     `,
     heading: css`
         ${headline.xsmall({ fontWeight: 'bold' })};
@@ -22,12 +25,16 @@ const styles = {
     copy: css`
         margin-top: 2px;
     `,
+    ctasContainer: css`
+        & > * + * {
+            margin-top: ${space[3]}px;
+        }
+    `,
     ctaContainer: css`
         > :first-child {
             margin-right: 5px;
         }
         margin-top: 20px;
-        padding-bottom: 20px;
     `,
     headingContainer: css`
         display: flex;
@@ -39,12 +46,14 @@ const styles = {
 
 interface ContributionsBannerMobileProps {
     onContributeClick: () => void;
+    onSecondaryCtaClick: () => void;
     onCloseClick: () => void;
     content: ContributionsBannerRenderedContent;
 }
 
 export const ContributionsBannerMobile: React.FC<ContributionsBannerMobileProps> = ({
     onContributeClick,
+    onSecondaryCtaClick,
     onCloseClick,
     content,
 }: ContributionsBannerMobileProps) => {
@@ -64,13 +73,25 @@ export const ContributionsBannerMobile: React.FC<ContributionsBannerMobileProps>
                 )}
             </div>
 
-            <div css={styles.ctaContainer}>
-                <ContributionsBannerCta
-                    onContributeClick={onContributeClick}
-                    ctaText={content.primaryCta?.ctaText || ''}
-                    ctaUrl={content.primaryCta?.ctaUrl || ''}
-                    stacked={true}
-                />
+            <div css={styles.ctasContainer}>
+                {content.primaryCta && (
+                    <div css={styles.ctaContainer}>
+                        <ContributionsBannerCta
+                            onContributeClick={onContributeClick}
+                            ctaText={content.primaryCta.ctaText}
+                            ctaUrl={content.primaryCta.ctaUrl}
+                            stacked={true}
+                        />
+                    </div>
+                )}
+
+                {content.secondaryCta && (
+                    <ContributionsBannerSecondaryCta
+                        onCtaClick={onSecondaryCtaClick}
+                        ctaText={content.secondaryCta.ctaText}
+                        ctaUrl={content.secondaryCta.ctaUrl}
+                    />
+                )}
             </div>
         </div>
     );

--- a/src/components/modules/banners/contributions/ContributionsBannerSecondaryCta.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerSecondaryCta.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ThemeProvider } from 'emotion-theming';
+import { buttonReaderRevenueBrandAlt } from '@guardian/src-button';
+import { LinkButton } from '@guardian/src-button';
+import { SvgArrowRightStraight } from '@guardian/src-icons';
+
+interface ContributionsBannerSecondaryCtaProps {
+    onCtaClick: () => void;
+    ctaText: string;
+    ctaUrl: string;
+}
+
+export const ContributionsBannerSecondaryCta: React.FC<ContributionsBannerSecondaryCtaProps> = ({
+    onCtaClick,
+    ctaText,
+    ctaUrl,
+}: ContributionsBannerSecondaryCtaProps) => {
+    return (
+        <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
+            <LinkButton
+                priority="tertiary"
+                size="small"
+                icon={<SvgArrowRightStraight />}
+                iconSide="right"
+                nudgeIcon={true}
+                onClick={onCtaClick}
+                href={ctaUrl}
+            >
+                {ctaText}
+            </LinkButton>
+        </ThemeProvider>
+    );
+};

--- a/src/components/modules/banners/utils/storybook.ts
+++ b/src/components/modules/banners/utils/storybook.ts
@@ -23,6 +23,10 @@ export const content: BannerContent = {
         baseUrl: 'https://support.theguardian.com/contribute',
         text: 'Support The Guardian',
     },
+    secondaryCta: {
+        baseUrl: 'https://support.theguardian.com/contribute',
+        text: 'Learn more',
+    },
 };
 
 export const tickerSettings = {


### PR DESCRIPTION
## What does this change?
Fix contributions banner secondary CTA. At the moment it shows a second primary CTA (payment icons included!) which doesn't look great. It's worth noting though that since the new banner design was rolled out, we haven't actually had a banner with a secondary CTA. 

This PR adds a new `ContributionsBannerSecondaryCta` component.

## Images
**mobile**
<img width="384" alt="Screenshot 2021-05-07 at 15 43 32" src="https://user-images.githubusercontent.com/17720442/117467168-5a75a700-af4b-11eb-9f7f-1a89d376a3e5.png">

**wide**
<img width="1308" alt="Screenshot 2021-05-07 at 15 43 54" src="https://user-images.githubusercontent.com/17720442/117467178-5cd80100-af4b-11eb-805b-b830d1544715.png">