### PR TITLE
Fix banner closing bug

### DIFF
--- a/src/components/modules/banners/ausMoment/AusBanner.tsx
+++ b/src/components/modules/banners/ausMoment/AusBanner.tsx
@@ -258,6 +258,6 @@ const AusMomentBanner: React.FC<BannerRenderProps> = ({
     );
 };
 
-const validated = validatedBannerWrapper(AusMomentBanner, 'aus-moment-banner', 'contributions');
+const validated = validatedBannerWrapper(AusMomentBanner, 'aus-moment-banner');
 
 export { validated as AusMomentBanner };

--- a/src/components/modules/banners/common/BannerWrapper.tsx
+++ b/src/components/modules/banners/common/BannerWrapper.tsx
@@ -5,12 +5,7 @@ import {
     createClickEventFromTracking,
 } from '../../../../lib/tracking';
 import React from 'react';
-import {
-    BannerChannel,
-    BannerContent,
-    BannerProps,
-    bannerSchema,
-} from '../../../../types/BannerTypes';
+import { BannerContent, BannerProps, bannerSchema } from '../../../../types/BannerTypes';
 import { Cta, SecondaryCta, SecondaryCtaType } from '../../../../types/shared';
 import {
     containsNonArticleCountPlaceholder,
@@ -181,8 +176,7 @@ const withBannerData = (
 export const bannerWrapper = (
     Banner: React.FC<BannerRenderProps>,
     bannerId: BannerId,
-    bannerChannel: BannerChannel,
-): React.FC<BannerProps> => withCloseable(withBannerData(Banner, bannerId), bannerChannel);
+): React.FC<BannerProps> => withCloseable(withBannerData(Banner, bannerId));
 
 const validate = (props: unknown): props is BannerProps => {
     const result = bannerSchema.safeParse(props);
@@ -192,8 +186,7 @@ const validate = (props: unknown): props is BannerProps => {
 export const validatedBannerWrapper = (
     Banner: React.FC<BannerRenderProps>,
     bannerId: BannerId,
-    bannerChannel: BannerChannel,
 ): React.FC<BannerProps> => {
-    const withoutValidation = bannerWrapper(Banner, bannerId, bannerChannel);
+    const withoutValidation = bannerWrapper(Banner, bannerId);
     return withParsedProps(withoutValidation, validate);
 };

--- a/src/components/modules/banners/contributions/ContributionsBanner.tsx
+++ b/src/components/modules/banners/contributions/ContributionsBanner.tsx
@@ -307,11 +307,7 @@ const ContributionsBanner: React.FC<BannerRenderProps> = ({
     );
 };
 
-const unvalidated = bannerWrapper(ContributionsBanner, 'contributions-banner', 'contributions');
-const validated = validatedBannerWrapper(
-    ContributionsBanner,
-    'contributions-banner',
-    'contributions',
-);
+const unvalidated = bannerWrapper(ContributionsBanner, 'contributions-banner');
+const validated = validatedBannerWrapper(ContributionsBanner, 'contributions-banner');
 
 export { validated as ContributionsBanner, unvalidated as ContributionsBannerUnvalidated };

--- a/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/src/components/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -169,6 +169,6 @@ const DigitalSubscriptionsBanner: React.FC<BannerRenderProps> = ({
     );
 };
 
-const wrapped = validatedBannerWrapper(DigitalSubscriptionsBanner, bannerId, 'subscriptions');
+const wrapped = validatedBannerWrapper(DigitalSubscriptionsBanner, bannerId);
 
 export { wrapped as DigitalSubscriptionsBanner };

--- a/src/components/modules/banners/g200/G200Banner.tsx
+++ b/src/components/modules/banners/g200/G200Banner.tsx
@@ -353,7 +353,7 @@ const G200Banner: React.FC<BannerRenderProps> = ({
     );
 };
 
-const unvalidated = bannerWrapper(G200Banner, 'g200-banner', 'contributions');
-const validated = validatedBannerWrapper(G200Banner, 'g200-banner', 'contributions');
+const unvalidated = bannerWrapper(G200Banner, 'g200-banner');
+const validated = validatedBannerWrapper(G200Banner, 'g200-banner');
 
 export { validated as G200Banner, unvalidated as G200BannerUnvalidated };

--- a/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/src/components/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -159,6 +159,6 @@ const GuardianWeeklyBanner: React.FC<BannerRenderProps> = ({
 };
 
 // const wrapped = bannerWrapper(GuardianWeeklyBanner, bannerId, 'subscriptions');
-const validated = validatedBannerWrapper(GuardianWeeklyBanner, bannerId, 'subscriptions');
+const validated = validatedBannerWrapper(GuardianWeeklyBanner, bannerId);
 
 export { validated as GuardianWeeklyBanner };

--- a/src/components/modules/banners/hocs/withCloseable.tsx
+++ b/src/components/modules/banners/hocs/withCloseable.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { BannerProps, BannerChannel } from '../../../../types/BannerTypes';
+import { BannerProps } from '../../../../types/BannerTypes';
 import { setChannelClosedTimestamp } from '../localStorage';
 import { useEscapeShortcut } from '../../../hooks/useEscapeShortcut';
 
@@ -7,15 +7,12 @@ export interface CloseableBannerProps extends BannerProps {
     onClose: () => void;
 }
 
-const withCloseable = (
-    CloseableBanner: React.FC<CloseableBannerProps>,
-    bannerChannel: BannerChannel,
-): React.FC<BannerProps> => {
+const withCloseable = (CloseableBanner: React.FC<CloseableBannerProps>): React.FC<BannerProps> => {
     const Banner: React.FC<BannerProps> = (bannerProps: BannerProps) => {
         const [isOpen, setIsOpen] = useState(true);
 
         const onClose = (): void => {
-            setChannelClosedTimestamp(bannerChannel);
+            setChannelClosedTimestamp(bannerProps.bannerChannel);
             setIsOpen(false);
         };
 


### PR DESCRIPTION
## What does this change?
Fixes a bug with closing the banners. When we close a banner we store a timestamp in local storage to record when a user dismissed a banner: `gu.prefs.engagementBannerLastClosedAt` for channel 1, and `gu.prefs.subscriptionBannerLastClosedAt` for channel 2. However, at the moment all contributions banners set the channel 1 timestamp, and all subs banners se the channel 2 timestamp. This is **regardless** of which channel they are actaully in. The fix was straight forward - the `bannerChannel` is already passed as a prop to the banners, so we use this value in the `withCloseable` hoc instead (previously it was a second arg). 
