### PR TITLE
Fix CLS caused by payment icons

### DIFF
--- a/src/components/modules/banners/contributions/ContributionsBannerCta.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerCta.tsx
@@ -13,7 +13,8 @@ const styles = {
     `,
     paymentMethods: css`
         display: block;
-        max-height: 1.25rem;
+        height: 1.25rem;
+        width: auto;
 
         ${from.tablet} {
             margin-left: ${space[4]}px;
@@ -54,6 +55,8 @@ export const ContributionsBannerCta: React.FC<ContributionsBannerCtaProps> = ({
                 </LinkButton>
             </ThemeProvider>
             <img
+                width={422}
+                height={60}
                 src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
                 alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
                 css={styles.paymentMethods}

--- a/src/components/modules/banners/contributionsTemplate/ContributionsTemplateCta.tsx
+++ b/src/components/modules/banners/contributionsTemplate/ContributionsTemplateCta.tsx
@@ -19,7 +19,8 @@ const container = css`
 
 const paymentMethods = css`
     display: block;
-    max-height: 1.25rem;
+    height: 1.25rem;
+    width: auto;
     margin-top: ${space[2]}px;
 `;
 
@@ -38,6 +39,8 @@ const ContributionsTemplateCta: React.FC<ContributionsTemplateCtaProps> = ({
             {secondaryCta}
         </div>
         <img
+            width={422}
+            height={60}
             src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
             alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
             css={paymentMethods}

--- a/src/components/modules/banners/g200/components/G200BannerCtas.tsx
+++ b/src/components/modules/banners/g200/components/G200BannerCtas.tsx
@@ -41,6 +41,7 @@ const paymentIconContainerStyles = css`
     img {
         display: block;
         height: 12px;
+        width: auto;
 
         ${from.tablet} {
             height: 20px;
@@ -133,6 +134,8 @@ const G200BannerCtas: React.FC<G200BannerCtasProps> = ({
 
                 <div css={paymentIconContainerStyles}>
                     <img
+                        width={422}
+                        height={60}
                         src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
                         alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
                     />

--- a/src/components/modules/epics/ContributionsEpicButtons.tsx
+++ b/src/components/modules/epics/ContributionsEpicButtons.tsx
@@ -150,6 +150,8 @@ export const ContributionsEpicButtons = ({
                     )}
 
                     <img
+                        width={422}
+                        height={60}
                         src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
                         alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
                         css={paymentImageStyles}


### PR DESCRIPTION
## What does this change?
Fix CLS caused by payment icons in the epic and banners. By specifying the width + height on the `img` tag the browser knows the aspect ratio of the image and can remove the layout shift by reserving space. Here's a good article for more info: https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/

## Images

<img width="664" alt="Screenshot 2021-05-20 at 12 17 07" src="https://user-images.githubusercontent.com/17720442/118969849-7a529500-b965-11eb-99e8-83e4e4ca2e81.png">

<img width="990" alt="Screenshot 2021-05-20 at 12 17 50" src="https://user-images.githubusercontent.com/17720442/118969864-7e7eb280-b965-11eb-9f4e-e802f9d28774.png">

<img width="990" alt="Screenshot 2021-05-20 at 12 17 56" src="https://user-images.githubusercontent.com/17720442/118969874-80e10c80-b965-11eb-8bb8-782c33c093cd.png">

<img width="990" alt="Screenshot 2021-05-20 at 12 18 05" src="https://user-images.githubusercontent.com/17720442/118969884-83436680-b965-11eb-9ab1-6deb1126e977.png">

