### PR TITLE
Add ASG policy to new cloudformation stack

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -608,6 +608,21 @@ chown -R dotcom-components:support /var/log/dotcom-components
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
+    "AutoScalingGroupDotcomcomponentsScalingPolicyCpuScalingPolicy29FF9AE6": Object {
+      "Properties": Object {
+        "AutoScalingGroupName": Object {
+          "Ref": "AutoScalingGroupDotcomcomponentsASG512C0EA8",
+        },
+        "PolicyType": "TargetTrackingScaling",
+        "TargetTrackingConfiguration": Object {
+          "PredefinedMetricSpecification": Object {
+            "PredefinedMetricType": "ASGAverageCPUUtilization",
+          },
+          "TargetValue": 50,
+        },
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
     "CertificateDotcomcomponents88C2E1C7": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -102,6 +102,10 @@ chown -R dotcom-components:support /var/log/dotcom-components
         const ec2AppAsg = ec2App.autoScalingGroup;
         Tags.of(ec2AppAsg).add('gu:riffraff:new-asg', 'true');
 
+        ec2App.autoScalingGroup.scaleOnCpuUtilization('CpuScalingPolicy', {
+            targetUtilizationPercent: 50,
+        });
+
         // TODO: Once this code has been removed we can delete old acm certificates
         new CfnInclude(this, 'Template', {
             templateFile: yamlTemplateFilePath,


### PR DESCRIPTION
## What does this change?
Add ASG policy to new cloudformation stack. 

Inspecting the snapshot diff shows that it's generating cloudformation that's exactly what we've got in the original `cfn.yaml`.