### PR TITLE
Reminders in contribs banner

### DIFF
--- a/src/api/supportRemindersApi.ts
+++ b/src/api/supportRemindersApi.ts
@@ -1,10 +1,10 @@
 import { isProd } from '../lib/env';
 
-type ReminderPlatform = 'WEB' | 'AMP';
+export type ReminderPlatform = 'WEB' | 'AMP';
 
-type ReminderComponent = 'EPIC' | 'BANNER';
+export type ReminderComponent = 'EPIC' | 'BANNER';
 
-type ReminderStage = 'PRE' | 'POST';
+export type ReminderStage = 'PRE' | 'POST';
 
 interface BaseSignupRequest {
     email: string;

--- a/src/components/hooks/useContributionsReminderEmailForm.ts
+++ b/src/components/hooks/useContributionsReminderEmailForm.ts
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { isValidEmail } from '../modules/utils/reminders';
+
+type SubmitHandler = (e: React.FormEvent<HTMLFormElement>) => void;
+
+interface ContributionsReminderEmailForm {
+    email: string;
+    inputError?: string;
+    updateEmail: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    handleSubmit: (onSubmit: () => void) => SubmitHandler;
+}
+
+export function useContributionsReminderEmailForm(): ContributionsReminderEmailForm {
+    const [isDirty, setIsDirty] = useState(false);
+    const [email, setEmail] = useState('');
+
+    const updateEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setEmail(e.target.value);
+        if (isDirty) {
+            setIsDirty(false);
+        }
+    };
+
+    const isEmpty = email.trim().length === 0;
+    const isValid = isValidEmail(email);
+
+    let inputError;
+    if (isDirty && isEmpty) {
+        inputError = 'Please enter your email address';
+    } else if (isDirty && !isValid) {
+        inputError = 'Please enter a valid email address';
+    }
+
+    const handleSubmit = (onSubmit: () => void) => {
+        const handler = (e: React.FormEvent<HTMLFormElement>) => {
+            e.preventDefault();
+            if (isValid) {
+                onSubmit();
+            } else {
+                setIsDirty(true);
+            }
+        };
+        return handler;
+    };
+
+    return { email, inputError, updateEmail, handleSubmit };
+}

--- a/src/components/hooks/useContributionsReminderSignup.ts
+++ b/src/components/hooks/useContributionsReminderSignup.ts
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { addContributionReminderCookie, ReminderStatus } from '../modules/utils/reminders';
+import {
+    OneOffSignupRequest,
+    ReminderPlatform,
+    ReminderComponent,
+    ReminderStage,
+} from '../../api/supportRemindersApi';
+
+const CREATE_ONE_OFF_REMINDER_ENDPOINT = 'https://support.theguardian.com/reminders/create/one-off';
+
+interface ContributionsReminderSignup {
+    reminderStatus: ReminderStatus;
+    createReminder: (email: string) => void;
+}
+
+export function useContributionsReminderSignup(
+    reminderPeriod: string,
+    reminderPlatform: ReminderPlatform,
+    reminderComponent: ReminderComponent,
+    reminderStage: ReminderStage,
+): ContributionsReminderSignup {
+    const [reminderStatus, setReminderStatus] = useState<ReminderStatus>(ReminderStatus.Editing);
+
+    const createReminder = (email: string): void => {
+        const reminderSignupData: OneOffSignupRequest = {
+            email,
+            reminderPeriod,
+            reminderPlatform,
+            reminderComponent,
+            reminderStage,
+        };
+
+        setReminderStatus(ReminderStatus.Submitting);
+        fetch(CREATE_ONE_OFF_REMINDER_ENDPOINT, {
+            body: JSON.stringify(reminderSignupData),
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        })
+            .then(response => {
+                if (!response.ok) {
+                    setReminderStatus(ReminderStatus.Error);
+                } else {
+                    setReminderStatus(ReminderStatus.Completed);
+                    addContributionReminderCookie(reminderPeriod);
+                }
+            })
+            .catch(() => setReminderStatus(ReminderStatus.Error));
+    };
+
+    return { reminderStatus, createReminder };
+}

--- a/src/components/modules/banners/common/getComponentIds.ts
+++ b/src/components/modules/banners/common/getComponentIds.ts
@@ -6,6 +6,9 @@ export interface ComponentIds {
     secondaryCta: string;
     notNow: string;
     signIn: string;
+    reminderCta: string;
+    reminderSet: string;
+    reminderClose: string;
 }
 
 export function getComponentIds(bannerId: BannerId): ComponentIds {
@@ -15,5 +18,8 @@ export function getComponentIds(bannerId: BannerId): ComponentIds {
         secondaryCta: `${bannerId} : secondary-cta`,
         notNow: `${bannerId} : not now`,
         signIn: `${bannerId} : sign in`,
+        reminderCta: `${bannerId} : reminder-cta`,
+        reminderSet: `${bannerId} : reminder-set`,
+        reminderClose: `${bannerId} : reminder-close`,
     };
 }

--- a/src/components/modules/banners/common/types.tsx
+++ b/src/components/modules/banners/common/types.tsx
@@ -1,3 +1,6 @@
+import { ReminderFields } from '../../../../lib/reminderFields';
+import { SecondaryCtaType } from '../../../../types/shared';
+
 export type BannerId =
     | 'contributions-banner'
     | 'g200-banner'
@@ -9,12 +12,30 @@ export interface BannerEnrichedCta {
     ctaText: string;
 }
 
+export interface BannerEnrichedCustomCta {
+    type: SecondaryCtaType.Custom;
+    cta: BannerEnrichedCta;
+}
+
+export interface BannerEnrichedReminderCta {
+    type: SecondaryCtaType.ContributionsReminder;
+    reminderFields: ReminderFields;
+}
+
+export type BannerEnrichedSecondaryCta = BannerEnrichedCustomCta | BannerEnrichedReminderCta;
+
+export interface ContributionsReminderTracking {
+    onReminderCtaClick: () => void;
+    onReminderSetClick: () => void;
+    onReminderCloseClick: () => void;
+}
+
 export interface BannerRenderedContent {
     heading: JSX.Element | JSX.Element[] | null;
     messageText: JSX.Element | JSX.Element[];
     highlightedText?: JSX.Element[] | null;
     primaryCta: BannerEnrichedCta | null;
-    secondaryCta: BannerEnrichedCta | null;
+    secondaryCta: BannerEnrichedSecondaryCta | null;
 }
 
 export interface BannerTextContent {
@@ -28,6 +49,8 @@ export interface BannerRenderProps {
     onNotNowClick: () => void;
     onCloseClick: () => void;
     onSignInClick?: () => void;
+    reminderTracking: ContributionsReminderTracking;
     content: BannerTextContent;
     countryCode?: string;
+    email?: string;
 }

--- a/src/components/modules/banners/contributions/ContributionsBanner.stories.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { ContributionsBannerUnvalidated as ContributionsBanner } from './ContributionsBanner';
-import { props } from '../utils/storybook';
+import { props, content } from '../utils/storybook';
 import { BannerProps } from '../../../../types/BannerTypes';
+import { SecondaryCtaType } from '../../../../types/shared';
 
 export default {
     component: ContributionsBanner,
@@ -13,3 +14,19 @@ export default {
 const Template: Story<BannerProps> = (props: BannerProps) => <ContributionsBanner {...props} />;
 
 export const Default = Template.bind({});
+
+export const WithReminder = Template.bind({});
+WithReminder.args = {
+    content: {
+        ...content,
+        secondaryCta: {
+            type: SecondaryCtaType.ContributionsReminder,
+        },
+    },
+};
+
+export const WithPrefilledReminder = Template.bind({});
+WithPrefilledReminder.args = {
+    ...WithReminder.args,
+    email: 'test@guardian.co.uk',
+};

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BannerRenderProps } from '../common/types';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
-import { Container, Columns, Column } from '@guardian/src-layout';
+import { Container, Columns, Column, Hide } from '@guardian/src-layout';
 import { commonStyles } from './ContributionsBannerCommonStyles';
 import { css } from '@emotion/react';
 import { between, from } from '@guardian/src-foundations/mq';
@@ -12,17 +12,17 @@ import { ContributionsBannerCta } from './ContributionsBannerCta';
 import { ContributionsBannerSecondaryCta } from './ContributionsBannerSecondaryCta';
 import { ContributionsBannerCloseButton } from './ContributionsBannerCloseButton';
 import { BannerText } from '../common/BannerText';
+import { ContributionsBannerReminder } from './ContributionsBannerReminder';
+import { SecondaryCtaType } from '../../../../types/shared';
 
 const styles = {
     bannerContainer: css`
         overflow: hidden;
         width: 100%;
         background-color: ${brandAlt[400]};
-        border-top: 1px solid ${neutral[7]};
-    `,
-    columnsContainer: css`
-        ${between.tablet.and.leftCol} {
-            border-left: 1px solid ${neutral[7]};
+        ${from.tablet} {
+            border-top: 1px solid ${neutral[7]};
+            padding-bottom: 0;
         }
     `,
     heading: css`
@@ -38,6 +38,10 @@ const styles = {
     `,
     bodyAndHeading: css`
         position: relative; // for positioning the opt-out popup
+
+        ${from.tablet} {
+            padding-bottom: ${space[5]}px;
+        }
         ${from.leftCol} {
             margin-left: -9px;
             border-left: 1px solid ${neutral[7]};
@@ -55,7 +59,6 @@ const styles = {
     buttonsContainer: css`
         display: flex;
         flex-direction: column;
-        align-items: flex-end;
         height: 100%;
         box-sizing: border-box;
         padding-top: 8px;
@@ -64,6 +67,84 @@ const styles = {
     ctasContainer: css`
         & > * + * {
             margin-top: ${space[3]}px;
+            `,
+    reminderContainer: css`
+        position: relative;
+        margin-top: ${space[2]}px;
+
+        ${from.tablet} {
+            margin-top: 0;
+        }
+    `,
+    reminderLine: css`
+        border-top: 1px solid black;
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
+
+        ${from.leftCol} {
+            left: calc(50% - 550px + 1120px * 0.14285714285714285 - 20px + 10px + 1px);
+        }
+
+        ${from.wide} {
+            left: calc(50% - 630px + 1280px * 0.1875 - 20px + 10px);
+        }
+
+        &:before {
+            content: '';
+            display: block;
+            position: absolute;
+            left: 90px;
+            bottom: 100%;
+            width: 0;
+            height: 0;
+            border: 10px solid transparent;
+            border-bottom-color: black;
+
+            ${from.tablet} {
+                left: calc(50% + 210px);
+            }
+
+            ${from.desktop} {
+                left: calc(50% + 253px);
+            }
+
+            ${from.leftCol} {
+                left: 732px;
+            }
+
+            ${from.wide} {
+                left: 733px;
+            }
+        }
+
+        &:after {
+            content: '';
+            display: block;
+            position: absolute;
+            left: 91px;
+            bottom: 100%;
+            width: 0;
+            height: 0;
+            border: 9px solid transparent;
+            border-bottom-color: ${brandAlt[400]};
+
+            ${from.tablet} {
+                left: calc(50% + 211px);
+            }
+
+            ${from.desktop} {
+                left: calc(50% + 254px);
+            }
+
+            ${from.leftCol} {
+                left: 733px;
+            }
+
+            ${from.wide} {
+                left: 734px;
+            }
         }
     `,
     tabletAndDesktop: css`
@@ -96,9 +177,23 @@ const columnCounts = {
 const ContributionsBanner: React.FC<BannerRenderProps> = ({
     onCtaClick,
     onSecondaryCtaClick,
+    reminderTracking,
     onCloseClick,
     content,
+    email,
 }: BannerRenderProps) => {
+    const [isReminderOpen, setIsReminderOpen] = useState(false);
+
+    const onReminderCtaClick = () => {
+        reminderTracking.onReminderCtaClick();
+        setIsReminderOpen(!isReminderOpen);
+    };
+
+    const onReminderCloseClick = () => {
+        reminderTracking.onReminderCloseClick();
+        setIsReminderOpen(false);
+    };
+
     const BodyAndHeading = () => (
         <BannerText
             styles={{
@@ -130,9 +225,9 @@ const ContributionsBanner: React.FC<BannerRenderProps> = ({
 
                 {content.mainContent.secondaryCta && (
                     <ContributionsBannerSecondaryCta
-                        onCtaClick={onSecondaryCtaClick}
-                        ctaText={content.mainContent.secondaryCta.ctaText}
-                        ctaUrl={content.mainContent.secondaryCta.ctaUrl}
+                        secondaryCta={content.mainContent.secondaryCta}
+                        onReminderCtaClick={onReminderCtaClick}
+                        onCustomCtaClick={onSecondaryCtaClick}
                     />
                 )}
             </div>
@@ -146,9 +241,14 @@ const ContributionsBanner: React.FC<BannerRenderProps> = ({
                 onContributeClick={onCtaClick}
                 onSecondaryCtaClick={onSecondaryCtaClick}
                 content={content.mobileContent || content.mainContent}
+                onReminderCtaClick={onReminderCtaClick}
+                isReminderOpen={isReminderOpen}
+                onReminderCloseClick={onReminderCloseClick}
+                trackReminderSetClick={reminderTracking.onReminderSetClick}
+                email={email}
             />
 
-            <Container cssOverrides={styles.columnsContainer}>
+            <Container>
                 <div css={styles.tabletAndDesktop}>
                     <Columns>
                         <Column width={8 / columnCounts.tablet}>
@@ -177,6 +277,31 @@ const ContributionsBanner: React.FC<BannerRenderProps> = ({
                     </Columns>
                 </div>
             </Container>
+
+            <Hide below="tablet">
+                {isReminderOpen &&
+                    content.mainContent.secondaryCta?.type ===
+                        SecondaryCtaType.ContributionsReminder && (
+                        <div css={styles.reminderContainer}>
+                            <div css={styles.reminderLine} />
+
+                            <Container>
+                                <Columns>
+                                    <Column width={1}>
+                                        <ContributionsBannerReminder
+                                            reminderCta={content.mainContent.secondaryCta}
+                                            trackReminderSetClick={
+                                                reminderTracking.onReminderSetClick
+                                            }
+                                            onReminderCloseClick={onReminderCloseClick}
+                                            email={email}
+                                        />
+                                    </Column>
+                                </Columns>
+                            </Container>
+                        </div>
+                    )}
+            </Hide>
         </div>
     );
 };

--- a/src/components/modules/banners/contributions/ContributionsBannerMobile.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerMobile.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { commonStyles } from './ContributionsBannerCommonStyles';
 import { css } from '@emotion/react';
-import { neutral } from '@guardian/src-foundations';
+import { brandAlt, neutral } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
@@ -9,14 +9,20 @@ import { ContributionsBannerCta } from './ContributionsBannerCta';
 import { ContributionsBannerSecondaryCta } from './ContributionsBannerSecondaryCta';
 import { ContributionsBannerCloseButton } from './ContributionsBannerCloseButton';
 import { BannerRenderedContent } from '../common/types';
+import { ContributionsBannerReminder } from './ContributionsBannerReminder';
+import { SecondaryCtaType } from '../../../../types/shared';
 
 const styles = {
-    container: css`
+    container: (isReminderOpen: boolean) => css`
         ${from.tablet} {
             display: none;
         }
-        margin: 0 12px;
-        padding-bottom: 20px;
+        border-top: 1px solid ${neutral[7]};
+        max-height: ${isReminderOpen ? '100vh' : '80vh'};
+        box-sizing: border-box;
+        padding-bottom: ${space[5]}px;
+        overflow-y: auto;
+        overflow-x: hidden;
     `,
     heading: css`
         ${headline.xxsmall({ fontWeight: 'bold' })};
@@ -24,8 +30,11 @@ const styles = {
     `,
     copy: css`
         margin-top: 2px;
+        padding: 0 ${space[3]}px;
     `,
     ctasContainer: css`
+        padding: 0 ${space[3]}px;
+
         & > * + * {
             margin-top: ${space[3]}px;
         }
@@ -37,10 +46,57 @@ const styles = {
         margin-top: 20px;
     `,
     headingContainer: css`
+        position: sticky;
+        top: 0;
+        background-color: ${brandAlt[400]};
         display: flex;
         flex-direction: row;
         border-bottom: 1px solid ${neutral[7]};
-        padding: 6px 5px 10px 0;
+        padding: 6px 12px 10px 12px;
+    `,
+    reminderAndLineContainer: css`
+        position: relative;
+        margin-top: ${space[2]}px;
+    `,
+    reminderContainer: css`
+        padding: 0 ${space[3]}px;
+    `,
+    reminderLine: css`
+        border-top: 1px solid black;
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
+
+        &:before {
+            content: '';
+            display: block;
+            position: absolute;
+            left: 90px;
+            bottom: 100%;
+            width: 0;
+            height: 0;
+            border: 10px solid transparent;
+            border-bottom-color: black;
+        }
+
+        &:after {
+            content: '';
+            display: block;
+            position: absolute;
+            left: 91px;
+            bottom: 100%;
+            width: 0;
+            height: 0;
+            border: 9px solid transparent;
+            border-bottom-color: ${brandAlt[400]};
+        }
+    `,
+    hide: css`
+        display: none;
+    `,
+    show: css`
+        display: block;
     `,
 };
 
@@ -49,6 +105,11 @@ interface ContributionsBannerMobileProps {
     onSecondaryCtaClick: () => void;
     onCloseClick: () => void;
     content: BannerRenderedContent;
+    onReminderCtaClick: () => void;
+    onReminderCloseClick: () => void;
+    trackReminderSetClick: () => void;
+    isReminderOpen: boolean;
+    email?: string;
 }
 
 export const ContributionsBannerMobile: React.FC<ContributionsBannerMobileProps> = ({
@@ -56,9 +117,22 @@ export const ContributionsBannerMobile: React.FC<ContributionsBannerMobileProps>
     onSecondaryCtaClick,
     onCloseClick,
     content,
+    onReminderCtaClick,
+    isReminderOpen,
+    onReminderCloseClick,
+    trackReminderSetClick,
+    email,
 }: ContributionsBannerMobileProps) => {
+    const reminderRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (reminderRef.current && isReminderOpen) {
+            reminderRef.current.scrollIntoView({ behavior: 'smooth' });
+        }
+    }, [reminderRef.current, isReminderOpen]);
+
     return (
-        <div css={styles.container}>
+        <div css={styles.container(isReminderOpen)}>
             <div css={styles.headingContainer}>
                 <div css={styles.heading}>{content.heading}</div>
                 <ContributionsBannerCloseButton onCloseClick={onCloseClick} />
@@ -86,11 +160,30 @@ export const ContributionsBannerMobile: React.FC<ContributionsBannerMobileProps>
                 )}
 
                 {content.secondaryCta && (
-                    <ContributionsBannerSecondaryCta
-                        onCtaClick={onSecondaryCtaClick}
-                        ctaText={content.secondaryCta.ctaText}
-                        ctaUrl={content.secondaryCta.ctaUrl}
-                    />
+                    <div>
+                        <ContributionsBannerSecondaryCta
+                            secondaryCta={content.secondaryCta}
+                            onReminderCtaClick={onReminderCtaClick}
+                            onCustomCtaClick={onSecondaryCtaClick}
+                        />
+                    </div>
+                )}
+            </div>
+
+            <div ref={reminderRef} css={isReminderOpen ? styles.show : styles.hide}>
+                {content.secondaryCta?.type === SecondaryCtaType.ContributionsReminder && (
+                    <div css={styles.reminderAndLineContainer}>
+                        <div css={styles.reminderLine}></div>
+
+                        <div css={styles.reminderContainer}>
+                            <ContributionsBannerReminder
+                                reminderCta={content.secondaryCta}
+                                trackReminderSetClick={trackReminderSetClick}
+                                onReminderCloseClick={onReminderCloseClick}
+                                email={email}
+                            />
+                        </div>
+                    </div>
                 )}
             </div>
         </div>

--- a/src/components/modules/banners/contributions/ContributionsBannerReminder.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerReminder.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { BannerEnrichedReminderCta } from '../common/types';
+import { ContributionsBannerReminderSignedIn } from './ContributionsBannerReminderSignedIn';
+import { ContributionsBannerReminderSignedOut } from './ContributionsBannerReminderSignedOut';
+import { useContributionsReminderSignup } from '../../../hooks/useContributionsReminderSignup';
+
+export interface ContributionsBannerReminderProps {
+    reminderCta: BannerEnrichedReminderCta;
+    trackReminderSetClick: () => void;
+    onReminderCloseClick: () => void;
+    email?: string;
+}
+
+export const ContributionsBannerReminder: React.FC<ContributionsBannerReminderProps> = ({
+    reminderCta,
+    trackReminderSetClick,
+    onReminderCloseClick,
+    email,
+}) => {
+    const { reminderStatus, createReminder } = useContributionsReminderSignup(
+        reminderCta.reminderFields.reminderPeriod,
+        'WEB',
+        'BANNER',
+        'PRE',
+    );
+
+    const onReminderSetClick = (email: string) => {
+        trackReminderSetClick();
+        createReminder(email);
+    };
+
+    return (
+        <div>
+            {email ? (
+                <ContributionsBannerReminderSignedIn
+                    reminderCta={reminderCta}
+                    reminderStatus={reminderStatus}
+                    onReminderSetClick={() => onReminderSetClick(email)}
+                    onReminderCloseClick={onReminderCloseClick}
+                />
+            ) : (
+                <ContributionsBannerReminderSignedOut
+                    reminderCta={reminderCta}
+                    reminderStatus={reminderStatus}
+                    onReminderSetClick={onReminderSetClick}
+                />
+            )}
+        </div>
+    );
+};

--- a/src/components/modules/banners/contributions/ContributionsBannerReminderSignedIn.stories.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerReminderSignedIn.stories.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import {
+    ContributionsBannerReminderSignedIn,
+    ContributionsBannerReminderSignedInProps,
+} from './ContributionsBannerReminderSignedIn';
+import { css } from '@emotion/core';
+import { brandAlt } from '@guardian/src-foundations/palette';
+import { SecondaryCtaType } from '../../../../types/shared';
+import { ReminderStatus } from '../../utils/reminders';
+
+const containerStyles = css`
+    background-color: ${brandAlt[400]};
+`;
+
+const BannerDecorator = (Story: Story): JSX.Element => (
+    <div css={containerStyles}>
+        <Story />
+    </div>
+);
+
+export default {
+    component: ContributionsBannerReminderSignedIn,
+    title: 'Banners/ContributionsBannerReminderSignedIn',
+    args: {
+        reminderCta: {
+            type: SecondaryCtaType.ContributionsReminder,
+            reminderFields: {
+                reminderCta: 'Remind me in May',
+                reminderLabel: 'May 2021',
+                reminderPeriod: '2021-05-01',
+            },
+        },
+        reminderStatus: ReminderStatus.Editing,
+    },
+    decorators: [BannerDecorator],
+} as Meta;
+
+const Template: Story<ContributionsBannerReminderSignedInProps> = (
+    props: ContributionsBannerReminderSignedInProps,
+) => <ContributionsBannerReminderSignedIn {...props} />;
+
+export const Default = Template.bind({});
+
+export const Completed = Template.bind({});
+Completed.args = {
+    reminderStatus: ReminderStatus.Completed,
+};
+
+export const Submitting = Template.bind({});
+Submitting.args = {
+    reminderStatus: ReminderStatus.Submitting,
+};
+
+export const Error = Template.bind({});
+Error.args = {
+    reminderStatus: ReminderStatus.Error,
+};

--- a/src/components/modules/banners/contributions/ContributionsBannerReminderSignedIn.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerReminderSignedIn.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { css, ThemeProvider } from '@emotion/react';
+import { Button, buttonBrandAlt } from '@guardian/src-button';
+import { textSans } from '@guardian/src-foundations/typography';
+import { space } from '@guardian/src-foundations';
+import { neutral, error } from '@guardian/src-foundations/palette';
+import { Columns, Column, Hide } from '@guardian/src-layout';
+import { from } from '@guardian/src-foundations/mq';
+import { SvgCheckmark } from '@guardian/src-icons';
+import { BannerEnrichedReminderCta } from '../common/types';
+import { ReminderStatus } from '../../utils/reminders';
+
+const bodyContainerStyles = css`
+    padding: 10px 0;
+    box-sizing: border-box;
+
+    ${from.tablet} {
+        height: 100%;
+    }
+
+    ${from.leftCol} {
+        margin-left: -9px;
+        padding: 10px ${space[3]}px;
+        border-left: 1px solid black;
+    }
+
+    ${from.wide} {
+        margin-left: -10px;
+    }
+`;
+
+const ctaContainerStyles = css`
+    padding: 10px 0 0;
+
+    ${from.tablet} {
+        padding: 10px 0;
+    }
+`;
+
+const secondaryCtaContainerStyles = css`
+    margin-left: ${space[4]}px;
+`;
+
+const bodyCopyContainerStyles = css`
+    ${textSans.small({ fontWeight: 'bold' })}
+`;
+
+const errorCopyContainerStyles = css`
+    ${textSans.small({ fontWeight: 'bold' })};
+    color: ${error[400]};
+    font-style: italic;
+    margin-top: ${space[1]}px;
+    margin-bottom: 0;
+`;
+
+const infoCopyContainerStyles = css`
+    ${textSans.small({})}
+    font-size: 12px;
+
+    margin-top: ${space[3]}px;
+`;
+
+const thankyouHeaderStyles = css`
+    ${textSans.small({ fontWeight: 'bold' })}
+`;
+
+const thankyouBodyStyles = css`
+    ${textSans.small({})}
+`;
+
+const privacyLinkSyles = css`
+    font-weight: bold;
+    color: ${neutral[0]};
+`;
+
+const contactLinkStyles = css`
+    color: ${neutral[0]};
+`;
+
+export interface ContributionsBannerReminderSignedInProps {
+    reminderCta: BannerEnrichedReminderCta;
+    reminderStatus: ReminderStatus;
+    onReminderSetClick: () => void;
+    onReminderCloseClick: () => void;
+}
+
+export const ContributionsBannerReminderSignedIn: React.FC<ContributionsBannerReminderSignedInProps> = ({
+    reminderCta,
+    reminderStatus,
+    onReminderSetClick,
+    onReminderCloseClick,
+}) => {
+    const Body = () => (
+        <div css={bodyContainerStyles}>
+            {reminderStatus !== ReminderStatus.Completed && (
+                <>
+                    <div css={bodyCopyContainerStyles}>
+                        Show your support for the Guardian at a later date. To make this easier, set
+                        a reminder and we’ll email you in May.
+                    </div>
+
+                    {reminderStatus === ReminderStatus.Error && (
+                        <div css={errorCopyContainerStyles}>
+                            Sorry we couldn&apos;t set a reminder for you this time. Please try
+                            again later.
+                        </div>
+                    )}
+
+                    <div css={infoCopyContainerStyles}>
+                        We will send you a maximum of two emails in{' '}
+                        {reminderCta.reminderFields.reminderLabel}. To find out what personal data
+                        we collect and how we use it, view our{' '}
+                        <a
+                            css={privacyLinkSyles}
+                            href="https://www.theguardian.com/help/privacy-policy"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Privacy policy
+                        </a>
+                    </div>
+                </>
+            )}
+
+            {reminderStatus === ReminderStatus.Completed && (
+                <>
+                    <div css={thankyouHeaderStyles}>Thank you! Your reminder is set</div>
+
+                    <div css={thankyouBodyStyles}>
+                        We will be in touch to invite you to contribute. Look out for a messsage in
+                        your inbox in {reminderCta.reminderFields.reminderLabel}. If you have any
+                        questions about contributing, please{' '}
+                        <a
+                            href="mailto:contribution.support@theguardian.com"
+                            css={contactLinkStyles}
+                        >
+                            contact us
+                        </a>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+
+    const Ctas = () => (
+        <div css={ctaContainerStyles}>
+            <div>
+                <ThemeProvider theme={buttonBrandAlt}>
+                    <div>
+                        <Button
+                            onClick={onReminderSetClick}
+                            size="small"
+                            priority="tertiary"
+                            icon={<SvgCheckmark />}
+                            iconSide="right"
+                            disabled={reminderStatus === ReminderStatus.Submitting}
+                        >
+                            Set a reminder
+                        </Button>
+                    </div>
+
+                    <div css={secondaryCtaContainerStyles}>
+                        <Button onClick={onReminderCloseClick} priority="subdued">
+                            Not now
+                        </Button>
+                    </div>
+                </ThemeProvider>
+            </div>
+        </div>
+    );
+
+    return (
+        <>
+            <Hide above="tablet">
+                <Columns>
+                    <Column width={1}>
+                        <Body />
+                        {reminderStatus !== ReminderStatus.Completed && <Ctas />}
+                    </Column>
+                </Columns>
+            </Hide>
+
+            <Hide below="tablet">
+                <Hide above="leftCol">
+                    <Columns>
+                        <Column width={8 / 12}>
+                            <Body />
+                        </Column>
+                        <Column width={4 / 12}>
+                            {reminderStatus !== ReminderStatus.Completed && <Ctas />}
+                        </Column>
+                    </Columns>
+                </Hide>
+            </Hide>
+
+            <Hide below="leftCol">
+                <Hide above="wide">
+                    <Columns>
+                        <Column width={2 / 14}> </Column>
+                        <Column width={8 / 14}>
+                            <Body />
+                        </Column>
+                        <Column width={4 / 14}>
+                            {reminderStatus !== ReminderStatus.Completed && <Ctas />}
+                        </Column>
+                    </Columns>
+                </Hide>
+            </Hide>
+
+            <Hide below="wide">
+                <Columns>
+                    <Column width={3 / 16}> </Column>
+                    <Column width={8 / 16}>
+                        <Body />
+                    </Column>
+                    <Column width={4 / 16}>
+                        {reminderStatus !== ReminderStatus.Completed && <Ctas />}
+                    </Column>
+                    <Column width={1 / 16}> </Column>
+                </Columns>
+            </Hide>
+        </>
+    );
+};

--- a/src/components/modules/banners/contributions/ContributionsBannerReminderSignedOut.stories.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerReminderSignedOut.stories.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import {
+    ContributionsBannerReminderSignedOut,
+    ContributionsBannerReminderSignedOutProps,
+} from './ContributionsBannerReminderSignedOut';
+import { css } from '@emotion/core';
+import { brandAlt } from '@guardian/src-foundations/palette';
+import { SecondaryCtaType } from '../../../../types/shared';
+import { ReminderStatus } from '../../utils/reminders';
+
+const containerStyles = css`
+    background-color: ${brandAlt[400]};
+`;
+
+const BannerDecorator = (Story: Story): JSX.Element => (
+    <div css={containerStyles}>
+        <Story />
+    </div>
+);
+
+export default {
+    component: ContributionsBannerReminderSignedOut,
+    title: 'Banners/ContributionsBannerReminderSignedOut',
+    args: {
+        reminderCta: {
+            type: SecondaryCtaType.ContributionsReminder,
+            reminderFields: {
+                reminderCta: 'Remind me in May',
+                reminderLabel: 'May 2021',
+                reminderPeriod: '2021-05-01',
+            },
+        },
+        reminderStatus: ReminderStatus.Editing,
+    },
+    decorators: [BannerDecorator],
+} as Meta;
+
+const Template: Story<ContributionsBannerReminderSignedOutProps> = (
+    props: ContributionsBannerReminderSignedOutProps,
+) => <ContributionsBannerReminderSignedOut {...props} />;
+
+export const Default = Template.bind({});
+
+export const Completed = Template.bind({});
+Completed.args = {
+    reminderStatus: ReminderStatus.Completed,
+};
+
+export const Submitting = Template.bind({});
+Submitting.args = {
+    reminderStatus: ReminderStatus.Submitting,
+};
+
+export const Error = Template.bind({});
+Error.args = {
+    reminderStatus: ReminderStatus.Error,
+};

--- a/src/components/modules/banners/contributions/ContributionsBannerReminderSignedOut.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerReminderSignedOut.tsx
@@ -1,0 +1,331 @@
+import React from 'react';
+import { css, ThemeProvider } from '@emotion/react';
+import { Button, buttonBrandAlt } from '@guardian/src-button';
+import { textSans } from '@guardian/src-foundations/typography';
+import { space } from '@guardian/src-foundations';
+import { neutral, error } from '@guardian/src-foundations/palette';
+import { Columns, Column, Hide } from '@guardian/src-layout';
+import { from } from '@guardian/src-foundations/mq';
+import { TextInput } from '@guardian/src-text-input';
+import { SvgCheckmark } from '@guardian/src-icons';
+import { BannerEnrichedReminderCta } from '../common/types';
+import { ReminderStatus } from '../../utils/reminders';
+import { useContributionsReminderEmailForm } from '../../../hooks/useContributionsReminderEmailForm';
+
+const bodyContainerStyles = css`
+    padding: 10px 0;
+    box-sizing: border-box;
+
+    ${from.tablet} {
+        height: 100%;
+    }
+
+    ${from.leftCol} {
+        padding: 10px ${space[3]}px;
+        margin-left: -9px;
+        border-left: 1px solid black;
+    }
+
+    ${from.wide} {
+        margin-left: -10px;
+    }
+`;
+
+const bodyCopyContainerStyles = css`
+    ${textSans.small({ fontWeight: 'bold' })}
+`;
+
+const formContainerStyles = css`
+    display: flex;
+    flex-direction: column;
+
+    // hack to tweak source text input
+    > label {
+        div {
+            font-size: 15px !important;
+        }
+
+        input {
+            height: 36px;
+        }
+    }
+
+    & > * + * {
+        margin-top: ${space[3]}px;
+    }
+
+    ${from.tablet} {
+        flex-direction: row;
+        align-items: flex-end;
+
+        & > * + * {
+            margin-top: 0;
+            margin-left: ${space[5]}px;
+        }
+    }
+`;
+
+const emailInputStyles = css`
+    max-width: 300px;
+
+    ${from.tablet} {
+        width: 300px;
+    }
+`;
+
+const errorCopyContainerStyles = css`
+    ${textSans.small({ fontWeight: 'bold' })};
+    color: ${error[400]};
+    font-style: italic;
+    margin-top: ${space[1]}px;
+    margin-bottom: 0;
+`;
+
+const infoCopyContainerStyles = css`
+    ${textSans.small({})}
+    font-size: 12px;
+
+    margin-top: ${space[3]}px;
+`;
+
+const thankyouHeaderStyles = css`
+    ${textSans.small({ fontWeight: 'bold' })}
+`;
+
+const thankyouBodyStyles = css`
+    ${textSans.small({})}
+`;
+
+const privacyLinkSyles = css`
+    font-weight: bold;
+    color: ${neutral[0]};
+`;
+
+const contactLinkStyles = css`
+    color: ${neutral[0]};
+`;
+
+export interface ContributionsBannerReminderSignedOutProps {
+    reminderCta: BannerEnrichedReminderCta;
+    reminderStatus: ReminderStatus;
+    onReminderSetClick: (email: string) => void;
+}
+
+export const ContributionsBannerReminderSignedOut: React.FC<ContributionsBannerReminderSignedOutProps> = ({
+    reminderCta,
+    reminderStatus,
+    onReminderSetClick,
+}) => {
+    const { email, inputError, updateEmail, handleSubmit } = useContributionsReminderEmailForm();
+
+    return (
+        <>
+            <Hide above="tablet">
+                <Columns>
+                    <Column width={1}>
+                        {reminderStatus !== ReminderStatus.Completed && (
+                            <Body
+                                onSubmit={handleSubmit(() => onReminderSetClick(email))}
+                                email={email}
+                                updateEmail={updateEmail}
+                                inputError={inputError}
+                                reminderLabel={reminderCta.reminderFields.reminderLabel}
+                                reminderStatus={reminderStatus}
+                            />
+                        )}
+
+                        {reminderStatus === ReminderStatus.Completed && (
+                            <ThankYou reminderLabel={reminderCta.reminderFields.reminderLabel} />
+                        )}
+                    </Column>
+                </Columns>
+            </Hide>
+
+            <Hide below="tablet">
+                <Hide above="leftCol">
+                    <Columns>
+                        {reminderStatus !== ReminderStatus.Completed && (
+                            <Column width={1}>
+                                <Body
+                                    onSubmit={handleSubmit(() => onReminderSetClick(email))}
+                                    email={email}
+                                    updateEmail={updateEmail}
+                                    inputError={inputError}
+                                    reminderLabel={reminderCta.reminderFields.reminderLabel}
+                                    reminderStatus={reminderStatus}
+                                />
+                            </Column>
+                        )}
+
+                        {reminderStatus === ReminderStatus.Completed && (
+                            <>
+                                <Column width={9 / 16}>
+                                    <ThankYou
+                                        reminderLabel={reminderCta.reminderFields.reminderLabel}
+                                    />
+                                </Column>
+
+                                <Column width={4 / 16}> </Column>
+                            </>
+                        )}
+                    </Columns>
+                </Hide>
+            </Hide>
+
+            <Hide below="leftCol">
+                <Hide above="wide">
+                    <Columns>
+                        <Column width={2 / 14}> </Column>
+
+                        {reminderStatus !== ReminderStatus.Completed && (
+                            <>
+                                <Column width={10 / 14}>
+                                    <Body
+                                        onSubmit={handleSubmit(() => onReminderSetClick(email))}
+                                        email={email}
+                                        updateEmail={updateEmail}
+                                        inputError={inputError}
+                                        reminderLabel={reminderCta.reminderFields.reminderLabel}
+                                        reminderStatus={reminderStatus}
+                                    />
+                                </Column>
+
+                                <Column width={2 / 16}> </Column>
+                            </>
+                        )}
+
+                        {reminderStatus === ReminderStatus.Completed && (
+                            <>
+                                <Column width={9 / 14}>
+                                    <ThankYou
+                                        reminderLabel={reminderCta.reminderFields.reminderLabel}
+                                    />
+                                </Column>
+
+                                <Column width={3 / 14}> </Column>
+                            </>
+                        )}
+                    </Columns>
+                </Hide>
+            </Hide>
+
+            <Hide below="wide">
+                <Columns>
+                    <Column width={3 / 16}> </Column>
+
+                    {reminderStatus !== ReminderStatus.Completed && (
+                        <Column width={13 / 16}>
+                            <Body
+                                onSubmit={handleSubmit(() => onReminderSetClick(email))}
+                                email={email}
+                                updateEmail={updateEmail}
+                                inputError={inputError}
+                                reminderLabel={reminderCta.reminderFields.reminderLabel}
+                                reminderStatus={reminderStatus}
+                            />
+                        </Column>
+                    )}
+
+                    {reminderStatus === ReminderStatus.Completed && (
+                        <>
+                            <Column width={9 / 16}>
+                                <ThankYou
+                                    reminderLabel={reminderCta.reminderFields.reminderLabel}
+                                />
+                            </Column>
+
+                            <Column width={4 / 16}> </Column>
+                        </>
+                    )}
+                </Columns>
+            </Hide>
+        </>
+    );
+};
+
+interface BodyProps {
+    reminderLabel: string;
+    email: string;
+    updateEmail: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    inputError?: string;
+    onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+    reminderStatus: ReminderStatus;
+}
+
+function Body({
+    reminderLabel,
+    email,
+    updateEmail,
+    inputError,
+    onSubmit,
+    reminderStatus,
+}: BodyProps) {
+    return (
+        <div css={bodyContainerStyles}>
+            <div css={bodyCopyContainerStyles}>Remind me in {reminderLabel}</div>
+            <form onSubmit={onSubmit} css={formContainerStyles}>
+                <TextInput
+                    label="Email address"
+                    value={email}
+                    error={inputError}
+                    onChange={updateEmail}
+                    cssOverrides={emailInputStyles}
+                />
+
+                <div>
+                    <ThemeProvider theme={buttonBrandAlt}>
+                        <Button
+                            type="submit"
+                            size="small"
+                            icon={<SvgCheckmark />}
+                            iconSide="right"
+                            priority="tertiary"
+                            disabled={reminderStatus === ReminderStatus.Submitting}
+                        >
+                            Set a reminder
+                        </Button>
+                    </ThemeProvider>
+                </div>
+            </form>
+
+            {reminderStatus === ReminderStatus.Error && (
+                <div css={errorCopyContainerStyles}>
+                    Sorry we couldn&apos;t set a reminder for you this time. Please try again later.
+                </div>
+            )}
+
+            <div css={infoCopyContainerStyles}>
+                We will send you a maximum of two emails in {reminderLabel}. To find out what
+                personal data we collect and how we use it, view our{' '}
+                <a
+                    css={privacyLinkSyles}
+                    href="https://www.theguardian.com/help/privacy-policy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Privacy policy
+                </a>
+            </div>
+        </div>
+    );
+}
+
+interface ThankYouProps {
+    reminderLabel: string;
+}
+
+function ThankYou({ reminderLabel }: ThankYouProps) {
+    return (
+        <div css={bodyContainerStyles}>
+            <div css={thankyouHeaderStyles}>Thank you! Your reminder is set</div>
+
+            <div css={thankyouBodyStyles}>
+                We will be in touch to invite you to contribute. Look out for a messsage in your
+                inbox in {reminderLabel}. If you have any questions about contributing, please{' '}
+                <a href="mailto:contribution.support@theguardian.com" css={contactLinkStyles}>
+                    contact us
+                </a>
+            </div>
+        </div>
+    );
+}

--- a/src/components/modules/banners/contributions/ContributionsBannerSecondaryCta.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerSecondaryCta.tsx
@@ -1,33 +1,59 @@
 import React from 'react';
 import { ThemeProvider } from '@emotion/react';
+import { css } from '@emotion/core';
 import { buttonReaderRevenueBrandAlt } from '@guardian/src-button';
 import { LinkButton } from '@guardian/src-button';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
+import { space } from '@guardian/src-foundations';
+import { neutral } from '@guardian/src-foundations/palette';
+import { Button } from '@guardian/src-button';
+import { BannerEnrichedSecondaryCta } from '../common/types';
+import { SecondaryCtaType } from '../../../../types/shared';
+import { hasSetReminder } from '../../utils/reminders';
 
-interface ContributionsBannerSecondaryCtaProps {
-    onCtaClick: () => void;
-    ctaText: string;
-    ctaUrl: string;
+const reminderButtonStyles = css`
+    color: ${neutral[0]};
+    margin-left: ${space[4]}px;
+`;
+
+export interface ContributionsBannerSecondaryCtaProps {
+    secondaryCta: BannerEnrichedSecondaryCta;
+    onCustomCtaClick: () => void;
+    onReminderCtaClick: () => void;
 }
 
 export const ContributionsBannerSecondaryCta: React.FC<ContributionsBannerSecondaryCtaProps> = ({
-    onCtaClick,
-    ctaText,
-    ctaUrl,
-}: ContributionsBannerSecondaryCtaProps) => {
+    secondaryCta,
+    onCustomCtaClick,
+    onReminderCtaClick,
+}) => {
     return (
-        <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
-            <LinkButton
-                priority="tertiary"
-                size="small"
-                icon={<SvgArrowRightStraight />}
-                iconSide="right"
-                nudgeIcon={true}
-                onClick={onCtaClick}
-                href={ctaUrl}
-            >
-                {ctaText}
-            </LinkButton>
-        </ThemeProvider>
+        <>
+            {secondaryCta.type === SecondaryCtaType.Custom && (
+                <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
+                    <LinkButton
+                        priority="tertiary"
+                        size="small"
+                        icon={<SvgArrowRightStraight />}
+                        iconSide="right"
+                        nudgeIcon={true}
+                        onClick={onCustomCtaClick}
+                        href={secondaryCta.cta.ctaUrl}
+                    >
+                        {secondaryCta.cta.ctaText}
+                    </LinkButton>
+                </ThemeProvider>
+            )}
+
+            {secondaryCta?.type === SecondaryCtaType.ContributionsReminder && !hasSetReminder() && (
+                <Button
+                    cssOverrides={reminderButtonStyles}
+                    priority="subdued"
+                    onClick={onReminderCtaClick}
+                >
+                    {secondaryCta.reminderFields.reminderCta}
+                </Button>
+            )}
+        </>
     );
 };

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
@@ -3,6 +3,7 @@ import { DigitalSubscriptionsBanner } from './DigitalSubscriptionsBanner';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import { StorybookWrapper, BannerWrapper } from '../../../../utils/StorybookWrapper';
 import { BannerContent, BannerProps, BannerTracking } from '../../../../types/BannerTypes';
+import { SecondaryCtaType } from '../../../../types/shared';
 
 export default {
     component: DigitalSubscriptionsBanner,
@@ -42,8 +43,11 @@ export const defaultStory = (): ReactElement => {
             'Reader funding powers our reporting. It protects our independence and ensures we can remain open for all. With <strong>a digital subscription starting from £5.99 a month</strong>, you can enjoy the richest, ad-free Guardian experience via our award-winning apps.',
         ),
         secondaryCta: {
-            text: 'Hide this',
-            baseUrl: '',
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Hide this',
+                baseUrl: '',
+            },
         },
     };
 

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -29,6 +29,7 @@ import { BannerContentRenderer } from '../common/BannerContentRenderer';
 import { BannerRenderProps } from '../common/types';
 import { validatedBannerWrapper } from '../common/BannerWrapper';
 import { getComponentIds } from '../common/getComponentIds';
+import { SecondaryCtaType } from '../../../../types/shared';
 
 const signInUrl =
     'https://profile.theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs';
@@ -108,7 +109,9 @@ const DigitalSubscriptionsBanner: React.FC<BannerRenderProps> = ({
                                                 data-link-name={componentIds.notNow}
                                                 onClick={onNotNowClick}
                                             >
-                                                {secondaryCta?.ctaText || fallbackSecondaryCta}
+                                                {(secondaryCta?.type === SecondaryCtaType.Custom &&
+                                                    secondaryCta.cta.ctaText) ||
+                                                    fallbackSecondaryCta}
                                             </Button>
                                         </ThemeProvider>
                                     </Inline>

--- a/src/components/modules/banners/g200/G200Banner.stories.tsx
+++ b/src/components/modules/banners/g200/G200Banner.stories.tsx
@@ -3,6 +3,7 @@ import { Story, Meta } from '@storybook/react';
 import { G200BannerUnvalidated as G200Banner } from './G200Banner';
 import { props } from '../utils/storybook';
 import { BannerProps } from '../../../../types/BannerTypes';
+import { SecondaryCtaType } from '../../../../types/shared';
 
 export default {
     component: G200Banner,
@@ -29,8 +30,11 @@ Default.args = {
             baseUrl: 'https://support.theguardian.com/contribute',
         },
         secondaryCta: {
-            text: 'Join the party',
-            baseUrl: 'https://theguardian.com',
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Join the party',
+                baseUrl: 'https://theguardian.com',
+            },
         },
     },
 };

--- a/src/components/modules/banners/g200/components/G200BannerCtas.tsx
+++ b/src/components/modules/banners/g200/components/G200BannerCtas.tsx
@@ -7,6 +7,7 @@ import { neutral } from '@guardian/src-foundations/palette';
 import { Inline, Hide } from '@guardian/src-layout';
 import { from } from '@guardian/src-foundations/mq';
 import { BannerTextContent } from '../../common/types';
+import { SecondaryCtaType } from '../../../../../types/shared';
 
 const containerStyles = css`
     > * {
@@ -64,6 +65,16 @@ const G200BannerCtas: React.FC<G200BannerCtasProps> = ({
         content.mobileContent?.secondaryCta ?? content.mainContent.secondaryCta;
     const mobilePrimaryCta = content.mobileContent?.primaryCta ?? content.mainContent.primaryCta;
 
+    const secondaryCtaHref =
+        mobileSecondaryCta?.type === SecondaryCtaType.Custom
+            ? mobileSecondaryCta.cta.ctaUrl
+            : undefined;
+
+    const secondaryCtaText =
+        mobileSecondaryCta?.type === SecondaryCtaType.Custom
+            ? mobileSecondaryCta.cta.ctaText
+            : undefined;
+
     return (
         <Inline cssOverrides={containerStyles} space={2}>
             <ThemeProvider theme={buttonBrand}>
@@ -71,12 +82,12 @@ const G200BannerCtas: React.FC<G200BannerCtasProps> = ({
                     <Hide above="tablet">
                         <LinkButton
                             onClick={onSecondaryCtaClick}
-                            href={mobileSecondaryCta.ctaUrl}
+                            href={secondaryCtaHref}
                             cssOverrides={secondaryCtaStyles}
                             priority="tertiary"
                             size="xsmall"
                         >
-                            {mobileSecondaryCta.ctaText}
+                            {secondaryCtaText}
                         </LinkButton>
                     </Hide>
                 )}
@@ -85,12 +96,12 @@ const G200BannerCtas: React.FC<G200BannerCtasProps> = ({
                     <Hide below="tablet">
                         <LinkButton
                             onClick={onSecondaryCtaClick}
-                            href={content.mainContent.secondaryCta.ctaUrl}
+                            href={secondaryCtaHref}
                             cssOverrides={secondaryCtaStyles}
                             priority="tertiary"
                             size="small"
                         >
-                            {content.mainContent.secondaryCta.ctaText}
+                            {secondaryCtaText}
                         </LinkButton>
                     </Hide>
                 )}

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -22,6 +22,7 @@ import { BannerText } from '../common/BannerText';
 import { BannerContentRenderer } from '../common/BannerContentRenderer';
 import { BannerRenderProps } from '../common/types';
 import { validatedBannerWrapper } from '../common/BannerWrapper';
+import { SecondaryCtaType } from '../../../../types/shared';
 
 const signInUrl =
     'https://profile.theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs';
@@ -117,7 +118,9 @@ const GuardianWeeklyBanner: React.FC<BannerRenderProps> = ({
                                             data-link-name={notNowComponentId}
                                             onClick={onNotNowClick}
                                         >
-                                            {secondaryCta?.ctaText || defaultSecondaryCta}
+                                            {(secondaryCta?.type === SecondaryCtaType.Custom &&
+                                                secondaryCta.cta.ctaText) ||
+                                                defaultSecondaryCta}
                                         </Button>
                                     </Inline>
                                 );

--- a/src/components/modules/banners/utils/storybook.ts
+++ b/src/components/modules/banners/utils/storybook.ts
@@ -1,5 +1,6 @@
 import { TickerCountType, TickerEndType } from '../../../../types/shared';
-import { BannerProps, BannerContent, BannerTracking } from '../../../../types/BannerTypes';
+import { BannerProps, BannerTracking } from '../../../../types/BannerTypes';
+import { SecondaryCtaType } from '../../../../types/shared';
 
 export const tracking: BannerTracking = {
     ophanPageId: 'kbluzw2csbf83eabedel',
@@ -12,7 +13,7 @@ export const tracking: BannerTracking = {
     campaignCode: 'UsEoyAppealBanner_control',
 };
 
-export const content: BannerContent = {
+export const content = {
     heading: 'Show your support for high&#8209;impact reporting',
     messageText:
         'In the extraordinary year that was 2020, our independent journalism was powered by more than a million supporters. Thanks to you, we provided vital news and analysis for everyone, led by science and truth. You’ve read %%ARTICLE_COUNT%% articles in the last year. As 2021 unfolds, offering new hope, we commit to another year of high-impact reporting.',
@@ -24,8 +25,11 @@ export const content: BannerContent = {
         text: 'Support The Guardian',
     },
     secondaryCta: {
-        baseUrl: 'https://support.theguardian.com/contribute',
-        text: 'Learn more',
+        type: SecondaryCtaType.Custom,
+        cta: {
+            baseUrl: 'https://support.theguardian.com/contribute',
+            text: 'Learn more',
+        },
     },
 };
 

--- a/src/components/modules/epics/ContributionsEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpic.stories.tsx
@@ -6,7 +6,8 @@ import { props } from './utils/storybook';
 import { from } from '@guardian/src-foundations/mq';
 import { css } from '@emotion/react';
 import { palette } from '@guardian/src-foundations';
-import { EpicProps, SecondaryCtaType } from '../../../types/EpicTypes';
+import { EpicProps } from '../../../types/EpicTypes';
+import { SecondaryCtaType } from '../../../types/shared';
 
 const containerStyles = css`
     margin: 3em auto;

--- a/src/components/modules/epics/ContributionsEpicButtons.tsx
+++ b/src/components/modules/epics/ContributionsEpicButtons.tsx
@@ -2,13 +2,14 @@ import React, { useEffect } from 'react';
 import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
 import { Button } from './Button';
-import { EpicTracking, EpicVariant, SecondaryCtaType } from '../../../types/EpicTypes';
+import { EpicTracking, EpicVariant } from '../../../types/EpicTypes';
+import { SecondaryCtaType } from '../../../types/shared';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
-import { getCookie } from '../../../lib/cookies';
 import { OphanComponentEvent } from '../../../types/OphanTypes';
 import { getReminderViewEvent, OPHAN_COMPONENT_EVENT_REMINDER_OPEN } from './utils/ophan';
 import { useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import { Cta } from '../../../types/shared';
+import { hasSetReminder } from '../utils/reminders';
 
 const buttonWrapperStyles = css`
     margin: ${space[6]}px ${space[2]}px ${space[1]}px 0;
@@ -104,14 +105,13 @@ export const ContributionsEpicButtons = ({
     const [hasBeenSeen, setNode] = useHasBeenSeen({}, true);
 
     const { cta, secondaryCta, showReminderFields } = variant;
-    const hasSetReminder = getCookie('gu_epic_contribution_reminder');
 
     if (!cta) {
         return null;
     }
 
     useEffect(() => {
-        if (hasBeenSeen && submitComponentEvent && showReminderFields && !hasSetReminder) {
+        if (hasBeenSeen && submitComponentEvent && showReminderFields && !hasSetReminder()) {
             submitComponentEvent(getReminderViewEvent(isSignedIn));
         }
     }, [hasBeenSeen]);
@@ -140,7 +140,7 @@ export const ContributionsEpicButtons = ({
                     ) : (
                         secondaryCta?.type === SecondaryCtaType.ContributionsReminder &&
                         showReminderFields &&
-                        !hasSetReminder && (
+                        !hasSetReminder() && (
                             <div css={buttonMargins}>
                                 <Button onClickAction={openReminder} isTertiary>
                                     {showReminderFields.reminderCta}

--- a/src/components/modules/epics/ContributionsEpicReminderSignedIn.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedIn.stories.tsx
@@ -4,7 +4,7 @@ import {
     ContributionsEpicReminderSignedIn,
     ContributionsEpicReminderSignedInProps,
 } from './ContributionsEpicReminderSignedIn';
-import { ReminderStatus } from './utils/reminders';
+import { ReminderStatus } from '../utils/reminders';
 import { EpicDecorator } from './ContributionsEpic.stories';
 
 export default {

--- a/src/components/modules/epics/ContributionsEpicReminderSignedIn.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedIn.tsx
@@ -9,7 +9,7 @@ import { Lines } from '../../Lines';
 import { Button } from '@guardian/src-button';
 import { Hide } from '@guardian/src-layout';
 import { SvgCheckmark, SvgCross } from '@guardian/src-icons';
-import { ensureHasPreposition, ReminderStatus } from './utils/reminders';
+import { ensureHasPreposition, ReminderStatus } from '../utils/reminders';
 
 // --- Styles --- //
 

--- a/src/components/modules/epics/ContributionsEpicReminderSignedOut.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedOut.stories.tsx
@@ -4,7 +4,7 @@ import {
     ContributionsEpicReminderSignedOut,
     ContributionsEpicReminderSignedOutProps,
 } from './ContributionsEpicReminderSignedOut';
-import { ReminderStatus } from './utils/reminders';
+import { ReminderStatus } from '../utils/reminders';
 import { EpicDecorator } from './ContributionsEpic.stories';
 
 export default {

--- a/src/components/modules/epics/ContributionsEpicReminderSignedOut.tsx
+++ b/src/components/modules/epics/ContributionsEpicReminderSignedOut.tsx
@@ -1,6 +1,6 @@
 // --- Imports --- //
 
-import React, { useState } from 'react';
+import React from 'react';
 import { css, SerializedStyles } from '@emotion/react';
 import { headline, textSans, body } from '@guardian/src-foundations/typography';
 import { palette, space } from '@guardian/src-foundations';
@@ -9,7 +9,8 @@ import { Lines } from '../../Lines';
 import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';
 import { SvgArrowRightStraight, SvgCross } from '@guardian/src-icons';
-import { ensureHasPreposition, isValidEmail, ReminderStatus } from './utils/reminders';
+import { ensureHasPreposition, ReminderStatus } from '../utils/reminders';
+import { useContributionsReminderEmailForm } from '../../hooks/useContributionsReminderEmailForm';
 
 // --- Styles --- //
 
@@ -126,34 +127,7 @@ export const ContributionsEpicReminderSignedOut: React.FC<ContributionsEpicRemin
     onSetReminderClick,
     onCloseReminderClick,
 }: ContributionsEpicReminderSignedOutProps) => {
-    const [isDirty, setIsDirty] = useState(false);
-    const [emailAddress, setEmailAddress] = useState('');
-
-    const updateEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setEmailAddress(e.target.value);
-        if (isDirty) {
-            setIsDirty(false);
-        }
-    };
-
-    const isEmpty = emailAddress.trim().length === 0;
-    const isValid = isValidEmail(emailAddress);
-
-    let inputError;
-    if (isDirty && isEmpty) {
-        inputError = 'Please enter your email address';
-    } else if (isDirty && !isValid) {
-        inputError = 'Please enter a valid email address';
-    }
-
-    const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault();
-        if (isValid) {
-            onSetReminderClick(emailAddress);
-        } else {
-            setIsDirty(true);
-        }
-    };
+    const { email, updateEmail, inputError, handleSubmit } = useContributionsReminderEmailForm();
 
     const reminderDateWithPreposition = ensureHasPreposition(reminderLabel);
 
@@ -168,7 +142,7 @@ export const ContributionsEpicReminderSignedOut: React.FC<ContributionsEpicRemin
             </div>
 
             <div css={containerStyles}>
-                <form onSubmit={onSubmit}>
+                <form onSubmit={handleSubmit(() => onSetReminderClick(email))}>
                     {reminderStatus !== ReminderStatus.Completed && (
                         <>
                             <h4 css={remindHeading}>Remind me {reminderDateWithPreposition}</h4>
@@ -177,7 +151,7 @@ export const ContributionsEpicReminderSignedOut: React.FC<ContributionsEpicRemin
                                     <TextInput
                                         label="Email address"
                                         error={inputError}
-                                        value={emailAddress}
+                                        value={email}
                                         onChange={updateEmail}
                                     />
                                 </div>

--- a/src/components/modules/epics/utils/storybook.ts
+++ b/src/components/modules/epics/utils/storybook.ts
@@ -2,9 +2,9 @@ import {
     EpicTestTracking,
     EpicPageTracking,
     EpicTracking,
-    SecondaryCtaType,
     EpicVariant,
 } from '../../../../types/EpicTypes';
+import { SecondaryCtaType } from '../../../../types/shared';
 import { EpicProps } from '../../../../types/EpicTypes';
 
 const variant: EpicVariant = {

--- a/src/components/modules/utils/reminders.ts
+++ b/src/components/modules/utils/reminders.ts
@@ -1,4 +1,4 @@
-import { addCookie } from '../../../../lib/cookies';
+import { addCookie, getCookie } from '../../../lib/cookies';
 
 // --- Types --- //
 
@@ -21,6 +21,10 @@ export const addContributionReminderCookie = (reminderDateString: string): void 
     const reminderDate = new Date(Date.parse(reminderDateString));
 
     addCookie('gu_epic_contribution_reminder', '1', dateDiff(today, reminderDate));
+};
+
+export const hasSetReminder = (): boolean => {
+    return !!getCookie('gu_epic_contribution_reminder');
 };
 
 // --- Text utils --- //

--- a/src/tests/epics/epicSelection.test.ts
+++ b/src/tests/epics/epicSelection.test.ts
@@ -12,7 +12,8 @@ import {
     userInTest,
     isNotExpired,
 } from './epicSelection';
-import { EpicTargeting, EpicTest, SecondaryCtaType } from '../../types/EpicTypes';
+import { EpicTargeting, EpicTest } from '../../types/EpicTypes';
+import { SecondaryCtaType } from '../../types/shared';
 import { withNowAs } from '../../utils/withNowAs';
 
 const testDefault: EpicTest = {

--- a/src/tests/epics/fallback.ts
+++ b/src/tests/epics/fallback.ts
@@ -1,4 +1,5 @@
-import { EpicTest, SecondaryCtaType } from '../../types/EpicTypes';
+import { EpicTest } from '../../types/EpicTypes';
+import { SecondaryCtaType } from '../../types/shared';
 
 export const fallbackEpicTest: EpicTest = {
     name: 'FallbackEpicTest',

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -10,14 +10,16 @@ import { CountryGroupId } from '../lib/geolocation';
 import {
     ArticlesViewedSettings,
     Audience,
-    Cta,
     Test,
     TickerSettings,
     Variant,
     WeeklyArticleHistory,
     ControlProportionSettings,
     ctaSchema,
+    secondaryCtaSchema,
     tickerSettingsSchema,
+    Cta,
+    SecondaryCta,
 } from './shared';
 
 export type BannerTargeting = {
@@ -74,7 +76,7 @@ export interface BannerContent {
     mobileMessageText?: string; // deprecated - use mobileBannerContent instead
     highlightedText?: string;
     cta?: Cta;
-    secondaryCta?: Cta;
+    secondaryCta?: SecondaryCta;
 }
 
 const bannerContentSchema = z.object({
@@ -83,7 +85,7 @@ const bannerContentSchema = z.object({
     mobileMessageText: z.string().optional(),
     highlightedText: z.string().optional(),
     cta: ctaSchema.optional(),
-    secondaryCta: ctaSchema.optional(),
+    secondaryCta: secondaryCtaSchema.optional(),
 });
 
 export enum BannerTemplate {
@@ -145,6 +147,7 @@ export interface BannerProps {
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
     numArticles?: number;
     hasOptedOutOfArticleCount?: boolean;
+    email?: string;
 }
 
 export const bannerSchema = z.object({
@@ -175,7 +178,7 @@ export interface RawVariantParams {
     heading?: string;
     highlightedText?: string;
     cta?: Cta;
-    secondaryCta?: Cta;
+    secondaryCta?: SecondaryCta;
 }
 
 export interface RawTestParams {

--- a/src/types/EpicTypes.ts
+++ b/src/types/EpicTypes.ts
@@ -2,6 +2,7 @@ import { OphanComponentEvent, OphanComponentType, OphanProduct } from './OphanTy
 import {
     ArticlesViewedSettings,
     Cta,
+    SecondaryCta,
     Test,
     TickerSettings,
     Variant,
@@ -94,22 +95,6 @@ export interface MaxViews {
     maxViewsDays: number;
     minDaysBetweenViews: number;
 }
-
-export enum SecondaryCtaType {
-    Custom = 'CustomSecondaryCta',
-    ContributionsReminder = 'ContributionsReminderSecondaryCta',
-}
-
-interface CustomSecondaryCta {
-    type: SecondaryCtaType.Custom;
-    cta: Cta;
-}
-
-interface ContributionsReminderSecondaryCta {
-    type: SecondaryCtaType.ContributionsReminder;
-}
-
-export type SecondaryCta = CustomSecondaryCta | ContributionsReminderSecondaryCta;
 
 export interface SeparateArticleCount {
     type: 'above';

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -19,6 +19,41 @@ export const ctaSchema = z.object({
     baseUrl: z.string(),
 });
 
+export enum SecondaryCtaType {
+    Custom = 'CustomSecondaryCta',
+    ContributionsReminder = 'ContributionsReminderSecondaryCta',
+}
+
+export const secondaryCtaTypeSchema = z.enum([
+    'CustomSecondaryCta',
+    'ContributionsReminderSecondaryCta',
+]);
+
+interface CustomSecondaryCta {
+    type: SecondaryCtaType.Custom;
+    cta: Cta;
+}
+
+export const customSecondaryCtaSchema = z.object({
+    type: z.literal('CustomSecondaryCta'),
+    cta: ctaSchema,
+});
+
+interface ContributionsReminderSecondaryCta {
+    type: SecondaryCtaType.ContributionsReminder;
+}
+
+export const contributionsReminderSecondaryCtaSchema = z.object({
+    type: z.literal('ContributionsReminderSecondaryCta'),
+});
+
+export type SecondaryCta = CustomSecondaryCta | ContributionsReminderSecondaryCta;
+
+export const secondaryCtaSchema = z.union([
+    customSecondaryCtaSchema,
+    contributionsReminderSecondaryCtaSchema,
+]);
+
 export type Audience =
     | 'AllExistingSupporters'
     | 'AllNonSupporters'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2574,6 +2574,13 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/compression@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@types/compression/-/compression-1.7.0.tgz#8dc2a56604873cf0dd4e746d9ae4d31ae77b2390"
+  integrity sha512-3LzWUM+3k3XdWOUk/RO+uSjv7YWOatYq2QADJntK1pjkk4DfVP0KrIEPDnXRJxAAGKe0VpIPRmlINLDuCedZWw==
+  dependencies:
+    "@types/express" "*"
+
 "@types/connect@*":
   version "3.4.34"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.34.tgz#170a40223a6d666006d93ca128af2beb1d9b1901"


### PR DESCRIPTION
## What does this change?
Add a reminder sign up to the contributions banner.

**Other PRs**

- admin-console: https://github.com/guardian/support-admin-console/pull/213
- dcr: https://github.com/guardian/dotcom-rendering/pull/2996

**Deployment Plan**
1. deploy admin-console. This breaks the banner tool, but at least this means users cannot modify the json file while we migrate!
2. fix json file and re upload
3. deploy dotcom-components

**TODO**
- [x] fix alignment
- [x] add tracking
- [x] admin-console PR
- [x] dcr PR
- [ ] frontend PR

## Images

### Signed in 

**mobile**
<img width="400" alt="Screenshot 2021-05-14 at 11 41 35" src="https://user-images.githubusercontent.com/17720442/118260051-c86d2180-b4a9-11eb-838d-3b892d765804.png">

**tablet**
<img width="767" alt="Screenshot 2021-05-14 at 11 41 57" src="https://user-images.githubusercontent.com/17720442/118260060-ca36e500-b4a9-11eb-8a8d-a545b23f568c.png">

**desktop**
<img width="997" alt="Screenshot 2021-05-14 at 11 42 12" src="https://user-images.githubusercontent.com/17720442/118260066-cb681200-b4a9-11eb-9bab-94b9c41a741e.png">

**left col**
<img width="1156" alt="Screenshot 2021-05-14 at 11 42 27" src="https://user-images.githubusercontent.com/17720442/118260070-cc00a880-b4a9-11eb-97a4-270d743b610e.png">

**wide**
<img width="1315" alt="Screenshot 2021-05-14 at 11 42 39" src="https://user-images.githubusercontent.com/17720442/118260073-cc993f00-b4a9-11eb-9852-c0055c711469.png">

### Signed out

**mobile**
<img width="329" alt="Screenshot 2021-05-14 at 11 43 05" src="https://user-images.githubusercontent.com/17720442/118260077-cdca6c00-b4a9-11eb-9dc4-295a2276b198.png">

**tablet**
<img width="756" alt="Screenshot 2021-05-14 at 11 43 25" src="https://user-images.githubusercontent.com/17720442/118260081-ce630280-b4a9-11eb-9757-969cb6ea1e72.png">

**desktop**
<img width="992" alt="Screenshot 2021-05-14 at 11 43 45" src="https://user-images.githubusercontent.com/17720442/118260084-cefb9900-b4a9-11eb-817f-73644b4c6b4f.png">

**left col**
<img width="1155" alt="Screenshot 2021-05-14 at 11 43 56" src="https://user-images.githubusercontent.com/17720442/118260085-cf942f80-b4a9-11eb-9c7c-6433f67fdd29.png">

**wide**
<img width="1316" alt="Screenshot 2021-05-14 at 11 44 14" src="https://user-images.githubusercontent.com/17720442/118260088-d02cc600-b4a9-11eb-9661-eefa5d2718f8.png">
