### PR TITLE
Switch for hardcoded epic tests

### DIFF
--- a/packages/server/src/channelSwitches.ts
+++ b/packages/server/src/channelSwitches.ts
@@ -6,6 +6,7 @@ interface ChannelSwitches {
     enableEpics: boolean;
     enableBanners: boolean;
     enableSuperMode: boolean;
+    enableHardcodedEpicTests: boolean;
 }
 
 const getSwitches = (): Promise<ChannelSwitches> =>

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -149,7 +149,11 @@ export const buildEpicData = async (
     params: Params,
     baseUrl: string,
 ): Promise<EpicDataResponse> => {
-    const { enableEpics, enableSuperMode, enableHardcodedEpicTests } = await cachedChannelSwitches();
+    const {
+        enableEpics,
+        enableSuperMode,
+        enableHardcodedEpicTests,
+    } = await cachedChannelSwitches();
     if (!enableEpics) {
         return {};
     }

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -108,15 +108,21 @@ const [, fetchSuperModeArticlesCached] = cacheAsync(
     'fetchSuperModeArticles',
 );
 
-const getArticleEpicTests = async (mvtId: number, isForcingTest: boolean): Promise<EpicTest[]> => {
+const getArticleEpicTests = async (
+    mvtId: number,
+    isForcingTest: boolean,
+    enableHardcodedEpicTests: boolean,
+): Promise<EpicTest[]> => {
     try {
         const [regular, holdback] = await Promise.all([
             fetchConfiguredArticleEpicTestsCached(),
             fetchConfiguredArticleEpicHoldbackTestsCached(),
         ]);
 
+        const hardcodedTests = enableHardcodedEpicTests ? epicChoiceCardsTests : [];
+
         if (isForcingTest) {
-            return [...epicChoiceCardsTests, ...regular, ...holdback, fallbackEpicTest];
+            return [...hardcodedTests, ...regular, ...holdback, fallbackEpicTest];
         }
 
         const shouldHoldBack = mvtId % 100 === 0; // holdback 1% of the audience
@@ -124,7 +130,7 @@ const getArticleEpicTests = async (mvtId: number, isForcingTest: boolean): Promi
             return [...holdback];
         }
 
-        return [...epicChoiceCardsTests, ...regular, fallbackEpicTest];
+        return [...hardcodedTests, ...regular, fallbackEpicTest];
     } catch (err) {
         logger.warn(`Error getting article epic tests: ${err}`);
 
@@ -143,13 +149,13 @@ export const buildEpicData = async (
     params: Params,
     baseUrl: string,
 ): Promise<EpicDataResponse> => {
-    const { enableEpics, enableSuperMode } = await cachedChannelSwitches();
+    const { enableEpics, enableSuperMode, enableHardcodedEpicTests } = await cachedChannelSwitches();
     if (!enableEpics) {
         return {};
     }
 
     const tests = await (type === 'ARTICLE'
-        ? getArticleEpicTests(targeting.mvtId || 1, !!params.force)
+        ? getArticleEpicTests(targeting.mvtId || 1, !!params.force, enableHardcodedEpicTests)
         : getLiveblogEpicTests());
 
     const superModeArticles = enableSuperMode ? await fetchSuperModeArticlesCached() : [];


### PR DESCRIPTION
this is set from the tool: https://github.com/guardian/support-admin-console/pull/232