### PR TITLE
Add "support again" header test

### DIFF
--- a/src/components/modules/header/Header.stories.tsx
+++ b/src/components/modules/header/Header.stories.tsx
@@ -5,7 +5,7 @@ import { Header } from './Header';
 import { css } from '@emotion/core';
 import { brand } from '@guardian/src-foundations';
 
-const props: HeaderProps = {
+export const props: HeaderProps = {
     content: {
         heading: 'Support the Guardian',
         subheading: 'Available for everyone, funded by readers',
@@ -36,17 +36,18 @@ const background = css`
     padding: 10px;
 `;
 
+export const HeaderDecorator = (Story: Story): JSX.Element => (
+    <div css={background}>
+        <Story />
+    </div>
+);
+
 export default {
     component: Header,
     title: 'Header/Header',
     args: props,
-    decorators: [
-        Story => (
-            <div css={background}>
-                <Story />
-            </div>
-        ),
-    ],
+    decorators: [HeaderDecorator],
+    excludeStories: ['props', 'HeaderDecorator'],
 } as Meta;
 
 const Template: Story<HeaderProps> = (props: HeaderProps) => <Header {...props} />;

--- a/src/components/modules/header/Header.tsx
+++ b/src/components/modules/header/Header.tsx
@@ -2,9 +2,11 @@ import React, { useEffect } from 'react';
 
 import { css } from '@emotion/core';
 import { from } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
 import { brandAlt, brandText } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
+import { Link, linkBrand } from '@guardian/src-link';
 import { Hide } from '@guardian/src-layout';
 import { ThemeProvider } from '@emotion/react';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
@@ -16,7 +18,6 @@ import { OphanAction } from '../../../types/OphanTypes';
 const messageStyles = (isThankYouMessage: boolean) => css`
     color: ${brandAlt[400]};
     ${headline.xxsmall({ fontWeight: 'bold' })};
-    padding-top: 3px;
     margin-bottom: 3px;
 
     ${from.desktop} {
@@ -28,6 +29,37 @@ const messageStyles = (isThankYouMessage: boolean) => css`
             ? headline.small({ fontWeight: 'bold' })
             : headline.medium({ fontWeight: 'bold' })}
     }
+`;
+
+const supportAgainHeadingStyles = css`
+    ${textSans.small({ fontWeight: 'bold' })}
+    color: ${brandAlt[400]};
+    font-size: 14px;
+
+    ${from.tablet} {
+        ${headline.xxsmall({ fontWeight: 'bold' })};
+    }
+
+    ${from.desktop} {
+        ${headline.xsmall({ fontWeight: 'bold' })}
+    }
+
+    ${from.leftCol} {
+        ${headline.small({ fontWeight: 'bold' })}
+    }
+`;
+
+const supportAgainSubheadingStyles = css`
+    ${textSans.medium()};
+    color: ${brandText.primary};
+`;
+
+const supportAgainLinkStyles = css`
+    font-size: 12px;
+`;
+
+const supportAgainButtonStyles = css`
+    margin-top: ${space[2]}px;
 `;
 
 const linkStyles = css`
@@ -51,7 +83,14 @@ const subMessageStyles = css`
     margin: 5px 0;
 `;
 
-export const Header: React.FC<HeaderProps> = (props: HeaderProps) => {
+export enum HeaderVariant {
+    Control,
+    SupportAgain,
+}
+
+export const getHeader: (variant: HeaderVariant) => React.FC<HeaderProps> = (
+    variant: HeaderVariant,
+) => (props: HeaderProps) => {
     const { heading, subheading, primaryCta, secondaryCta } = props.content;
     const { abTestName, abTestVariant, componentType, campaignCode } = props.tracking;
 
@@ -92,15 +131,27 @@ export const Header: React.FC<HeaderProps> = (props: HeaderProps) => {
 
     return (
         <div ref={setNode}>
-            <Hide below="tablet">
-                <div css={messageStyles(false)}>
-                    <span>{heading}</span>
+            {variant === HeaderVariant.Control ? (
+                <Hide below="tablet">
+                    <div css={messageStyles(false)}>
+                        <span>{heading}</span>
+                    </div>
+
+                    <div css={subMessageStyles}>
+                        <div>{subheading}</div>
+                    </div>
+                </Hide>
+            ) : (
+                <div>
+                    <div css={supportAgainHeadingStyles}>{heading}</div>
+
+                    <Hide below="tablet">
+                        <div css={supportAgainSubheadingStyles}>{subheading}</div>
+                    </Hide>
                 </div>
-                <div css={subMessageStyles}>
-                    <div>{subheading}</div>
-                </div>
-            </Hide>
-            {primaryCta && (
+            )}
+
+            {primaryCta && variant === HeaderVariant.Control && (
                 <ThemeProvider theme={buttonReaderRevenueBrand}>
                     <Hide below="mobileMedium">
                         <LinkButton
@@ -114,6 +165,7 @@ export const Header: React.FC<HeaderProps> = (props: HeaderProps) => {
                             {primaryCta.text}
                         </LinkButton>
                     </Hide>
+
                     <Hide above="mobileMedium">
                         <LinkButton
                             priority="primary"
@@ -125,6 +177,39 @@ export const Header: React.FC<HeaderProps> = (props: HeaderProps) => {
                     </Hide>
                 </ThemeProvider>
             )}
+
+            {primaryCta && variant === HeaderVariant.SupportAgain && (
+                <>
+                    <Hide above="tablet">
+                        <ThemeProvider theme={linkBrand}>
+                            <Link
+                                priority="primary"
+                                href={addTracking(primaryCta.url)}
+                                cssOverrides={supportAgainLinkStyles}
+                            >
+                                {primaryCta.text}
+                            </Link>
+                        </ThemeProvider>
+                    </Hide>
+
+                    <Hide below="tablet">
+                        <ThemeProvider theme={buttonReaderRevenueBrand}>
+                            <LinkButton
+                                priority="primary"
+                                href={addTracking(primaryCta.url)}
+                                icon={<SvgArrowRightStraight />}
+                                iconSide="right"
+                                nudgeIcon={true}
+                                size="xsmall"
+                                cssOverrides={supportAgainButtonStyles}
+                            >
+                                {primaryCta.text}
+                            </LinkButton>
+                        </ThemeProvider>
+                    </Hide>
+                </>
+            )}
+
             {secondaryCta && (
                 <Hide below="tablet">
                     <ThemeProvider theme={buttonReaderRevenueBrand}>
@@ -144,3 +229,5 @@ export const Header: React.FC<HeaderProps> = (props: HeaderProps) => {
         </div>
     );
 };
+
+export const Header = getHeader(HeaderVariant.Control);

--- a/src/components/modules/header/HeaderSupportAgain.stories.tsx
+++ b/src/components/modules/header/HeaderSupportAgain.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { HeaderProps } from '../../../types/HeaderTypes';
+import { Header } from './HeaderSupportAgain';
+import { props, HeaderDecorator } from './Header.stories';
+
+export default {
+    component: Header,
+    title: 'Header/HeaderSupportAgain',
+    args: {
+        ...props,
+        content: {
+            ...props.content,
+            heading: 'Thank you',
+            subheading: 'Your support powers our independent journalism',
+            primaryCta: {
+                url: '',
+                text: 'Support us again',
+            },
+            secondaryCta: undefined,
+        },
+    },
+    decorators: [HeaderDecorator],
+} as Meta;
+
+const Template: Story<HeaderProps> = (props: HeaderProps) => <Header {...props} />;
+
+export const DefaultHeader = Template.bind({});

--- a/src/components/modules/header/HeaderSupportAgain.tsx
+++ b/src/components/modules/header/HeaderSupportAgain.tsx
@@ -1,0 +1,3 @@
+import { getHeader, HeaderVariant } from './Header';
+
+export const Header = getHeader(HeaderVariant.SupportAgain);

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -55,6 +55,11 @@ export const puzzlesBanner: ModuleInfo = getDefaultModuleInfo(
 
 export const header: ModuleInfo = getDefaultModuleInfo('header', 'header/Header');
 
+export const headerSupportAgain: ModuleInfo = getDefaultModuleInfo(
+    'header-support-again',
+    'header/HeaderSupportAgain',
+);
+
 export const moduleInfos: ModuleInfo[] = [
     epic,
     epicWithArticleCountOptOut,
@@ -65,4 +70,5 @@ export const moduleInfos: ModuleInfo[] = [
     guardianWeekly,
     puzzlesBanner,
     header,
+    headerSupportAgain,
 ];

--- a/src/payloads.ts
+++ b/src/payloads.ts
@@ -342,7 +342,7 @@ export const buildHeaderData = async (
         return {
             data: {
                 module: {
-                    url: `${baseUrl}/${header.endpointPathBuilder(targeting.modulesVersion)}`,
+                    url: `${baseUrl}/${variant.modulePathBuilder(targeting.modulesVersion)}`,
                     name: header.name,
                     props: {
                         content: variant.content,

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -62,22 +62,67 @@ const supportersTest: HeaderTest = {
     ],
 };
 
+// const supportAgainTest: HeaderTest = {
+//     name: 'header-support-again',
+//     audience: 'AllNonSupporters',
+//     variants: [
+//         {
+//             name: 'control',
+//             modulePathBuilder: headerSupportAgain.endpointPathBuilder,
+//             content: {
+//                 heading: 'Thank you',
+//                 subheading: 'Your support powers our independent journalism',
+//                 primaryCta: {
+//                     text: 'Support us again',
+//                     url:
+//                         'https://support.theguardian.com/contribute?selected-contribution-type=ONE_OFF',
+//                 },
+//             },
+//         },
+//     ],
+// };
+
+// const monthDiff = (from: Date, to: Date): number => {
+//     return 12 * (to.getFullYear() - from.getFullYear()) + (to.getMonth() - from.getMonth());
+// };
+
+// const isLastOneOffContributionWithinLast2To3Months = (
+//     lastOneOffContributionDate?: string,
+// ): boolean => {
+//     if (lastOneOffContributionDate === undefined) {
+//         return false;
+//     }
+
+//     const now = new Date();
+//     const date = new Date(lastOneOffContributionDate);
+
+//     const monthsSinceLastContribution = monthDiff(date, now);
+
+//     return monthsSinceLastContribution === 2;
+// };
+
 const getNonSupportersTest = (edition: string): HeaderTest =>
     edition === 'UK' ? nonSupportersTestUK : nonSupportersTestNonUK;
 
 export const selectHeaderTest = (
     targeting: HeaderTargeting,
 ): Promise<HeaderTestSelection | null> => {
-    const test = targeting.showSupportMessaging
-        ? getNonSupportersTest(targeting.edition)
-        : supportersTest;
+    const select = (): HeaderTest => {
+        if (targeting.showSupportMessaging) {
+            return getNonSupportersTest(targeting.edition);
+        } else {
+            return supportersTest;
+        }
+    };
+
+    const test = select();
     const variant = test.variants[targeting.mvtId % test.variants.length];
     if (test && variant) {
         return Promise.resolve({
             test,
             variant,
             moduleName: header.name,
-            moduleUrl: variant.modulePathBuilder(targeting.modulesVersion),
+            modulePathBuilder: variant.modulePathBuilder,
         });
     }
     return Promise.resolve(null);

--- a/src/types/HeaderTypes.ts
+++ b/src/types/HeaderTypes.ts
@@ -35,7 +35,7 @@ export interface HeaderProps {
 export interface HeaderTestSelection {
     test: HeaderTest;
     variant: HeaderVariant;
-    moduleUrl: string;
+    modulePathBuilder: (version?: string) => string;
     moduleName: string;
 }
 
@@ -60,4 +60,5 @@ export interface HeaderTargeting {
     countryCode: string;
     modulesVersion?: string;
     mvtId: number;
+    lastOneOffContributionDate?: string;
 }


### PR DESCRIPTION
## What does this change?
Add "support again" header test. Currently the test is disabled (commented out). This is to allow us to merge this PR before we are ready to go live in order to make some parallel development on the header easier.

## Images

**mobile**
<img width="520" alt="Screenshot 2021-06-15 at 13 22 19" src="https://user-images.githubusercontent.com/17720442/122052964-332db780-cdde-11eb-90fe-e3f12596fd89.png">

**tablet**
<img width="770" alt="Screenshot 2021-06-15 at 13 22 34" src="https://user-images.githubusercontent.com/17720442/122053185-6cfebe00-cdde-11eb-8ec4-b26bd775a3a5.png">

**desktop**
<img width="1004" alt="Screenshot 2021-06-15 at 13 22 45" src="https://user-images.githubusercontent.com/17720442/122053193-6f611800-cdde-11eb-98fc-1d68bf2d7a5a.png">

