### PR TITLE
Puzzles Banner: Disable QR code square

### DIFF
--- a/packages/modules/src/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
+++ b/packages/modules/src/modules/puzzles/puzzlesBanner/squares/ContentSquares.tsx
@@ -7,7 +7,7 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { Square } from './Square';
 import { SquareSide } from './SquareSide';
 import { squareBorder, squareBoxShadow } from '../puzzlesStyleUtils';
-import { qrCode } from '../images';
+// import { qrCode } from '../images';
 
 function desktopGridPlacement(row: number, column: number) {
     return css`
@@ -136,32 +136,32 @@ const downShiftedSquare = css`
     }
 `;
 
-const qrCodeSquare = css`
-    border-bottom: none;
-    box-shadow: none;
+// const qrCodeSquare = css`
+//     border-bottom: none;
+//     box-shadow: none;
 
-    & * {
-        box-shadow: none;
-    }
+//     & * {
+//         box-shadow: none;
+//     }
 
-    ${until.tablet} {
-        display: none;
-    }
-`;
+//     ${until.tablet} {
+//         display: none;
+//     }
+// `;
 
-const qrCodeContainer = css`
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    padding-bottom: ${space[3]}px;
+// const qrCodeContainer = css`
+//     display: flex;
+//     flex-direction: column;
+//     justify-content: space-between;
+//     padding-bottom: ${space[3]}px;
 
-    ${until.desktop} {
-        img {
-            width: 84px;
-            height: 84px;
-        }
-    }
-`;
+//     ${until.desktop} {
+//         img {
+//             width: 84px;
+//             height: 84px;
+//         }
+//     }
+// `;
 
 const textHighlight = css`
     background-color: ${brandAlt[400]};
@@ -239,7 +239,7 @@ export const ContentSquares: React.FC<ContentSquaresProps> = ({ minimiseButton }
                 <p>Solve with&nbsp;no distractions</p>
                 <div css={minimiseButtonContainer}>{minimiseButton}</div>
             </ContentSquare>
-            <ContentSquare cssOverrides={[qrCodeSquare, desktopGridPlacement(3, 1)]}>
+            {/* <ContentSquare cssOverrides={[qrCodeSquare, desktopGridPlacement(3, 1)]}>
                 <div css={qrCodeContainer}>
                     <p>
                         <span css={textHighlight}>Scan to download</span>
@@ -251,7 +251,7 @@ export const ContentSquares: React.FC<ContentSquaresProps> = ({ minimiseButton }
                         height="100"
                     />
                 </div>
-            </ContentSquare>
+            </ContentSquare> */}
         </div>
     );
 };


### PR DESCRIPTION
## What does this change?
This PR removes the QR code from the Puzzles Banner. I've commented this code out rather than removing it completely as we may want to restore it in time.

## Images

### Before

<img width="1161" alt="Screenshot 2021-08-06 at 14 59 46" src="https://user-images.githubusercontent.com/1590704/128523266-dc430762-87f7-49ac-8caf-6c5112e3a966.png">

### After

<img width="1161" alt="Screenshot 2021-08-06 at 14 59 55" src="https://user-images.githubusercontent.com/1590704/128523228-f06b8bb1-9448-473b-9c69-cb78b944403f.png">
