### PR TITLE
Use 'ACQUISITIONS_OTHER' componentType for AC opt-out popup events

### DIFF
--- a/packages/modules/src/modules/shared/helpers/ophan.ts
+++ b/packages/modules/src/modules/shared/helpers/ophan.ts
@@ -9,38 +9,42 @@ export const ophanComponentEventOptOutView = (
     componentType: OphanComponentType,
 ): OphanComponentEvent => ({
     component: {
-        componentType,
+        componentType: 'ACQUISITIONS_OTHER',
         id: OPHAN_COMPONENT_ID_OPT_OUT_VIEW,
     },
     action: 'VIEW',
+    value: `article-count-opt-out-popup-${componentType}`,
 });
 
 export const ophanComponentEventOptOutOpen = (
     componentType: OphanComponentType,
 ): OphanComponentEvent => ({
     component: {
-        componentType,
+        componentType: 'ACQUISITIONS_OTHER',
         id: OPHAN_COMPONENT_ID_OPT_OUT_OPEN,
     },
     action: 'CLICK',
+    value: `article-count-opt-out-popup-${componentType}`,
 });
 
 export const ophanComponentEventOptOutClose = (
     componentType: OphanComponentType,
 ): OphanComponentEvent => ({
     component: {
-        componentType,
+        componentType: 'ACQUISITIONS_OTHER',
         id: OPHAN_COMPONENT_ID_OPT_OUT_CLOSE,
     },
     action: 'CLICK',
+    value: `article-count-opt-out-popup-${componentType}`,
 });
 
 export const ophanComponentEventOptOutConfirm = (
     componentType: OphanComponentType,
 ): OphanComponentEvent => ({
     component: {
-        componentType,
+        componentType: 'ACQUISITIONS_OTHER',
         id: OPHAN_COMPONENT_ID_OPT_OUT_CONFIRM,
     },
     action: 'CLICK',
+    value: `article-count-opt-out-popup-${componentType}`,
 });


### PR DESCRIPTION
We need to avoid using ACQUISITIONS_EPIC and ACQUISITIONS_BANNER for components _within_ the epic/banner, as they can get mixed up with the overall events (e.g. epic VIEW event).

Currently the old-style AC opt-out does send these componentTypes. So this PR replaces that with ACQUISITIONS_OTHER, as we do elsewhere. It would confuse things further to change the `component.id` field at this point, so I've added a `value` field which specifies the parent componentType and the fact that it's the AC opt-out popup.