### PR TITLE
Fix withParsedProps warning

### DIFF
--- a/src/components/modules/shared/ModuleWrapper.tsx
+++ b/src/components/modules/shared/ModuleWrapper.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 
 export function withParsedProps<ModuleProps>(
     Module: React.FC<ModuleProps>,
@@ -6,7 +7,12 @@ export function withParsedProps<ModuleProps>(
 ): React.FC<unknown> {
     const WrappedModule = (props: unknown) => {
         if (validate(props)) {
-            return <Module {...props} />;
+            return (
+                <Module
+                    // This is taken from: https://github.com/emotion-js/emotion/issues/2169
+                    {...(props as EmotionJSX.LibraryManagedAttributes<typeof Module, ModuleProps>)}
+                />
+            );
         }
         return null;
     };


### PR DESCRIPTION
## What does this change?
Upgrading to emotion 11 has caused the following warning to appear in the console (w.r.t `withParsedProps` wrapper): 

```
(!) Plugin typescript: @rollup/plugin-typescript TS2322: Type 'ModuleProps' is not assignable to type 'IntrinsicAttributes & WithConditionalCSSProp<PropsWithChildren<ModuleProps>> & ModuleProps & { ...; }'.
  Type 'ModuleProps' is not assignable to type 'WithConditionalCSSProp<PropsWithChildren<ModuleProps>>'.
```

This 'fix' was found it here: https://github.com/emotion-js/emotion/issues/2169. It's not really a fix, but it keeps typescript happy. I'm not 100% sure what's going on with this issue. It's to do with the fact that we're no longer transforming our jsx to the `React.createElement` form, but instead using the `jsx` function from `emotion`. 