### PR TITLE
Factor out useOnSeenEffect

### DIFF
--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/react';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { palette, space } from '@guardian/src-foundations';
@@ -17,7 +17,7 @@ import { ContributionsEpicArticleCountOptOut } from './ContributionsEpicArticleC
 import { EpicArticleCountOptOutTestVariants } from '../../../tests/epics/articleCountOptOut';
 import { ContributionsEpicArticleCountAbove } from './ContributionsEpicArticleCountAbove';
 import { useArticleCountOptOut } from '../../hooks/useArticleCountOptOut';
-import { HasBeenSeen, useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
+import { useOnSeenEffect } from '../../../hooks/useHasBeenSeen';
 import { Stage } from '../../../types/shared';
 import { isProd } from '../shared/helpers/stage';
 
@@ -235,13 +235,9 @@ export const getContributionsEpicComponent: (
 
     const { backgroundImageUrl, showReminderFields, tickerSettings } = variant;
 
-    const [hasBeenSeen, setNode] = useHasBeenSeen({ threshold: 0 }, true) as HasBeenSeen;
-
-    useEffect(() => {
-        if (hasBeenSeen) {
-            sendEpicViewEvent(tracking.referrerUrl, stage);
-        }
-    }, [hasBeenSeen]);
+    const setNode = useOnSeenEffect({ threshold: 0 }, true, () => {
+        sendEpicViewEvent(tracking.referrerUrl, stage);
+    });
 
     const cleanHighlighted = replaceNonArticleCountPlaceholders(
         variant.highlightedText,

--- a/src/hooks/useHasBeenSeen.ts
+++ b/src/hooks/useHasBeenSeen.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState, useRef } from 'react';
 import libDebounce from 'lodash.debounce';
 
-export type HasBeenSeen = [boolean, (el: HTMLDivElement) => void];
+type SetNode = (el: HTMLDivElement) => void;
+export type HasBeenSeen = [boolean, SetNode];
 
 const useHasBeenSeen = (options: IntersectionObserverInit, debounce?: boolean): HasBeenSeen => {
     const [hasBeenSeen, setHasBeenSeen] = useState<boolean>(false);
@@ -37,4 +38,20 @@ const useHasBeenSeen = (options: IntersectionObserverInit, debounce?: boolean): 
     return [hasBeenSeen, setNode];
 };
 
-export { useHasBeenSeen };
+const useOnSeenEffect = (
+    options: IntersectionObserverInit,
+    debounce: boolean,
+    effect: () => void,
+): SetNode => {
+    const [hasBeenSeen, setNode] = useHasBeenSeen(options, debounce);
+
+    useEffect(() => {
+        if (hasBeenSeen) {
+            effect();
+        }
+    }, [hasBeenSeen]);
+
+    return setNode;
+};
+
+export { useHasBeenSeen, useOnSeenEffect };


### PR DESCRIPTION
## What does this change?
Factor out a `useOneSeenEffect`. We have pattern used in several places across the code base where we want to run some sort of effect (i.e send an ophan event) when a component is seen. Currently we use a combination of `useHasBeenSeen` and `useEffect` to achieve this. As this is so common, I thought I'd have a go at wrapping that up as a single custom hook!
