### PR TITLE
Add module prop validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "log4js": "^6.3.0",
     "node-fetch": "^2.6.1",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "zod": "^3.0.0"
   },
   "devDependencies": {
     "@aws-cdk/aws-apigateway": "^1.22.0",

--- a/src/components/modules/banners/contributions/ContributionsBanner.stories.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { ContributionsBanner } from './ContributionsBanner';
+import { ContributionsBannerUnwrapped as ContributionsBanner } from './ContributionsBanner';
 import { props } from '../utils/storybook';
 import { BannerProps } from '../../../../types/BannerTypes';
 

--- a/src/components/modules/shared/ModuleWrapper.tsx
+++ b/src/components/modules/shared/ModuleWrapper.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export function withParsedProps<ModuleProps>(
+    Module: React.FC<ModuleProps>,
+    validate: (props: unknown) => props is ModuleProps,
+): React.FC<unknown> {
+    const WrappedModule = (props: unknown) => {
+        if (validate(props)) {
+            return <Module {...props} />;
+        }
+        return null;
+    };
+
+    return WrappedModule;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15221,3 +15221,8 @@ zip-stream@^2.1.2:
     archiver-utils "^2.1.0"
     compress-commons "^2.1.1"
     readable-stream "^3.4.0"
+
+zod@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.0.0.tgz#f64304fc24c836e9cc1608d7fc2352784e18f2a5"
+  integrity sha512-4DBG6siN02ooPB1yvEEqoe32maHzKEdGgtQ2HEz6FnFtgTjwZtzJ3ScuiDgtssWfDyLnQ3MvtSj6ff5ANL4STw==


### PR DESCRIPTION
## What does this change?
Add prop validation to remote modules served by SDC. 

### What's the problem?

The problem we're trying to address here is how we can more sustainably make breaking changes (not that we should do that too often) to the props used in the remote modules.

### What's the issue with breaking changes?

The SDC architecture has separate `data` requests and `module` requests. The `data` request returns (amongst other things) the props to pass to the component and the url for the `module` request. The `module` request then actually requests the component. The `module` request is cached both by fastly, and a users browser. This two stage process means right after we deploy a breaking change to the props, a user may receive the new version of the props but request a cached (i.e old) version of the module. This means the component is passed the wrong props which leads to undefined behaviour.

### How do we currently deal with this?

We currrently:

- do ad-hoc problem solving based on the specific issue that would be caused by the breaking change
- ignore the issue if the problem is sufficiently minor/non-existant 

### What solutions did we consider?

We considered a few different approaches:

- never make breaking changes to props, i.e deprecate old props and add new ones
- do a phased release of new props, i.e using union types we could try: `myProp: Old` -> `myProp: Old | New` -> `myProp: New`
- validate props passed to the component (this is what this PR implements)
- module versioning, i.e if the `moduleUrl` returned by the `data` request changed, there would be no cached modules

We decided to go for the validation approach. This is a simple and general solution that requires a dev only make minimal changes (i.e updating the schemas) when updating the props.


## Implementation 

We went for `zod` as it has a nice builder syntax for specifying schemas and is quite lightweight. Initially I tried `typecheck.macro` as that uses babel macros to derive the validators from the types (i.e no redundancy) but found that harder to get up and running with out current build pipeline. 
