### PR TITLE
Fix banner highlighted text styles

### DIFF
--- a/src/components/modules/banners/contributions/ContributionsBannerCommonStyles.ts
+++ b/src/components/modules/banners/contributions/ContributionsBannerCommonStyles.ts
@@ -35,9 +35,12 @@ export const commonStyles = {
     highlightedText: css`
         background-color: ${neutral[100]};
         padding: 0.15rem 0.15rem;
-        ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
+        ${body.small({ fontWeight: 'bold', lineHeight: 'loose' })};
         ${until.tablet} {
             font-weight: 800;
+        }
+        ${from.tablet} {
+            ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
         }
         &::selection {
             background-color: ${brandAlt[400]};


### PR DESCRIPTION
## What does this change?
Update the font size of the highlighted text at mobile

## Images
<img width="396" alt="Screenshot 2021-05-26 at 15 25 49" src="https://user-images.githubusercontent.com/17720442/119678772-b68b6700-be37-11eb-871c-31f32055dc4b.png">
