### PR TITLE
Add alarms to cdk

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -983,10 +983,11 @@ chown -R dotcom-components:support /var/log/dotcom-components
           "Fn::Join": Array [
             "",
             Array [
-              "High 5XX error % from dotcom-components in ",
+              "URGENT 9-5 - high 5XX error rate on ",
               Object {
                 "Ref": "Stage",
               },
+              " support-dotcom-components",
             ],
           ],
         },

--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -5,11 +5,13 @@ Object {
   "Mappings": Object {
     "stagemapping": Object {
       "CODE": Object {
+        "alarmActionsEnabled": false,
         "domainName": "dotcom-components-code.support.guardianapis.com",
         "maxInstances": 2,
         "minInstances": 1,
       },
       "PROD": Object {
+        "alarmActionsEnabled": true,
         "domainName": "dotcom-components.support.guardianapis.com",
         "maxInstances": 18,
         "minInstances": 3,
@@ -947,6 +949,130 @@ chown -R dotcom-components:support /var/log/dotcom-components
       },
       "Type": "AWS::IAM::Policy",
     },
+    "High5xxPercentageAlarmDotcomcomponents70DE8F71": Object {
+      "Properties": Object {
+        "ActionsEnabled": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "alarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":reader-revenue-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "dotcom-components exceeded 0.002% error rate",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "High 5XX error % from dotcom-components in ",
+              Object {
+                "Ref": "Stage",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*(m1+m2)/m3",
+            "Id": "expr_1",
+            "Label": "% of 5XX responses served for dotcom-components (load balancer and instances combined)",
+          },
+          Object {
+            "Id": "m1",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "LoadBalancer",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "LoadBalancerDotcomcomponentsFF5A6F9F",
+                        "LoadBalancerFullName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "HTTPCode_ELB_5XX_Count",
+                "Namespace": "AWS/ApplicationELB",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "LoadBalancer",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "LoadBalancerDotcomcomponentsFF5A6F9F",
+                        "LoadBalancerFullName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "HTTPCode_Target_5XX_Count",
+                "Namespace": "AWS/ApplicationELB",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m3",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "LoadBalancer",
+                    "Value": Object {
+                      "Fn::GetAtt": Array [
+                        "LoadBalancerDotcomcomponentsFF5A6F9F",
+                        "LoadBalancerFullName",
+                      ],
+                    },
+                  },
+                ],
+                "MetricName": "RequestCount",
+                "Namespace": "AWS/ApplicationELB",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.002,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "InstanceRoleDotcomcomponents2E8FDE7D": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
@@ -1554,6 +1680,125 @@ chown -R dotcom-components:support /var/log/dotcom-components
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "UnhealthyInstancesAlarmDotcomcomponentsB1904A86": Object {
+      "Properties": Object {
+        "ActionsEnabled": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "alarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":reader-revenue-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "dotcom-components's instances have failed healthchecks several times over the last hour.
+      This typically results in the AutoScaling Group cycling instances and can lead to problems with deployment,
+      scaling or handling traffic spikes.
+
+      Check dotcom-components's application logs or ssh onto an unhealthy instance in order to debug these problems.",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Unhealthy instances for dotcom-components in ",
+              Object {
+                "Ref": "Stage",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 6,
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancer",
+            "Value": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  Object {
+                    "Fn::Select": Array [
+                      1,
+                      Object {
+                        "Fn::Split": Array [
+                          "/",
+                          Object {
+                            "Ref": "ListenerDotcomcomponentsF68CDC56",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      2,
+                      Object {
+                        "Fn::Split": Array [
+                          "/",
+                          Object {
+                            "Ref": "ListenerDotcomcomponentsF68CDC56",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      3,
+                      Object {
+                        "Fn::Split": Array [
+                          "/",
+                          Object {
+                            "Ref": "ListenerDotcomcomponentsF68CDC56",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          Object {
+            "Name": "TargetGroup",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "TargetGroupDotcomcomponents54FF73AB",
+                "TargetGroupFullName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 12,
+        "MetricName": "UnHealthyHostCount",
+        "Namespace": "AWS/ApplicationELB",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "WazuhSecurityGroup": Object {
       "Properties": Object {

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -92,6 +92,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
                 http5xxAlarm: {
                     tolerated5xxPercentage: 0.002,
                     numberOfMinutesAboveThresholdBeforeAlarm: 1,
+                    alarmName: `URGENT 9-5 - high 5XX error rate on ${this.stage} support-dotcom-components`,
                 },
                 unhealthyInstancesAlarm: true,
                 snsTopicName: 'reader-revenue-dev',

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -88,8 +88,14 @@ chown -R dotcom-components:support /var/log/dotcom-components
                     domainName: 'dotcom-components.support.guardianapis.com',
                 },
             },
-            // TODO: review monitoring config
-            monitoringConfiguration: { noMonitoring: true },
+            monitoringConfiguration: {
+                http5xxAlarm: {
+                    tolerated5xxPercentage: 0.002,
+                    numberOfMinutesAboveThresholdBeforeAlarm: 1,
+                },
+                unhealthyInstancesAlarm: true,
+                snsTopicName: 'reader-revenue-dev',
+            },
             userData,
             roleConfiguration: {
                 additionalPolicies: policies,


### PR DESCRIPTION
The existing alarm is not part of the cloudformation stack.

This change adds 2 alarms for:
- 5XX rate above 0.002%
- unhealthy instances