### PR TITLE
Aus Moment Header 

### DIFF
--- a/src/components/modules/header/HeaderAusMomentNonSupporter.stories.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { HeaderProps } from '../../../types/HeaderTypes';
+import { Header } from './HeaderAusMomentNonSupporter';
+import { props, HeaderDecorator } from './Header.stories';
+
+export default {
+    component: Header,
+    title: 'Header/AusMomentNonSupporter',
+    args: {
+        ...props,
+        content: {
+            ...props.content,
+            heading: 'Support The Guardian',
+            primaryCta: {
+                url: '',
+                text: 'Contribute',
+            },
+            secondaryCta: {
+                url: '',
+                text: 'Subscribe',
+            },
+        },
+    },
+    decorators: [HeaderDecorator],
+} as Meta;
+
+const Template: Story<HeaderProps> = (props: HeaderProps) => <Header {...props} />;
+
+export const NonSupporter = Template.bind({});

--- a/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
@@ -31,15 +31,12 @@ const ausMomentHeadingStyles = css`
 const ausMomentSubheadingStyles = css`
     ${textSans.small()};
     color: ${brandText.primary};
-    margin-bottom: ${space[1]}px;
+    margin-bottom: ${space[2]}px;
     line-height: 1.15;
-
-    ${from.tablet} {
-        margin-bottom: ${space[1]}px;
-    }
 
     ${from.desktop} {
         ${textSans.medium()};
+        margin-bottom: ${space[1]}px;
     }
 `;
 

--- a/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/core';
-import { brandAlt, brandText } from '@guardian/src-foundations';
+import { brandAlt, brandText, space } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
 import { ThemeProvider } from '@emotion/react';
@@ -12,11 +12,12 @@ import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
 import useNumberOfSupporters from '../../../hooks/useNumberOfSupporters';
 
 const ausMomentHeadingStyles = css`
-    ${headline.small({ fontWeight: 'bold' })}
-    color: ${brandAlt[400]};
-
+    ${from.mobileMedium} {
+        ${textSans.xsmall({ fontWeight: 'bold' })}
+        color: ${brandAlt[400]};
+    }
     ${from.tablet} {
-        ${headline.xxsmall({ fontWeight: 'bold' })}
+        ${headline.xsmall({ fontWeight: 'bold' })}
     }
 
     ${from.desktop} {
@@ -25,29 +26,20 @@ const ausMomentHeadingStyles = css`
 `;
 
 const ausMomentSubheadingStyles = css`
-    ${textSans.medium()};
+    ${textSans.small()};
     color: ${brandText.primary};
-`;
+    margin-bottom: ${space[1]}px;
+    line-height: 1.15;
 
-const linkStyles = css`
-    height: 32px;
-    min-height: 32px;
-    ${textSans.small({ fontWeight: 'bold' })};
-    border-radius: 16px;
-    padding: 0 12px 0 12px;
-    line-height: 18px;
-    margin-right: 10px;
-    margin-bottom: 6px;
-
-    svg {
-        width: 24px;
+    ${from.desktop} {
+        ${textSans.medium()};
     }
 `;
 
 const headerYellowHighlight = css`
     color: ${brandAlt[400]};
     font-weight: 700;
-    margin: 5px 0;
+    margin-bottom: 5px 0;
 `;
 
 const mobileSubheadingStyles = css`
@@ -57,6 +49,28 @@ const mobileSubheadingStyles = css`
 
     ${textSans.xxsmall()}
     color: ${brandAlt[400]};
+`;
+
+const linkStyles = css`
+    height: 24px;
+    min-height: 24px;
+    ${textSans.small({ fontWeight: 'bold' })};
+    border-radius: 16px;
+    padding: 0 ${space[3]}px;
+    margin-right: 10px;
+    margin-bottom: 6px;
+
+    ${from.desktop} {
+        ${textSans.medium({ fontWeight: 'bold' })};
+        height: 36px;
+        min-height: 36px;
+        padding: 0 ${space[4]}px;
+        border-radius: 36px;
+    }
+
+    svg {
+        width: 24px;
+    }
 `;
 
 const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
@@ -87,6 +101,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                                     icon={<SvgArrowRightStraight />}
                                     iconSide="right"
                                     nudgeIcon={true}
+                                    size="xsmall"
                                     css={linkStyles}
                                 >
                                     {primaryCta.ctaText}
@@ -104,6 +119,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                             icon={<SvgArrowRightStraight />}
                             iconSide="right"
                             nudgeIcon={true}
+                            size="xsmall"
                             css={linkStyles}
                         >
                             {secondaryCta.ctaText}

--- a/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
@@ -18,10 +18,13 @@ const ausMomentHeadingStyles = css`
     }
     ${from.tablet} {
         ${headline.xsmall({ fontWeight: 'bold' })}
+        margin-bottom: ${space[1]}px;
+
     }
 
     ${from.desktop} {
         ${headline.medium({ fontWeight: 'bold' })}
+        margin-bottom: 0;
     }
 `;
 
@@ -31,8 +34,13 @@ const ausMomentSubheadingStyles = css`
     margin-bottom: ${space[1]}px;
     line-height: 1.15;
 
+    ${from.tablet} {
+        margin-bottom: ${space[1]}px;
+    }
+
     ${from.desktop} {
         ${textSans.medium()};
+        margin-bottom: 0;
     }
 `;
 
@@ -49,6 +57,7 @@ const mobileCtaStyles = css`
 
     ${textSans.xxsmall()}
     color: ${brandAlt[400]};
+    line-height: 1.15;
 `;
 
 const linkStyles = css`

--- a/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
@@ -6,25 +6,27 @@ import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
 import { ThemeProvider } from '@emotion/react';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
 import { Link } from '@guardian/src-link';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { Hide } from '@guardian/src-layout';
 import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
 import useNumberOfSupporters from '../../../hooks/useNumberOfSupporters';
 
 const ausMomentHeadingStyles = css`
-    ${headline.medium({ fontWeight: 'bold' })}
+    ${headline.small({ fontWeight: 'bold' })}
     color: ${brandAlt[400]};
+
+    ${from.tablet} {
+        ${headline.xxsmall({ fontWeight: 'bold' })}
+    }
+
+    ${from.desktop} {
+        ${headline.medium({ fontWeight: 'bold' })}
+    }
 `;
 
 const ausMomentSubheadingStyles = css`
-    ${textSans.small()};
-    color: ${brandAlt[400]};
-    margin-bottom: 5px;
-
-    ${from.tablet} {
-        ${textSans.medium()};
-        color: ${brandText.primary};
-    }
+    ${textSans.medium()};
+    color: ${brandText.primary};
 `;
 
 const linkStyles = css`
@@ -46,6 +48,15 @@ const headerYellowHighlight = css`
     color: ${brandAlt[400]};
     font-weight: 700;
     margin: 5px 0;
+`;
+
+const mobileSubheadingStyles = css`
+    ${until.mobileMedium} {
+        display: none;
+    }
+
+    ${textSans.xxsmall()}
+    color: ${brandAlt[400]};
 `;
 
 const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
@@ -103,7 +114,10 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
 
             <Hide above="tablet">
                 <div>
-                    <Link cssOverrides={ausMomentSubheadingStyles}>
+                    <Link
+                        href="http://support.theguardian.com/contribute"
+                        cssOverrides={mobileSubheadingStyles}
+                    >
                         Join {numberOfSupporters} supporters in Australia
                     </Link>
                 </div>

--- a/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
@@ -42,7 +42,7 @@ const headerYellowHighlight = css`
     margin-bottom: 5px 0;
 `;
 
-const mobileSubheadingStyles = css`
+const mobileCtaStyles = css`
     ${until.mobileMedium} {
         display: none;
     }
@@ -132,7 +132,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                 <div>
                     <Link
                         href="http://support.theguardian.com/contribute"
-                        cssOverrides={mobileSubheadingStyles}
+                        cssOverrides={mobileCtaStyles}
                     >
                         Join {numberOfSupporters} supporters in Australia
                     </Link>

--- a/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
@@ -5,6 +5,9 @@ import { headline, textSans } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
 import { ThemeProvider } from '@emotion/react';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
+import { Link } from '@guardian/src-link';
+import { from } from '@guardian/src-foundations/mq';
+import { Hide } from '@guardian/src-layout';
 import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
 import useNumberOfSupporters from '../../../hooks/useNumberOfSupporters';
 
@@ -14,9 +17,14 @@ const ausMomentHeadingStyles = css`
 `;
 
 const ausMomentSubheadingStyles = css`
-    ${textSans.medium()};
-    color: ${brandText.primary};
+    ${textSans.small()};
+    color: ${brandAlt[400]};
     margin-bottom: 5px;
+
+    ${from.tablet} {
+        ${textSans.medium()};
+        color: ${brandText.primary};
+    }
 `;
 
 const linkStyles = css`
@@ -47,48 +55,59 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
 
     return (
         <div>
-            <div>
-                <div css={ausMomentHeadingStyles}>{heading}</div>
-            </div>
-            <div>
-                <div css={ausMomentSubheadingStyles}>
-                    We&apos;re funded by{' '}
-                    <span css={headerYellowHighlight}>{numberOfSupporters} </span>
-                    readers across Australia.
+            <Hide below="tablet">
+                <div>
+                    <div css={ausMomentHeadingStyles}>{heading}</div>
                 </div>
-            </div>
+                <div>
+                    <div css={ausMomentSubheadingStyles}>
+                        Join <span css={headerYellowHighlight}>{numberOfSupporters} </span>
+                        supporters in Australia
+                    </div>
+                </div>
 
-            {primaryCta && (
-                <>
+                {primaryCta && (
+                    <>
+                        <Hide below="tablet">
+                            <ThemeProvider theme={buttonReaderRevenueBrand}>
+                                <LinkButton
+                                    priority="primary"
+                                    href={primaryCta.ctaUrl}
+                                    icon={<SvgArrowRightStraight />}
+                                    iconSide="right"
+                                    nudgeIcon={true}
+                                    css={linkStyles}
+                                >
+                                    {primaryCta.ctaText}
+                                </LinkButton>
+                            </ThemeProvider>
+                        </Hide>
+                    </>
+                )}
+
+                {secondaryCta && (
                     <ThemeProvider theme={buttonReaderRevenueBrand}>
                         <LinkButton
                             priority="primary"
-                            href={primaryCta.ctaUrl}
+                            href={secondaryCta.ctaUrl}
                             icon={<SvgArrowRightStraight />}
                             iconSide="right"
                             nudgeIcon={true}
                             css={linkStyles}
                         >
-                            {primaryCta.ctaText}
+                            {secondaryCta.ctaText}
                         </LinkButton>
                     </ThemeProvider>
-                </>
-            )}
+                )}
+            </Hide>
 
-            {secondaryCta && (
-                <ThemeProvider theme={buttonReaderRevenueBrand}>
-                    <LinkButton
-                        priority="primary"
-                        href={secondaryCta.ctaUrl}
-                        icon={<SvgArrowRightStraight />}
-                        iconSide="right"
-                        nudgeIcon={true}
-                        css={linkStyles}
-                    >
-                        {secondaryCta.ctaText}
-                    </LinkButton>
-                </ThemeProvider>
-            )}
+            <Hide above="tablet">
+                <div>
+                    <Link cssOverrides={ausMomentSubheadingStyles}>
+                        Join {numberOfSupporters} supporters in Australia
+                    </Link>
+                </div>
+            </Hide>
         </div>
     );
 };

--- a/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
@@ -1,15 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { css } from '@emotion/core';
-import { from } from '@guardian/src-foundations/mq';
-import { space } from '@guardian/src-foundations';
 import { brandAlt, brandText } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
-import { Link, linkBrand } from '@guardian/src-link';
-import { Hide } from '@guardian/src-layout';
 import { ThemeProvider } from '@emotion/react';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
 import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
+import useNumberOfSupporters from '../../../hooks/useNumberOfSupporters';
 
 const ausMomentHeadingStyles = css`
     ${headline.medium({ fontWeight: 'bold' })}
@@ -45,7 +42,8 @@ const headerYellowHighlight = css`
 
 const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
     const { heading, primaryCta, secondaryCta } = props.content;
-    const [numberOfSupporters, setNumberOfSupporters] = useState<string>('147,784');
+
+    const numberOfSupporters = useNumberOfSupporters();
 
     return (
         <div>

--- a/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
@@ -12,15 +12,9 @@ import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
 import useNumberOfSupporters from '../../../hooks/useNumberOfSupporters';
 
 const ausMomentHeadingStyles = css`
-    ${from.mobileMedium} {
-        ${textSans.xsmall({ fontWeight: 'bold' })}
-        color: ${brandAlt[400]};
-    }
-    ${from.tablet} {
-        ${headline.xsmall({ fontWeight: 'bold' })}
-        margin-bottom: ${space[1]}px;
-
-    }
+    ${headline.xsmall({ fontWeight: 'bold' })}
+    color: ${brandAlt[400]};
+    margin-bottom: ${space[1]}px;
 
     ${from.desktop} {
         ${headline.medium({ fontWeight: 'bold' })}

--- a/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { css } from '@emotion/core';
+import { from } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
+import { brandAlt, brandText } from '@guardian/src-foundations';
+import { headline, textSans } from '@guardian/src-foundations/typography';
+import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
+import { Link, linkBrand } from '@guardian/src-link';
+import { Hide } from '@guardian/src-layout';
+import { ThemeProvider } from '@emotion/react';
+import { SvgArrowRightStraight } from '@guardian/src-icons';
+import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
+
+const ausMomentHeadingStyles = css`
+    ${headline.medium({ fontWeight: 'bold' })}
+    color: ${brandAlt[400]};
+`;
+
+const ausMomentSubheadingStyles = css`
+    ${textSans.medium()};
+    color: ${brandText.primary};
+    margin-bottom: 5px;
+`;
+
+const linkStyles = css`
+    height: 32px;
+    min-height: 32px;
+    ${textSans.small({ fontWeight: 'bold' })};
+    border-radius: 16px;
+    padding: 0 12px 0 12px;
+    line-height: 18px;
+    margin-right: 10px;
+    margin-bottom: 6px;
+
+    svg {
+        width: 24px;
+    }
+`;
+
+const headerYellowHighlight = css`
+    color: ${brandAlt[400]};
+    font-weight: 700;
+    margin: 5px 0;
+`;
+
+const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
+    const { heading, primaryCta, secondaryCta } = props.content;
+    const [numberOfSupporters, setNumberOfSupporters] = useState<string>('147,784');
+
+    return (
+        <div>
+            <div>
+                <div css={ausMomentHeadingStyles}>{heading}</div>
+            </div>
+            <div>
+                <div css={ausMomentSubheadingStyles}>
+                    We&apos;re funded by{' '}
+                    <span css={headerYellowHighlight}>{numberOfSupporters} </span>
+                    readers across Australia.
+                </div>
+            </div>
+
+            {primaryCta && (
+                <>
+                    <ThemeProvider theme={buttonReaderRevenueBrand}>
+                        <LinkButton
+                            priority="primary"
+                            href={primaryCta.ctaUrl}
+                            icon={<SvgArrowRightStraight />}
+                            iconSide="right"
+                            nudgeIcon={true}
+                            css={linkStyles}
+                        >
+                            {primaryCta.ctaText}
+                        </LinkButton>
+                    </ThemeProvider>
+                </>
+            )}
+
+            {secondaryCta && (
+                <ThemeProvider theme={buttonReaderRevenueBrand}>
+                    <LinkButton
+                        priority="primary"
+                        href={secondaryCta.ctaUrl}
+                        icon={<SvgArrowRightStraight />}
+                        iconSide="right"
+                        nudgeIcon={true}
+                        css={linkStyles}
+                    >
+                        {secondaryCta.ctaText}
+                    </LinkButton>
+                </ThemeProvider>
+            )}
+        </div>
+    );
+};
+
+const wrapped = headerWrapper(Header);
+export { wrapped as Header };

--- a/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
@@ -40,7 +40,6 @@ const ausMomentSubheadingStyles = css`
 
     ${from.desktop} {
         ${textSans.medium()};
-        margin-bottom: 0;
     }
 `;
 

--- a/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentNonSupporter.tsx
@@ -92,21 +92,19 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
 
                 {primaryCta && (
                     <>
-                        <Hide below="tablet">
-                            <ThemeProvider theme={buttonReaderRevenueBrand}>
-                                <LinkButton
-                                    priority="primary"
-                                    href={primaryCta.ctaUrl}
-                                    icon={<SvgArrowRightStraight />}
-                                    iconSide="right"
-                                    nudgeIcon={true}
-                                    size="xsmall"
-                                    css={linkStyles}
-                                >
-                                    {primaryCta.ctaText}
-                                </LinkButton>
-                            </ThemeProvider>
-                        </Hide>
+                        <ThemeProvider theme={buttonReaderRevenueBrand}>
+                            <LinkButton
+                                priority="primary"
+                                href={primaryCta.ctaUrl}
+                                icon={<SvgArrowRightStraight />}
+                                iconSide="right"
+                                nudgeIcon={true}
+                                size="xsmall"
+                                css={linkStyles}
+                            >
+                                {primaryCta.ctaText}
+                            </LinkButton>
+                        </ThemeProvider>
                     </>
                 )}
 
@@ -127,16 +125,15 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                 )}
             </Hide>
 
-            <Hide above="tablet">
-                <div>
-                    <Link
-                        href="http://support.theguardian.com/contribute"
-                        cssOverrides={mobileCtaStyles}
-                    >
-                        Join {numberOfSupporters} supporters in Australia
-                    </Link>
-                </div>
-            </Hide>
+            {primaryCta && (
+                <Hide above="tablet">
+                    <div>
+                        <Link href={primaryCta.ctaUrl} cssOverrides={mobileCtaStyles}>
+                            Join {numberOfSupporters} supporters in Australia
+                        </Link>
+                    </div>
+                </Hide>
+            )}
         </div>
     );
 };

--- a/src/components/modules/header/HeaderAusMomentSupporter.stories.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.stories.tsx
@@ -16,10 +16,6 @@ export default {
                 url: '',
                 text: 'Support us again',
             },
-            secondaryCta: {
-                url: '',
-                text: 'Support us again',
-            },
         },
     },
     decorators: [HeaderDecorator],
@@ -39,10 +35,6 @@ RecurringSupporter.args = {
         primaryCta: {
             url: '',
             text: 'Make an extra contribution',
-        },
-        secondaryCta: {
-            url: '',
-            text: 'Support us again',
         },
     },
 };

--- a/src/components/modules/header/HeaderAusMomentSupporter.stories.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { HeaderProps } from '../../../types/HeaderTypes';
+import { Header } from './HeaderAusMomentSupporter';
+import { props, HeaderDecorator } from './Header.stories';
+
+export default {
+    component: Header,
+    title: 'Header/AusMomentSupporter',
+    args: {
+        ...props,
+        content: {
+            ...props.content,
+            heading: 'Thank you',
+            primaryCta: {
+                url: '',
+                text: 'Hear from our supporters',
+            },
+            secondaryCta: null,
+        },
+    },
+    decorators: [HeaderDecorator],
+} as Meta;
+
+const Template: Story<HeaderProps> = (props: HeaderProps) => <Header {...props} />;
+
+export const Supporter = Template.bind({});

--- a/src/components/modules/header/HeaderAusMomentSupporter.stories.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.stories.tsx
@@ -16,6 +16,10 @@ export default {
                 url: '',
                 text: 'Support us again',
             },
+            secondaryCta: {
+                url: '',
+                text: 'Support us again',
+            },
         },
     },
     decorators: [HeaderDecorator],
@@ -35,6 +39,10 @@ RecurringSupporter.args = {
         primaryCta: {
             url: '',
             text: 'Make an extra contribution',
+        },
+        secondaryCta: {
+            url: '',
+            text: 'Support us again',
         },
     },
 };

--- a/src/components/modules/header/HeaderAusMomentSupporter.stories.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.stories.tsx
@@ -14,9 +14,8 @@ export default {
             heading: 'Thank you',
             primaryCta: {
                 url: '',
-                text: 'Hear from our supporters',
+                text: 'Support us again',
             },
-            secondaryCta: null,
         },
     },
     decorators: [HeaderDecorator],
@@ -24,4 +23,18 @@ export default {
 
 const Template: Story<HeaderProps> = (props: HeaderProps) => <Header {...props} />;
 
-export const Supporter = Template.bind({});
+export const SingleSupporter = Template.bind({});
+
+export const RecurringSupporter = Template.bind({});
+
+RecurringSupporter.args = {
+    ...props,
+    content: {
+        ...props.content,
+        heading: 'Thank you',
+        primaryCta: {
+            url: '',
+            text: 'Make an extra contribution',
+        },
+    },
+};

--- a/src/components/modules/header/HeaderAusMomentSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.tsx
@@ -12,7 +12,6 @@ import { Hide } from '@guardian/src-layout';
 import useNumberOfSupporters from '../../../hooks/useNumberOfSupporters';
 
 const ausMomentHeadingStyles = css`
-
     ${from.mobileMedium} {
         ${textSans.xsmall({ fontWeight: 'bold' })};
         color: ${brandAlt[400]};

--- a/src/components/modules/header/HeaderAusMomentSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.tsx
@@ -1,22 +1,29 @@
 import React from 'react';
 import { css } from '@emotion/core';
+import { from } from '@guardian/src-foundations/mq';
 import { brandAlt, brandText } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
 import { ThemeProvider } from '@emotion/react';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
 import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
-import { background } from '@guardian/src-foundations/palette';
+import { Link } from '@guardian/src-link';
+import { Hide } from '@guardian/src-layout';
 import useNumberOfSupporters from '../../../hooks/useNumberOfSupporters';
 
 const ausMomentHeadingStyles = css`
-    ${headline.medium({ fontWeight: 'bold' })}
+    ${textSans.medium({ fontWeight: 'bold' })};
     color: ${brandAlt[400]};
+
+    ${from.tablet} {
+        ${headline.medium({ fontWeight: 'bold' })}
+    }
 `;
 
 const ausMomentSubheadingStyles = css`
     ${textSans.medium()};
     color: ${brandText.primary};
+    margin-bottom: 5px;
 `;
 
 const linkStyles = css`
@@ -28,11 +35,6 @@ const linkStyles = css`
     line-height: 18px;
     margin-right: 10px;
     margin-bottom: 6px;
-    background-color: ${background.ctaSecondary};
-
-    &:hover {
-        background-color: ${background.ctaSecondaryHover};
-    }
 
     svg {
         width: 24px;
@@ -45,6 +47,11 @@ const headerYellowHighlight = css`
     margin: 5px 0;
 `;
 
+const mobileSubheadingStyles = css`
+    ${textSans.small()}
+    color: ${brandAlt[400]};
+`;
+
 const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
     const { heading, primaryCta } = props.content;
 
@@ -55,30 +62,44 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
             <div>
                 <div css={ausMomentHeadingStyles}>{heading}</div>
             </div>
-            <div>
-                <div css={ausMomentSubheadingStyles}>
-                    We&apos;re funded by{' '}
-                    <span css={headerYellowHighlight}>{numberOfSupporters} </span>
-                    readers across Australia.
+            <Hide below="tablet">
+                <div>
+                    <div css={ausMomentSubheadingStyles}>
+                        You&apos;re one of the{' '}
+                        <u>
+                            <span css={headerYellowHighlight}>{numberOfSupporters} </span>
+                            supporters in Australia
+                        </u>
+                    </div>
                 </div>
-            </div>
 
-            {primaryCta && (
-                <>
-                    <ThemeProvider theme={buttonReaderRevenueBrand}>
-                        <LinkButton
-                            priority="primary"
-                            href={primaryCta.ctaUrl}
-                            icon={<SvgArrowRightStraight />}
-                            iconSide="right"
-                            nudgeIcon={true}
-                            css={linkStyles}
-                        >
-                            {primaryCta.ctaText}
-                        </LinkButton>
-                    </ThemeProvider>
-                </>
-            )}
+                {primaryCta && (
+                    <>
+                        <ThemeProvider theme={buttonReaderRevenueBrand}>
+                            <LinkButton
+                                priority="primary"
+                                href={primaryCta.ctaUrl}
+                                icon={<SvgArrowRightStraight />}
+                                iconSide="right"
+                                nudgeIcon={true}
+                                css={linkStyles}
+                            >
+                                {primaryCta.ctaText}
+                            </LinkButton>
+                        </ThemeProvider>
+                    </>
+                )}
+            </Hide>
+            <Hide above="tablet">
+                <div>
+                    <Link
+                        href="http://support.theguardian.com/contribute"
+                        css={mobileSubheadingStyles}
+                    >
+                        Support us again
+                    </Link>
+                </div>
+            </Hide>
         </div>
     );
 };

--- a/src/components/modules/header/HeaderAusMomentSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/core';
-import { from } from '@guardian/src-foundations/mq';
-import { brandAlt, brandText } from '@guardian/src-foundations';
+import { from, until } from '@guardian/src-foundations/mq';
+import { brandAlt, brandText, space } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
 import { ThemeProvider } from '@emotion/react';
@@ -12,10 +12,20 @@ import { Hide } from '@guardian/src-layout';
 import useNumberOfSupporters from '../../../hooks/useNumberOfSupporters';
 
 const ausMomentHeadingStyles = css`
-    ${textSans.medium({ fontWeight: 'bold' })};
-    color: ${brandAlt[400]};
+    ${until.mobileMedium} {
+        display: none;
+    }
+
+    ${from.mobileMedium} {
+        ${textSans.xsmall({ fontWeight: 'bold' })};
+        color: ${brandAlt[400]};
+    }
 
     ${from.tablet} {
+        ${headline.xxsmall({ fontWeight: 'bold' })}
+    }
+
+    ${from.desktop} {
         ${headline.medium({ fontWeight: 'bold' })}
     }
 `;
@@ -23,22 +33,11 @@ const ausMomentHeadingStyles = css`
 const ausMomentSubheadingStyles = css`
     ${textSans.medium()};
     color: ${brandText.primary};
-    margin-bottom: 5px;
 `;
 
-const linkStyles = css`
-    height: 32px;
-    min-height: 32px;
-    ${textSans.medium({ fontWeight: 'bold' })};
-    border-radius: 16px;
-    padding: 0 12px 0 12px;
-    line-height: 18px;
-    margin-right: 10px;
-    margin-bottom: 6px;
-
-    svg {
-        width: 24px;
-    }
+const ctaStyles = css`
+    /* ${textSans.small({ fontWeight: 'bold' })}; */
+    margin-top: ${space[2]}px;
 `;
 
 const headerYellowHighlight = css`
@@ -48,8 +47,16 @@ const headerYellowHighlight = css`
 `;
 
 const mobileSubheadingStyles = css`
-    ${textSans.small()}
+    ${until.mobileMedium} {
+        display: none;
+    }
+
+    ${textSans.xxsmall()}
     color: ${brandAlt[400]};
+`;
+
+const ausMapLinkStyles = css`
+    color: ${brandText.primary};
 `;
 
 const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
@@ -65,11 +72,14 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
             <Hide below="tablet">
                 <div>
                     <div css={ausMomentSubheadingStyles}>
-                        You&apos;re one of the{' '}
-                        <u>
+                        You&apos;re one of{' '}
+                        <Link
+                            href="https://support.theguardian.com/aus-map?INTCMP"
+                            css={ausMapLinkStyles}
+                        >
                             <span css={headerYellowHighlight}>{numberOfSupporters} </span>
                             supporters in Australia
-                        </u>
+                        </Link>
                     </div>
                 </div>
 
@@ -82,7 +92,8 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                                 icon={<SvgArrowRightStraight />}
                                 iconSide="right"
                                 nudgeIcon={true}
-                                css={linkStyles}
+                                size="small"
+                                cssOverrides={ctaStyles}
                             >
                                 {primaryCta.ctaText}
                             </LinkButton>

--- a/src/components/modules/header/HeaderAusMomentSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.tsx
@@ -103,7 +103,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                 <div css={ausMomentSubheadingStyles}>
                     You&apos;re one of{' '}
                     <Link
-                        href="https://support.theguardian.com/aus-map?INTCMP"
+                        href="https://support.theguardian.com/aus-map?INTCMP=Aus_moment_2021_header"
                         css={ausMapLinkStyles}
                     >
                         <span css={headerYellowHighlight}>{numberOfSupporters} </span>
@@ -128,15 +128,16 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                             </LinkButton>
                         </Hide>
                     </ThemeProvider>
+
+                    <Hide above="tablet">
+                        <div>
+                            <Link href={primaryCta.ctaUrl} css={mobileCtaStyles}>
+                                Support us again
+                            </Link>
+                        </div>
+                    </Hide>
                 </>
             )}
-            <Hide above="tablet">
-                <div>
-                    <Link href="http://support.theguardian.com/contribute" css={mobileCtaStyles}>
-                        Support us again
-                    </Link>
-                </div>
-            </Hide>
         </div>
     );
 };

--- a/src/components/modules/header/HeaderAusMomentSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.tsx
@@ -1,19 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { css } from '@emotion/core';
-import { from } from '@guardian/src-foundations/mq';
-import { space } from '@guardian/src-foundations';
 import { brandAlt, brandText } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
-import { Link, linkBrand } from '@guardian/src-link';
-import { Hide } from '@guardian/src-layout';
 import { ThemeProvider } from '@emotion/react';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
 import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
 import { background } from '@guardian/src-foundations/palette';
-import { fetchTickerData } from '../../../lib/fetchTickerDataClient';
-import { TickerCountType, TickerData } from '../../../types/shared';
-import { addForMinutes, getCookie } from '../../../lib/cookies';
+import useNumberOfSupporters from '../../../hooks/useNumberOfSupporters';
 
 const ausMomentHeadingStyles = css`
     ${headline.medium({ fontWeight: 'bold' })}
@@ -51,28 +45,10 @@ const headerYellowHighlight = css`
     margin: 5px 0;
 `;
 
-const AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME = 'gu_aus_moment_supporter_count';
-
 const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
-    const { heading, primaryCta, secondaryCta } = props.content;
-    const [numberOfSupporters, setNumberOfSupporters] = useState<string>('147,784');
+    const { heading, primaryCta } = props.content;
 
-    useEffect(() => {
-        const cookieValue = getCookie(AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME);
-
-        if (cookieValue) {
-            setNumberOfSupporters(cookieValue);
-        } else {
-            fetchTickerData(TickerCountType.people).then((td: TickerData) => {
-                addForMinutes(
-                    AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME,
-                    `${td.total.toLocaleString('en-US')}`,
-                    60,
-                );
-                setNumberOfSupporters(td.total.toLocaleString('en-US'));
-            });
-        }
-    }, []);
+    const numberOfSupporters = useNumberOfSupporters();
 
     return (
         <div>
@@ -102,21 +78,6 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                         </LinkButton>
                     </ThemeProvider>
                 </>
-            )}
-
-            {secondaryCta && (
-                <ThemeProvider theme={buttonReaderRevenueBrand}>
-                    <LinkButton
-                        priority="primary"
-                        href={secondaryCta.ctaUrl}
-                        icon={<SvgArrowRightStraight />}
-                        iconSide="right"
-                        nudgeIcon={true}
-                        css={linkStyles}
-                    >
-                        {secondaryCta.ctaText}
-                    </LinkButton>
-                </ThemeProvider>
             )}
         </div>
     );

--- a/src/components/modules/header/HeaderAusMomentSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.tsx
@@ -12,9 +12,6 @@ import { Hide } from '@guardian/src-layout';
 import useNumberOfSupporters from '../../../hooks/useNumberOfSupporters';
 
 const ausMomentHeadingStyles = css`
-    ${until.mobileMedium} {
-        display: none;
-    }
 
     ${from.mobileMedium} {
         ${textSans.xsmall({ fontWeight: 'bold' })};
@@ -22,22 +19,25 @@ const ausMomentHeadingStyles = css`
     }
 
     ${from.tablet} {
-        ${headline.xxsmall({ fontWeight: 'bold' })}
+        ${headline.xsmall({ fontWeight: 'bold' })}
+        margin-bottom: ${space[1]}px;
     }
 
     ${from.desktop} {
         ${headline.medium({ fontWeight: 'bold' })}
+        margin-bottom: 0;
     }
 `;
 
 const ausMomentSubheadingStyles = css`
-    ${textSans.medium()};
+    ${textSans.small()};
     color: ${brandText.primary};
-`;
+    margin-bottom: ${space[2]}px;
+    line-height: 1.15;
 
-const ctaStyles = css`
-    /* ${textSans.small({ fontWeight: 'bold' })}; */
-    margin-top: ${space[2]}px;
+    ${from.desktop} {
+        ${textSans.medium()};
+    }
 `;
 
 const headerYellowHighlight = css`
@@ -46,7 +46,17 @@ const headerYellowHighlight = css`
     margin: 5px 0;
 `;
 
-const mobileSubheadingStyles = css`
+const ausMapLinkStyles = css`
+    ${textSans.small()};
+    color: ${brandText.primary};
+    line-height: 1.15;
+
+    ${from.desktop} {
+        ${textSans.medium()};
+    }
+`;
+
+const mobileCtaStyles = css`
     ${until.mobileMedium} {
         display: none;
     }
@@ -55,8 +65,26 @@ const mobileSubheadingStyles = css`
     color: ${brandAlt[400]};
 `;
 
-const ausMapLinkStyles = css`
-    color: ${brandText.primary};
+const linkStyles = css`
+    height: 24px;
+    min-height: 24px;
+    ${textSans.small({ fontWeight: 'bold' })};
+    border-radius: 16px;
+    padding: 0 ${space[3]}px;
+    margin-right: 10px;
+    margin-bottom: 6px;
+
+    ${from.desktop} {
+        ${textSans.medium({ fontWeight: 'bold' })};
+        height: 36px;
+        min-height: 36px;
+        padding: 0 ${space[4]}px;
+        border-radius: 36px;
+    }
+
+    svg {
+        width: 24px;
+    }
 `;
 
 const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
@@ -66,47 +94,45 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
 
     return (
         <div>
-            <div>
-                <div css={ausMomentHeadingStyles}>{heading}</div>
-            </div>
-            <Hide below="tablet">
+            <Hide below="mobileMedium">
                 <div>
-                    <div css={ausMomentSubheadingStyles}>
-                        You&apos;re one of{' '}
-                        <Link
-                            href="https://support.theguardian.com/aus-map?INTCMP"
-                            css={ausMapLinkStyles}
-                        >
-                            <span css={headerYellowHighlight}>{numberOfSupporters} </span>
-                            supporters in Australia
-                        </Link>
-                    </div>
+                    <div css={ausMomentHeadingStyles}>{heading}</div>
                 </div>
+            </Hide>
+            <Hide below="tablet">
+                <div css={ausMomentSubheadingStyles}>
+                    You&apos;re one of{' '}
+                    <Link
+                        href="https://support.theguardian.com/aus-map?INTCMP"
+                        css={ausMapLinkStyles}
+                    >
+                        <span css={headerYellowHighlight}>{numberOfSupporters} </span>
+                        supporters in Australia
+                    </Link>
+                </div>
+            </Hide>
 
-                {primaryCta && (
-                    <>
-                        <ThemeProvider theme={buttonReaderRevenueBrand}>
+            {primaryCta && (
+                <>
+                    <ThemeProvider theme={buttonReaderRevenueBrand}>
+                        <Hide below="tablet">
                             <LinkButton
                                 priority="primary"
                                 href={primaryCta.ctaUrl}
                                 icon={<SvgArrowRightStraight />}
                                 iconSide="right"
                                 nudgeIcon={true}
-                                size="small"
-                                cssOverrides={ctaStyles}
+                                css={linkStyles}
                             >
                                 {primaryCta.ctaText}
                             </LinkButton>
-                        </ThemeProvider>
-                    </>
-                )}
-            </Hide>
+                        </Hide>
+                    </ThemeProvider>
+                </>
+            )}
             <Hide above="tablet">
                 <div>
-                    <Link
-                        href="http://support.theguardian.com/contribute"
-                        css={mobileSubheadingStyles}
-                    >
+                    <Link href="http://support.theguardian.com/contribute" css={mobileCtaStyles}>
                         Support us again
                     </Link>
                 </div>

--- a/src/components/modules/header/HeaderAusMomentSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.tsx
@@ -37,6 +37,7 @@ const ausMomentSubheadingStyles = css`
 
     ${from.desktop} {
         ${textSans.medium()};
+        margin-bottom: ${space[1]}px;
     }
 `;
 

--- a/src/components/modules/header/HeaderAusMomentSupporter.tsx
+++ b/src/components/modules/header/HeaderAusMomentSupporter.tsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect } from 'react';
+import { css } from '@emotion/core';
+import { from } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
+import { brandAlt, brandText } from '@guardian/src-foundations';
+import { headline, textSans } from '@guardian/src-foundations/typography';
+import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
+import { Link, linkBrand } from '@guardian/src-link';
+import { Hide } from '@guardian/src-layout';
+import { ThemeProvider } from '@emotion/react';
+import { SvgArrowRightStraight } from '@guardian/src-icons';
+import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
+import { background } from '@guardian/src-foundations/palette';
+import { fetchTickerData } from '../../../lib/fetchTickerDataClient';
+import { TickerCountType, TickerData } from '../../../types/shared';
+import { addForMinutes, getCookie } from '../../../lib/cookies';
+
+const ausMomentHeadingStyles = css`
+    ${headline.medium({ fontWeight: 'bold' })}
+    color: ${brandAlt[400]};
+`;
+
+const ausMomentSubheadingStyles = css`
+    ${textSans.medium()};
+    color: ${brandText.primary};
+`;
+
+const linkStyles = css`
+    height: 32px;
+    min-height: 32px;
+    ${textSans.medium({ fontWeight: 'bold' })};
+    border-radius: 16px;
+    padding: 0 12px 0 12px;
+    line-height: 18px;
+    margin-right: 10px;
+    margin-bottom: 6px;
+    background-color: ${background.ctaSecondary};
+
+    &:hover {
+        background-color: ${background.ctaSecondaryHover};
+    }
+
+    svg {
+        width: 24px;
+    }
+`;
+
+const headerYellowHighlight = css`
+    color: ${brandAlt[400]};
+    font-weight: 700;
+    margin: 5px 0;
+`;
+
+const AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME = 'gu_aus_moment_supporter_count';
+
+const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
+    const { heading, primaryCta, secondaryCta } = props.content;
+    const [numberOfSupporters, setNumberOfSupporters] = useState<string>('147,784');
+
+    useEffect(() => {
+        const cookieValue = getCookie(AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME);
+
+        if (cookieValue) {
+            setNumberOfSupporters(cookieValue);
+        } else {
+            fetchTickerData(TickerCountType.people).then((td: TickerData) => {
+                addForMinutes(
+                    AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME,
+                    `${td.total.toLocaleString('en-US')}`,
+                    60,
+                );
+                setNumberOfSupporters(td.total.toLocaleString('en-US'));
+            });
+        }
+    }, []);
+
+    return (
+        <div>
+            <div>
+                <div css={ausMomentHeadingStyles}>{heading}</div>
+            </div>
+            <div>
+                <div css={ausMomentSubheadingStyles}>
+                    We&apos;re funded by{' '}
+                    <span css={headerYellowHighlight}>{numberOfSupporters} </span>
+                    readers across Australia.
+                </div>
+            </div>
+
+            {primaryCta && (
+                <>
+                    <ThemeProvider theme={buttonReaderRevenueBrand}>
+                        <LinkButton
+                            priority="primary"
+                            href={primaryCta.ctaUrl}
+                            icon={<SvgArrowRightStraight />}
+                            iconSide="right"
+                            nudgeIcon={true}
+                            css={linkStyles}
+                        >
+                            {primaryCta.ctaText}
+                        </LinkButton>
+                    </ThemeProvider>
+                </>
+            )}
+
+            {secondaryCta && (
+                <ThemeProvider theme={buttonReaderRevenueBrand}>
+                    <LinkButton
+                        priority="primary"
+                        href={secondaryCta.ctaUrl}
+                        icon={<SvgArrowRightStraight />}
+                        iconSide="right"
+                        nudgeIcon={true}
+                        css={linkStyles}
+                    >
+                        {secondaryCta.ctaText}
+                    </LinkButton>
+                </ThemeProvider>
+            )}
+        </div>
+    );
+};
+
+const wrapped = headerWrapper(Header);
+export { wrapped as Header };

--- a/src/hooks/useNumberOfSupporters.ts
+++ b/src/hooks/useNumberOfSupporters.ts
@@ -11,7 +11,7 @@ const useNumberOfSupporters = (): string => {
     useEffect(() => {
         const cookieValue = getCookie(AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME);
         if (cookieValue) {
-            setNumberOfSupporters(Number(cookieValue).toLocaleString());
+            setNumberOfSupporters(Number(cookieValue).toLocaleString('en-US'));
         } else {
             fetchTickerData(TickerCountType.people).then((td: TickerData) => {
                 addForMinutes(AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME, `${td.total}`, 60);

--- a/src/hooks/useNumberOfSupporters.ts
+++ b/src/hooks/useNumberOfSupporters.ts
@@ -10,16 +10,11 @@ const useNumberOfSupporters = (): string => {
 
     useEffect(() => {
         const cookieValue = getCookie(AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME);
-
         if (cookieValue) {
-            setNumberOfSupporters(cookieValue);
+            setNumberOfSupporters(Number(cookieValue).toLocaleString());
         } else {
             fetchTickerData(TickerCountType.people).then((td: TickerData) => {
-                addForMinutes(
-                    AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME,
-                    `${td.total.toLocaleString('en-US')}`,
-                    60,
-                );
+                addForMinutes(AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME, `${td.total}`, 60);
                 setNumberOfSupporters(td.total.toLocaleString('en-US'));
             });
         }

--- a/src/hooks/useNumberOfSupporters.ts
+++ b/src/hooks/useNumberOfSupporters.ts
@@ -1,0 +1,31 @@
+import { addForMinutes, getCookie } from '../lib/cookies';
+import { fetchTickerData } from '../lib/fetchTickerDataClient';
+import { useEffect, useState } from 'react';
+import { TickerCountType, TickerData } from '../types/shared';
+
+const AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME = 'gu_aus_moment_supporter_count';
+
+const useNumberOfSupporters = (): string => {
+    const [numberOfSupporters, setNumberOfSupporters] = useState<string>('');
+
+    useEffect(() => {
+        const cookieValue = getCookie(AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME);
+
+        if (cookieValue) {
+            setNumberOfSupporters(cookieValue);
+        } else {
+            fetchTickerData(TickerCountType.people).then((td: TickerData) => {
+                addForMinutes(
+                    AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME,
+                    `${td.total.toLocaleString('en-US')}`,
+                    60,
+                );
+                setNumberOfSupporters(td.total.toLocaleString('en-US'));
+            });
+        }
+    }, []);
+
+    return numberOfSupporters;
+};
+
+export default useNumberOfSupporters;

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -79,3 +79,14 @@ export const removeCookie = (name: string, currentDomainOnly: boolean = false): 
         document.cookie = `${name}=;${path}${expires} domain=${getShortDomain()};`;
     }
 };
+
+export const addForMinutes = (name: string, value: string, minutesToLive: number): void => {
+    const expires = new Date();
+
+    if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
+        throw new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`);
+    }
+
+    expires.setMinutes(expires.getMinutes() + minutesToLive);
+    document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute()}`;
+};

--- a/src/lib/fetchTickerDataClient.ts
+++ b/src/lib/fetchTickerDataClient.ts
@@ -1,0 +1,35 @@
+import { TickerCountType, TickerData } from '../types/shared';
+
+const tickerUrl = (countType: TickerCountType): string =>
+    countType === TickerCountType.people
+        ? 'https://support.theguardian.com/supporters-ticker.json'
+        : 'https://support.theguardian.com/ticker.json';
+
+const checkForErrors = (response: Response): Promise<Response> => {
+    if (!response.ok) {
+        return Promise.reject(
+            response.statusText || `Ticker api call returned HTTP status ${response.status}`,
+        );
+    }
+    return Promise.resolve(response);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const parse = (json: any): Promise<TickerData> => {
+    const total = parseInt(json.total, 10);
+    const goal = parseInt(json.goal, 10);
+
+    if (!Number.isNaN(total) && !Number.isNaN(goal)) {
+        return Promise.resolve({
+            total,
+            goal,
+        });
+    }
+    return Promise.reject(Error(`Failed to parse ticker data: ${json}`));
+};
+
+export const fetchTickerData = (tickerType: TickerCountType): Promise<TickerData> =>
+    fetch(tickerUrl(tickerType))
+        .then(response => checkForErrors(response))
+        .then(response => response.json())
+        .then(parse);

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -60,6 +60,16 @@ export const headerSupportAgain: ModuleInfo = getDefaultModuleInfo(
     'header/HeaderSupportAgain',
 );
 
+export const ausMomentHeaderSupporter: ModuleInfo = getDefaultModuleInfo(
+    'aus-moment-header-supporter',
+    'header/HeaderAusMomentSupporter',
+);
+
+export const ausMomentHeaderNonSupporter: ModuleInfo = getDefaultModuleInfo(
+    'aus-moment-header-nonsupporter',
+    'header/HeaderAusMomentNonSupporter',
+);
+
 export const moduleInfos: ModuleInfo[] = [
     epic,
     epicWithArticleCountOptOut,
@@ -71,4 +81,6 @@ export const moduleInfos: ModuleInfo[] = [
     puzzlesBanner,
     header,
     headerSupportAgain,
+    ausMomentHeaderSupporter,
+    ausMomentHeaderNonSupporter,
 ];

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -111,17 +111,19 @@ const getNonSupportersTest = (edition: string): HeaderTest =>
 
 const isAusMoment = (countryCode: string): boolean => countryCode === 'AU' && isAusMomentLive();
 
-const isAusMomentLive = () => Date.now() >= Date.parse('2021-07-19');
+const isAusMomentLive = () => Date.now() >= Date.parse('2021-06-19');
 
 export const selectHeaderTest = (
     targeting: HeaderTargeting,
 ): Promise<HeaderTestSelection | null> => {
     const select = (): HeaderTest => {
         if (isAusMoment(targeting.countryCode)) {
-            if (targeting.showSupportMessaging) {
-                return ausMomentNonSupporter;
+            if (targeting.lastOneOffContributionDate) {
+                return ausMomentOneOffContributor;
+            } else if (!targeting.showSupportMessaging) {
+                return ausMomentRecurringSupporter;
             } else {
-                return ausMomentSupporter;
+                return ausMomentNonSupporter;
             }
         }
         if (isLastOneOffContributionWithinLast2To13Months(targeting.lastOneOffContributionDate)) {
@@ -146,7 +148,7 @@ export const selectHeaderTest = (
     return Promise.resolve(null);
 };
 
-const ausMomentSupporter: HeaderTest = {
+const ausMomentRecurringSupporter: HeaderTest = {
     name: 'aus-moment-supporter',
     audience: 'AllExistingSupporters',
     variants: [
@@ -157,9 +159,27 @@ const ausMomentSupporter: HeaderTest = {
                 heading: 'Thank you',
                 subheading: '',
                 primaryCta: {
-                    text: 'Hear from our supporters',
-                    url:
-                        'https://support.theguardian.com/aus-2020-map?INTCMP=Aus_moment_2020_frontend_header',
+                    text: 'Make an extra contribution',
+                    url: 'https://support.theguardian.com/contribute',
+                },
+            },
+        },
+    ],
+};
+
+const ausMomentOneOffContributor: HeaderTest = {
+    name: 'aus-moment-supporter',
+    audience: 'AllExistingSupporters',
+    variants: [
+        {
+            name: 'control',
+            modulePathBuilder: ausMomentHeaderSupporter.endpointPathBuilder,
+            content: {
+                heading: 'Thank you',
+                subheading: '',
+                primaryCta: {
+                    text: 'Support us again',
+                    url: 'https://support.theguardian.com/contribute',
                 },
             },
         },
@@ -174,7 +194,7 @@ const ausMomentNonSupporter: HeaderTest = {
             name: 'control',
             modulePathBuilder: ausMomentHeaderNonSupporter.endpointPathBuilder,
             content: {
-                heading: 'Support the Guarian',
+                heading: 'Support the Guardian',
                 subheading: '',
                 primaryCta: {
                     text: 'Contribute',
@@ -182,7 +202,7 @@ const ausMomentNonSupporter: HeaderTest = {
                 },
                 secondaryCta: {
                     text: 'Subscribe',
-                    url: 'https://support.theguardian.com/subscribe',
+                    url: 'https://support.theguardian.com/subsribe',
                 },
             },
         },

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -1,5 +1,10 @@
 import { HeaderTargeting, HeaderTest, HeaderTestSelection } from '../../types/HeaderTypes';
-import { header, headerSupportAgain } from '../../modules';
+import {
+    ausMomentHeaderNonSupporter,
+    ausMomentHeaderSupporter,
+    header,
+    headerSupportAgain,
+} from '../../modules';
 
 const modulePathBuilder = header.endpointPathBuilder;
 
@@ -104,10 +109,21 @@ const isLastOneOffContributionWithinLast2To13Months = (
 const getNonSupportersTest = (edition: string): HeaderTest =>
     edition === 'UK' ? nonSupportersTestUK : nonSupportersTestNonUK;
 
+const isAusMoment = (countryCode: string): boolean => countryCode === 'AU' && isAusMomentLive();
+
+const isAusMomentLive = () => Date.now() >= Date.parse('2021-07-19');
+
 export const selectHeaderTest = (
     targeting: HeaderTargeting,
 ): Promise<HeaderTestSelection | null> => {
     const select = (): HeaderTest => {
+        if (isAusMoment(targeting.countryCode)) {
+            if (targeting.showSupportMessaging) {
+                return ausMomentNonSupporter;
+            } else {
+                return ausMomentSupporter;
+            }
+        }
         if (isLastOneOffContributionWithinLast2To13Months(targeting.lastOneOffContributionDate)) {
             return supportAgainTest;
         } else if (targeting.showSupportMessaging) {
@@ -128,4 +144,47 @@ export const selectHeaderTest = (
         });
     }
     return Promise.resolve(null);
+};
+
+const ausMomentSupporter: HeaderTest = {
+    name: 'aus-moment-supporter',
+    audience: 'AllExistingSupporters',
+    variants: [
+        {
+            name: 'control',
+            modulePathBuilder: ausMomentHeaderSupporter.endpointPathBuilder,
+            content: {
+                heading: 'Thank you',
+                subheading: '',
+                primaryCta: {
+                    text: 'Hear from our supporters',
+                    url:
+                        'https://support.theguardian.com/aus-2020-map?INTCMP=Aus_moment_2020_frontend_header',
+                },
+            },
+        },
+    ],
+};
+
+const ausMomentNonSupporter: HeaderTest = {
+    name: 'aus-moment-nonsupporter',
+    audience: 'AllNonSupporters',
+    variants: [
+        {
+            name: 'control',
+            modulePathBuilder: ausMomentHeaderNonSupporter.endpointPathBuilder,
+            content: {
+                heading: 'Support the Guarian',
+                subheading: '',
+                primaryCta: {
+                    text: 'Contribute',
+                    url: 'https://support.theguardian.com/contribute',
+                },
+                secondaryCta: {
+                    text: 'Subscribe',
+                    url: 'https://support.theguardian.com/subscribe',
+                },
+            },
+        },
+    ],
 };

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -119,10 +119,10 @@ export const selectHeaderTest = (
 ): Promise<HeaderTestSelection | null> => {
     const select = (): HeaderTest => {
         if (isAusMoment(targeting.countryCode)) {
-            if (targeting.isRecurringContributor) {
-                return ausMomentRecurringSupporter;
-            } else if (targeting.lastOneOffContributionDate) {
+            if (targeting.lastOneOffContributionDate) {
                 return ausMomentOneOffContributor;
+            } else if (!targeting.showSupportMessaging) {
+                return ausMomentRecurringSupporter;
             } else {
                 return ausMomentNonSupporter;
             }

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -111,7 +111,7 @@ const getNonSupportersTest = (edition: string): HeaderTest =>
 
 const isAusMoment = (countryCode: string): boolean => countryCode === 'AU' && isAusMomentLive();
 
-const isAusMomentLive = () => Date.now() >= Date.parse('2021-06-19');
+const isAusMomentLive = () => Date.now() >= Date.parse('2021-07-19');
 
 export const selectHeaderTest = (
     targeting: HeaderTargeting,

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -111,6 +111,7 @@ const getNonSupportersTest = (edition: string): HeaderTest =>
 
 const isAusMoment = (countryCode: string): boolean => countryCode === 'AU' && isAusMomentLive();
 
+// date is set to present for testing purposes - needs to be changed to july 17th when aus moment goes live
 const isAusMomentLive = () => Date.now() >= Date.parse('2021-06-19');
 
 export const selectHeaderTest = (

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -118,10 +118,10 @@ export const selectHeaderTest = (
 ): Promise<HeaderTestSelection | null> => {
     const select = (): HeaderTest => {
         if (isAusMoment(targeting.countryCode)) {
-            if (targeting.lastOneOffContributionDate) {
-                return ausMomentOneOffContributor;
-            } else if (!targeting.showSupportMessaging) {
+            if (targeting.isRecurringContributor) {
                 return ausMomentRecurringSupporter;
+            } else if (targeting.lastOneOffContributionDate) {
+                return ausMomentOneOffContributor;
             } else {
                 return ausMomentNonSupporter;
             }
@@ -162,6 +162,10 @@ const ausMomentRecurringSupporter: HeaderTest = {
                     text: 'Make an extra contribution',
                     url: 'https://support.theguardian.com/contribute',
                 },
+                secondaryCta: {
+                    text: 'Support us again',
+                    url: 'https://support.theguardian.com/contribute',
+                },
             },
         },
     ],
@@ -178,6 +182,10 @@ const ausMomentOneOffContributor: HeaderTest = {
                 heading: 'Thank you',
                 subheading: '',
                 primaryCta: {
+                    text: 'Support us again',
+                    url: 'https://support.theguardian.com/contribute',
+                },
+                secondaryCta: {
                     text: 'Support us again',
                     url: 'https://support.theguardian.com/contribute',
                 },

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -111,7 +111,6 @@ const getNonSupportersTest = (edition: string): HeaderTest =>
 
 const isAusMoment = (countryCode: string): boolean => countryCode === 'AU' && isAusMomentLive();
 
-// date is set to present for testing purposes - needs to be changed to july 17th when aus moment goes live
 const isAusMomentLive = () => Date.now() >= Date.parse('2021-06-19');
 
 export const selectHeaderTest = (
@@ -119,7 +118,9 @@ export const selectHeaderTest = (
 ): Promise<HeaderTestSelection | null> => {
     const select = (): HeaderTest => {
         if (isAusMoment(targeting.countryCode)) {
-            if (targeting.lastOneOffContributionDate) {
+            if (
+                isLastOneOffContributionWithinLast2To13Months(targeting.lastOneOffContributionDate)
+            ) {
                 return ausMomentOneOffContributor;
             } else if (!targeting.showSupportMessaging) {
                 return ausMomentRecurringSupporter;
@@ -163,10 +164,6 @@ const ausMomentRecurringSupporter: HeaderTest = {
                     text: 'Make an extra contribution',
                     url: 'https://support.theguardian.com/contribute',
                 },
-                secondaryCta: {
-                    text: 'Support us again',
-                    url: 'https://support.theguardian.com/contribute',
-                },
             },
         },
     ],
@@ -183,10 +180,6 @@ const ausMomentOneOffContributor: HeaderTest = {
                 heading: 'Thank you',
                 subheading: '',
                 primaryCta: {
-                    text: 'Support us again',
-                    url: 'https://support.theguardian.com/contribute',
-                },
-                secondaryCta: {
                     text: 'Support us again',
                     url: 'https://support.theguardian.com/contribute',
                 },
@@ -211,7 +204,7 @@ const ausMomentNonSupporter: HeaderTest = {
                 },
                 secondaryCta: {
                     text: 'Subscribe',
-                    url: 'https://support.theguardian.com/subsribe',
+                    url: 'https://support.theguardian.com/subscribe',
                 },
             },
         },

--- a/src/types/HeaderTypes.ts
+++ b/src/types/HeaderTypes.ts
@@ -61,4 +61,5 @@ export interface HeaderTargeting {
     modulesVersion?: string;
     mvtId: number;
     lastOneOffContributionDate?: string;
+    isRecurringContributor?: boolean;
 }

--- a/src/types/HeaderTypes.ts
+++ b/src/types/HeaderTypes.ts
@@ -61,5 +61,4 @@ export interface HeaderTargeting {
     modulesVersion?: string;
     mvtId: number;
     lastOneOffContributionDate?: string;
-    isRecurringContributor?: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,12 +1307,25 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.5.0.tgz#b31d8a2a41c594bbc4551c9d53738f2515f321f5"
   integrity sha512-Xx5kq1bJLKpghBRnFjzKAfnZsWcP76aQfTf7sA1hgq61o/CXHYTTL2iv3AF186zvxEMZ1oZ+Xo0E8TvzX1aLBQ==
 
+"@guardian/src-foundations@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.7.0.tgz#f5f3a3c6d20c72d257447d1a8d97d1ffb613da0d"
+  integrity sha512-YLbr1D8VCoSg2nngMlMuq25zTcgngw01VZaqiyY4j9tC8IxFDliLbIf7mvQigKq9qn8RAlfM7HkMGzxSxVHtDg==
+
 "@guardian/src-helpers@^3.5.0":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-3.5.0.tgz#9b685ef8b900a6df2ca86ca2a5dc8f810b2fb650"
   integrity sha512-6fav708zODa0fkhlj67k8xdu4MAEQUaUgj8HjIYFU6qiohZI6cS57U5RrQlXV5BYAhz6vts9/EMzjawxV5IHcA==
   dependencies:
     "@guardian/src-foundations" "^3.5.0"
+
+"@guardian/src-helpers@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-3.7.0.tgz#58f7a8fe19370cf6a74a5a5cd4581a77d56c4018"
+  integrity sha512-JvFd1EAjf/IHBsyDIAvObcrqChu6OERaE+TlploALBeVvGaZWonyPFNu83f/O9De3/rCq6xuS23NWhjDEuaMxA==
+  dependencies:
+    "@guardian/src-foundations" "^3.7.0"
+    mini-svg-data-uri "^1.2.3"
 
 "@guardian/src-icons@^3.3.0", "@guardian/src-icons@^3.5.0":
   version "3.5.0"
@@ -1333,12 +1346,12 @@
   dependencies:
     "@guardian/src-helpers" "^3.5.0"
 
-"@guardian/src-link@^3.3.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-link/-/src-link-3.5.0.tgz#96501b9e210e053e47c1ba3febba06b7edf6c328"
-  integrity sha512-BMNYbk1+RuqIVliulQvIoLUGWHhp2py9GBuaDSElUHGEfK6LmKoSSR9HjjmZtGSbxm7B+bAmKmWxWv6s3Jj3WA==
+"@guardian/src-link@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-link/-/src-link-3.7.0.tgz#8cb3e79644050a5cbc95dbd09807ec67e2bfe1cb"
+  integrity sha512-8wGjCVSR0wR8OwNuSA6X04hIOANl6asjyWtmKa845hl5MCYP55LORjMGvYGTZc72e6KCwpTKED+yvKZ14MDaRQ==
   dependencies:
-    "@guardian/src-helpers" "^3.5.0"
+    "@guardian/src-helpers" "^3.7.0"
 
 "@guardian/src-text-input@^3.3.0":
   version "3.5.0"
@@ -9369,6 +9382,11 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-svg-data-uri@^1.2.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.3.3.tgz#91d2c09f45e056e5e1043340b8b37ba7b50f4fac"
+  integrity sha512-+fA2oRcR1dJI/7ITmeQJDrYWks0wodlOz0pAEhKYJ2IVc1z0AnwJUsKY2fzFmPAM3Jo9J0rBx8JAA9QQSJ5PuA==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- Special header for Aus Moment 2021
- Renders different copies for recurring / one-off and non-supporters & mobile design
- Fetches supporter number data

## Images
**Non-supporter**
desktop
<img width="1076" alt="Screenshot 2021-06-28 at 16 00 35" src="https://user-images.githubusercontent.com/47318984/123659270-68002c80-d82a-11eb-9860-bf7f3898c0dd.png">

mobile 
<img width="380" alt="Screenshot 2021-06-28 at 15 42 43" src="https://user-images.githubusercontent.com/47318984/123659299-6f273a80-d82a-11eb-8516-417e3e2d7218.png">

**Supporter**

Recurring contributors
<img width="1127" alt="Screenshot 2021-06-28 at 16 07 05" src="https://user-images.githubusercontent.com/47318984/123659788-f5438100-d82a-11eb-9840-5618b244848e.png">


One-off contributors
<img width="1295" alt="Screenshot 2021-06-28 at 15 40 43" src="https://user-images.githubusercontent.com/47318984/123659402-8d8d3600-d82a-11eb-8e53-c1ce2b9c4b3a.png">

mobile for both one-off and recurring
<img width="380" alt="Screenshot 2021-06-28 at 15 41 24" src="https://user-images.githubusercontent.com/47318984/123659333-79e1cf80-d82a-11eb-9870-d3f541d48b3b.png">


