### PR TITLE
Fx sign in problem in puzzles banner

### DIFF
--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.tsx
@@ -130,8 +130,7 @@ export const PuzzlesBanner: React.FC<PuzzlesBannerProps> = ({ tracking, submitCo
         onMinimiseClick(stateChange);
     }
 
-    const onSignInClick = (evt: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
-        evt.preventDefault();
+    const onSignInClick = (): void => {
         const componentClickEvent = createClickEventFromTracking(tracking, signInComponentId);
         if (submitComponentEvent) {
             submitComponentEvent(componentClickEvent);


### PR DESCRIPTION
## What does this change?
This removes the `event.preventDefault()` call from the puzzles banner sign-in handler, so the sign-in will work correctly.

This is a fix for a bug arising from changes in https://github.com/guardian/support-dotcom-components/pull/439

## How can we measure success?
Users can click the sin in link on the puzzles banner and will be taken through to the sign-in page.
