### PR TITLE
Log article counts

### DIFF
--- a/packages/server/src/middleware/logging.ts
+++ b/packages/server/src/middleware/logging.ts
@@ -17,6 +17,7 @@ export const logging = (
             didRenderBanner: res.locals.didRenderBanner,
             clientName: res.locals.clientName || 'unknown',
             bannerTargeting: res.locals.bannerTargeting,
+            epicTargeting: res.locals.epicTargeting,
         }),
     );
     next();

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -67,7 +67,7 @@ app.post(
             res.locals.clientName = tracking.clientName;
             res.locals.epicTargeting = {
                 weeklyArticleHistory: (targeting.weeklyArticleHistory ?? [])
-                    .slice(0, 4)
+                    .slice(0, 3)
                     .map((c: WeeklyArticleLog) => JSON.stringify(c)),
             };
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -60,6 +60,9 @@ app.post(
             // for response logging
             res.locals.didRenderEpic = !!response.data;
             res.locals.clientName = tracking.clientName;
+            res.locals.epicTargeting = {
+                weeklyArticleHistory: (targeting.weeklyArticleHistory ?? []).slice(0, 6).map(c => JSON.stringify(c)),
+            };
 
             res.send(response);
         } catch (error) {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,7 +1,12 @@
 import fs from 'fs';
 import { ModuleInfo, moduleInfos } from '@sdc/shared/config';
 import { buildAmpEpicCampaignCode } from '@sdc/shared/lib';
-import { EpicType, OphanComponentEvent, OneOffSignupRequest } from '@sdc/shared/types';
+import {
+    EpicType,
+    OphanComponentEvent,
+    OneOffSignupRequest,
+    WeeklyArticleLog,
+} from '@sdc/shared/types';
 import bodyParser from 'body-parser';
 import compression from 'compression';
 import cors from 'cors';
@@ -61,7 +66,9 @@ app.post(
             res.locals.didRenderEpic = !!response.data;
             res.locals.clientName = tracking.clientName;
             res.locals.epicTargeting = {
-                weeklyArticleHistory: (targeting.weeklyArticleHistory ?? []).slice(0, 6).map(c => JSON.stringify(c)),
+                weeklyArticleHistory: (targeting.weeklyArticleHistory ?? [])
+                    .slice(0, 4)
+                    .map((c: WeeklyArticleLog) => JSON.stringify(c)),
             };
 
             res.send(response);


### PR DESCRIPTION
For epic requests, log the first 4 weeks of `weeklyArticleHistory`. We want to see examples of the new tag counts.
We'll be able to see this in kibana

E.g.
```
{
   status: 200,
   method: 'POST',
   path: '/epic',
   didRenderEpic: false,
   didRenderBanner: undefined,
   clientName: 'dcr',
   bannerTargeting: undefined,
   epicTargeting: {
     weeklyArticleHistory: [
           '{"week":18882,"count":13,"tags":{"world/europe-news":1,"world/world":1}}'
     ]
   }
}
```