### PR TITLE
Apply bold font to b tags

### DIFF
--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -31,6 +31,10 @@ const wrapperStyles = css`
             background: ${palette.brandAlt[400]};
         }
     }
+
+    b {
+        font-weight: bold;
+    }
 `;
 
 const headingStyles = css`


### PR DESCRIPTION
## What does this change?
DCR resets the styles of bold tags, this adds them back to the epic. This is a quick fix - perhaps we could think about how best to handle unwanted overrides caused by the platform more generally? 

## Images

**before**
<img width="642" alt="Screenshot 2021-06-03 at 15 37 54" src="https://user-images.githubusercontent.com/17720442/120663625-18744e00-c482-11eb-96f7-e8d750fd2054.png">

**after**
<img width="642" alt="Screenshot 2021-06-03 at 15 38 34" src="https://user-images.githubusercontent.com/17720442/120663638-1ad6a800-c482-11eb-850c-975e5813a19a.png">

