### PR TITLE
Epic props validation

### DIFF
--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
@@ -2,8 +2,8 @@ import React, { ReactElement } from 'react';
 import { DigitalSubscriptionsBanner } from './DigitalSubscriptionsBanner';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import { StorybookWrapper, BannerWrapper } from '../../../../utils/StorybookWrapper';
-import { BannerContent, BannerProps, BannerTracking } from '../../../../types/BannerTypes';
-import { SecondaryCtaType } from '../../../../types/shared';
+import { BannerContent, BannerProps } from '../../../../types/BannerTypes';
+import { SecondaryCtaType, Tracking } from '../../../../types/shared';
 
 export default {
     component: DigitalSubscriptionsBanner,
@@ -15,7 +15,7 @@ export default {
     ],
 };
 
-const tracking: BannerTracking = {
+const tracking: Tracking = {
     ophanPageId: 'kbluzw2csbf83eaberrr',
     platformId: 'GUARDIAN_WEB',
     clientName: 'dcr',

--- a/src/components/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
+++ b/src/components/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
@@ -2,7 +2,8 @@ import React, { ReactElement } from 'react';
 import { GuardianWeeklyBanner } from './GuardianWeeklyBanner';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import { StorybookWrapper } from '../../../../utils/StorybookWrapper';
-import { BannerContent, BannerProps, BannerTracking } from '../../../../types/BannerTypes';
+import { BannerContent, BannerProps } from '../../../../types/BannerTypes';
+import { Tracking } from '../../../../types/shared';
 
 export default {
     component: GuardianWeeklyBanner,
@@ -14,7 +15,7 @@ export default {
     ],
 };
 
-const tracking: BannerTracking = {
+const tracking: Tracking = {
     ophanPageId: 'kbluzw2csbf83eabettt',
     platformId: 'GUARDIAN_WEB',
     clientName: 'dcr',

--- a/src/components/modules/banners/utils/storybook.ts
+++ b/src/components/modules/banners/utils/storybook.ts
@@ -1,8 +1,8 @@
 import { TickerCountType, TickerEndType } from '../../../../types/shared';
-import { BannerProps, BannerTracking } from '../../../../types/BannerTypes';
-import { SecondaryCtaType } from '../../../../types/shared';
+import { BannerProps } from '../../../../types/BannerTypes';
+import { SecondaryCtaType, Tracking } from '../../../../types/shared';
 
-export const tracking: BannerTracking = {
+export const tracking: Tracking = {
     ophanPageId: 'kbluzw2csbf83eabedel',
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     platformId: 'GUARDIAN_WEB',

--- a/src/components/modules/epics/ContributionsEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpic.stories.tsx
@@ -39,9 +39,7 @@ export default {
     excludeStories: /.*Decorator$/,
 } as Meta;
 
-const Template: Story<EpicProps> = (props: EpicProps) => (
-    <ContributionsEpic {...props} />
-);
+const Template: Story<EpicProps> = (props: EpicProps) => <ContributionsEpic {...props} />;
 
 export const Default = Template.bind({});
 

--- a/src/components/modules/epics/ContributionsEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpic.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { ContributionsEpicUnvalidated } from './ContributionsEpic';
+import { ContributionsEpicUnvalidated as ContributionsEpic } from './ContributionsEpic';
 import { TickerCountType, TickerEndType } from '../../../types/shared';
 import { props } from './utils/storybook';
 import { from } from '@guardian/src-foundations/mq';
@@ -32,7 +32,7 @@ export const EpicDecorator = (Story: Story): JSX.Element => (
 );
 
 export default {
-    component: ContributionsEpicUnvalidated,
+    component: ContributionsEpic,
     title: 'Epics/Contributions',
     args: props,
     decorators: [EpicDecorator],
@@ -40,7 +40,7 @@ export default {
 } as Meta;
 
 const Template: Story<EpicProps> = (props: EpicProps) => (
-    <ContributionsEpicUnvalidated {...props} />
+    <ContributionsEpic {...props} />
 );
 
 export const Default = Template.bind({});

--- a/src/components/modules/epics/ContributionsEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpic.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { ContributionsEpic } from './ContributionsEpic';
+import { ContributionsEpicUnvalidated } from './ContributionsEpic';
 import { TickerCountType, TickerEndType } from '../../../types/shared';
 import { props } from './utils/storybook';
 import { from } from '@guardian/src-foundations/mq';
@@ -32,14 +32,16 @@ export const EpicDecorator = (Story: Story): JSX.Element => (
 );
 
 export default {
-    component: ContributionsEpic,
+    component: ContributionsEpicUnvalidated,
     title: 'Epics/Contributions',
     args: props,
     decorators: [EpicDecorator],
     excludeStories: /.*Decorator$/,
 } as Meta;
 
-const Template: Story<EpicProps> = (props: EpicProps) => <ContributionsEpic {...props} />;
+const Template: Story<EpicProps> = (props: EpicProps) => (
+    <ContributionsEpicUnvalidated {...props} />
+);
 
 export const Default = Template.bind({});
 

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -351,7 +351,6 @@ const ContributionsEpic: React.FC<EpicProps> = ({
 
 const validate = (props: unknown): props is EpicProps => {
     const result = epicPropsSchema.safeParse(props);
-    console.log(result)
     return result.success;
 };
 

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -7,7 +7,7 @@ import {
     containsNonArticleCountPlaceholder,
     replaceNonArticleCountPlaceholders,
 } from '../../../lib/placeholders';
-import { EpicProps } from '../../../types/EpicTypes';
+import { EpicProps, epicPropsSchema } from '../../../types/EpicTypes';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { ContributionsEpicTicker } from './ContributionsEpicTicker';
@@ -18,6 +18,7 @@ import { useArticleCountOptOut } from '../../hooks/useArticleCountOptOut';
 import { HasBeenSeen, useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import { Stage } from '../../../types/shared';
 import { isProd } from '../shared/helpers/stage';
+import { withParsedProps } from '../shared/ModuleWrapper';
 
 const sendEpicViewEvent = (url: string, stage?: Stage): void => {
     const path = 'events/epic-view';
@@ -214,7 +215,7 @@ const EpicBody: React.FC<BodyProps> = ({
     );
 };
 
-export const ContributionsEpic: React.FC<EpicProps> = ({
+const ContributionsEpic: React.FC<EpicProps> = ({
     variant,
     tracking,
     countryCode,
@@ -347,3 +348,12 @@ export const ContributionsEpic: React.FC<EpicProps> = ({
         </section>
     );
 };
+
+const validate = (props: unknown): props is EpicProps => {
+    const result = epicPropsSchema.safeParse(props);
+    console.log(result)
+    return result.success;
+};
+
+const validatedEpic = withParsedProps(ContributionsEpic, validate);
+export { validatedEpic as ContributionsEpic, ContributionsEpic as ContributionsEpicUnvalidated };

--- a/src/components/modules/epics/ContributionsEpicButtons.tsx
+++ b/src/components/modules/epics/ContributionsEpicButtons.tsx
@@ -2,8 +2,8 @@ import React, { useEffect } from 'react';
 import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
 import { Button } from './Button';
-import { EpicTracking, EpicVariant } from '../../../types/EpicTypes';
-import { SecondaryCtaType } from '../../../types/shared';
+import { EpicVariant } from '../../../types/EpicTypes';
+import { SecondaryCtaType, Tracking } from '../../../types/shared';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
 import { OphanComponentEvent } from '../../../types/OphanTypes';
 import {
@@ -43,7 +43,7 @@ const PrimaryCtaButton = ({
     countryCode,
 }: {
     cta?: Cta;
-    tracking: EpicTracking;
+    tracking: Tracking;
     countryCode?: string;
 }): JSX.Element | null => {
     if (!cta) {
@@ -73,7 +73,7 @@ const SecondaryCtaButton = ({
     countryCode,
 }: {
     cta: Cta;
-    tracking: EpicTracking;
+    tracking: Tracking;
     countryCode?: string;
 }): JSX.Element | null => {
     const url = addRegionIdAndTrackingParamsToSupportUrl(cta.baseUrl, tracking, countryCode);
@@ -89,7 +89,7 @@ const SecondaryCtaButton = ({
 
 interface ContributionsEpicButtonsProps {
     variant: EpicVariant;
-    tracking: EpicTracking;
+    tracking: Tracking;
     countryCode?: string;
     onOpenReminderClick: () => void;
     submitComponentEvent?: (event: OphanComponentEvent) => void;

--- a/src/components/modules/epics/ContributionsLiveblogEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.stories.tsx
@@ -4,7 +4,8 @@ import { withKnobs, text, object } from '@storybook/addon-knobs';
 import { StorybookWrapper } from '../../../utils/StorybookWrapper';
 import testData from './ContributionsLiveblogEpic.testData';
 import { getArticleViewCountForWeeks } from '../../../lib/history';
-import { EpicTracking, EpicVariant } from '../../../types/EpicTypes';
+import { EpicVariant } from '../../../types/EpicTypes';
+import { Tracking } from '../../../types/shared';
 
 export default {
     component: ContributionsLiveblogEpic,
@@ -32,14 +33,17 @@ export const defaultStory = (): ReactElement => {
     };
 
     // Epic metadata props
-    const epicTracking: EpicTracking = {
+    const epicTracking: Tracking = {
         ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
         componentType: testData.tracking.componentType,
         products: testData.tracking.products,
         platformId: text('platformId', testData.tracking.platformId),
         clientName: testData.tracking.clientName,
         campaignCode: text('campaignCode', testData.tracking.campaignCode),
-        campaignId: text('campaignId', testData.tracking.campaignId),
+        campaignId: text(
+            'campaignId',
+            testData.tracking.campaignId || testData.tracking.abTestName,
+        ),
         abTestName: text('abTestName', testData.tracking.abTestName),
         abTestVariant: text('abTestVariant', testData.tracking.abTestVariant),
         referrerUrl: text('referrerUrl', testData.tracking.referrerUrl),

--- a/src/components/modules/epics/ContributionsLiveblogEpic.testData.ts
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.testData.ts
@@ -1,9 +1,5 @@
-import {
-    EpicTestTracking,
-    EpicPageTracking,
-    EpicTracking,
-    EpicTargeting,
-} from '../../../types/EpicTypes';
+import { EpicTargeting } from '../../../types/EpicTypes';
+import { PageTracking, TestTracking, Tracking } from '../../../types/shared';
 
 const content = {
     paragraphs: [
@@ -17,7 +13,7 @@ const content = {
     },
 };
 
-const pageTracking: EpicPageTracking = {
+const pageTracking: PageTracking = {
     ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
     platformId: 'GUARDIAN_WEB',
     clientName: 'dcr',
@@ -25,7 +21,7 @@ const pageTracking: EpicPageTracking = {
         'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
 };
 
-const testTracking: EpicTestTracking = {
+const testTracking: TestTracking = {
     campaignCode: 'gdnwb_copts_memco_remote_epic_test_api',
     campaignId: 'remote_epic_test',
     abTestName: 'remote_epic_test',
@@ -34,7 +30,7 @@ const testTracking: EpicTestTracking = {
     products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 };
 
-const tracking: EpicTracking = {
+const tracking: Tracking = {
     ...pageTracking,
     ...testTracking,
 };

--- a/src/components/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/src/components/modules/epics/ContributionsLiveblogEpic.tsx
@@ -10,9 +10,10 @@ import {
     replaceNonArticleCountPlaceholders,
     containsNonArticleCountPlaceholder,
 } from '../../../lib/placeholders';
-import { EpicTracking, EpicVariant } from '../../../types/EpicTypes';
+import { EpicVariant } from '../../../types/EpicTypes';
 import { replaceArticleCount } from '../../../lib/replaceArticleCount';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '../../../lib/tracking';
+import { Tracking } from '../../../types/shared';
 
 const container: SerializedStyles = css`
     padding: 6px 10px 28px 10px;
@@ -146,7 +147,7 @@ interface LiveblogEpicCtaProps {
     text?: string;
     baseUrl?: string;
     countryCode?: string;
-    tracking: EpicTracking;
+    tracking: Tracking;
 }
 
 const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
@@ -176,7 +177,7 @@ const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
 
 interface LiveblogEpicProps {
     variant: EpicVariant;
-    tracking: EpicTracking;
+    tracking: Tracking;
     countryCode?: string;
     numArticles: number;
 }

--- a/src/components/modules/epics/utils/storybook.ts
+++ b/src/components/modules/epics/utils/storybook.ts
@@ -1,10 +1,5 @@
-import {
-    EpicTestTracking,
-    EpicPageTracking,
-    EpicTracking,
-    EpicVariant,
-} from '../../../../types/EpicTypes';
-import { SecondaryCtaType } from '../../../../types/shared';
+import { EpicVariant } from '../../../../types/EpicTypes';
+import { PageTracking, SecondaryCtaType, TestTracking, Tracking } from '../../../../types/shared';
 import { EpicProps } from '../../../../types/EpicTypes';
 
 const variant: EpicVariant = {
@@ -32,7 +27,7 @@ const variant: EpicVariant = {
     },
 };
 
-const pageTracking: EpicPageTracking = {
+const pageTracking: PageTracking = {
     ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
     platformId: 'GUARDIAN_WEB',
     clientName: 'dcr',
@@ -40,7 +35,7 @@ const pageTracking: EpicPageTracking = {
         'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
 };
 
-const testTracking: EpicTestTracking = {
+const testTracking: TestTracking = {
     campaignCode: 'gdnwb_copts_memco_remote_epic_test_api',
     campaignId: 'remote_epic_test',
     abTestName: 'remote_epic_test',
@@ -49,7 +44,7 @@ const testTracking: EpicTestTracking = {
     products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 };
 
-const tracking: EpicTracking = {
+const tracking: Tracking = {
     ...pageTracking,
     ...testTracking,
 };

--- a/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.stories.tsx
+++ b/src/components/modules/puzzles/puzzlesBanner/PuzzlesBanner.stories.tsx
@@ -1,14 +1,14 @@
 import React, { ReactElement } from 'react';
 import { PuzzlesBanner } from './PuzzlesBanner';
 import { StorybookWrapper, BannerWrapper } from '../../../../utils/StorybookWrapper';
-import { BannerTracking } from '../../../../types/BannerTypes';
+import { Tracking } from '../../../../types/shared';
 
 export default {
     component: PuzzlesBanner,
     title: 'Puzzles/PuzzlesBanner',
 };
 
-const tracking: BannerTracking = {
+const tracking: Tracking = {
     ophanPageId: 'kbluzw2csbf83eabettt',
     platformId: 'GUARDIAN_WEB',
     clientName: 'dcr',

--- a/src/components/modules/shared/ModuleWrapper.tsx
+++ b/src/components/modules/shared/ModuleWrapper.tsx
@@ -14,7 +14,6 @@ export function withParsedProps<ModuleProps>(
                 />
             );
         }
-        console.log("failed to validate")
         return null;
     };
 

--- a/src/components/modules/shared/ModuleWrapper.tsx
+++ b/src/components/modules/shared/ModuleWrapper.tsx
@@ -14,6 +14,7 @@ export function withParsedProps<ModuleProps>(
                 />
             );
         }
+        console.log("failed to validate")
         return null;
     };
 

--- a/src/factories/tracking.ts
+++ b/src/factories/tracking.ts
@@ -1,7 +1,7 @@
 import { Factory } from 'fishery';
-import { EpicTestTracking, EpicPageTracking, EpicTracking } from '../types/EpicTypes';
+import { TestTracking, PageTracking, Tracking } from '../types/shared';
 
-export const pageTracking = Factory.define<EpicPageTracking>(() => ({
+export const pageTracking = Factory.define<PageTracking>(() => ({
     ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
     platformId: 'GUARDIAN_WEB',
     clientName: 'dcr',
@@ -9,7 +9,7 @@ export const pageTracking = Factory.define<EpicPageTracking>(() => ({
         'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
 }));
 
-export const testTracking = Factory.define<EpicTestTracking>(() => ({
+export const testTracking = Factory.define<TestTracking>(() => ({
     campaignCode: 'gdnwb_copts_memco_remote_epic_test_api',
     campaignId: 'remote_epic_test',
     abTestName: 'remote_epic_test',
@@ -18,7 +18,7 @@ export const testTracking = Factory.define<EpicTestTracking>(() => ({
     products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 }));
 
-export const tracking = Factory.define<EpicTracking>(({ factories }) => ({
+export const tracking = Factory.define<Tracking>(({ factories }) => ({
     ...factories.pageTracking.build(),
     ...factories.testTracking.build(),
 }));

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -1,8 +1,8 @@
-import { EpicTest, EpicTracking, EpicVariant } from '../types/EpicTypes';
-import { BannerTest, BannerVariant, BannerTracking } from '../types/BannerTypes';
+import { EpicTest, EpicVariant } from '../types/EpicTypes';
+import { BannerTest, BannerVariant } from '../types/BannerTypes';
 import { OphanAction, OphanComponentEvent } from '../types/OphanTypes';
 import { addRegionIdToSupportUrl } from './geolocation';
-import { HeaderTracking } from '../types/HeaderTypes';
+import { Tracking } from '../types/shared';
 
 type LinkParams = {
     REFPVID: string;
@@ -11,10 +11,7 @@ type LinkParams = {
 };
 
 // TODO: Unify Epic and Banner tracking?
-export const addTrackingParams = (
-    baseUrl: string,
-    params: EpicTracking | BannerTracking | HeaderTracking,
-): string => {
+export const addTrackingParams = (baseUrl: string, params: Tracking): string => {
     const acquisitionData = encodeURIComponent(
         JSON.stringify({
             source: params.platformId,
@@ -46,7 +43,7 @@ export const addTrackingParams = (
 
 export const addRegionIdAndTrackingParamsToSupportUrl = (
     baseUrl: string,
-    tracking: EpicTracking | BannerTracking | HeaderTracking,
+    tracking: Tracking,
     countryCode?: string,
 ): string => {
     const isSupportUrl = /\bsupport\./.test(baseUrl);
@@ -68,7 +65,7 @@ export const buildAmpEpicCampaignCode = (testName: string, variantName: string):
     `AMP__${testName}__${variantName}`;
 
 const createEventFromTracking = (action: OphanAction) => {
-    return (tracking: BannerTracking, componentId: string): OphanComponentEvent => {
+    return (tracking: Tracking, componentId: string): OphanComponentEvent => {
         const { abTestName, abTestVariant, componentType, products = [], campaignCode } = tracking;
         const abTest =
             abTestName && abTestVariant

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -10,7 +10,6 @@ type LinkParams = {
     acquisitionData: string;
 };
 
-// TODO: Unify Epic and Banner tracking?
 export const addTrackingParams = (baseUrl: string, params: Tracking): string => {
     const acquisitionData = encodeURIComponent(
         JSON.stringify({

--- a/src/payloads.ts
+++ b/src/payloads.ts
@@ -1,15 +1,7 @@
 import express from 'express';
 import { fetchConfiguredEpicTests } from './api/contributionsApi';
 import { cacheAsync } from './lib/cache';
-import {
-    EpicPageTracking,
-    EpicProps,
-    EpicTargeting,
-    EpicTest,
-    EpicTestTracking,
-    EpicType,
-    EpicVariant,
-} from './types/EpicTypes';
+import { EpicProps, EpicTargeting, EpicTest, EpicType, EpicVariant } from './types/EpicTypes';
 import { Debug, findTestAndVariant, findForcedTestAndVariant } from './tests/epics/epicSelection';
 import { getArticleViewCountForWeeks } from './lib/history';
 import { buildBannerCampaignCode, buildCampaignCode } from './lib/tracking';
@@ -17,22 +9,11 @@ import { Params } from './lib/params';
 import { baseUrl } from './lib/env';
 import { addTickerDataToSettings, getTickerSettings } from './lib/fetchTickerData';
 import { fetchSuperModeArticles } from './lib/superMode';
-import {
-    BannerPageTracking,
-    BannerProps,
-    BannerTargeting,
-    BannerTestTracking,
-    PuzzlesBannerProps,
-} from './types/BannerTypes';
+import { BannerProps, BannerTargeting, PuzzlesBannerProps } from './types/BannerTypes';
 import { selectBannerTest } from './tests/banners/bannerSelection';
 import { getCachedTests } from './tests/banners/bannerTests';
 import { bannerDeployCaches } from './tests/banners/bannerDeployCache';
-import {
-    HeaderPageTracking,
-    HeaderProps,
-    HeaderTargeting,
-    HeaderTestTracking,
-} from './types/HeaderTypes';
+import { HeaderProps, HeaderTargeting } from './types/HeaderTypes';
 import { selectHeaderTest } from './tests/header/headerSelection';
 import {
     epic as epicModule,
@@ -44,6 +25,7 @@ import { fallbackEpicTest } from './tests/epics/fallback';
 import { getReminderFields } from './lib/reminderFields';
 import { logger } from './utils/logging';
 import { cachedChannelSwitches } from './channelSwitches';
+import { PageTracking, TestTracking } from './types/shared';
 
 interface EpicDataResponse {
     data?: {
@@ -52,7 +34,7 @@ interface EpicDataResponse {
             props: EpicProps;
         };
         variant: EpicVariant;
-        meta: EpicTestTracking;
+        meta: TestTracking;
     };
     debug?: Debug;
 }
@@ -64,7 +46,7 @@ interface BannerDataResponse {
             name: string;
             props: BannerProps;
         };
-        meta: BannerTestTracking;
+        meta: TestTracking;
     };
     debug?: Debug;
 }
@@ -88,7 +70,7 @@ interface HeaderDataResponse {
             name: string;
             props: HeaderProps;
         };
-        meta: HeaderTestTracking;
+        meta: TestTracking;
     };
 }
 
@@ -146,7 +128,7 @@ const getLiveblogEpicTests = async (): Promise<EpicTest[]> => {
 };
 
 export const buildEpicData = async (
-    pageTracking: EpicPageTracking,
+    pageTracking: PageTracking,
     targeting: EpicTargeting,
     type: EpicType,
     params: Params,
@@ -184,7 +166,7 @@ export const buildEpicData = async (
 
     const variantWithTickerAndReminder = { ...variant, tickerSettings, showReminderFields };
 
-    const testTracking: EpicTestTracking = {
+    const testTracking: TestTracking = {
         abTestName: test.name,
         abTestVariant: variant.name,
         campaignCode: buildCampaignCode(test, variant),
@@ -224,7 +206,7 @@ export const buildEpicData = async (
 };
 
 export const buildBannerData = async (
-    pageTracking: BannerPageTracking,
+    pageTracking: PageTracking,
     targeting: BannerTargeting,
     params: Params,
     req: express.Request,
@@ -246,7 +228,7 @@ export const buildBannerData = async (
     if (selectedTest) {
         const { test, variant, moduleUrl, moduleName } = selectedTest;
 
-        const testTracking: BannerTestTracking = {
+        const testTracking: TestTracking = {
             abTestName: test.name,
             abTestVariant: variant.name,
             campaignCode: buildBannerCampaignCode(test, variant),
@@ -290,7 +272,7 @@ export const buildBannerData = async (
 };
 
 export const buildPuzzlesData = async (
-    pageTracking: BannerPageTracking,
+    pageTracking: PageTracking,
     targeting: BannerTargeting,
     params: Params,
     req: express.Request,
@@ -325,14 +307,14 @@ export const buildPuzzlesData = async (
 };
 
 export const buildHeaderData = async (
-    pageTracking: HeaderPageTracking,
+    pageTracking: PageTracking,
     targeting: HeaderTargeting,
     baseUrl: string,
 ): Promise<HeaderDataResponse> => {
     const testSelection = await selectHeaderTest(targeting);
     if (testSelection) {
         const { test, variant } = testSelection;
-        const testTracking: HeaderTestTracking = {
+        const testTracking: TestTracking = {
             abTestName: test.name,
             abTestVariant: variant.name,
             campaignCode: `header_support_${test.name}_${variant.name}`,

--- a/src/tests/banners/DefaultContributionsBannerTest.ts
+++ b/src/tests/banners/DefaultContributionsBannerTest.ts
@@ -1,13 +1,14 @@
-import { BannerPageTracking, BannerTargeting, BannerTest } from '../../types/BannerTypes';
+import { BannerTargeting, BannerTest } from '../../types/BannerTypes';
 import { DefaultBannerContent } from './DefaultContributionsBannerContent';
 import { contributionsBanner } from '../../modules';
+import { PageTracking } from '../../types/shared';
 
 export const DefaultContributionsBanner: BannerTest = {
     name: 'DefaultContributionsBanner',
     bannerChannel: 'contributions',
     userCohort: 'AllNonSupporters',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    canRun: (_targeting: BannerTargeting, _pageTracking: BannerPageTracking) => true,
+    canRun: (_targeting: BannerTargeting, _pageTracking: PageTracking) => true,
     minPageViews: 2,
     variants: [
         {

--- a/src/tests/banners/bannerSelection.ts
+++ b/src/tests/banners/bannerSelection.ts
@@ -1,5 +1,4 @@
 import {
-    BannerPageTracking,
     BannerTargeting,
     BannerTestSelection,
     BannerChannel,
@@ -11,7 +10,7 @@ import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
 import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { TestVariant } from '../../lib/params';
 import { userIsInTest } from '../../lib/targeting';
-import { UserCohort } from '../../types/shared';
+import {PageTracking, UserCohort} from '../../types/shared';
 import { selectVariant } from '../../lib/ab';
 
 export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
@@ -102,7 +101,7 @@ const getForcedVariant = (
 
 export const selectBannerTest = async (
     targeting: BannerTargeting,
-    pageTracking: BannerPageTracking,
+    pageTracking: PageTracking,
     baseUrl: string,
     getTests: () => Promise<BannerTest[]>,
     bannerDeployCaches: BannerDeployCaches,

--- a/src/tests/banners/bannerSelection.ts
+++ b/src/tests/banners/bannerSelection.ts
@@ -10,7 +10,7 @@ import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
 import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { TestVariant } from '../../lib/params';
 import { userIsInTest } from '../../lib/targeting';
-import {PageTracking, UserCohort} from '../../types/shared';
+import { PageTracking, UserCohort } from '../../types/shared';
 import { selectVariant } from '../../lib/ab';
 
 export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {

--- a/src/types/BannerTypes.ts
+++ b/src/types/BannerTypes.ts
@@ -1,11 +1,5 @@
 import * as z from 'zod';
-import {
-    OphanProduct,
-    OphanComponentType,
-    OphanComponentEvent,
-    ophanComponentTypeSchema,
-    ophanProductSchema,
-} from './OphanTypes';
+import { OphanProduct, OphanComponentType, OphanComponentEvent } from './OphanTypes';
 import { CountryGroupId } from '../lib/geolocation';
 import {
     ArticlesViewedSettings,
@@ -20,6 +14,9 @@ import {
     tickerSettingsSchema,
     Cta,
     SecondaryCta,
+    Tracking,
+    PageTracking,
+    trackingSchema,
 } from './shared';
 
 export type BannerTargeting = {
@@ -36,39 +33,8 @@ export type BannerTargeting = {
     modulesVersion?: string;
 };
 
-export type BannerTestTracking = {
-    abTestName: string;
-    abTestVariant: string;
-    campaignCode: string;
-    componentType: OphanComponentType;
-    products?: OphanProduct[];
-    labels?: string[];
-};
-
-export type BannerPageTracking = {
-    ophanPageId: string;
-    platformId: string;
-    referrerUrl: string;
-    clientName: string;
-};
-
-export type BannerTracking = BannerTestTracking & BannerPageTracking;
-
-const bannerTrackingSchema = z.object({
-    abTestName: z.string(),
-    abTestVariant: z.string(),
-    campaignCode: z.string(),
-    componentType: ophanComponentTypeSchema,
-    products: z.array(ophanProductSchema).optional(),
-    labels: z.array(z.string()).optional(),
-    ophanPageId: z.string(),
-    platformId: z.string(),
-    referrerUrl: z.string(),
-    clientName: z.string(),
-});
-
 export type BannerDataRequestPayload = {
-    tracking: BannerPageTracking;
+    tracking: PageTracking;
     targeting: BannerTargeting;
 };
 
@@ -112,7 +78,7 @@ export const bannerChannelSchema = z.enum(['contributions', 'subscriptions']);
 
 export type BannerChannel = z.infer<typeof bannerChannelSchema>;
 
-export type CanRun = (targeting: BannerTargeting, pageTracking: BannerPageTracking) => boolean;
+export type CanRun = (targeting: BannerTargeting, pageTracking: PageTracking) => boolean;
 
 export type BannerTestGenerator = () => Promise<BannerTest[]>;
 
@@ -139,7 +105,7 @@ export interface BannerTestSelection {
 }
 
 export interface BannerProps {
-    tracking: BannerTracking;
+    tracking: Tracking;
     bannerChannel: BannerChannel;
     content?: BannerContent;
     mobileContent?: BannerContent;
@@ -153,7 +119,7 @@ export interface BannerProps {
 }
 
 export const bannerSchema = z.object({
-    tracking: bannerTrackingSchema,
+    tracking: trackingSchema,
     bannerChannel: bannerChannelSchema,
     content: bannerContentSchema.optional(),
     mobileContent: bannerContentSchema.optional(),
@@ -166,7 +132,7 @@ export const bannerSchema = z.object({
 });
 
 export interface PuzzlesBannerProps extends Partial<BannerProps> {
-    tracking: BannerTracking;
+    tracking: Tracking;
 }
 
 export interface RawVariantParams {

--- a/src/types/EpicTypes.ts
+++ b/src/types/EpicTypes.ts
@@ -1,4 +1,4 @@
-import { OphanComponentEvent, OphanComponentType, OphanProduct } from './OphanTypes';
+import { OphanComponentEvent } from './OphanTypes';
 import {
     ArticlesViewedSettings,
     UserCohort,
@@ -9,28 +9,16 @@ import {
     TickerSettings,
     Variant,
     WeeklyArticleHistory,
+    tickerSettingsSchema,
+    ctaSchema,
+    Tracking,
+    PageTracking,
+    trackingSchema,
+    secondaryCtaSchema,
 } from './shared';
 import { ReminderFields } from '../lib/reminderFields';
 import { CountryGroupId } from '../lib/geolocation';
-
-export type EpicPageTracking = {
-    ophanPageId: string;
-    platformId: string;
-    referrerUrl: string;
-    clientName: string;
-};
-
-export type EpicTestTracking = {
-    abTestName: string;
-    abTestVariant: string;
-    campaignCode: string;
-    campaignId: string;
-    componentType: OphanComponentType;
-    products: OphanProduct[];
-    labels?: string[];
-};
-
-export type EpicTracking = EpicPageTracking & EpicTestTracking;
+import { z } from 'zod';
 
 export type Tag = {
     id: string;
@@ -71,25 +59,11 @@ export type EpicTargeting = {
 };
 
 export type EpicPayload = {
-    tracking: EpicPageTracking;
+    tracking: PageTracking;
     targeting: EpicTargeting;
 };
 
 export type EpicType = 'ARTICLE' | 'LIVEBLOG';
-
-export type EpicProps = {
-    variant: EpicVariant;
-    tracking: EpicTracking;
-    countryCode?: string;
-    numArticles: number;
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    onReminderOpen?: Function;
-    email?: string;
-    submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
-    openCmp?: () => void;
-    hasConsentForArticleCount?: boolean;
-    stage?: Stage;
-};
 
 export interface MaxViews {
     maxViewsCount: number;
@@ -97,9 +71,25 @@ export interface MaxViews {
     minDaysBetweenViews: number;
 }
 
+const maxViewsSchema = z.object({
+    maxViewsCount: z.number(),
+    maxViewsDays: z.number(),
+    minDaysBetweenViews: z.number(),
+});
+
 export interface SeparateArticleCount {
     type: 'above';
 }
+
+const separateArticleCountSchema = z.object({
+    type: z.string(),
+});
+
+const reminderFieldsSchema = z.object({
+    reminderCta: z.string(),
+    reminderLabel: z.string(),
+    reminderPeriod: z.string(),
+});
 
 export interface EpicVariant extends Variant {
     name: string;
@@ -124,6 +114,48 @@ export interface EpicVariant extends Variant {
     // with lower priority.
     maxViews?: MaxViews;
 }
+
+const variantSchema = z.object({
+    name: z.string(),
+    heading: z.string().optional(),
+    paragraphs: z.array(z.string()),
+    highlightedText: z.string().optional(),
+    tickerSettings: tickerSettingsSchema.optional(),
+    cta: ctaSchema.optional(),
+    secondaryCta: secondaryCtaSchema.optional(),
+    footer: z.string().optional(),
+    backgroundImageUrl: z.string().optional(),
+    showReminderFields: reminderFieldsSchema.optional(),
+    separateArticleCount: separateArticleCountSchema.optional(),
+    maxViews: maxViewsSchema.optional(),
+});
+
+export type EpicProps = {
+    variant: EpicVariant;
+    tracking: Tracking;
+    countryCode?: string;
+    numArticles: number;
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    onReminderOpen?: Function;
+    email?: string;
+    submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
+    openCmp?: () => void;
+    hasConsentForArticleCount?: boolean;
+    stage?: Stage;
+};
+
+export const epicPropsSchema = z.object({
+    variant: variantSchema,
+    tracking: trackingSchema,
+    countryCode: z.string().optional(),
+    numArticles: z.number(),
+    onReminderOpen: z.any().optional(),
+    email: z.string().optional(),
+    submitComponentEvent: z.any().optional(),
+    openCmp: z.any().optional(),
+    hasConsentForArticleCount: z.boolean().optional(),
+    stage: z.string().optional(),
+});
 
 interface ControlProportionSettings {
     proportion: number;

--- a/src/types/HeaderTypes.ts
+++ b/src/types/HeaderTypes.ts
@@ -1,5 +1,5 @@
-import { OphanComponentEvent, OphanComponentType } from './OphanTypes';
-import { UserCohort, Test, Variant } from './shared';
+import { OphanComponentEvent } from './OphanTypes';
+import { UserCohort, Test, Variant, Tracking } from './shared';
 
 export interface Cta {
     url: string;
@@ -27,7 +27,7 @@ export interface HeaderTest extends Test<HeaderVariant> {
 
 export interface HeaderProps {
     content: HeaderContent;
-    tracking: HeaderTracking;
+    tracking: Tracking;
     countryCode?: string;
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
 }
@@ -38,22 +38,6 @@ export interface HeaderTestSelection {
     modulePathBuilder: (version?: string) => string;
     moduleName: string;
 }
-
-export interface HeaderPageTracking {
-    ophanPageId: string;
-    platformId: string;
-    referrerUrl: string;
-    clientName: string;
-}
-export interface HeaderTestTracking {
-    abTestName: string;
-    abTestVariant: string;
-    campaignCode: string;
-    componentType: OphanComponentType;
-    labels?: string[];
-}
-
-export type HeaderTracking = HeaderPageTracking & HeaderTestTracking;
 
 export interface HeaderTargeting {
     showSupportMessaging: boolean;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1,5 +1,10 @@
 import * as z from 'zod';
-import {OphanComponentType, ophanComponentTypeSchema, OphanProduct, ophanProductSchema} from "./OphanTypes";
+import {
+    OphanComponentType,
+    ophanComponentTypeSchema,
+    OphanProduct,
+    ophanProductSchema,
+} from './OphanTypes';
 
 export interface Variant {
     name: string;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import {OphanComponentType, ophanComponentTypeSchema, OphanProduct, ophanProductSchema} from "./OphanTypes";
 
 export interface Variant {
     name: string;
@@ -131,3 +132,35 @@ export interface ControlProportionSettings {
 }
 
 export type Stage = 'PROD' | 'CODE' | 'DEV';
+
+export type TestTracking = {
+    abTestName: string;
+    abTestVariant: string;
+    campaignCode: string;
+    campaignId?: string;
+    componentType: OphanComponentType;
+    products?: OphanProduct[];
+    labels?: string[];
+};
+
+export type PageTracking = {
+    ophanPageId: string;
+    platformId: string;
+    referrerUrl: string;
+    clientName: string;
+};
+
+export type Tracking = TestTracking & PageTracking;
+
+export const trackingSchema = z.object({
+    abTestName: z.string(),
+    abTestVariant: z.string(),
+    campaignCode: z.string(),
+    componentType: ophanComponentTypeSchema,
+    products: z.array(ophanProductSchema).optional(),
+    labels: z.array(z.string()).optional(),
+    ophanPageId: z.string(),
+    platformId: z.string(),
+    referrerUrl: z.string(),
+    clientName: z.string(),
+});


### PR DESCRIPTION
We already do this for the banner.
Validate the props client-side, to prevent backwards incompatible props changes. If validation fails then the epic is not displayed.
Also I refactored the tracking types, so epic/banner/header now all use the same `Tracking` type.