### PR TITLE
Tweak mobile banner styles

### DIFF
--- a/src/components/modules/banners/contributions/ContributionsBannerCommonStyles.ts
+++ b/src/components/modules/banners/contributions/ContributionsBannerCommonStyles.ts
@@ -8,13 +8,14 @@ export const commonStyles = {
         max-width: 40rem;
         display: block;
         padding-bottom: 0;
-        ${body.medium({ lineHeight: 'loose' })};
+        ${body.small({ lineHeight: 'loose' })};
         ${until.tablet} {
             strong {
                 font-weight: 800;
             }
         }
         ${from.tablet} {
+            ${body.medium({ lineHeight: 'loose' })};
             strong {
                 ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
             }

--- a/src/components/modules/banners/contributions/ContributionsBannerMobile.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBannerMobile.tsx
@@ -19,7 +19,7 @@ const styles = {
         padding-bottom: 20px;
     `,
     heading: css`
-        ${headline.xsmall({ fontWeight: 'bold' })};
+        ${headline.xxsmall({ fontWeight: 'bold' })};
         max-width: 90%; /* to avoid pushing the close button off screen on mobile devices with extra large font */
     `,
     copy: css`


### PR DESCRIPTION
## What does this change?
Tweak mobile banner styles to squeeze in some more copy.

**Changes**
- mobile body copy 17px -> 15px
- mobile header copy 24px -> 20px

## Images
<img width="330" alt="Screenshot 2021-05-21 at 16 09 50" src="https://user-images.githubusercontent.com/17720442/119159783-8024a500-ba4f-11eb-883a-0d15c6c9e884.png">
