### PR TITLE
Fix liveblog article count

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsLiveblogEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsLiveblogEpic.stories.tsx
@@ -13,7 +13,10 @@ export default {
 
 // Number of articles viewed
 // Used to replace the template placeholder
-const numArticles = 99;
+const articleCounts = {
+    for52Weeks: 99,
+    forTargetedWeeks: 99,
+};
 
 export const defaultStory = (): ReactElement => {
     // Epic content props
@@ -52,7 +55,7 @@ export const defaultStory = (): ReactElement => {
                 variant={variant}
                 tracking={epicTracking}
                 countryCode={countryCode}
-                numArticles={numArticles}
+                articleCounts={articleCounts}
             />
         </StorybookWrapper>
     );

--- a/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
@@ -13,6 +13,7 @@ import {
 import { EpicVariant, Tracking } from '@sdc/shared/types';
 import { replaceArticleCount } from '../../lib/replaceArticleCount';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/lib';
+import { ArticleCounts } from '@sdc/shared/types';
 
 const container: SerializedStyles = css`
     padding: 6px 10px 28px 10px;
@@ -178,13 +179,13 @@ interface LiveblogEpicProps {
     variant: EpicVariant;
     tracking: Tracking;
     countryCode?: string;
-    numArticles: number;
+    articleCounts: ArticleCounts;
 }
 
 export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
     variant,
     countryCode,
-    numArticles,
+    articleCounts,
     tracking,
 }: LiveblogEpicProps): JSX.Element | null => {
     const cleanParagraphs = variant.paragraphs.map(paragraph =>
@@ -204,7 +205,10 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
         <>
             {cleanHeading && <div css={yellowHeading}>{cleanHeading}</div>}
             <section css={container}>
-                <LiveblogEpicBody paragraphs={cleanParagraphs} numArticles={numArticles} />
+                <LiveblogEpicBody
+                    paragraphs={cleanParagraphs}
+                    numArticles={articleCounts.forTargetedWeeks}
+                />
                 <LiveblogEpicCta
                     text={variant.cta?.text}
                     baseUrl={variant.cta?.baseUrl}


### PR DESCRIPTION
Fortunately we don't currently use article count in the liveblog.
But the prop for the liveblog epic component is wrong. This PR fixes it, in case we do want to use article count.

![Screen Shot 2021-08-10 at 12 34 14](https://user-images.githubusercontent.com/1513454/128860356-d2c0a2aa-7f78-4406-9052-663341077e9d.png)
