### PR TITLE
Set minViews to 0 for epic AC test

### DIFF
--- a/src/tests/epics/articleCountOptOut.ts
+++ b/src/tests/epics/articleCountOptOut.ts
@@ -62,7 +62,7 @@ const buildEpicArticleCountOptOutTest = (
     highPriority: true,
     useLocalViewLog: true,
     articlesViewedSettings: {
-        minViews: 5,
+        minViews: 0,
         maxViews: 50,
         periodInWeeks: 52,
     },


### PR DESCRIPTION
If the user opts out of seeing the article count, they should still be in the test, so that they can potentially opt back in again