### PR TITLE
Turn off aus moment header

### DIFF
--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -153,7 +153,7 @@ const getNonSupportersTest = (edition: string): HeaderTest =>
 
 const isAusMoment = (countryCode: string): boolean => countryCode === 'AU' && isAusMomentLive();
 
-const isAusMomentLive = () => Date.now() >= Date.parse('2021-07-19');
+const isAusMomentLive = () => false;
 
 export const selectHeaderTest = (
     targeting: HeaderTargeting,


### PR DESCRIPTION
## What does this do?
Turn off the aus moment header. I've created a [card](https://trello.com/c/luC8oJOW/2776-remove-aus-moment-references) to clean up more thoroughly 