### PR TITLE
Remove aus supporter header

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -55,6 +55,11 @@ export const ausMomentHeaderNonSupporter: ModuleInfo = getDefaultModuleInfo(
     'header/HeaderAusMomentNonSupporter',
 );
 
+export const ausMomentHeaderSupporter: ModuleInfo = getDefaultModuleInfo(
+    'aus-moment-header-supporter',
+    'header/HeaderAusMomentSupporter',
+);
+
 export const ausMomentBanner: ModuleInfo = getDefaultModuleInfo(
     'aus-moment-banner',
     'banners/ausMoment/AusBanner',
@@ -70,5 +75,6 @@ export const moduleInfos: ModuleInfo[] = [
     header,
     headerSupportAgain,
     ausMomentHeaderNonSupporter,
+    ausMomentHeaderSupporter,
     ausMomentBanner,
 ];

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -50,11 +50,6 @@ export const headerSupportAgain: ModuleInfo = getDefaultModuleInfo(
     'header/HeaderSupportAgain',
 );
 
-export const ausMomentHeaderSupporter: ModuleInfo = getDefaultModuleInfo(
-    'aus-moment-header-supporter',
-    'header/HeaderAusMomentSupporter',
-);
-
 export const ausMomentHeaderNonSupporter: ModuleInfo = getDefaultModuleInfo(
     'aus-moment-header-nonsupporter',
     'header/HeaderAusMomentNonSupporter',
@@ -74,7 +69,6 @@ export const moduleInfos: ModuleInfo[] = [
     puzzlesBanner,
     header,
     headerSupportAgain,
-    ausMomentHeaderSupporter,
     ausMomentHeaderNonSupporter,
     ausMomentBanner,
 ];

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -166,7 +166,7 @@ export const selectHeaderTest = (
         if (isAusMoment(targeting.countryCode)) {
             if (lastContributed2To13MonthsAgo) {
                 return ausMomentOneOffContributor;
-            } else if (!targeting.showSupportMessaging) {
+            } else if (targeting.showSupportMessaging) {
                 return ausMomentNonSupporter;
             }
         }

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -1,10 +1,5 @@
 import { HeaderTargeting, HeaderTest, HeaderTestSelection } from '../../types/HeaderTypes';
-import {
-    ausMomentHeaderNonSupporter,
-    ausMomentHeaderSupporter,
-    header,
-    headerSupportAgain,
-} from '../../modules';
+import { ausMomentHeaderNonSupporter, header, headerSupportAgain } from '../../modules';
 
 const modulePathBuilder = header.endpointPathBuilder;
 
@@ -87,23 +82,31 @@ const supportAgainTest: HeaderTest = {
     ],
 };
 
-const monthDiff = (from: Date, to: Date): number => {
-    return 12 * (to.getFullYear() - from.getFullYear()) + (to.getMonth() - from.getMonth());
+const ausMomentNonSupporter: HeaderTest = {
+    name: 'aus-moment-nonsupporter',
+    audience: 'AllNonSupporters',
+    variants: [
+        {
+            name: 'control',
+            modulePathBuilder: ausMomentHeaderNonSupporter.endpointPathBuilder,
+            content: {
+                heading: 'Support the Guardian',
+                subheading: '',
+                primaryCta: {
+                    text: 'Contribute',
+                    url: 'https://support.theguardian.com/contribute',
+                },
+                secondaryCta: {
+                    text: 'Subscribe',
+                    url: 'https://support.theguardian.com/subscribe',
+                },
+            },
+        },
+    ],
 };
 
-const isLastOneOffContributionWithinLast2Months = (
-    lastOneOffContributionDate?: string,
-): boolean => {
-    if (lastOneOffContributionDate === undefined) {
-        return false;
-    }
-
-    const now = new Date();
-    const date = new Date(lastOneOffContributionDate);
-
-    const monthsSinceLastContribution = monthDiff(date, now);
-
-    return monthsSinceLastContribution <= 2;
+const monthDiff = (from: Date, to: Date): number => {
+    return 12 * (to.getFullYear() - from.getFullYear()) + (to.getMonth() - from.getMonth());
 };
 
 const isLastOneOffContributionWithinLast2To13Months = (
@@ -133,24 +136,12 @@ export const selectHeaderTest = (
 ): Promise<HeaderTestSelection | null> => {
     const select = (): HeaderTest => {
         if (isAusMoment(targeting.countryCode)) {
-            if (isLastOneOffContributionWithinLast2Months(targeting.lastOneOffContributionDate)) {
-                return supportersTest;
-            } else if (
-                isLastOneOffContributionWithinLast2To13Months(targeting.lastOneOffContributionDate)
-            ) {
-                return ausMomentOneOffContributor;
-            } else if (!targeting.showSupportMessaging) {
-                return ausMomentRecurringSupporter;
-            } else {
+            if (!targeting.showSupportMessaging) {
                 return ausMomentNonSupporter;
             }
         }
 
-        if (isLastOneOffContributionWithinLast2Months(targeting.lastOneOffContributionDate)) {
-            return supportersTest;
-        } else if (
-            isLastOneOffContributionWithinLast2To13Months(targeting.lastOneOffContributionDate)
-        ) {
+        if (isLastOneOffContributionWithinLast2To13Months(targeting.lastOneOffContributionDate)) {
             return supportAgainTest;
         } else if (targeting.showSupportMessaging) {
             return getNonSupportersTest(targeting.edition);
@@ -170,65 +161,4 @@ export const selectHeaderTest = (
         });
     }
     return Promise.resolve(null);
-};
-
-const ausMomentRecurringSupporter: HeaderTest = {
-    name: 'aus-moment-supporter',
-    audience: 'AllExistingSupporters',
-    variants: [
-        {
-            name: 'control',
-            modulePathBuilder: ausMomentHeaderSupporter.endpointPathBuilder,
-            content: {
-                heading: 'Thank you',
-                subheading: '',
-                primaryCta: {
-                    text: 'Make an extra contribution',
-                    url: 'https://support.theguardian.com/contribute',
-                },
-            },
-        },
-    ],
-};
-
-const ausMomentOneOffContributor: HeaderTest = {
-    name: 'aus-moment-supporter',
-    audience: 'AllExistingSupporters',
-    variants: [
-        {
-            name: 'control',
-            modulePathBuilder: ausMomentHeaderSupporter.endpointPathBuilder,
-            content: {
-                heading: 'Thank you',
-                subheading: '',
-                primaryCta: {
-                    text: 'Support us again',
-                    url: 'https://support.theguardian.com/contribute',
-                },
-            },
-        },
-    ],
-};
-
-const ausMomentNonSupporter: HeaderTest = {
-    name: 'aus-moment-nonsupporter',
-    audience: 'AllNonSupporters',
-    variants: [
-        {
-            name: 'control',
-            modulePathBuilder: ausMomentHeaderNonSupporter.endpointPathBuilder,
-            content: {
-                heading: 'Support the Guardian',
-                subheading: '',
-                primaryCta: {
-                    text: 'Contribute',
-                    url: 'https://support.theguardian.com/contribute',
-                },
-                secondaryCta: {
-                    text: 'Subscribe',
-                    url: 'https://support.theguardian.com/subscribe',
-                },
-            },
-        },
-    ],
 };

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -103,7 +103,7 @@ const isLastOneOffContributionWithinLast2Months = (
 
     const monthsSinceLastContribution = monthDiff(date, now);
 
-    return monthsSinceLastContribution < 2;
+    return monthsSinceLastContribution <= 2;
 };
 
 const isLastOneOffContributionWithinLast2To13Months = (

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -91,6 +91,21 @@ const monthDiff = (from: Date, to: Date): number => {
     return 12 * (to.getFullYear() - from.getFullYear()) + (to.getMonth() - from.getMonth());
 };
 
+const isLastOneOffContributionWithinLast2Months = (
+    lastOneOffContributionDate?: string,
+): boolean => {
+    if (lastOneOffContributionDate === undefined) {
+        return false;
+    }
+
+    const now = new Date();
+    const date = new Date(lastOneOffContributionDate);
+
+    const monthsSinceLastContribution = monthDiff(date, now);
+
+    return monthsSinceLastContribution < 2;
+};
+
 const isLastOneOffContributionWithinLast2To13Months = (
     lastOneOffContributionDate?: string,
 ): boolean => {
@@ -118,7 +133,9 @@ export const selectHeaderTest = (
 ): Promise<HeaderTestSelection | null> => {
     const select = (): HeaderTest => {
         if (isAusMoment(targeting.countryCode)) {
-            if (
+            if (isLastOneOffContributionWithinLast2Months(targeting.lastOneOffContributionDate)) {
+                return supportersTest;
+            } else if (
                 isLastOneOffContributionWithinLast2To13Months(targeting.lastOneOffContributionDate)
             ) {
                 return ausMomentOneOffContributor;
@@ -128,7 +145,12 @@ export const selectHeaderTest = (
                 return ausMomentNonSupporter;
             }
         }
-        if (isLastOneOffContributionWithinLast2To13Months(targeting.lastOneOffContributionDate)) {
+
+        if (isLastOneOffContributionWithinLast2Months(targeting.lastOneOffContributionDate)) {
+            return supportersTest;
+        } else if (
+            isLastOneOffContributionWithinLast2To13Months(targeting.lastOneOffContributionDate)
+        ) {
             return supportAgainTest;
         } else if (targeting.showSupportMessaging) {
             return getNonSupportersTest(targeting.edition);

--- a/src/tests/header/headerSelection.ts
+++ b/src/tests/header/headerSelection.ts
@@ -163,18 +163,18 @@ export const selectHeaderTest = (
             targeting.lastOneOffContributionDate,
         );
 
-        if (isAusMoment(targeting.countryCode)) {
-            if (lastContributed2To13MonthsAgo) {
-                return ausMomentOneOffContributor;
-            } else if (targeting.showSupportMessaging) {
-                return ausMomentNonSupporter;
-            }
-        }
-
         if (lastContributed2To13MonthsAgo) {
-            return supportAgainTest;
+            if (isAusMoment(targeting.countryCode)) {
+                return ausMomentOneOffContributor;
+            } else {
+                return supportAgainTest;
+            }
         } else if (targeting.showSupportMessaging) {
-            return getNonSupportersTest(targeting.edition);
+            if (isAusMoment(targeting.countryCode)) {
+                return ausMomentNonSupporter;
+            } else {
+                return getNonSupportersTest(targeting.edition);
+            }
         } else {
             return supportersTest;
         }


### PR DESCRIPTION
we need to improve our targeting to prevent e.g. recent subscribers seeing the message. For now it only targets non-supporters