### PR TITLE
Epic choice cards test

### DIFF
--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -17,15 +17,16 @@
     "@emotion/react": "^11.1.5",
     "@guardian/src-brand": "3.8.0",
     "@guardian/src-button": "3.8.0",
+    "@guardian/src-choice-card": "^3.8.0",
     "@guardian/src-foundations": "3.8.0",
     "@guardian/src-icons": "3.8.0",
     "@guardian/src-layout": "3.8.0",
     "@guardian/src-link": "3.8.0",
     "@guardian/src-text-input": "3.8.0",
+    "@sdc/shared": "1.0.0",
     "@types/babel__standalone": "^7.1.2",
     "preact": "^10.5.12",
-    "zod": "^3.2.0",
-    "@sdc/shared": "1.0.0"
+    "zod": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -6,6 +6,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { css } from '@emotion/react';
 import { palette } from '@guardian/src-foundations';
 import { EpicProps, SecondaryCtaType, TickerCountType, TickerEndType } from '@sdc/shared/types';
+import { UK_DATA } from '@sdc/server/src/tests/epics/choiceCardsTestData';
 
 const containerStyles = css`
     margin: 3em auto;
@@ -130,4 +131,24 @@ WithAboveArticleCountNoConsent.args = {
         forTargetedWeeks: 99,
     },
     hasConsentForArticleCount: false,
+};
+
+export const WithChoiceCards = Template.bind({});
+WithChoiceCards.args = {
+    variant: {
+        ...props.variant,
+        secondaryCta: {
+            type: SecondaryCtaType.ContributionsReminder,
+        },
+        showReminderFields: {
+            reminderCta: 'Remind me in September',
+            reminderPeriod: '2021-09-01',
+            reminderLabel: 'September',
+        },
+        choiceCardSettings: {
+            showChoiceCards: true,
+            amounts: UK_DATA.AMOUNTS,
+            currencySymbol: '£',
+        },
+    },
 };

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -145,10 +145,6 @@ WithChoiceCards.args = {
             reminderPeriod: '2021-09-01',
             reminderLabel: 'September',
         },
-        choiceCardSettings: {
-            showChoiceCards: true,
-            amounts: UK_DATA.AMOUNTS,
-            currencySymbol: '£',
-        },
+        choiceCardAmounts: UK_DATA.AMOUNTS,
     },
 };

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -6,7 +6,6 @@ import { from } from '@guardian/src-foundations/mq';
 import { css } from '@emotion/react';
 import { palette } from '@guardian/src-foundations';
 import { EpicProps, SecondaryCtaType, TickerCountType, TickerEndType } from '@sdc/shared/types';
-import { UK_DATA } from '@sdc/server/src/tests/epics/choiceCardsTestData';
 
 const containerStyles = css`
     margin: 3em auto;
@@ -145,6 +144,10 @@ WithChoiceCards.args = {
             reminderPeriod: '2021-09-01',
             reminderLabel: 'September',
         },
-        choiceCardAmounts: UK_DATA.AMOUNTS,
+        choiceCardAmounts: {
+            SINGLE: [30, 60],
+            MONTHLY: [3, 6],
+            ANNUAL: [60, 120],
+        },
     },
 };

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -233,7 +233,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
     const [isReminderActive, setIsReminderActive] = useState(false);
     const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } = useArticleCountOptOut();
 
-    const { backgroundImageUrl, showReminderFields, tickerSettings, choiceCardSettings } = variant;
+    const { backgroundImageUrl, showReminderFields, tickerSettings, choiceCardAmounts } = variant;
 
     const [hasBeenSeen, setNode] = useHasBeenSeen({ threshold: 0 }, true) as HasBeenSeen;
 
@@ -315,12 +315,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 tracking={ophanTracking}
             />
 
-            {choiceCardSettings?.showChoiceCards && (
-                <ContributionsEpicChoiceCards
-                    amounts={choiceCardSettings.amounts}
-                    currencySymbol={choiceCardSettings.currencySymbol}
-                />
-            )}
+            {choiceCardAmounts && <ContributionsEpicChoiceCards amounts={choiceCardAmounts} />}
 
             <ContributionsEpicButtons
                 variant={variant}

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -321,12 +321,13 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 tracking={ophanTracking}
             />
 
-            {choiceCardSelection && choiceCardAmounts && (
+            {choiceCardSelection && choiceCardAmounts && submitComponentEvent && (
                 <ContributionsEpicChoiceCards
                     amounts={choiceCardAmounts}
                     setSelectionsCallback={setChoiceCardSelection}
                     selection={choiceCardSelection}
                     countryCode={countryCode}
+                    submitComponentEvent={submitComponentEvent}
                 />
             )}
 

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -18,7 +18,7 @@ import { useArticleCountOptOut } from '../../hooks/useArticleCountOptOut';
 import { HasBeenSeen, useHasBeenSeen } from '../../hooks/useHasBeenSeen';
 import { isProd } from '../shared/helpers/stage';
 import { withParsedProps } from '../shared/ModuleWrapper';
-import { ContributionsEpicChoiceCards } from './ContributionsEpicChoiceCards';
+import { ChoiceCardSelection, ContributionsEpicChoiceCards } from './ContributionsEpicChoiceCards';
 
 const sendEpicViewEvent = (url: string, countryCode?: string, stage?: Stage): void => {
     const path = 'events/epic-view';
@@ -230,6 +230,12 @@ const ContributionsEpic: React.FC<EpicProps> = ({
     hasConsentForArticleCount,
     stage,
 }: EpicProps) => {
+    const [choiceCardSelection, setChoiceCardSelection] = useState<ChoiceCardSelection | undefined>(
+        variant.choiceCardAmounts && {
+            frequency: 'MONTHLY',
+            amount: variant.choiceCardAmounts['MONTHLY'][1],
+        },
+    );
     const [isReminderActive, setIsReminderActive] = useState(false);
     const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } = useArticleCountOptOut();
 
@@ -315,7 +321,13 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 tracking={ophanTracking}
             />
 
-            {choiceCardAmounts && <ContributionsEpicChoiceCards amounts={choiceCardAmounts} />}
+            {choiceCardSelection && choiceCardAmounts && (
+                <ContributionsEpicChoiceCards
+                    amounts={choiceCardAmounts}
+                    setSelectionsCallback={setChoiceCardSelection}
+                    selection={choiceCardSelection}
+                />
+            )}
 
             <ContributionsEpicButtons
                 variant={variant}
@@ -339,6 +351,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 submitComponentEvent={submitComponentEvent}
                 isReminderActive={isReminderActive}
                 isSignedIn={Boolean(email)}
+                choiceCardSelection={choiceCardSelection}
             />
 
             {isReminderActive && showReminderFields && (

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -18,6 +18,7 @@ import { useArticleCountOptOut } from '../../hooks/useArticleCountOptOut';
 import { HasBeenSeen, useHasBeenSeen } from '../../hooks/useHasBeenSeen';
 import { isProd } from '../shared/helpers/stage';
 import { withParsedProps } from '../shared/ModuleWrapper';
+import { ContributionsEpicChoiceCards } from './ContributionsEpicChoiceCards';
 
 const sendEpicViewEvent = (url: string, countryCode?: string, stage?: Stage): void => {
     const path = 'events/epic-view';
@@ -232,7 +233,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
     const [isReminderActive, setIsReminderActive] = useState(false);
     const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } = useArticleCountOptOut();
 
-    const { backgroundImageUrl, showReminderFields, tickerSettings } = variant;
+    const { backgroundImageUrl, showReminderFields, tickerSettings, choiceCardSettings } = variant;
 
     const [hasBeenSeen, setNode] = useHasBeenSeen({ threshold: 0 }, true) as HasBeenSeen;
 
@@ -313,6 +314,13 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 numArticles={articleCounts.forTargetedWeeks}
                 tracking={ophanTracking}
             />
+
+            {choiceCardSettings?.showChoiceCards && (
+                <ContributionsEpicChoiceCards
+                    amounts={choiceCardSettings.amounts}
+                    currencySymbol={choiceCardSettings.currencySymbol}
+                />
+            )}
 
             <ContributionsEpicButtons
                 variant={variant}

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -326,6 +326,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                     amounts={choiceCardAmounts}
                     setSelectionsCallback={setChoiceCardSelection}
                     selection={choiceCardSelection}
+                    countryCode={countryCode}
                 />
             )}
 

--- a/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
@@ -12,6 +12,7 @@ import {
 } from './utils/ophan';
 import { useHasBeenSeen } from '../../hooks/useHasBeenSeen';
 import { hasSetReminder } from '../utils/reminders';
+import { ChoiceCardSelection } from './ContributionsEpicChoiceCards';
 
 const buttonWrapperStyles = css`
     margin: ${space[6]}px ${space[2]}px ${space[1]}px 0;
@@ -93,6 +94,7 @@ interface ContributionsEpicButtonsProps {
     submitComponentEvent?: (event: OphanComponentEvent) => void;
     isReminderActive: boolean;
     isSignedIn: boolean;
+    choiceCardSelection?: ChoiceCardSelection;
 }
 
 export const ContributionsEpicButtons = ({
@@ -103,14 +105,22 @@ export const ContributionsEpicButtons = ({
     submitComponentEvent,
     isReminderActive,
     isSignedIn,
+    choiceCardSelection,
 }: ContributionsEpicButtonsProps): JSX.Element | null => {
     const [hasBeenSeen, setNode] = useHasBeenSeen({}, true);
-
     const { cta, secondaryCta, showReminderFields } = variant;
 
     if (!cta) {
         return null;
     }
+
+    const getCta = (cta: Cta): Cta =>
+        choiceCardSelection
+            ? {
+                  text: cta.text,
+                  baseUrl: `${cta.baseUrl}?selected-contribution-type=${choiceCardSelection.frequency}&selected-amount=${choiceCardSelection.amount}`,
+              }
+            : cta;
 
     useEffect(() => {
         if (hasBeenSeen && submitComponentEvent) {
@@ -133,7 +143,11 @@ export const ContributionsEpicButtons = ({
         <div ref={setNode} css={buttonWrapperStyles} data-testid="epic=buttons">
             {!isReminderActive && (
                 <>
-                    <PrimaryCtaButton cta={cta} tracking={tracking} countryCode={countryCode} />
+                    <PrimaryCtaButton
+                        cta={getCta(cta)}
+                        tracking={tracking}
+                        countryCode={countryCode}
+                    />
 
                     {secondaryCta?.type === SecondaryCtaType.Custom &&
                     secondaryCta.cta.baseUrl &&

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -1,23 +1,44 @@
+import React from 'react';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
-import React, { useState } from 'react';
-import { ChoiceCardFrequencies, EpicChoiceCardProps } from '@sdc/shared/dist/types';
+import { ChoiceCardAmounts, ChoiceCardFrequency } from '@sdc/shared/dist/types';
 import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib/geolocation';
+
+export interface ChoiceCardSelection {
+    frequency: ChoiceCardFrequency;
+    amount: number | 'other';
+}
+
+interface EpicChoiceCardProps {
+    amounts: ChoiceCardAmounts;
+    selection: ChoiceCardSelection;
+    setSelectionsCallback: (choiceCardSelection: ChoiceCardSelection) => void;
+}
 
 export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
     amounts,
+    selection,
+    setSelectionsCallback,
 }: EpicChoiceCardProps) => {
-    const [contributionFrequency, setContributionFrequency] = useState<ChoiceCardFrequencies>(
-        'MONTHLY',
-    );
-
     const currencySymbol = getLocalCurrencySymbol();
+
+    const updateAmount = (amount: number | 'other') =>
+        setSelectionsCallback({
+            frequency: selection.frequency,
+            amount: amount,
+        });
+
+    const updateFrequency = (frequency: ChoiceCardFrequency) =>
+        setSelectionsCallback({
+            frequency: frequency,
+            amount: amounts[frequency][1],
+        });
 
     const frequencySuffix = () => {
         return {
             SINGLE: '',
             MONTHLY: ' per month',
             ANNUAL: ' per year',
-        }[contributionFrequency];
+        }[selection.frequency];
     };
 
     return (
@@ -28,20 +49,22 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
                     value="single"
                     label="Single"
                     id="single"
-                    onChange={() => setContributionFrequency('SINGLE')}
+                    checked={selection.frequency == 'SINGLE'}
+                    onChange={() => updateFrequency('SINGLE')}
                 />
                 <ChoiceCard
                     value="monthly"
                     label="Monthly"
                     id="monthly"
-                    defaultChecked={true}
-                    onChange={() => setContributionFrequency('MONTHLY')}
+                    checked={selection.frequency == 'MONTHLY'}
+                    onChange={() => updateFrequency('MONTHLY')}
                 />
                 <ChoiceCard
                     value="annual"
                     label="Annual"
                     id="annual"
-                    onChange={() => setContributionFrequency('ANNUAL')}
+                    checked={selection.frequency == 'ANNUAL'}
+                    onChange={() => updateFrequency('ANNUAL')}
                 />
             </ChoiceCardGroup>
             <br />
@@ -49,19 +72,28 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
                 <ChoiceCard
                     value="first"
                     label={`${currencySymbol}${
-                        amounts[contributionFrequency][0]
+                        amounts[selection.frequency][0]
                     }${frequencySuffix()}`}
                     id="first"
+                    checked={selection.amount == amounts[selection.frequency][0]}
+                    onChange={() => updateAmount(amounts[selection.frequency][0])}
                 />
                 <ChoiceCard
                     value="second"
                     label={`${currencySymbol}${
-                        amounts[contributionFrequency][1]
+                        amounts[selection.frequency][1]
                     }${frequencySuffix()}`}
                     id="second"
-                    defaultChecked={true}
+                    checked={selection.amount == amounts[selection.frequency][1]}
+                    onChange={() => updateAmount(amounts[selection.frequency][1])}
                 />
-                <ChoiceCard value="third" label="Other" id="third" />
+                <ChoiceCard
+                    value="third"
+                    label="Other"
+                    id="third"
+                    checked={selection.amount == 'other'}
+                    onChange={() => updateAmount('other')}
+                />
             </ChoiceCardGroup>
         </div>
     );

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
-import { ChoiceCardAmounts, ChoiceCardFrequency } from '@sdc/shared/dist/types';
+import {
+    ChoiceCardAmounts,
+    ChoiceCardFrequency,
+    OphanComponentEvent,
+} from '@sdc/shared/dist/types';
 import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib/geolocation';
 import { css } from '@emotion/react';
 import { until } from '@guardian/src-foundations/mq';
@@ -34,6 +38,7 @@ interface EpicChoiceCardProps {
     selection: ChoiceCardSelection;
     setSelectionsCallback: (choiceCardSelection: ChoiceCardSelection) => void;
     countryCode?: string;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
 }
 
 export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
@@ -41,20 +46,34 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
     selection,
     setSelectionsCallback,
     countryCode,
+    submitComponentEvent,
 }: EpicChoiceCardProps) => {
     const currencySymbol = getLocalCurrencySymbol(countryCode);
 
-    const updateAmount = (amount: number | 'other') =>
+    const trackClick = (type: 'amount' | 'frequency'): void =>
+        submitComponentEvent({
+            component: {
+                componentType: 'ACQUISITIONS_OTHER',
+                id: `contributions-epic-choice-cards-change-${type}`,
+            },
+            action: 'CLICK',
+        });
+
+    const updateAmount = (amount: number | 'other') => {
+        trackClick('amount');
         setSelectionsCallback({
             frequency: selection.frequency,
             amount: amount,
         });
+    };
 
-    const updateFrequency = (frequency: ChoiceCardFrequency) =>
+    const updateFrequency = (frequency: ChoiceCardFrequency) => {
+        trackClick('frequency');
         setSelectionsCallback({
             frequency: frequency,
             amount: amounts[frequency][1],
         });
+    };
 
     const frequencySuffix = () => {
         return {

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -1,12 +1,16 @@
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
 import React, { useState } from 'react';
-import { EpicChoiceCardProps } from '@sdc/shared/dist/types';
+import { ChoiceCardFrequencies, EpicChoiceCardProps } from '@sdc/shared/dist/types';
+import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib/geolocation';
 
 export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
     amounts,
-    currencySymbol,
 }: EpicChoiceCardProps) => {
-    const [contributionFrequency, setContributionFrequency] = useState('MONTHLY');
+    const [contributionFrequency, setContributionFrequency] = useState<ChoiceCardFrequencies>(
+        'MONTHLY',
+    );
+
+    const currencySymbol = getLocalCurrencySymbol();
 
     const frequencySuffix = () => {
         return {

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -2,6 +2,21 @@ import React from 'react';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
 import { ChoiceCardAmounts, ChoiceCardFrequency } from '@sdc/shared/dist/types';
 import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib/geolocation';
+import { css } from '@emotion/react';
+import { until } from '@guardian/src-foundations/mq';
+
+const choiceCardGroupOverrides = css`
+    ${until.mobileLandscape} {
+        > div {
+            display: flex !important;
+        }
+
+        > div label:nth-of-type(2) {
+            margin-left: 4px !important;
+            margin-right: 4px !important;
+        }
+    }
+`;
 
 export interface ChoiceCardSelection {
     frequency: ChoiceCardFrequency;
@@ -44,7 +59,11 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
     return (
         <div>
             <br />
-            <ChoiceCardGroup name="contribution-frequency" columns={3}>
+            <ChoiceCardGroup
+                name="contribution-frequency"
+                columns={3}
+                css={choiceCardGroupOverrides}
+            >
                 <ChoiceCard
                     value="single"
                     label="Single"

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -5,7 +5,13 @@ import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib/geolocation';
 import { css } from '@emotion/react';
 import { until } from '@guardian/src-foundations/mq';
 
-const choiceCardGroupOverrides = css`
+const radioInputOverride = css`
+    input[type='radio'] {
+        visibility: hidden !important;
+    }
+`;
+
+const frequencyChoiceCardGroupOverrides = css`
     ${until.mobileLandscape} {
         > div {
             display: flex !important;
@@ -62,7 +68,7 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
             <ChoiceCardGroup
                 name="contribution-frequency"
                 columns={3}
-                css={choiceCardGroupOverrides}
+                css={[frequencyChoiceCardGroupOverrides, radioInputOverride]}
             >
                 <ChoiceCard
                     value="single"
@@ -87,7 +93,7 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
                 />
             </ChoiceCardGroup>
             <br />
-            <ChoiceCardGroup name="contribution-amount">
+            <ChoiceCardGroup name="contribution-amount" css={radioInputOverride}>
                 <ChoiceCard
                     value="first"
                     label={`${currencySymbol}${

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -33,14 +33,16 @@ interface EpicChoiceCardProps {
     amounts: ChoiceCardAmounts;
     selection: ChoiceCardSelection;
     setSelectionsCallback: (choiceCardSelection: ChoiceCardSelection) => void;
+    countryCode?: string;
 }
 
 export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
     amounts,
     selection,
     setSelectionsCallback,
+    countryCode,
 }: EpicChoiceCardProps) => {
-    const currencySymbol = getLocalCurrencySymbol();
+    const currencySymbol = getLocalCurrencySymbol(countryCode);
 
     const updateAmount = (amount: number | 'other') =>
         setSelectionsCallback({

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -1,0 +1,64 @@
+import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
+import React, { useState } from 'react';
+import { EpicChoiceCardProps } from '@sdc/shared/dist/types';
+
+export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
+    amounts,
+    currencySymbol,
+}: EpicChoiceCardProps) => {
+    const [contributionFrequency, setContributionFrequency] = useState('MONTHLY');
+
+    const frequencySuffix = () => {
+        return {
+            SINGLE: '',
+            MONTHLY: ' per month',
+            ANNUAL: ' per year',
+        }[contributionFrequency];
+    };
+
+    return (
+        <div>
+            <br />
+            <ChoiceCardGroup name="contribution-frequency" columns={3}>
+                <ChoiceCard
+                    value="single"
+                    label="Single"
+                    id="single"
+                    onChange={() => setContributionFrequency('SINGLE')}
+                />
+                <ChoiceCard
+                    value="monthly"
+                    label="Monthly"
+                    id="monthly"
+                    defaultChecked={true}
+                    onChange={() => setContributionFrequency('MONTHLY')}
+                />
+                <ChoiceCard
+                    value="annual"
+                    label="Annual"
+                    id="annual"
+                    onChange={() => setContributionFrequency('ANNUAL')}
+                />
+            </ChoiceCardGroup>
+            <br />
+            <ChoiceCardGroup name="contribution-amount">
+                <ChoiceCard
+                    value="first"
+                    label={`${currencySymbol}${
+                        amounts[contributionFrequency][0]
+                    }${frequencySuffix()}`}
+                    id="first"
+                />
+                <ChoiceCard
+                    value="second"
+                    label={`${currencySymbol}${
+                        amounts[contributionFrequency][1]
+                    }${frequencySuffix()}`}
+                    id="second"
+                    defaultChecked={true}
+                />
+                <ChoiceCard value="third" label="Other" id="third" />
+            </ChoiceCardGroup>
+        </div>
+    );
+};

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -31,11 +31,11 @@ import { fetchSuperModeArticles } from './lib/superMode';
 import { bannerDeployCaches } from './tests/banners/bannerDeployCache';
 import { selectBannerTest } from './tests/banners/bannerSelection';
 import { getCachedTests } from './tests/banners/bannerTests';
-import { findForcedTestAndVariant, findTestAndVariant } from './tests/epics/epicSelection';
-import { Debug } from './tests/epics/epicSelection';
+import { Debug, findForcedTestAndVariant, findTestAndVariant } from './tests/epics/epicSelection';
 import { fallbackEpicTest } from './tests/epics/fallback';
 import { selectHeaderTest } from './tests/header/headerSelection';
 import { logger } from './utils/logging';
+import { epicChoiceCardsTests } from './tests/epics/choiceCards';
 
 interface EpicDataResponse {
     data?: {
@@ -124,7 +124,7 @@ const getArticleEpicTests = async (mvtId: number, isForcingTest: boolean): Promi
             return [...holdback];
         }
 
-        return [...regular, fallbackEpicTest];
+        return [...epicChoiceCardsTests, ...regular, fallbackEpicTest];
     } catch (err) {
         logger.warn(`Error getting article epic tests: ${err}`);
 
@@ -133,8 +133,7 @@ const getArticleEpicTests = async (mvtId: number, isForcingTest: boolean): Promi
 };
 
 const getLiveblogEpicTests = async (): Promise<EpicTest[]> => {
-    const configuredTests = await fetchConfiguredLiveblogEpicTestsCached();
-    return configuredTests;
+    return await fetchConfiguredLiveblogEpicTestsCached();
 };
 
 export const buildEpicData = async (

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -116,7 +116,7 @@ const getArticleEpicTests = async (mvtId: number, isForcingTest: boolean): Promi
         ]);
 
         if (isForcingTest) {
-            return [...regular, ...holdback, fallbackEpicTest];
+            return [...epicChoiceCardsTests, ...regular, ...holdback, fallbackEpicTest];
         }
 
         const shouldHoldBack = mvtId % 100 === 0; // holdback 1% of the audience

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -2,7 +2,7 @@ import { ChoiceCardAmounts, EpicTest } from '@sdc/shared/src/types/epic';
 import { epic } from '@sdc/shared/src/config/modules';
 import { UK_DATA, EU_DATA, ROW_DATA, US_DATA, CA_DATA, NZ_DATA, CTAS } from './choiceCardsTestData';
 import { CountryGroupId } from '@sdc/shared/dist/lib';
-import { ArticlesViewedSettings } from '@sdc/shared/types';
+import { ArticlesViewedSettings, SecondaryCtaType } from '@sdc/shared/types';
 
 const testName = '2021-09-03-EpicChoiceCardsTest';
 
@@ -47,6 +47,9 @@ const buildEpicChoiceCardsTest = (
             cta: CTAS.control,
             choiceCardAmounts: choiceCardAmounts,
             separateArticleCount: articlesViewedSettings ? undefined : { type: 'above' },
+            secondaryCta: {
+                type: SecondaryCtaType.ContributionsReminder,
+            },
         },
         {
             name: EpicChoiceCardsTestVariants.variant1,
@@ -56,6 +59,9 @@ const buildEpicChoiceCardsTest = (
             cta: CTAS.variant1,
             choiceCardAmounts: choiceCardAmounts,
             separateArticleCount: articlesViewedSettings ? undefined : { type: 'above' },
+            secondaryCta: {
+                type: SecondaryCtaType.ContributionsReminder,
+            },
         },
         {
             name: EpicChoiceCardsTestVariants.variant2,
@@ -65,6 +71,9 @@ const buildEpicChoiceCardsTest = (
             cta: CTAS.variant2,
             choiceCardAmounts: choiceCardAmounts,
             separateArticleCount: articlesViewedSettings ? undefined : { type: 'above' },
+            secondaryCta: {
+                type: SecondaryCtaType.ContributionsReminder,
+            },
         },
     ],
     highPriority: true,

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -85,7 +85,7 @@ export const epicChoiceCardsTests = [
     // TOP READERS /////////////////////////////////////////////////////////////
     buildEpicChoiceCardsTest(
         ['GBPCountries'],
-        'UK',
+        'TOP_UK',
         UK_DATA.TOP_READER.PARAGRAPHS,
         UK_DATA.TOP_READER.HIGHLIGHTED_TEXT,
         UK_DATA.AMOUNTS,
@@ -97,7 +97,7 @@ export const epicChoiceCardsTests = [
 
     buildEpicChoiceCardsTest(
         ['UnitedStates'],
-        'US',
+        'TOP_US',
         US_DATA.TOP_READER.PARAGRAPHS,
         US_DATA.TOP_READER.HIGHLIGHTED_TEXT,
         US_DATA.AMOUNTS,
@@ -109,7 +109,7 @@ export const epicChoiceCardsTests = [
 
     buildEpicChoiceCardsTest(
         ['EURCountries'],
-        'EU',
+        'TOP_EU',
         EU_DATA.TOP_READER.PARAGRAPHS,
         EU_DATA.TOP_READER.HIGHLIGHTED_TEXT,
         EU_DATA.AMOUNTS,
@@ -121,7 +121,7 @@ export const epicChoiceCardsTests = [
 
     buildEpicChoiceCardsTest(
         ['International'],
-        'ROW',
+        'TOP_ROW',
         ROW_DATA.TOP_READER.PARAGRAPHS,
         ROW_DATA.TOP_READER.HIGHLIGHTED_TEXT,
         ROW_DATA.AMOUNTS,
@@ -133,7 +133,7 @@ export const epicChoiceCardsTests = [
 
     buildEpicChoiceCardsTest(
         ['Canada'],
-        'CA',
+        'TOP_CA',
         CA_DATA.TOP_READER.PARAGRAPHS,
         CA_DATA.TOP_READER.HIGHLIGHTED_TEXT,
         CA_DATA.AMOUNTS,
@@ -145,7 +145,7 @@ export const epicChoiceCardsTests = [
 
     buildEpicChoiceCardsTest(
         ['NZDCountries'],
-        'NZ',
+        'TOP_NZ',
         NZ_DATA.TOP_READER.PARAGRAPHS,
         NZ_DATA.TOP_READER.HIGHLIGHTED_TEXT,
         NZ_DATA.AMOUNTS,
@@ -158,7 +158,7 @@ export const epicChoiceCardsTests = [
     // REGULAR READERS /////////////////////////////////////////////////////////
     buildEpicChoiceCardsTest(
         ['GBPCountries'],
-        'UK',
+        'REGULAR_UK',
         UK_DATA.REGULAR_READER.PARAGRAPHS,
         UK_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
         UK_DATA.AMOUNTS,
@@ -166,7 +166,7 @@ export const epicChoiceCardsTests = [
 
     buildEpicChoiceCardsTest(
         ['UnitedStates'],
-        'US',
+        'REGULAR_US',
         US_DATA.REGULAR_READER.PARAGRAPHS,
         US_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
         US_DATA.AMOUNTS,
@@ -174,7 +174,7 @@ export const epicChoiceCardsTests = [
 
     buildEpicChoiceCardsTest(
         ['EURCountries'],
-        'EU',
+        'REGULAR_EU',
         EU_DATA.REGULAR_READER.PARAGRAPHS,
         EU_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
         EU_DATA.AMOUNTS,
@@ -182,7 +182,7 @@ export const epicChoiceCardsTests = [
 
     buildEpicChoiceCardsTest(
         ['International'],
-        'ROW',
+        'REGULAR_ROW',
         ROW_DATA.REGULAR_READER.PARAGRAPHS,
         ROW_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
         ROW_DATA.AMOUNTS,
@@ -190,7 +190,7 @@ export const epicChoiceCardsTests = [
 
     buildEpicChoiceCardsTest(
         ['Canada'],
-        'CA',
+        'REGULAR_CA',
         CA_DATA.REGULAR_READER.PARAGRAPHS,
         CA_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
         CA_DATA.AMOUNTS,
@@ -198,7 +198,7 @@ export const epicChoiceCardsTests = [
 
     buildEpicChoiceCardsTest(
         ['NZDCountries'],
-        'NZ',
+        'REGULAR_NZ',
         NZ_DATA.REGULAR_READER.PARAGRAPHS,
         NZ_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
         NZ_DATA.AMOUNTS,

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -4,7 +4,7 @@ import { UK_DATA, EU_DATA, ROW_DATA, US_DATA, CA_DATA, NZ_DATA, CTAS } from './c
 import { CountryGroupId } from '@sdc/shared/dist/lib';
 import { ArticlesViewedSettings } from '@sdc/shared/types';
 
-const testName = '2021-08-25-EpicChoiceCardsTest';
+const testName = '2021-09-03-EpicChoiceCardsTest';
 
 export enum EpicChoiceCardsTestVariants {
     control = 'control',

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -4,7 +4,7 @@ import { UK_DATA, EU_DATA, ROW_DATA, US_DATA, CA_DATA, NZ_DATA, CTAS } from './c
 import { CountryGroupId } from '@sdc/shared/dist/lib';
 import { ArticlesViewedSettings, SecondaryCtaType } from '@sdc/shared/types';
 
-const testName = '2021-09-03-EpicChoiceCardsTest';
+const testName = '2021-09-06-EpicChoiceCardsTest';
 
 export enum EpicChoiceCardsTestVariants {
     control = 'control',

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -1,6 +1,6 @@
-import { EpicTest } from '@sdc/shared/src/types/epic';
+import { ChoiceCardAmounts, EpicTest } from '@sdc/shared/src/types/epic';
 import { epic } from '@sdc/shared/src/config/modules';
-import { UK_DATA, EU_DATA, ROW_DATA, US_DATA, CTAS } from './choiceCardsTestData';
+import { UK_DATA, EU_DATA, ROW_DATA, US_DATA, CA_DATA, NZ_DATA, CTAS } from './choiceCardsTestData';
 import { CountryGroupId } from '@sdc/shared/dist/lib';
 import { ArticlesViewedSettings } from '@sdc/shared/types';
 
@@ -17,6 +17,7 @@ const buildEpicChoiceCardsTest = (
     suffix: string,
     paragraphs: string[],
     highlightedText: string,
+    choiceCardAmounts: ChoiceCardAmounts,
     articlesViewedSettings?: ArticlesViewedSettings,
 ): EpicTest => ({
     name: `${testName}__${suffix}`,
@@ -44,6 +45,7 @@ const buildEpicChoiceCardsTest = (
             paragraphs: paragraphs,
             highlightedText: highlightedText,
             cta: CTAS.control,
+            choiceCardAmounts: choiceCardAmounts,
             separateArticleCount: articlesViewedSettings ? undefined : { type: 'above' },
         },
         {
@@ -52,6 +54,7 @@ const buildEpicChoiceCardsTest = (
             paragraphs: paragraphs,
             highlightedText: highlightedText,
             cta: CTAS.variant1,
+            choiceCardAmounts: choiceCardAmounts,
             separateArticleCount: articlesViewedSettings ? undefined : { type: 'above' },
         },
         {
@@ -60,6 +63,7 @@ const buildEpicChoiceCardsTest = (
             paragraphs: paragraphs,
             highlightedText: highlightedText,
             cta: CTAS.variant2,
+            choiceCardAmounts: choiceCardAmounts,
             separateArticleCount: articlesViewedSettings ? undefined : { type: 'above' },
         },
     ],
@@ -70,87 +74,125 @@ const buildEpicChoiceCardsTest = (
 });
 
 export const epicChoiceCardsTests = [
-    // UK_TOP_READERS
+    // TOP READERS /////////////////////////////////////////////////////////////
+    buildEpicChoiceCardsTest(
+        ['GBPCountries'],
+        'UK',
+        UK_DATA.TOP_READER.PARAGRAPHS,
+        UK_DATA.TOP_READER.HIGHLIGHTED_TEXT,
+        UK_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
+    ),
+
+    buildEpicChoiceCardsTest(
+        ['UnitedStates'],
+        'US',
+        US_DATA.TOP_READER.PARAGRAPHS,
+        US_DATA.TOP_READER.HIGHLIGHTED_TEXT,
+        US_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
+    ),
+
+    buildEpicChoiceCardsTest(
+        ['EURCountries'],
+        'EU',
+        EU_DATA.TOP_READER.PARAGRAPHS,
+        EU_DATA.TOP_READER.HIGHLIGHTED_TEXT,
+        EU_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
+    ),
+
+    buildEpicChoiceCardsTest(
+        ['International'],
+        'ROW',
+        ROW_DATA.TOP_READER.PARAGRAPHS,
+        ROW_DATA.TOP_READER.HIGHLIGHTED_TEXT,
+        ROW_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
+    ),
+
+    buildEpicChoiceCardsTest(
+        ['Canada'],
+        'CA',
+        CA_DATA.TOP_READER.PARAGRAPHS,
+        CA_DATA.TOP_READER.HIGHLIGHTED_TEXT,
+        CA_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
+    ),
+
+    buildEpicChoiceCardsTest(
+        ['NZDCountries'],
+        'NZ',
+        NZ_DATA.TOP_READER.PARAGRAPHS,
+        NZ_DATA.TOP_READER.HIGHLIGHTED_TEXT,
+        NZ_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
+    ),
+
+    // REGULAR READERS /////////////////////////////////////////////////////////
     buildEpicChoiceCardsTest(
         ['GBPCountries'],
         'UK',
         UK_DATA.REGULAR_READER.PARAGRAPHS,
         UK_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        {
-            periodInWeeks: 52,
-            minViews: 50,
-        },
+        UK_DATA.AMOUNTS,
     ),
 
-    // US_TOP_READERS
     buildEpicChoiceCardsTest(
         ['UnitedStates'],
         'US',
         US_DATA.REGULAR_READER.PARAGRAPHS,
         US_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        {
-            periodInWeeks: 52,
-            minViews: 50,
-        },
+        US_DATA.AMOUNTS,
     ),
 
-    // EU_TOP_READERS
     buildEpicChoiceCardsTest(
         ['EURCountries'],
         'EU',
         EU_DATA.REGULAR_READER.PARAGRAPHS,
         EU_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        {
-            periodInWeeks: 52,
-            minViews: 50,
-        },
+        EU_DATA.AMOUNTS,
     ),
 
-    // ROW_TOP_READERS
     buildEpicChoiceCardsTest(
         ['International'],
         'ROW',
         ROW_DATA.REGULAR_READER.PARAGRAPHS,
         ROW_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        {
-            periodInWeeks: 52,
-            minViews: 50,
-        },
+        ROW_DATA.AMOUNTS,
     ),
 
-    // UK_REGULAR_READERS
     buildEpicChoiceCardsTest(
-        ['GBPCountries'],
-        'UK',
-        UK_DATA.REGULAR_READER.PARAGRAPHS,
-        UK_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        {
-            periodInWeeks: 52,
-            minViews: 50,
-        },
+        ['Canada'],
+        'CA',
+        CA_DATA.REGULAR_READER.PARAGRAPHS,
+        CA_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        CA_DATA.AMOUNTS,
     ),
 
-    // US_REGULAR_READERS
     buildEpicChoiceCardsTest(
-        ['UnitedStates'],
-        'US',
-        US_DATA.REGULAR_READER.PARAGRAPHS,
-        US_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-    ),
-
-    // EU_REGULAR_READERS
-    buildEpicChoiceCardsTest(
-        ['EURCountries'],
-        'EU',
-        EU_DATA.REGULAR_READER.PARAGRAPHS,
-        EU_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-    ),
-
-    // ROW_REGULAR_READERS
-    buildEpicChoiceCardsTest(
-        ['International'],
-        'ROW',
-        ROW_DATA.REGULAR_READER.PARAGRAPHS,
-        ROW_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        ['NZDCountries'],
+        'NZ',
+        NZ_DATA.REGULAR_READER.PARAGRAPHS,
+        NZ_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        NZ_DATA.AMOUNTS,
     ),
 ];

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -1,0 +1,105 @@
+import { ChoiceCardAmounts, EpicTest } from '@sdc/shared/src/types/epic';
+import { epic, epicWithChoiceCards } from '@sdc/shared/src/config/modules';
+import { UK_DATA, EU_DATA, ROW_DATA, US_DATA, CTAS } from './choiceCardsTestData';
+import { CountryGroupId } from '@sdc/shared/dist/lib';
+
+const testName = '2021-08-25-EpicChoiceCardsTest';
+
+export enum EpicChoiceCardsTestVariants {
+    control = 'control',
+    variant1 = 'variant1',
+    variant2 = 'variant2',
+}
+
+const buildEpicChoiceCardsTest = (
+    locations: CountryGroupId[],
+    suffix: string,
+    paragraphs: string[],
+    highlightedText: string,
+    choiceCardAmounts: ChoiceCardAmounts,
+): EpicTest => ({
+    name: `${testName}__${suffix}`,
+    campaignId: testName,
+    isOn: true,
+    locations,
+    audience: 1,
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: false,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
+    userCohort: 'AllNonSupporters',
+    isLiveBlog: false,
+    hasCountryName: true,
+    variants: [
+        {
+            name: EpicChoiceCardsTestVariants.control,
+            modulePathBuilder: epic.endpointPathBuilder,
+            paragraphs: paragraphs,
+            highlightedText: highlightedText,
+            cta: CTAS.control,
+            separateArticleCount: { type: 'above' },
+        },
+        {
+            name: EpicChoiceCardsTestVariants.variant1,
+            modulePathBuilder: epicWithChoiceCards.endpointPathBuilder,
+            paragraphs: paragraphs,
+            highlightedText: highlightedText,
+            cta: CTAS.variant1,
+            separateArticleCount: { type: 'above' },
+        },
+        {
+            name: EpicChoiceCardsTestVariants.variant2,
+            modulePathBuilder: epicWithChoiceCards.endpointPathBuilder,
+            paragraphs: paragraphs,
+            highlightedText: highlightedText,
+            cta: CTAS.variant2,
+            separateArticleCount: { type: 'above' },
+        },
+    ],
+    highPriority: true,
+    useLocalViewLog: true,
+    articlesViewedSettings: {
+        minViews: 0,
+        maxViews: 50,
+        periodInWeeks: 52,
+    },
+    hasArticleCountInCopy: true,
+    choiceCardAmounts,
+});
+
+export const epicChoiceCardsTests = [
+    buildEpicChoiceCardsTest(
+        ['GBPCountries'],
+        'UK',
+        UK_DATA.REGULAR_READER.PARAGRAPHS,
+        UK_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        UK_DATA.AMOUNTS,
+    ),
+    buildEpicChoiceCardsTest(
+        ['UnitedStates'],
+        'US',
+        US_DATA.REGULAR_READER.PARAGRAPHS,
+        US_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        US_DATA.AMOUNTS,
+    ),
+    buildEpicChoiceCardsTest(
+        ['EURCountries'],
+        'EU',
+        EU_DATA.REGULAR_READER.PARAGRAPHS,
+        EU_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        EU_DATA.AMOUNTS,
+    ),
+    buildEpicChoiceCardsTest(
+        ['International'],
+        'ROW',
+        ROW_DATA.REGULAR_READER.PARAGRAPHS,
+        ROW_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        ROW_DATA.AMOUNTS,
+    ),
+];

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -45,7 +45,6 @@ const buildEpicChoiceCardsTest = (
             paragraphs: paragraphs,
             highlightedText: highlightedText,
             cta: CTAS.control,
-            choiceCardAmounts: choiceCardAmounts,
             separateArticleCount: articlesViewedSettings ? undefined : { type: 'above' },
             secondaryCta: {
                 type: SecondaryCtaType.ContributionsReminder,

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -44,7 +44,7 @@ const buildEpicChoiceCardsTest = (
             paragraphs: paragraphs,
             highlightedText: highlightedText,
             cta: CTAS.control,
-            separateArticleCount: articlesViewedSettings ? { type: 'above' } : undefined,
+            separateArticleCount: articlesViewedSettings ? undefined : { type: 'above' },
         },
         {
             name: EpicChoiceCardsTestVariants.variant1,
@@ -52,7 +52,7 @@ const buildEpicChoiceCardsTest = (
             paragraphs: paragraphs,
             highlightedText: highlightedText,
             cta: CTAS.variant1,
-            separateArticleCount: articlesViewedSettings ? { type: 'above' } : undefined,
+            separateArticleCount: articlesViewedSettings ? undefined : { type: 'above' },
         },
         {
             name: EpicChoiceCardsTestVariants.variant2,
@@ -60,7 +60,7 @@ const buildEpicChoiceCardsTest = (
             paragraphs: paragraphs,
             highlightedText: highlightedText,
             cta: CTAS.variant2,
-            separateArticleCount: articlesViewedSettings ? { type: 'above' } : undefined,
+            separateArticleCount: articlesViewedSettings ? undefined : { type: 'above' },
         },
     ],
     highPriority: true,

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -2,6 +2,7 @@ import { ChoiceCardAmounts, EpicTest } from '@sdc/shared/src/types/epic';
 import { epic, epicWithChoiceCards } from '@sdc/shared/src/config/modules';
 import { UK_DATA, EU_DATA, ROW_DATA, US_DATA, CTAS } from './choiceCardsTestData';
 import { CountryGroupId } from '@sdc/shared/dist/lib';
+import { ArticlesViewedSettings } from '@sdc/shared/types';
 
 const testName = '2021-08-25-EpicChoiceCardsTest';
 
@@ -17,6 +18,7 @@ const buildEpicChoiceCardsTest = (
     paragraphs: string[],
     highlightedText: string,
     choiceCardAmounts: ChoiceCardAmounts,
+    articlesViewedSettings?: ArticlesViewedSettings,
 ): EpicTest => ({
     name: `${testName}__${suffix}`,
     campaignId: testName,
@@ -64,23 +66,78 @@ const buildEpicChoiceCardsTest = (
     ],
     highPriority: true,
     useLocalViewLog: true,
-    articlesViewedSettings: {
-        minViews: 0,
-        maxViews: 50,
-        periodInWeeks: 52,
-    },
-    hasArticleCountInCopy: true,
+    hasArticleCountInCopy: !!articlesViewedSettings,
+    articlesViewedSettings,
     choiceCardAmounts,
 });
 
 export const epicChoiceCardsTests = [
+    // UK_TOP_READERS
     buildEpicChoiceCardsTest(
         ['GBPCountries'],
         'UK',
         UK_DATA.REGULAR_READER.PARAGRAPHS,
         UK_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
         UK_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
     ),
+
+    // US_TOP_READERS
+    buildEpicChoiceCardsTest(
+        ['UnitedStates'],
+        'US',
+        US_DATA.REGULAR_READER.PARAGRAPHS,
+        US_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        US_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
+    ),
+
+    // EU_TOP_READERS
+    buildEpicChoiceCardsTest(
+        ['EURCountries'],
+        'EU',
+        EU_DATA.REGULAR_READER.PARAGRAPHS,
+        EU_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        EU_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
+    ),
+
+    // ROW_TOP_READERS
+    buildEpicChoiceCardsTest(
+        ['International'],
+        'ROW',
+        ROW_DATA.REGULAR_READER.PARAGRAPHS,
+        ROW_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        ROW_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
+    ),
+
+    // UK_REGULAR_READERS
+    buildEpicChoiceCardsTest(
+        ['GBPCountries'],
+        'UK',
+        UK_DATA.REGULAR_READER.PARAGRAPHS,
+        UK_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        UK_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
+    ),
+
+    // US_REGULAR_READERS
     buildEpicChoiceCardsTest(
         ['UnitedStates'],
         'US',
@@ -88,6 +145,8 @@ export const epicChoiceCardsTests = [
         US_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
         US_DATA.AMOUNTS,
     ),
+
+    // EU_REGULAR_READERS
     buildEpicChoiceCardsTest(
         ['EURCountries'],
         'EU',
@@ -95,6 +154,8 @@ export const epicChoiceCardsTests = [
         EU_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
         EU_DATA.AMOUNTS,
     ),
+
+    // ROW_REGULAR_READERS
     buildEpicChoiceCardsTest(
         ['International'],
         'ROW',

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -27,7 +27,15 @@ const buildEpicChoiceCardsTest = (
     audience: 1,
     tagIds: [],
     sections: [],
-    excludedTagIds: [],
+    excludedTagIds: [
+        'world/german-federal-election-2021',
+        'world/series/the-merkel-years',
+        'world/germany',
+        'world/europe-news',
+        'world/angela-merkel',
+        'world/eu',
+        'world/series/this-is-europe',
+    ],
     excludedSections: [],
     alwaysAsk: false,
     maxViews: {

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -1,5 +1,5 @@
-import { ChoiceCardAmounts, EpicTest } from '@sdc/shared/src/types/epic';
-import { epic, epicWithChoiceCards } from '@sdc/shared/src/config/modules';
+import { EpicTest } from '@sdc/shared/src/types/epic';
+import { epic } from '@sdc/shared/src/config/modules';
 import { UK_DATA, EU_DATA, ROW_DATA, US_DATA, CTAS } from './choiceCardsTestData';
 import { CountryGroupId } from '@sdc/shared/dist/lib';
 import { ArticlesViewedSettings } from '@sdc/shared/types';
@@ -17,7 +17,6 @@ const buildEpicChoiceCardsTest = (
     suffix: string,
     paragraphs: string[],
     highlightedText: string,
-    choiceCardAmounts: ChoiceCardAmounts,
     articlesViewedSettings?: ArticlesViewedSettings,
 ): EpicTest => ({
     name: `${testName}__${suffix}`,
@@ -45,30 +44,29 @@ const buildEpicChoiceCardsTest = (
             paragraphs: paragraphs,
             highlightedText: highlightedText,
             cta: CTAS.control,
-            separateArticleCount: { type: 'above' },
+            separateArticleCount: articlesViewedSettings ? { type: 'above' } : undefined,
         },
         {
             name: EpicChoiceCardsTestVariants.variant1,
-            modulePathBuilder: epicWithChoiceCards.endpointPathBuilder,
+            modulePathBuilder: epic.endpointPathBuilder,
             paragraphs: paragraphs,
             highlightedText: highlightedText,
             cta: CTAS.variant1,
-            separateArticleCount: { type: 'above' },
+            separateArticleCount: articlesViewedSettings ? { type: 'above' } : undefined,
         },
         {
             name: EpicChoiceCardsTestVariants.variant2,
-            modulePathBuilder: epicWithChoiceCards.endpointPathBuilder,
+            modulePathBuilder: epic.endpointPathBuilder,
             paragraphs: paragraphs,
             highlightedText: highlightedText,
             cta: CTAS.variant2,
-            separateArticleCount: { type: 'above' },
+            separateArticleCount: articlesViewedSettings ? { type: 'above' } : undefined,
         },
     ],
     highPriority: true,
     useLocalViewLog: true,
     hasArticleCountInCopy: !!articlesViewedSettings,
     articlesViewedSettings,
-    choiceCardAmounts,
 });
 
 export const epicChoiceCardsTests = [
@@ -78,7 +76,6 @@ export const epicChoiceCardsTests = [
         'UK',
         UK_DATA.REGULAR_READER.PARAGRAPHS,
         UK_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        UK_DATA.AMOUNTS,
         {
             periodInWeeks: 52,
             minViews: 50,
@@ -91,7 +88,6 @@ export const epicChoiceCardsTests = [
         'US',
         US_DATA.REGULAR_READER.PARAGRAPHS,
         US_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        US_DATA.AMOUNTS,
         {
             periodInWeeks: 52,
             minViews: 50,
@@ -104,7 +100,6 @@ export const epicChoiceCardsTests = [
         'EU',
         EU_DATA.REGULAR_READER.PARAGRAPHS,
         EU_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        EU_DATA.AMOUNTS,
         {
             periodInWeeks: 52,
             minViews: 50,
@@ -117,7 +112,6 @@ export const epicChoiceCardsTests = [
         'ROW',
         ROW_DATA.REGULAR_READER.PARAGRAPHS,
         ROW_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        ROW_DATA.AMOUNTS,
         {
             periodInWeeks: 52,
             minViews: 50,
@@ -130,7 +124,6 @@ export const epicChoiceCardsTests = [
         'UK',
         UK_DATA.REGULAR_READER.PARAGRAPHS,
         UK_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        UK_DATA.AMOUNTS,
         {
             periodInWeeks: 52,
             minViews: 50,
@@ -143,7 +136,6 @@ export const epicChoiceCardsTests = [
         'US',
         US_DATA.REGULAR_READER.PARAGRAPHS,
         US_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        US_DATA.AMOUNTS,
     ),
 
     // EU_REGULAR_READERS
@@ -152,7 +144,6 @@ export const epicChoiceCardsTests = [
         'EU',
         EU_DATA.REGULAR_READER.PARAGRAPHS,
         EU_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        EU_DATA.AMOUNTS,
     ),
 
     // ROW_REGULAR_READERS
@@ -161,6 +152,5 @@ export const epicChoiceCardsTests = [
         'ROW',
         ROW_DATA.REGULAR_READER.PARAGRAPHS,
         ROW_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        ROW_DATA.AMOUNTS,
     ),
 ];

--- a/packages/server/src/tests/epics/choiceCardsTestData.ts
+++ b/packages/server/src/tests/epics/choiceCardsTestData.ts
@@ -1,0 +1,138 @@
+export const UK_DATA = {
+    TOP_READER: {
+        PARAGRAPHS: [
+            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions.',
+            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s high-impact journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, in 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    REGULAR_READER: {
+        PARAGRAPHS: [
+            '… we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    AMOUNTS: {
+        SINGLE: [30, 60],
+        MONTHLY: [3, 6],
+        ANNUAL: [60, 120],
+    },
+};
+
+export const US_DATA = {
+    TOP_READER: {
+        PARAGRAPHS: [
+            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions.',
+            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s high-impact journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, in 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.',
+    },
+    REGULAR_READER: {
+        PARAGRAPHS: [
+            '… we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.',
+    },
+    AMOUNTS: {
+        SINGLE: [25, 50],
+        MONTHLY: [7, 15],
+        ANNUAL: [50, 100],
+    },
+};
+
+export const EU_DATA = {
+    TOP_READER: {
+        PARAGRAPHS: [
+            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions, and joining us today from %%COUNTRY_NAME%%.',
+            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s high-impact journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, in 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    REGULAR_READER: {
+        PARAGRAPHS: [
+            '… as you’re joining us today from %%COUNTRY_NAME%%, we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    AMOUNTS: {
+        SINGLE: [25, 50],
+        MONTHLY: [6, 10],
+        ANNUAL: [50, 100],
+    },
+};
+
+export const ROW_DATA = {
+    TOP_READER: {
+        PARAGRAPHS: [
+            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions, and joining us today from %%COUNTRY_NAME%%.',
+            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s high-impact journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, in 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    REGULAR_READER: {
+        PARAGRAPHS: [
+            '… as you’re joining us today from %%COUNTRY_NAME%%, we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    AMOUNTS: {
+        SINGLE: [25, 50],
+        MONTHLY: [5, 10],
+        ANNUAL: [60, 100],
+    },
+};
+
+export const CTAS = {
+    control: {
+        text: 'Support the Guardian',
+        baseUrl: 'https://support.theguardian.com/contribute',
+    },
+    variant1: {
+        text: 'Support the Guardian',
+        baseUrl: 'https://support.theguardian.com/contribute',
+    },
+    variant2: {
+        text: 'Continue',
+        baseUrl: 'https://support.theguardian.com/contribute',
+    },
+};

--- a/packages/server/src/tests/epics/choiceCardsTestData.ts
+++ b/packages/server/src/tests/epics/choiceCardsTestData.ts
@@ -1,3 +1,29 @@
+const EU_AND_ROW_DATA = {
+    TOP_READER: {
+        PARAGRAPHS: [
+            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions, and joining us today from %%COUNTRY_NAME%%.',
+            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s high-impact journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, in 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    REGULAR_READER: {
+        PARAGRAPHS: [
+            '… as you’re joining us today from %%COUNTRY_NAME%%, we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+};
+
 export const UK_DATA = {
     TOP_READER: {
         PARAGRAPHS: [
@@ -61,29 +87,7 @@ export const US_DATA = {
 };
 
 export const EU_DATA = {
-    TOP_READER: {
-        PARAGRAPHS: [
-            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions, and joining us today from %%COUNTRY_NAME%%.',
-            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s high-impact journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, in 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
-            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
-            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
-            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
-            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
-        ],
-        HIGHLIGHTED_TEXT:
-            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
-    },
-    REGULAR_READER: {
-        PARAGRAPHS: [
-            '… as you’re joining us today from %%COUNTRY_NAME%%, we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
-            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
-            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
-            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
-            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
-        ],
-        HIGHLIGHTED_TEXT:
-            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
-    },
+    ...EU_AND_ROW_DATA,
     AMOUNTS: {
         SINGLE: [25, 50],
         MONTHLY: [6, 10],
@@ -92,60 +96,7 @@ export const EU_DATA = {
 };
 
 export const ROW_DATA = {
-    TOP_READER: {
-        PARAGRAPHS: [
-            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions, and joining us today from %%COUNTRY_NAME%%.',
-            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s high-impact journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, in 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
-            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
-            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
-            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
-            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
-        ],
-        HIGHLIGHTED_TEXT:
-            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
-    },
-    REGULAR_READER: {
-        PARAGRAPHS: [
-            '… as you’re joining us today from %%COUNTRY_NAME%%, we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
-            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
-            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
-            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
-            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
-        ],
-        HIGHLIGHTED_TEXT:
-            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
-    },
-    AMOUNTS: {
-        SINGLE: [25, 50],
-        MONTHLY: [5, 10],
-        ANNUAL: [60, 100],
-    },
-};
-
-export const CA_DATA = {
-    TOP_READER: {
-        PARAGRAPHS: [
-            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions, and joining us today from %%COUNTRY_NAME%%.',
-            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s high-impact journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, in 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
-            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
-            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
-            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
-            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
-        ],
-        HIGHLIGHTED_TEXT:
-            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
-    },
-    REGULAR_READER: {
-        PARAGRAPHS: [
-            '… as you’re joining us today from %%COUNTRY_NAME%%, we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
-            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
-            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
-            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
-            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
-        ],
-        HIGHLIGHTED_TEXT:
-            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
-    },
+    ...EU_AND_ROW_DATA,
     AMOUNTS: {
         SINGLE: [25, 50],
         MONTHLY: [5, 10],
@@ -154,33 +105,20 @@ export const CA_DATA = {
 };
 
 export const NZ_DATA = {
-    TOP_READER: {
-        PARAGRAPHS: [
-            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions, and joining us today from %%COUNTRY_NAME%%.',
-            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s high-impact journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, in 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
-            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
-            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
-            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
-            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
-        ],
-        HIGHLIGHTED_TEXT:
-            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
-    },
-    REGULAR_READER: {
-        PARAGRAPHS: [
-            '… as you’re joining us today from %%COUNTRY_NAME%%, we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
-            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
-            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
-            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
-            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
-        ],
-        HIGHLIGHTED_TEXT:
-            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
-    },
+    ...EU_AND_ROW_DATA,
     AMOUNTS: {
         SINGLE: [50, 100],
         MONTHLY: [10, 20],
         ANNUAL: [50, 100],
+    },
+};
+
+export const CA_DATA = {
+    ...EU_AND_ROW_DATA,
+    AMOUNTS: {
+        SINGLE: [25, 50],
+        MONTHLY: [5, 10],
+        ANNUAL: [60, 100],
     },
 };
 

--- a/packages/server/src/tests/epics/choiceCardsTestData.ts
+++ b/packages/server/src/tests/epics/choiceCardsTestData.ts
@@ -122,6 +122,68 @@ export const ROW_DATA = {
     },
 };
 
+export const CA_DATA = {
+    TOP_READER: {
+        PARAGRAPHS: [
+            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions, and joining us today from %%COUNTRY_NAME%%.',
+            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s high-impact journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, in 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    REGULAR_READER: {
+        PARAGRAPHS: [
+            '… as you’re joining us today from %%COUNTRY_NAME%%, we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    AMOUNTS: {
+        SINGLE: [25, 50],
+        MONTHLY: [5, 10],
+        ANNUAL: [60, 100],
+    },
+};
+
+export const NZ_DATA = {
+    TOP_READER: {
+        PARAGRAPHS: [
+            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions, and joining us today from %%COUNTRY_NAME%%.',
+            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s high-impact journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, in 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    REGULAR_READER: {
+        PARAGRAPHS: [
+            '… as you’re joining us today from %%COUNTRY_NAME%%, we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+            'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+            'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+            "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        HIGHLIGHTED_TEXT:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    AMOUNTS: {
+        SINGLE: [50, 100],
+        MONTHLY: [10, 20],
+        ANNUAL: [50, 100],
+    },
+};
+
 export const CTAS = {
     control: {
         text: 'Support the Guardian',

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -18,11 +18,6 @@ export const getDefaultModuleInfo = (name: string, path: string): ModuleInfo => 
 
 export const epic: ModuleInfo = getDefaultModuleInfo('epic', 'epics/ContributionsEpic');
 
-export const epicWithChoiceCards: ModuleInfo = getDefaultModuleInfo(
-    'epic-with-choice-cards',
-    'epics/ContributionsEpicWithChoiceCards',
-);
-
 export const liveblogEpic: ModuleInfo = getDefaultModuleInfo(
     'liveblog-epic',
     'epics/ContributionsLiveblogEpic',
@@ -57,7 +52,6 @@ export const headerSupportAgain: ModuleInfo = getDefaultModuleInfo(
 
 export const moduleInfos: ModuleInfo[] = [
     epic,
-    epicWithChoiceCards,
     liveblogEpic,
     contributionsBanner,
     digiSubs,

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -18,6 +18,11 @@ export const getDefaultModuleInfo = (name: string, path: string): ModuleInfo => 
 
 export const epic: ModuleInfo = getDefaultModuleInfo('epic', 'epics/ContributionsEpic');
 
+export const epicWithChoiceCards: ModuleInfo = getDefaultModuleInfo(
+    'epic-with-choice-cards',
+    'epics/ContributionsEpicWithChoiceCards',
+);
+
 export const liveblogEpic: ModuleInfo = getDefaultModuleInfo(
     'liveblog-epic',
     'epics/ContributionsLiveblogEpic',
@@ -52,6 +57,7 @@ export const headerSupportAgain: ModuleInfo = getDefaultModuleInfo(
 
 export const moduleInfos: ModuleInfo[] = [
     epic,
+    epicWithChoiceCards,
     liveblogEpic,
     contributionsBanner,
     digiSubs,

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -209,6 +209,4 @@ export interface EpicTest extends Test<EpicVariant> {
     controlProportionSettings?: ControlProportionSettings;
 
     isSuperMode?: boolean;
-
-    choiceCardAmounts?: ChoiceCardAmounts;
 }

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -15,7 +15,6 @@ import {
     PageTracking,
     trackingSchema,
     secondaryCtaSchema,
-    ChoiceCardSettings,
 } from './shared';
 import { ReminderFields } from '../lib/reminderFields';
 import { CountryGroupId } from '../lib/geolocation';
@@ -176,14 +175,10 @@ interface ControlProportionSettings {
     offset: number;
 }
 
-export type ChoiceCardFrequencies = 'SINGLE' | 'MONTHLY' | 'ANNUAL';
+export type ChoiceCardFrequency = 'SINGLE' | 'MONTHLY' | 'ANNUAL';
 export type ChoiceCardAmounts = {
-    [index in ChoiceCardFrequencies]: number[];
+    [index in ChoiceCardFrequency]: number[];
 };
-
-export interface EpicChoiceCardProps {
-    amounts: ChoiceCardAmounts;
-}
 
 export interface EpicTest extends Test<EpicVariant> {
     name: string;

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -16,8 +16,7 @@ import {
     trackingSchema,
     secondaryCtaSchema,
 } from './shared';
-import { ReminderFields } from '../lib/reminderFields';
-import { CountryGroupId } from '../lib/geolocation';
+import { ReminderFields, CountryGroupId } from '../lib';
 import { z } from 'zod';
 
 export type Tag = {

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -115,7 +115,6 @@ export interface EpicVariant extends Variant {
     showReminderFields?: ReminderFields;
     modulePathBuilder?: (version?: string) => string;
     separateArticleCount?: SeparateArticleCount;
-    choiceCardSettings?: ChoiceCardSettings;
 
     // Variant level maxViews are for special targeting tests. These
     // are handled differently to our usual copy/design tests. To
@@ -125,6 +124,9 @@ export interface EpicVariant extends Variant {
     // the test + variant. This means users **wont** fall through to a test
     // with lower priority.
     maxViews?: MaxViews;
+
+    // For hard coded choice cards test
+    choiceCardAmounts?: ChoiceCardAmounts;
 }
 
 const variantSchema = z.object({
@@ -174,13 +176,13 @@ interface ControlProportionSettings {
     offset: number;
 }
 
-export interface ChoiceCardAmounts {
-    [index: string]: number[];
-}
+export type ChoiceCardFrequencies = 'SINGLE' | 'MONTHLY' | 'ANNUAL';
+export type ChoiceCardAmounts = {
+    [index in ChoiceCardFrequencies]: number[];
+};
 
 export interface EpicChoiceCardProps {
     amounts: ChoiceCardAmounts;
-    currencySymbol: string;
 }
 
 export interface EpicTest extends Test<EpicVariant> {

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -15,6 +15,7 @@ import {
     PageTracking,
     trackingSchema,
     secondaryCtaSchema,
+    ChoiceCardSettings,
 } from './shared';
 import { ReminderFields } from '../lib/reminderFields';
 import { CountryGroupId } from '../lib/geolocation';
@@ -114,6 +115,7 @@ export interface EpicVariant extends Variant {
     showReminderFields?: ReminderFields;
     modulePathBuilder?: (version?: string) => string;
     separateArticleCount?: SeparateArticleCount;
+    choiceCardSettings?: ChoiceCardSettings;
 
     // Variant level maxViews are for special targeting tests. These
     // are handled differently to our usual copy/design tests. To
@@ -172,6 +174,15 @@ interface ControlProportionSettings {
     offset: number;
 }
 
+export interface ChoiceCardAmounts {
+    [index: string]: number[];
+}
+
+export interface EpicChoiceCardProps {
+    amounts: ChoiceCardAmounts;
+    currencySymbol: string;
+}
+
 export interface EpicTest extends Test<EpicVariant> {
     name: string;
     isOn: boolean;
@@ -201,4 +212,6 @@ export interface EpicTest extends Test<EpicVariant> {
     controlProportionSettings?: ControlProportionSettings;
 
     isSuperMode?: boolean;
+
+    choiceCardAmounts?: ChoiceCardAmounts;
 }

--- a/packages/shared/src/types/shared.ts
+++ b/packages/shared/src/types/shared.ts
@@ -5,6 +5,7 @@ import {
     OphanProduct,
     ophanProductSchema,
 } from './ophan';
+import { ChoiceCardAmounts } from './epic';
 
 export interface Variant {
     name: string;
@@ -117,6 +118,12 @@ export const tickerSettingsSchema = z.object({
     copy: tickerCopySchema,
     tickerData: tickerDataSchema.optional(),
 });
+
+export interface ChoiceCardSettings {
+    amounts: ChoiceCardAmounts;
+    currencySymbol: string;
+    showChoiceCards: boolean;
+}
 
 export type WeeklyArticleLog = {
     week: number;

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -26,3 +26,4 @@ deployments:
         dependencies: [ dotcom-components-cloudformation ]
         parameters:
             bucket: membership-dist
+            asgMigrationInProgress: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,6 +1783,15 @@
   dependencies:
     "@guardian/src-helpers" "^3.8.0"
 
+"@guardian/src-choice-card@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-choice-card/-/src-choice-card-3.8.0.tgz#fb0d239fb6758b3b97f9fa5032330a09988c084a"
+  integrity sha512-eQy7mZ4Vcyobqptwc4pfu73dpdrcgPPNBKis6IYGl2bkpf9U2W1CFpNxLp3u8HiWR4BfiZz1stR93ySycoOf6Q==
+  dependencies:
+    "@guardian/src-helpers" "^3.8.0"
+    "@guardian/src-label" "^3.8.0"
+    "@guardian/src-user-feedback" "^3.8.0"
+
 "@guardian/src-foundations@3.8.0", "@guardian/src-foundations@^3.8.0":
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.8.0.tgz#2a17748cced540ea137618feddc85d2b12c16023"


### PR DESCRIPTION
### What does this PR do?
Implements hard-coded test for choice cards in epics. See [this Trello card](https://trello.com/c/HPVUJmfY/2759-implement-frequencies-and-amounts-on-the-epic-as-an-ab-test) for more info.

Test name:
`2021-09-06-EpicChoiceCardsTest`

The copy and amounts vary per region.
We also have separate copy for top vs regular readers. The latter see the 'above' article count.

### Screenshots
<img width="319" alt="mobile" src="https://user-images.githubusercontent.com/25020231/131990717-4703c7b8-271b-4b28-9b9c-29b2a98f3099.png">

<img width="633" alt="desktop" src="https://user-images.githubusercontent.com/25020231/131990723-621de070-ae47-49ab-9823-eb2c7561e1e4.png">
