### PR TITLE
Fix banner module

### DIFF
--- a/src/lib/reminderFields.ts
+++ b/src/lib/reminderFields.ts
@@ -1,5 +1,4 @@
-import { EpicTargeting, EpicVariant } from '../types/EpicTypes';
-import { getUserCohorts } from '../tests/epics/epicSelection';
+import { EpicVariant } from '../types/EpicTypes';
 
 export interface ReminderFields {
     reminderCta: string;
@@ -29,16 +28,6 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-export const getReminderFields = (
-    variant: EpicVariant,
-    targeting: EpicTargeting,
-): ReminderFields | undefined => {
-    const userCohorts = getUserCohorts(targeting);
-    const isSupporter = userCohorts.includes('AllExistingSupporters');
-
-    if (isSupporter) {
-        return undefined;
-    }
-
+export const getReminderFields = (variant: EpicVariant): ReminderFields | undefined => {
     return !!variant.showReminderFields ? variant.showReminderFields : buildReminderFields();
 };

--- a/src/payloads.ts
+++ b/src/payloads.ts
@@ -180,7 +180,7 @@ export const buildEpicData = async (
     const { test, variant } = result.result;
 
     const tickerSettings = await getTickerSettings(variant);
-    const showReminderFields = getReminderFields(variant, targeting);
+    const showReminderFields = getReminderFields(variant);
 
     const variantWithTickerAndReminder = { ...variant, tickerSettings, showReminderFields };
 

--- a/src/tests/banners/ChannelBannerTests.ts
+++ b/src/tests/banners/ChannelBannerTests.ts
@@ -77,7 +77,7 @@ const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTes
                         return {
                             name: testParams.name,
                             bannerChannel,
-                            testAudience: testParams.userCohort,
+                            userCohort: testParams.userCohort,
                             locations: testParams.locations,
                             canRun: (): boolean => testParams.isOn,
                             minPageViews: testParams.minArticlesBeforeShowingBanner,

--- a/src/tests/banners/DefaultContributionsBannerTest.ts
+++ b/src/tests/banners/DefaultContributionsBannerTest.ts
@@ -5,7 +5,7 @@ import { contributionsBanner } from '../../modules';
 export const DefaultContributionsBanner: BannerTest = {
     name: 'DefaultContributionsBanner',
     bannerChannel: 'contributions',
-    testAudience: 'AllNonSupporters',
+    userCohort: 'AllNonSupporters',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (_targeting: BannerTargeting, _pageTracking: BannerPageTracking) => true,
     minPageViews: 2,

--- a/src/tests/banners/bannerSelection.test.ts
+++ b/src/tests/banners/bannerSelection.test.ts
@@ -53,7 +53,7 @@ describe('selectBannerTest', () => {
         const test: BannerTest = {
             name: 'test',
             bannerChannel: 'contributions',
-            testAudience: 'Everyone',
+            userCohort: 'Everyone',
             canRun: () => true,
             minPageViews: 2,
             variants: [
@@ -175,7 +175,7 @@ describe('selectBannerTest', () => {
         const test: BannerTest = {
             name: 'test',
             bannerChannel: 'subscriptions',
-            testAudience: 'Everyone',
+            userCohort: 'Everyone',
             canRun: (): boolean => true,
             minPageViews: 2,
             variants: [

--- a/src/tests/banners/bannerSelection.ts
+++ b/src/tests/banners/bannerSelection.ts
@@ -11,7 +11,7 @@ import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
 import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { TestVariant } from '../../lib/params';
 import { userIsInTest } from '../../lib/targeting';
-import { Audience } from '../../types/shared';
+import { UserCohort } from '../../types/shared';
 import { selectVariant } from '../../lib/ab';
 
 export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
@@ -65,7 +65,7 @@ export const redeployedSinceLastClosed = (
     return Promise.resolve(true);
 };
 
-const audienceMatches = (showSupportMessaging: boolean, testAudience: Audience): boolean => {
+const audienceMatches = (showSupportMessaging: boolean, testAudience: UserCohort): boolean => {
     switch (testAudience) {
         case 'AllNonSupporters':
             return showSupportMessaging;
@@ -119,7 +119,7 @@ export const selectBannerTest = async (
         if (
             !targeting.shouldHideReaderRevenue &&
             !targeting.isPaidContent &&
-            audienceMatches(targeting.showSupportMessaging, test.testAudience) &&
+            audienceMatches(targeting.showSupportMessaging, test.userCohort) &&
             inCountryGroups(targeting.countryCode, test.locations) &&
             targeting.alreadyVisitedCount >= test.minPageViews &&
             test.canRun(targeting, pageTracking) &&

--- a/src/tests/epics/epicSelection.ts
+++ b/src/tests/epics/epicSelection.ts
@@ -1,9 +1,9 @@
-import { EpicTargeting, ViewLog, UserCohort, EpicTest, EpicVariant } from '../../types/EpicTypes';
+import { EpicTargeting, ViewLog, EpicTest, EpicVariant } from '../../types/EpicTypes';
 import { shouldThrottle, shouldNotRenderEpic, userIsInTest } from '../../lib/targeting';
 import { getCountryName, inCountryGroups } from '../../lib/geolocation';
 import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { isRecentOneOffContributor } from '../../lib/dates';
-import { WeeklyArticleHistory } from '../../types/shared';
+import { UserCohort, WeeklyArticleHistory } from '../../types/shared';
 import { selectVariant } from '../../lib/ab';
 import { EpicType } from '../../types/EpicTypes';
 import { TestVariant } from '../../lib/params';

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -9,7 +9,7 @@ import {
 import { CountryGroupId } from '../lib/geolocation';
 import {
     ArticlesViewedSettings,
-    Audience,
+    UserCohort,
     Test,
     TickerSettings,
     Variant,
@@ -119,7 +119,7 @@ export type BannerTestGenerator = () => Promise<BannerTest[]>;
 export interface BannerTest extends Test<BannerVariant> {
     name: string;
     bannerChannel: BannerChannel;
-    testAudience: Audience;
+    userCohort: UserCohort;
     canRun: CanRun;
     minPageViews: number;
     variants: BannerVariant[];
@@ -188,7 +188,7 @@ export interface RawTestParams {
     nickname: string;
     isOn: boolean;
     minArticlesBeforeShowingBanner: number;
-    userCohort: Audience;
+    userCohort: UserCohort;
     locations: CountryGroupId[];
     variants: RawVariantParams[];
     articlesViewedSettings?: ArticlesViewedSettings;

--- a/src/types/EpicTypes.ts
+++ b/src/types/EpicTypes.ts
@@ -1,6 +1,6 @@
 import { OphanComponentEvent, OphanComponentType, OphanProduct } from './OphanTypes';
 import {
-    ArticlesViewedSettings,
+    ArticlesViewedSettings, UserCohort,
     Cta,
     SecondaryCta,
     Stage,
@@ -35,12 +35,6 @@ export type Tag = {
     id: string;
     type: string;
 };
-
-export type UserCohort =
-    | 'AllExistingSupporters'
-    | 'AllNonSupporters'
-    | 'Everyone'
-    | 'PostAskPauseSingleContributors';
 
 interface View {
     date: number;

--- a/src/types/EpicTypes.ts
+++ b/src/types/EpicTypes.ts
@@ -1,6 +1,7 @@
 import { OphanComponentEvent, OphanComponentType, OphanProduct } from './OphanTypes';
 import {
-    ArticlesViewedSettings, UserCohort,
+    ArticlesViewedSettings,
+    UserCohort,
     Cta,
     SecondaryCta,
     Stage,

--- a/src/types/HeaderTypes.ts
+++ b/src/types/HeaderTypes.ts
@@ -1,5 +1,5 @@
 import { OphanComponentEvent, OphanComponentType } from './OphanTypes';
-import { Audience, Test, Variant } from './shared';
+import { UserCohort, Test, Variant } from './shared';
 
 export interface Cta {
     url: string;
@@ -21,7 +21,7 @@ interface HeaderVariant extends Variant {
 
 export interface HeaderTest extends Test<HeaderVariant> {
     name: string;
-    audience: Audience;
+    audience: UserCohort;
     variants: HeaderVariant[];
 }
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -54,7 +54,7 @@ export const secondaryCtaSchema = z.union([
     contributionsReminderSecondaryCtaSchema,
 ]);
 
-export type Audience =
+export type UserCohort =
     | 'AllExistingSupporters'
     | 'AllNonSupporters'
     | 'Everyone'


### PR DESCRIPTION
Co-authored-by: @TomPretty

A recent PR accidentally caused an indirect import of the aws sdk in the banner module.
This broke the rendering of the banner (and made the module huge).

The actual fix here is to remove the import of `epicSelection.ts` from `reminderFields.ts`.
This is because a field shared between client + server was importing from a server-specific file.

In the process we decided to unify the `Audience` and `UserCohort` types. We now use `UserCohort` everywhere, which is consistent with the admin-console.

This all points to something we already knew - *we need to properly separate client and server parts of this codebase*. It's far too easy to accidentally mess up the imports. @TomPretty has already been investigating this


Tested in CODE:
![Screen Shot 2021-07-07 at 14 00 08](https://user-images.githubusercontent.com/1513454/124763265-b056d300-df2b-11eb-8401-92b5c274e0aa.png)
