### PR TITLE
Fix overflow issue with Guardian Weekly banner packshot

### DIFF
--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -129,7 +129,7 @@ export const packShotContainer = css`
 
     picture {
         display: flex;
-        width: 100%;
+        max-width: 450px;
         height: 100%;
         justify-content: flex-end;
         align-items: flex-end;
@@ -142,7 +142,7 @@ export const packShotContainer = css`
 
     img {
         max-width: 100%;
-        height: 100%;
+        max-height: 100%;
     }
 `;
 

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -129,11 +129,11 @@ export const packShotContainer = css`
 
     picture {
         display: flex;
-        max-width: 450px;
         height: 100%;
         justify-content: flex-end;
         align-items: flex-end;
         ${between.tablet.and.desktop} {
+            max-width: 450px;
             position: absolute;
             right: 0;
             bottom: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2574,13 +2574,6 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/compression@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@types/compression/-/compression-1.7.0.tgz#8dc2a56604873cf0dd4e746d9ae4d31ae77b2390"
-  integrity sha512-3LzWUM+3k3XdWOUk/RO+uSjv7YWOatYq2QADJntK1pjkk4DfVP0KrIEPDnXRJxAAGKe0VpIPRmlINLDuCedZWw==
-  dependencies:
-    "@types/express" "*"
-
 "@types/connect@*":
   version "3.4.34"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.34.tgz#170a40223a6d666006d93ca128af2beb1d9b1901"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2574,6 +2574,13 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/compression@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@types/compression/-/compression-1.7.0.tgz#8dc2a56604873cf0dd4e746d9ae4d31ae77b2390"
+  integrity sha512-3LzWUM+3k3XdWOUk/RO+uSjv7YWOatYq2QADJntK1pjkk4DfVP0KrIEPDnXRJxAAGKe0VpIPRmlINLDuCedZWw==
+  dependencies:
+    "@types/express" "*"
+
 "@types/connect@*":
   version "3.4.34"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.34.tgz#170a40223a6d666006d93ca128af2beb1d9b1901"


### PR DESCRIPTION
## What does this change?
This fixes an issue with the Guardian Weekly banner at the tablet breakpoint where the image would overflow and cover the text.