### PR TITLE
Disable choice cards test in US, add Aus

### DIFF
--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -103,17 +103,17 @@ export const epicChoiceCardsTests = [
         },
     ),
 
-    buildEpicChoiceCardsTest(
-        ['UnitedStates'],
-        'TOP_US',
-        US_DATA.TOP_READER.PARAGRAPHS,
-        US_DATA.TOP_READER.HIGHLIGHTED_TEXT,
-        US_DATA.AMOUNTS,
-        {
-            periodInWeeks: 52,
-            minViews: 50,
-        },
-    ),
+    // buildEpicChoiceCardsTest(
+    //     ['UnitedStates'],
+    //     'TOP_US',
+    //     US_DATA.TOP_READER.PARAGRAPHS,
+    //     US_DATA.TOP_READER.HIGHLIGHTED_TEXT,
+    //     US_DATA.AMOUNTS,
+    //     {
+    //         periodInWeeks: 52,
+    //         minViews: 50,
+    //     },
+    // ),
 
     buildEpicChoiceCardsTest(
         ['EURCountries'],
@@ -172,13 +172,13 @@ export const epicChoiceCardsTests = [
         UK_DATA.AMOUNTS,
     ),
 
-    buildEpicChoiceCardsTest(
-        ['UnitedStates'],
-        'REGULAR_US',
-        US_DATA.REGULAR_READER.PARAGRAPHS,
-        US_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
-        US_DATA.AMOUNTS,
-    ),
+    // buildEpicChoiceCardsTest(
+    //     ['UnitedStates'],
+    //     'REGULAR_US',
+    //     US_DATA.REGULAR_READER.PARAGRAPHS,
+    //     US_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+    //     US_DATA.AMOUNTS,
+    // ),
 
     buildEpicChoiceCardsTest(
         ['EURCountries'],

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -1,6 +1,14 @@
 import { ChoiceCardAmounts, EpicTest } from '@sdc/shared/src/types/epic';
 import { epic } from '@sdc/shared/src/config/modules';
-import { UK_DATA, EU_DATA, ROW_DATA, US_DATA, CA_DATA, NZ_DATA, CTAS } from './choiceCardsTestData';
+import {
+    UK_DATA,
+    EU_DATA,
+    ROW_DATA,
+    CA_DATA,
+    NZ_DATA,
+    CTAS,
+    AU_DATA,
+} from './choiceCardsTestData';
 import { CountryGroupId } from '@sdc/shared/dist/lib';
 import { ArticlesViewedSettings, SecondaryCtaType } from '@sdc/shared/types';
 
@@ -103,6 +111,18 @@ export const epicChoiceCardsTests = [
         },
     ),
 
+    buildEpicChoiceCardsTest(
+        ['AUDCountries'],
+        'TOP_AU',
+        AU_DATA.TOP_READER.PARAGRAPHS,
+        AU_DATA.TOP_READER.HIGHLIGHTED_TEXT,
+        AU_DATA.AMOUNTS,
+        {
+            periodInWeeks: 52,
+            minViews: 50,
+        },
+    ),
+
     // buildEpicChoiceCardsTest(
     //     ['UnitedStates'],
     //     'TOP_US',
@@ -170,6 +190,14 @@ export const epicChoiceCardsTests = [
         UK_DATA.REGULAR_READER.PARAGRAPHS,
         UK_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
         UK_DATA.AMOUNTS,
+    ),
+
+    buildEpicChoiceCardsTest(
+        ['AUDCountries'],
+        'REGULAR_AU',
+        AU_DATA.REGULAR_READER.PARAGRAPHS,
+        AU_DATA.REGULAR_READER.HIGHLIGHTED_TEXT,
+        AU_DATA.AMOUNTS,
     ),
 
     // buildEpicChoiceCardsTest(

--- a/packages/server/src/tests/epics/choiceCards.ts
+++ b/packages/server/src/tests/epics/choiceCards.ts
@@ -1,14 +1,6 @@
 import { ChoiceCardAmounts, EpicTest } from '@sdc/shared/src/types/epic';
 import { epic } from '@sdc/shared/src/config/modules';
-import {
-    UK_DATA,
-    EU_DATA,
-    ROW_DATA,
-    CA_DATA,
-    NZ_DATA,
-    CTAS,
-    AU_DATA,
-} from './choiceCardsTestData';
+import { UK_DATA, EU_DATA, ROW_DATA, CA_DATA, NZ_DATA, CTAS, AU_DATA } from './choiceCardsTestData';
 import { CountryGroupId } from '@sdc/shared/dist/lib';
 import { ArticlesViewedSettings, SecondaryCtaType } from '@sdc/shared/types';
 

--- a/packages/server/src/tests/epics/choiceCardsTestData.ts
+++ b/packages/server/src/tests/epics/choiceCardsTestData.ts
@@ -24,7 +24,7 @@ const EU_AND_ROW_DATA = {
     },
 };
 
-export const UK_DATA = {
+const UK_AU_DATA = {
     TOP_READER: {
         PARAGRAPHS: [
             '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions.',
@@ -48,10 +48,23 @@ export const UK_DATA = {
         HIGHLIGHTED_TEXT:
             'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
     },
+};
+
+export const UK_DATA = {
+    ...UK_AU_DATA,
     AMOUNTS: {
         SINGLE: [30, 60],
         MONTHLY: [3, 6],
         ANNUAL: [60, 120],
+    },
+};
+
+export const AU_DATA = {
+    ...UK_AU_DATA,
+    AMOUNTS: {
+        SINGLE: [60, 100],
+        MONTHLY: [10, 20],
+        ANNUAL: [80, 250],
     },
 };
 


### PR DESCRIPTION
We need to run copy tests in the US.
We haven't yet tested in Aus