### PR TITLE
send ophan event when epic CTA buttons are viewed

### DIFF
--- a/src/components/modules/epics/ContributionsEpicButtons.tsx
+++ b/src/components/modules/epics/ContributionsEpicButtons.tsx
@@ -6,7 +6,11 @@ import { EpicTracking, EpicVariant } from '../../../types/EpicTypes';
 import { SecondaryCtaType } from '../../../types/shared';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
 import { OphanComponentEvent } from '../../../types/OphanTypes';
-import { getReminderViewEvent, OPHAN_COMPONENT_EVENT_REMINDER_OPEN } from './utils/ophan';
+import {
+    getReminderViewEvent,
+    OPHAN_COMPONENT_EVENT_CTAS_VIEW,
+    OPHAN_COMPONENT_EVENT_REMINDER_OPEN,
+} from './utils/ophan';
 import { useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import { Cta } from '../../../types/shared';
 import { hasSetReminder } from '../utils/reminders';
@@ -111,8 +115,12 @@ export const ContributionsEpicButtons = ({
     }
 
     useEffect(() => {
-        if (hasBeenSeen && submitComponentEvent && showReminderFields && !hasSetReminder()) {
-            submitComponentEvent(getReminderViewEvent(isSignedIn));
+        if (hasBeenSeen && submitComponentEvent) {
+            submitComponentEvent(OPHAN_COMPONENT_EVENT_CTAS_VIEW);
+
+            if (showReminderFields && !hasSetReminder()) {
+                submitComponentEvent(getReminderViewEvent(isSignedIn));
+            }
         }
     }, [hasBeenSeen]);
 

--- a/src/components/modules/epics/utils/ophan.ts
+++ b/src/components/modules/epics/utils/ophan.ts
@@ -1,5 +1,6 @@
 import { OphanComponentEvent } from '../../../../types/OphanTypes';
 
+const OPHAN_COMPONENT_ID_CTAS_VIEW = 'contributions-epic-ctas-view';
 const OPHAN_COMPONENT_ID_REMINDER_VIEW = 'contributions-epic-reminder-view';
 const OPHAN_COMPONENT_ID_REMINDER_OPEN = 'contributions-epic-reminder-open';
 const OPHAN_COMPONENT_ID_REMINDER_SET = 'contributions-epic-reminder-set';
@@ -19,6 +20,14 @@ export const getReminderViewEvent = (isSignedIn: boolean): OphanComponentEvent =
     action: 'VIEW',
     value: isSignedIn.toString(),
 });
+
+export const OPHAN_COMPONENT_EVENT_CTAS_VIEW: OphanComponentEvent = {
+    component: {
+        componentType: 'ACQUISITIONS_OTHER',
+        id: OPHAN_COMPONENT_ID_CTAS_VIEW,
+    },
+    action: 'CLICK',
+};
 
 export const OPHAN_COMPONENT_EVENT_REMINDER_OPEN: OphanComponentEvent = {
     component: {


### PR DESCRIPTION
### What does this PR do?
Adds an additional Ophan event for when the epic CTA buttons enter the viewport. This is to allow us to assess the drop-off rate midway through the epic.