### PR TITLE
Decouple 'above' AC from targeting

### DIFF
--- a/src/components/modules/epics/ContributionsEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpic.stories.tsx
@@ -113,7 +113,7 @@ WithAboveArticleCount.args = {
         },
     },
     articleCounts: {
-        total: 99,
+        for52Weeks: 99,
         forTargetedWeeks: 99,
     },
     hasConsentForArticleCount: true,
@@ -128,7 +128,7 @@ WithAboveArticleCountNoConsent.args = {
         },
     },
     articleCounts: {
-        total: 99,
+        for52Weeks: 99,
         forTargetedWeeks: 99,
     },
     hasConsentForArticleCount: false,

--- a/src/components/modules/epics/ContributionsEpic.stories.tsx
+++ b/src/components/modules/epics/ContributionsEpic.stories.tsx
@@ -112,7 +112,10 @@ WithAboveArticleCount.args = {
             type: 'above',
         },
     },
-    numArticles: 99,
+    articleCounts: {
+        total: 99,
+        forTargetedWeeks: 99,
+    },
     hasConsentForArticleCount: true,
 };
 
@@ -124,6 +127,9 @@ WithAboveArticleCountNoConsent.args = {
             type: 'above',
         },
     },
-    numArticles: 99,
+    articleCounts: {
+        total: 99,
+        forTargetedWeeks: 99,
+    },
     hasConsentForArticleCount: false,
 };

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -219,7 +219,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
     variant,
     tracking,
     countryCode,
-    numArticles,
+    articleCounts,
     onReminderOpen,
     email,
     submitComponentEvent,
@@ -268,7 +268,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
             {variant.separateArticleCount?.type === 'above' && hasConsentForArticleCount && (
                 <div css={articleCountAboveContainerStyles}>
                     <ContributionsEpicArticleCountAboveWithOptOut
-                        numArticles={numArticles}
+                        numArticles={articleCounts.total}
                         isArticleCountOn={!hasOptedOut}
                         onArticleCountOptOut={onArticleCountOptOut}
                         onArticleCountOptIn={onArticleCountOptIn}
@@ -299,7 +299,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
             {cleanHeading && (
                 <EpicHeader
                     text={cleanHeading}
-                    numArticles={numArticles}
+                    numArticles={articleCounts.forTargetedWeeks}
                     tracking={ophanTracking}
                 />
             )}
@@ -308,7 +308,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 paragraphs={cleanParagraphs}
                 highlightedText={cleanHighlighted}
                 countryCode={countryCode}
-                numArticles={numArticles}
+                numArticles={articleCounts.forTargetedWeeks}
                 tracking={ophanTracking}
             />
 

--- a/src/components/modules/epics/ContributionsEpic.tsx
+++ b/src/components/modules/epics/ContributionsEpic.tsx
@@ -268,7 +268,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
             {variant.separateArticleCount?.type === 'above' && hasConsentForArticleCount && (
                 <div css={articleCountAboveContainerStyles}>
                     <ContributionsEpicArticleCountAboveWithOptOut
-                        numArticles={articleCounts.total}
+                        numArticles={articleCounts.for52Weeks}
                         isArticleCountOn={!hasOptedOut}
                         onArticleCountOptOut={onArticleCountOptOut}
                         onArticleCountOptIn={onArticleCountOptIn}

--- a/src/components/modules/epics/utils/storybook.ts
+++ b/src/components/modules/epics/utils/storybook.ts
@@ -51,4 +51,4 @@ const tracking: Tracking = {
 
 const openCmp = (): void => console.log('open cmp');
 
-export const props: EpicProps = { variant, tracking, numArticles: 0, openCmp };
+export const props: EpicProps = { variant, tracking, openCmp };

--- a/src/components/modules/epics/utils/storybook.ts
+++ b/src/components/modules/epics/utils/storybook.ts
@@ -1,4 +1,4 @@
-import { EpicVariant } from '../../../../types/EpicTypes';
+import { ArticleCounts, EpicVariant } from '../../../../types/EpicTypes';
 import { PageTracking, SecondaryCtaType, TestTracking, Tracking } from '../../../../types/shared';
 import { EpicProps } from '../../../../types/EpicTypes';
 
@@ -27,6 +27,11 @@ const variant: EpicVariant = {
     },
 };
 
+const articleCounts: ArticleCounts = {
+    total: 99,
+    forTargetedWeeks: 99,
+};
+
 const pageTracking: PageTracking = {
     ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
     platformId: 'GUARDIAN_WEB',
@@ -51,4 +56,4 @@ const tracking: Tracking = {
 
 const openCmp = (): void => console.log('open cmp');
 
-export const props: EpicProps = { variant, tracking, openCmp };
+export const props: EpicProps = { variant, tracking, openCmp, articleCounts };

--- a/src/components/modules/epics/utils/storybook.ts
+++ b/src/components/modules/epics/utils/storybook.ts
@@ -28,7 +28,7 @@ const variant: EpicVariant = {
 };
 
 const articleCounts: ArticleCounts = {
-    total: 99,
+    for52Weeks: 99,
     forTargetedWeeks: 99,
 };
 

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -13,6 +13,8 @@ export const getArticleViewCountForWeeks = (
     weeks: number = 52,
     rightNow: Date = new Date(),
 ): number => {
+    console.log('history', history)
+    console.log(weeks)
     const mondayThisWeek = getMondayFromDate(rightNow);
     const cutOffWeek = mondayThisWeek - weeks * 7;
 

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -32,11 +32,12 @@ export const getArticleViewCounts = (
     history: WeeklyArticleHistory = [],
     weeks: number = 52,
 ): ArticleCounts => {
-    const total = getArticleViewCountForWeeks(history, 52);
-    const forTargetedWeeks = weeks === 52 ? total : getArticleViewCountForWeeks(history, weeks);
+    const for52Weeks = getArticleViewCountForWeeks(history, 52);
+    const forTargetedWeeks =
+        weeks === 52 ? for52Weeks : getArticleViewCountForWeeks(history, weeks);
 
     return {
-        total,
+        for52Weeks,
         forTargetedWeeks,
     };
 };

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,4 +1,5 @@
 import { ArticlesViewedSettings, WeeklyArticleHistory, WeeklyArticleLog } from '../types/shared';
+import { ArticleCounts } from '../types/EpicTypes';
 
 export const getMondayFromDate = (date: Date): number => {
     const day = date.getDay() || 7;
@@ -13,8 +14,6 @@ export const getArticleViewCountForWeeks = (
     weeks: number = 52,
     rightNow: Date = new Date(),
 ): number => {
-    console.log('history', history)
-    console.log(weeks)
     const mondayThisWeek = getMondayFromDate(rightNow);
     const cutOffWeek = mondayThisWeek - weeks * 7;
 
@@ -27,6 +26,19 @@ export const getArticleViewCountForWeeks = (
         (accumulator: number, currentValue: WeeklyArticleLog) => currentValue.count + accumulator,
         0,
     );
+};
+
+export const getArticleViewCounts = (
+    history: WeeklyArticleHistory = [],
+    weeks: number = 52,
+): ArticleCounts => {
+    const total = getArticleViewCountForWeeks(history, 52);
+    const forTargetedWeeks = weeks === 52 ? total : getArticleViewCountForWeeks(history, weeks);
+
+    return {
+        total,
+        forTargetedWeeks,
+    };
 };
 
 export const historyWithinArticlesViewedSettings = (

--- a/src/payloads.ts
+++ b/src/payloads.ts
@@ -176,13 +176,20 @@ export const buildEpicData = async (
         labels: !!test.isSuperMode ? ['SUPER_MODE'] : undefined,
     };
 
+    console.log('EPIC')
     const props: EpicProps = {
         variant: variantWithTickerAndReminder,
         tracking: { ...pageTracking, ...testTracking },
-        numArticles: getArticleViewCountForWeeks(
-            targeting.weeklyArticleHistory,
-            test.articlesViewedSettings?.periodInWeeks,
-        ),
+        articleCounts: {
+            total: getArticleViewCountForWeeks(
+                targeting.weeklyArticleHistory,
+                52,
+            ),
+            forTargetedWeeks: getArticleViewCountForWeeks(
+                targeting.weeklyArticleHistory,
+                test.articlesViewedSettings?.periodInWeeks,
+            ),
+        },
         countryCode: targeting.countryCode,
     };
 

--- a/src/payloads.ts
+++ b/src/payloads.ts
@@ -3,7 +3,7 @@ import { fetchConfiguredEpicTests } from './api/contributionsApi';
 import { cacheAsync } from './lib/cache';
 import { EpicProps, EpicTargeting, EpicTest, EpicType, EpicVariant } from './types/EpicTypes';
 import { Debug, findTestAndVariant, findForcedTestAndVariant } from './tests/epics/epicSelection';
-import {getArticleViewCountForWeeks, getArticleViewCounts} from './lib/history';
+import { getArticleViewCountForWeeks, getArticleViewCounts } from './lib/history';
 import { buildBannerCampaignCode, buildCampaignCode } from './lib/tracking';
 import { Params } from './lib/params';
 import { baseUrl } from './lib/env';

--- a/src/payloads.ts
+++ b/src/payloads.ts
@@ -3,7 +3,7 @@ import { fetchConfiguredEpicTests } from './api/contributionsApi';
 import { cacheAsync } from './lib/cache';
 import { EpicProps, EpicTargeting, EpicTest, EpicType, EpicVariant } from './types/EpicTypes';
 import { Debug, findTestAndVariant, findForcedTestAndVariant } from './tests/epics/epicSelection';
-import { getArticleViewCountForWeeks } from './lib/history';
+import {getArticleViewCountForWeeks, getArticleViewCounts} from './lib/history';
 import { buildBannerCampaignCode, buildCampaignCode } from './lib/tracking';
 import { Params } from './lib/params';
 import { baseUrl } from './lib/env';
@@ -176,20 +176,13 @@ export const buildEpicData = async (
         labels: !!test.isSuperMode ? ['SUPER_MODE'] : undefined,
     };
 
-    console.log('EPIC')
     const props: EpicProps = {
         variant: variantWithTickerAndReminder,
         tracking: { ...pageTracking, ...testTracking },
-        articleCounts: {
-            total: getArticleViewCountForWeeks(
-                targeting.weeklyArticleHistory,
-                52,
-            ),
-            forTargetedWeeks: getArticleViewCountForWeeks(
-                targeting.weeklyArticleHistory,
-                test.articlesViewedSettings?.periodInWeeks,
-            ),
-        },
+        articleCounts: getArticleViewCounts(
+            targeting.weeklyArticleHistory,
+            test.articlesViewedSettings?.periodInWeeks,
+        ),
         countryCode: targeting.countryCode,
     };
 

--- a/src/types/EpicTypes.ts
+++ b/src/types/EpicTypes.ts
@@ -65,7 +65,7 @@ export type EpicPayload = {
 
 export type EpicType = 'ARTICLE' | 'LIVEBLOG';
 
-interface ArticleCounts {
+export interface ArticleCounts {
     total: number; // The user's total article view count, which currently goes back as far as 52 weeks
     forTargetedWeeks: number; // The user's article view count for the configured periodInWeeks
 }
@@ -144,8 +144,7 @@ export type EpicProps = {
     variant: EpicVariant;
     tracking: Tracking;
     countryCode?: string;
-    numArticles: number;
-    articleCounts?: ArticleCounts;
+    articleCounts: ArticleCounts;
     // eslint-disable-next-line @typescript-eslint/ban-types
     onReminderOpen?: Function;
     email?: string;
@@ -159,8 +158,7 @@ export const epicPropsSchema = z.object({
     variant: variantSchema,
     tracking: trackingSchema,
     countryCode: z.string().optional(),
-    numArticles: z.number(),
-    articleCounts: articleCountsSchema.optional(),
+    articleCounts: articleCountsSchema,
     onReminderOpen: z.any().optional(),
     email: z.string().optional(),
     submitComponentEvent: z.any().optional(),

--- a/src/types/EpicTypes.ts
+++ b/src/types/EpicTypes.ts
@@ -65,6 +65,16 @@ export type EpicPayload = {
 
 export type EpicType = 'ARTICLE' | 'LIVEBLOG';
 
+interface ArticleCounts {
+    total: number; // The user's total article view count, which currently goes back as far as 52 weeks
+    forTargetedWeeks: number; // The user's article view count for the configured periodInWeeks
+}
+
+const articleCountsSchema = z.object({
+    total: z.number(),
+    forTargetedWeeks: z.number(),
+});
+
 export interface MaxViews {
     maxViewsCount: number;
     maxViewsDays: number;
@@ -135,6 +145,7 @@ export type EpicProps = {
     tracking: Tracking;
     countryCode?: string;
     numArticles: number;
+    articleCounts?: ArticleCounts;
     // eslint-disable-next-line @typescript-eslint/ban-types
     onReminderOpen?: Function;
     email?: string;
@@ -149,6 +160,7 @@ export const epicPropsSchema = z.object({
     tracking: trackingSchema,
     countryCode: z.string().optional(),
     numArticles: z.number(),
+    articleCounts: articleCountsSchema.optional(),
     onReminderOpen: z.any().optional(),
     email: z.string().optional(),
     submitComponentEvent: z.any().optional(),

--- a/src/types/EpicTypes.ts
+++ b/src/types/EpicTypes.ts
@@ -66,12 +66,12 @@ export type EpicPayload = {
 export type EpicType = 'ARTICLE' | 'LIVEBLOG';
 
 export interface ArticleCounts {
-    total: number; // The user's total article view count, which currently goes back as far as 52 weeks
+    for52Weeks: number; // The user's total article view count, which currently goes back as far as 52 weeks
     forTargetedWeeks: number; // The user's article view count for the configured periodInWeeks
 }
 
 const articleCountsSchema = z.object({
-    total: z.number(),
+    for52Weeks: z.number(),
     forTargetedWeeks: z.number(),
 });
 


### PR DESCRIPTION
Currently in the epic, both the Above and Inline versions of AC use the same count. This count is based on the 'period in weeks' set from the tool, defaulting to 52.

We need to decouple the Above AC from 'period in weeks', to enable them to display ACs for different periods.

This is a breaking change to the props, but now that we have props validation in the epic it means clients with older versions of the module will just not display an epic (while we wait for caches to clear).

It replaces the `numArticles` prop with an object containing both the count for the whole year, and the count based on the configured 'period in weeks'.

![Screen Shot 2021-07-09 at 10 52 51](https://user-images.githubusercontent.com/1513454/125060718-8d9bfa00-e0a4-11eb-8fe5-8038e6b6d6e3.png)
