### PR TITLE
Increase module max-age to 5mins

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
         parameters:
             bucket: gu-contributions-public
             prefixStack: false
-            cacheControl: max-age=120
+            cacheControl: max-age=300
             surrogateControl: max-age=300
 
     dotcom-components-cloudformation:


### PR DESCRIPTION
Currently fastly caches modules for 5 mins, and the client for 2 mins.