### PR TITLE
Base a banner variant's Ophan component type on the channel, not the template

### DIFF
--- a/packages/server/src/tests/banners/ChannelBannerTests.ts
+++ b/packages/server/src/tests/banners/ChannelBannerTests.ts
@@ -27,11 +27,10 @@ export const BannerPaths: {
 };
 
 export const BannerTemplateComponentTypes: {
-    [key in BannerTemplate]: OphanComponentType;
+    [key in BannerChannel]: OphanComponentType;
 } = {
-    [BannerTemplate.ContributionsBanner]: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-    [BannerTemplate.DigitalSubscriptionsBanner]: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
-    [BannerTemplate.GuardianWeeklyBanner]: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
+    contributions: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    subscriptions: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
 };
 
 export const BannerTemplateProducts: {
@@ -41,33 +40,35 @@ export const BannerTemplateProducts: {
     [BannerTemplate.GuardianWeeklyBanner]: ['PRINT_SUBSCRIPTION'],
 };
 
-const BannerVariantFromParams = (variant: RawVariantParams): BannerVariant => {
-    const bannerContent = () => {
-        if (variant.bannerContent) {
-            return variant.bannerContent;
-        } else {
-            // legacy model
-            return {
-                messageText: variant.body,
-                heading: variant.heading,
-                highlightedText: variant.highlightedText,
-                cta: variant.cta,
-                secondaryCta: variant.secondaryCta,
-            };
-        }
-    };
+const BannerVariantFromParams = (forChannel: BannerChannel) => {
+    return (variant: RawVariantParams): BannerVariant => {
+        const bannerContent = () => {
+            if (variant.bannerContent) {
+                return variant.bannerContent;
+            } else {
+                // legacy model
+                return {
+                    messageText: variant.body,
+                    heading: variant.heading,
+                    highlightedText: variant.highlightedText,
+                    cta: variant.cta,
+                    secondaryCta: variant.secondaryCta,
+                };
+            }
+        };
 
-    const tickerSettings = undefined;
+        const tickerSettings = undefined;
 
-    return {
-        name: variant.name,
-        modulePathBuilder: BannerPaths[variant.template],
-        moduleName: variant.template,
-        bannerContent: bannerContent(),
-        mobileBannerContent: variant.mobileBannerContent,
-        componentType: BannerTemplateComponentTypes[variant.template],
-        products: BannerTemplateProducts[variant.template],
-        tickerSettings,
+        return {
+            name: variant.name,
+            modulePathBuilder: BannerPaths[variant.template],
+            moduleName: variant.template,
+            bannerContent: bannerContent(),
+            mobileBannerContent: variant.mobileBannerContent,
+            componentType: BannerTemplateComponentTypes[forChannel],
+            products: BannerTemplateProducts[variant.template],
+            tickerSettings,
+        };
     };
 };
 
@@ -90,7 +91,9 @@ const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTes
                             canRun: (): boolean => testParams.isOn,
                             minPageViews: testParams.minArticlesBeforeShowingBanner,
                             articlesViewedSettings: testParams.articlesViewedSettings,
-                            variants: testParams.variants.map(BannerVariantFromParams),
+                            variants: testParams.variants.map(
+                                BannerVariantFromParams(bannerChannel),
+                            ),
                             controlProportionSettings: testParams.controlProportionSettings,
                         };
                     },


### PR DESCRIPTION
## What does this change?
This makes the component event type for banners derive from the banner channel, not the banner template.

[Trello card](https://trello.com/c/OpRVBm2O)

## How can we measure success?
This should enable colleagues to better track click-through events relating to subscriptions banners even when the template used is for the contributions banner.

## Have we considered potential risks?
This fix still relies on making an assumption about what kind of banner a test variant is in order to send the correct component event, except this time based on the channel it belongs to rather than the template used. BRR colleagues have already run subscriptions banners in channel 1 and contributions banners in channel 2 in the past- this is not a perfect fix!

It would be worth considering in the near term either:
a) Adding another field to the banner tooling to explicitly state that any banner variant, in either channel and using any template, is either a subscriptions or contributions banner.

b) Ceasing to use two separate acquisition events, as we can differentiate in the data based on the test/variant and the product sold.