### PR TITLE
Send epic view events

### DIFF
--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -22,13 +22,13 @@ import { Stage } from '../../../types/shared';
 import { isProd } from '../shared/helpers/stage';
 
 const sendEpicViewEvent = (url: string, stage?: Stage): void => {
-    // TODO - fastly
-    const endpoint = isProd(stage)
-        ? 'https://component-events.support.guardianapis.com/epic-view'
-        : 'https://component-events-code.support.guardianapis.com/epic-view';
+    const path = 'events/epic-view';
+    const host = isProd(stage)
+        ? 'https://contributions.guardianapis.com'
+        : 'https://contributions.code.dev-guardianapis.com';
     const body = JSON.stringify({ url });
 
-    fetch(endpoint, {
+    fetch(`${host}/${path}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body,

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { palette, space } from '@guardian/src-foundations';
@@ -17,6 +17,27 @@ import { ContributionsEpicArticleCountOptOut } from './ContributionsEpicArticleC
 import { EpicArticleCountOptOutTestVariants } from '../../../tests/epics/articleCountOptOut';
 import { ContributionsEpicArticleCountAbove } from './ContributionsEpicArticleCountAbove';
 import { useArticleCountOptOut } from '../../hooks/useArticleCountOptOut';
+import { HasBeenSeen, useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
+import { Stage } from '../../../types/shared';
+import { isProd } from '../shared/helpers/stage';
+
+const sendEpicViewEvent = (url: string, stage?: Stage): void => {
+    // TODO - fastly
+    const endpoint = isProd(stage)
+        ? 'https://component-events.support.guardianapis.com/epic-view'
+        : 'https://component-events-code.support.guardianapis.com/epic-view';
+    const body = JSON.stringify({ url });
+
+    fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+    }).then(response => {
+        if (!response.ok) {
+            console.log('Epic view event request failed', response);
+        }
+    });
+};
 
 const wrapperStyles = css`
     padding: ${space[1]}px ${space[2]}px ${space[3]}px;
@@ -207,11 +228,20 @@ export const getContributionsEpicComponent: (
     submitComponentEvent,
     openCmp,
     hasConsentForArticleCount,
+    stage,
 }: EpicProps) => {
     const [isReminderActive, setIsReminderActive] = useState(false);
     const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } = useArticleCountOptOut();
 
     const { backgroundImageUrl, showReminderFields, tickerSettings } = variant;
+
+    const [hasBeenSeen, setNode] = useHasBeenSeen({ threshold: 0 }, true) as HasBeenSeen;
+
+    useEffect(() => {
+        if (hasBeenSeen) {
+            sendEpicViewEvent(tracking.referrerUrl, stage);
+        }
+    }, [hasBeenSeen]);
 
     const cleanHighlighted = replaceNonArticleCountPlaceholders(
         variant.highlightedText,
@@ -237,7 +267,7 @@ export const getContributionsEpicComponent: (
     };
 
     return (
-        <section css={wrapperStyles}>
+        <section ref={setNode} css={wrapperStyles}>
             {variant.separateArticleCount?.type === 'above' && hasConsentForArticleCount && (
                 <div css={articleCountAboveContainerStyles}>
                     {optOutVariant === EpicArticleCountOptOutTestVariants.control ? (

--- a/src/components/modules/shared/helpers/stage.ts
+++ b/src/components/modules/shared/helpers/stage.ts
@@ -1,0 +1,4 @@
+import { Stage } from '../../../../types/shared';
+
+// Default to PROD to avoid risk of showing test data to users
+export const isProd = (stage?: Stage): boolean => !(stage === 'CODE' || stage === 'DEV');

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,5 +1,7 @@
 import express from 'express';
 
+// WARNING - do not use these in the modules, they are server-side only
+
 export const isProd = process.env.stage === 'PROD';
 
 export const isDev = process.env.stage === 'DEV';

--- a/src/types/EpicTypes.ts
+++ b/src/types/EpicTypes.ts
@@ -3,6 +3,7 @@ import {
     ArticlesViewedSettings,
     Cta,
     SecondaryCta,
+    Stage,
     Test,
     TickerSettings,
     Variant,
@@ -90,6 +91,7 @@ export type EpicProps = {
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
     openCmp?: () => void;
     hasConsentForArticleCount?: boolean;
+    stage?: Stage;
 };
 
 export interface MaxViews {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -129,3 +129,5 @@ export interface ControlProportionSettings {
     proportion: number;
     offset: number;
 }
+
+export type Stage = 'PROD' | 'CODE' | 'DEV';


### PR DESCRIPTION
We have a new stream for epic view events (https://github.com/guardian/support-analytics).
This is for the 'super mode' feature, which will use intraday conversion rate data to change the ask strategy of epics on specific articles.

This change makes the epic component send an event when it is viewed. The events api is behind fastly.