### PR TITLE
Send ophan header events from the module

### DIFF
--- a/src/components/modules/header/Header.tsx
+++ b/src/components/modules/header/Header.tsx
@@ -56,6 +56,7 @@ export const Header: React.FC<HeaderProps> = (props: HeaderProps) => {
     const { abTestName, abTestVariant, componentType, campaignCode } = props.tracking;
 
     const sendOphanEvent = (action: OphanAction): void =>
+        props.submitComponentEvent &&
         props.submitComponentEvent({
             component: {
                 componentType,

--- a/src/types/HeaderTypes.ts
+++ b/src/types/HeaderTypes.ts
@@ -1,4 +1,4 @@
-import { OphanComponentType } from './OphanTypes';
+import {OphanComponentEvent, OphanComponentType} from './OphanTypes';
 import { Audience, Test, Variant } from './shared';
 
 interface Cta {
@@ -29,6 +29,7 @@ export interface HeaderProps {
     content: HeaderContent;
     tracking: HeaderTracking;
     countryCode?: string;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
 }
 
 export interface HeaderTestSelection {

--- a/src/types/HeaderTypes.ts
+++ b/src/types/HeaderTypes.ts
@@ -1,4 +1,4 @@
-import {OphanComponentEvent, OphanComponentType} from './OphanTypes';
+import { OphanComponentEvent, OphanComponentType } from './OphanTypes';
 import { Audience, Test, Variant } from './shared';
 
 interface Cta {

--- a/src/types/HeaderTypes.ts
+++ b/src/types/HeaderTypes.ts
@@ -29,7 +29,7 @@ export interface HeaderProps {
     content: HeaderContent;
     tracking: HeaderTracking;
     countryCode?: string;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
 }
 
 export interface HeaderTestSelection {

--- a/src/types/OphanTypes.ts
+++ b/src/types/OphanTypes.ts
@@ -9,7 +9,7 @@ export const ophanProductSchema = z.enum([
 
 export type OphanProduct = z.infer<typeof ophanProductSchema>;
 
-export type OphanAction = 'CLICK' | 'VIEW';
+export type OphanAction = 'CLICK' | 'VIEW' | 'INSERT';
 
 export const ophanComponentTypeSchema = z.enum([
     'ACQUISITIONS_EPIC',


### PR DESCRIPTION
Currently the header module is only being used by DCR.
I'm working on making frontend use it as well.

The INSERT and VIEW events are currently sent by the platform (DCR). This is following the convention set by epic/banner. But actually there's no reason for the platform to do this. And in the case of the header it's problematic because frontend's view tracking requires the user to scroll first, even if it's in view.

So this PR moves the INSERT and VIEW events into the module in SDC.
I will disable the remote header in DCR temporarily before merging this, as it's a breaking change.