### PR TITLE
Add "super mode" support

### DIFF
--- a/src/lib/superMode.ts
+++ b/src/lib/superMode.ts
@@ -1,0 +1,23 @@
+import { isProd } from './env';
+import { fetchS3Data } from '../utils/S3';
+import { EpicTest } from '../types/EpicTypes';
+
+const S3_BUCKET = 'gu-contributions-public';
+const S3_KEY = `super-mode/${isProd ? 'PROD' : 'CODE'}/articles.json`;
+
+export interface SuperModeArticle {
+    url: string;
+    timestamp: number;
+}
+
+export const fetchSuperModeArticles = async (): Promise<SuperModeArticle[]> => {
+    return fetchS3Data(S3_BUCKET, S3_KEY).then(JSON.parse);
+};
+
+export const isInSuperMode = (url: string, superModeArticles: SuperModeArticle[]): boolean => {
+    return superModeArticles.map(a => a.url).includes(url);
+};
+
+export const superModeify = (test?: EpicTest): EpicTest | undefined => {
+    return test && { ...test, isSuperMode: true };
+};

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -28,6 +28,7 @@ export const addTrackingParams = (
             referrerPageviewId: params.ophanPageId,
             referrerUrl: params.referrerUrl,
             isRemote: true, // Temp param to indicate served by remote service
+            labels: params.labels,
         }),
     );
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -52,6 +52,14 @@ jest.mock('./channelSwitches', () => {
     };
 });
 
+jest.mock('./lib/superMode', () => {
+    return {
+        fetchSuperModeArticles: jest.fn().mockImplementation(() => {
+            Promise.resolve([]);
+        }),
+    };
+});
+
 describe('POST /epic', () => {
     it('should return epic data', async () => {
         const targeting = factories.targeting.build({

--- a/src/tests/epics/epicSelection.test.ts
+++ b/src/tests/epics/epicSelection.test.ts
@@ -15,6 +15,7 @@ import {
 import { EpicTargeting, EpicTest } from '../../types/EpicTypes';
 import { SecondaryCtaType } from '../../types/shared';
 import { withNowAs } from '../../utils/withNowAs';
+import { SuperModeArticle } from '../../lib/superMode';
 
 const testDefault: EpicTest = {
     name: 'example-1',
@@ -81,6 +82,8 @@ const targetingDefault: EpicTargeting = {
     hasOptedOutOfArticleCount: false,
 };
 
+const superModeArticles: SuperModeArticle[] = [];
+
 describe('findTestAndVariant', () => {
     it('should find the correct variant for test and targeting data', () => {
         const testWithoutArticlesViewedSettings = {
@@ -94,7 +97,7 @@ describe('findTestAndVariant', () => {
         };
         const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, epicType);
+        const got = findTestAndVariant(tests, targeting, superModeArticles, epicType);
 
         expect(got?.result?.test.name).toBe('example-1');
         expect(got?.result?.variant.name).toBe('control-example-1');
@@ -109,7 +112,7 @@ describe('findTestAndVariant', () => {
         };
         const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, epicType);
+        const got = findTestAndVariant(tests, targeting, superModeArticles, epicType);
 
         expect(got.result).toBe(undefined);
     });
@@ -120,7 +123,7 @@ describe('findTestAndVariant', () => {
         const targeting = { ...targetingDefault, sectionName: 'news' };
         const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, epicType);
+        const got = findTestAndVariant(tests, targeting, superModeArticles, epicType);
 
         expect(got.result).toBe(undefined);
     });
@@ -138,7 +141,7 @@ describe('findTestAndVariant', () => {
         };
         const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, epicType);
+        const got = findTestAndVariant(tests, targeting, superModeArticles, epicType);
 
         expect(got?.result?.variant.showReminderFields).toBe(undefined);
     });

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -42,6 +42,7 @@ export type BannerTestTracking = {
     campaignCode: string;
     componentType: OphanComponentType;
     products?: OphanProduct[];
+    labels?: string[];
 };
 
 export type BannerPageTracking = {
@@ -59,6 +60,7 @@ const bannerTrackingSchema = z.object({
     campaignCode: z.string(),
     componentType: ophanComponentTypeSchema,
     products: z.array(ophanProductSchema).optional(),
+    labels: z.array(z.string()).optional(),
     ophanPageId: z.string(),
     platformId: z.string(),
     referrerUrl: z.string(),

--- a/src/types/EpicTypes.ts
+++ b/src/types/EpicTypes.ts
@@ -26,6 +26,7 @@ export type EpicTestTracking = {
     campaignId: string;
     componentType: OphanComponentType;
     products: OphanProduct[];
+    labels?: string[];
 };
 
 export type EpicTracking = EpicPageTracking & EpicTestTracking;
@@ -71,6 +72,7 @@ export type EpicTargeting = {
     isRecurringContributor: boolean;
     lastOneOffContributionDate?: number; // Platform to send undefined or a timestamp date
     modulesVersion?: string;
+    url?: string;
 };
 
 export type EpicPayload = {
@@ -160,4 +162,6 @@ export interface EpicTest extends Test<EpicVariant> {
     campaignId?: string;
 
     controlProportionSettings?: ControlProportionSettings;
+
+    isSuperMode?: boolean;
 }

--- a/src/types/HeaderTypes.ts
+++ b/src/types/HeaderTypes.ts
@@ -50,6 +50,7 @@ export interface HeaderTestTracking {
     abTestVariant: string;
     campaignCode: string;
     componentType: OphanComponentType;
+    labels?: string[];
 }
 
 export type HeaderTracking = HeaderPageTracking & HeaderTestTracking;

--- a/teamcity.sh
+++ b/teamcity.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export NODE_OPTIONS="--max-old-space-size=8192"
+export NODE_OPTIONS="--max-old-space-size=16384"
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
 


### PR DESCRIPTION
## What does this change?
Add "super mode" support. SDC will now poll an `articles.json` in s3 (produced by the super mode calculator) to get a list of articles currently in super mode. We have new logic when assigning a user to a test for a super mode article. First we do a regular pass through the tests. If there is a suitable test, the user will be assigned to. This **does not** count as a super mode test. If there are no suitable tests, we do a second, "super mode", pass through the tests. This time, we effectively treat all tests as "always ask". If there is a suitable test, the user will be assigned to it. This **does** count as a super mode test. In this manner, super mode tests are only ever **incremental** i.e we only consider it a super mode test if the user wouldn't have seen a test if not for super mode. 