### PR TITLE
Add article count to cta url

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -52,7 +52,12 @@ const withBannerData = (
     // For safety, this function throws if not all placeholders are replaced
     const buildRenderedContent = (bannerContent: BannerContent): BannerRenderedContent => {
         const buildEnrichedCta = (cta: Cta): BannerEnrichedCta => ({
-            ctaUrl: addRegionIdAndTrackingParamsToSupportUrl(cta.baseUrl, tracking, countryCode),
+            ctaUrl: addRegionIdAndTrackingParamsToSupportUrl(
+                cta.baseUrl,
+                tracking,
+                numArticles,
+                countryCode,
+            ),
             ctaText: cta.text,
         });
 

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -354,6 +354,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 isReminderActive={isReminderActive}
                 isSignedIn={Boolean(email)}
                 choiceCardSelection={choiceCardSelection}
+                articleCounts={articleCounts}
             />
 
             {isReminderActive && showReminderFields && (

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -354,7 +354,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 isReminderActive={isReminderActive}
                 isSignedIn={Boolean(email)}
                 choiceCardSelection={choiceCardSelection}
-                articleCounts={articleCounts}
+                numArticles={articleCounts}
             />
 
             {isReminderActive && showReminderFields && (

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -354,7 +354,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 isReminderActive={isReminderActive}
                 isSignedIn={Boolean(email)}
                 choiceCardSelection={choiceCardSelection}
-                numArticles={articleCounts}
+                numArticles={articleCounts.for52Weeks}
             />
 
             {isReminderActive && showReminderFields && (

--- a/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
 import { Button } from './Button';
-import { EpicVariant, SecondaryCtaType, Tracking, Cta, ArticleCounts } from '@sdc/shared/types';
+import { EpicVariant, SecondaryCtaType, Tracking, Cta } from '@sdc/shared/types';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/lib';
 import { OphanComponentEvent } from '@sdc/shared/types';
 import {

--- a/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
@@ -51,6 +51,7 @@ const PrimaryCtaButton = ({
     if (!cta) {
         return null;
     }
+
     const buttonText = cta.text || 'Support The Guardian';
     const baseUrl = cta.baseUrl || 'https://support.theguardian.com/contribute';
     const urlWithRegionAndTracking = addRegionIdAndTrackingParamsToSupportUrl(

--- a/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
 import { Button } from './Button';
-import { EpicVariant, SecondaryCtaType, Tracking, Cta } from '@sdc/shared/types';
+import { EpicVariant, SecondaryCtaType, Tracking, Cta, ArticleCounts } from '@sdc/shared/types';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/lib';
 import { OphanComponentEvent } from '@sdc/shared/types';
 import {
@@ -40,20 +40,23 @@ const PrimaryCtaButton = ({
     cta,
     tracking,
     countryCode,
-}: {
+    numArticles,
+}: // articleCounts,
+{
     cta?: Cta;
     tracking: Tracking;
     countryCode?: string;
+    numArticles: ArticleCounts;
 }): JSX.Element | null => {
     if (!cta) {
         return null;
     }
-
     const buttonText = cta.text || 'Support The Guardian';
     const baseUrl = cta.baseUrl || 'https://support.theguardian.com/contribute';
     const urlWithRegionAndTracking = addRegionIdAndTrackingParamsToSupportUrl(
         baseUrl,
         tracking,
+        numArticles.for52Weeks,
         countryCode,
     );
 
@@ -69,13 +72,20 @@ const PrimaryCtaButton = ({
 const SecondaryCtaButton = ({
     cta,
     tracking,
+    numArticles,
     countryCode,
 }: {
     cta: Cta;
     tracking: Tracking;
     countryCode?: string;
+    numArticles: ArticleCounts;
 }): JSX.Element | null => {
-    const url = addRegionIdAndTrackingParamsToSupportUrl(cta.baseUrl, tracking, countryCode);
+    const url = addRegionIdAndTrackingParamsToSupportUrl(
+        cta.baseUrl,
+        tracking,
+        numArticles.for52Weeks,
+        countryCode,
+    );
 
     return (
         <div css={buttonMargins}>
@@ -95,6 +105,7 @@ interface ContributionsEpicButtonsProps {
     isReminderActive: boolean;
     isSignedIn: boolean;
     choiceCardSelection?: ChoiceCardSelection;
+    numArticles: ArticleCounts;
 }
 
 export const ContributionsEpicButtons = ({
@@ -106,7 +117,9 @@ export const ContributionsEpicButtons = ({
     isReminderActive,
     isSignedIn,
     choiceCardSelection,
-}: ContributionsEpicButtonsProps): JSX.Element | null => {
+    numArticles,
+}: // articleCounts,
+ContributionsEpicButtonsProps): JSX.Element | null => {
     const [hasBeenSeen, setNode] = useHasBeenSeen({}, true);
     const { cta, secondaryCta, showReminderFields } = variant;
 
@@ -146,6 +159,7 @@ export const ContributionsEpicButtons = ({
                     <PrimaryCtaButton
                         cta={getCta(cta)}
                         tracking={tracking}
+                        numArticles={numArticles}
                         countryCode={countryCode}
                     />
 
@@ -156,6 +170,7 @@ export const ContributionsEpicButtons = ({
                             cta={secondaryCta.cta}
                             tracking={tracking}
                             countryCode={countryCode}
+                            numArticles={numArticles}
                         />
                     ) : (
                         secondaryCta?.type === SecondaryCtaType.ContributionsReminder &&

--- a/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
@@ -41,8 +41,7 @@ const PrimaryCtaButton = ({
     tracking,
     countryCode,
     numArticles,
-}: // articleCounts,
-{
+}: {
     cta?: Cta;
     tracking: Tracking;
     countryCode?: string;
@@ -119,8 +118,7 @@ export const ContributionsEpicButtons = ({
     isSignedIn,
     choiceCardSelection,
     numArticles,
-}: // articleCounts,
-ContributionsEpicButtonsProps): JSX.Element | null => {
+}: ContributionsEpicButtonsProps): JSX.Element | null => {
     const [hasBeenSeen, setNode] = useHasBeenSeen({}, true);
     const { cta, secondaryCta, showReminderFields } = variant;
 

--- a/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
@@ -46,7 +46,7 @@ const PrimaryCtaButton = ({
     cta?: Cta;
     tracking: Tracking;
     countryCode?: string;
-    numArticles: ArticleCounts;
+    numArticles: number;
 }): JSX.Element | null => {
     if (!cta) {
         return null;
@@ -56,7 +56,7 @@ const PrimaryCtaButton = ({
     const urlWithRegionAndTracking = addRegionIdAndTrackingParamsToSupportUrl(
         baseUrl,
         tracking,
-        numArticles.for52Weeks,
+        numArticles,
         countryCode,
     );
 
@@ -78,12 +78,12 @@ const SecondaryCtaButton = ({
     cta: Cta;
     tracking: Tracking;
     countryCode?: string;
-    numArticles: ArticleCounts;
+    numArticles: number;
 }): JSX.Element | null => {
     const url = addRegionIdAndTrackingParamsToSupportUrl(
         cta.baseUrl,
         tracking,
-        numArticles.for52Weeks,
+        numArticles,
         countryCode,
     );
 
@@ -105,7 +105,7 @@ interface ContributionsEpicButtonsProps {
     isReminderActive: boolean;
     isSignedIn: boolean;
     choiceCardSelection?: ChoiceCardSelection;
-    numArticles: ArticleCounts;
+    numArticles: number;
 }
 
 export const ContributionsEpicButtons = ({

--- a/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
@@ -147,6 +147,7 @@ interface LiveblogEpicCtaProps {
     text?: string;
     baseUrl?: string;
     countryCode?: string;
+    numArticles?: number;
     tracking: Tracking;
 }
 
@@ -154,11 +155,13 @@ const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
     text,
     baseUrl,
     tracking,
+    numArticles,
     countryCode,
 }: LiveblogEpicCtaProps) => {
     const url = addRegionIdAndTrackingParamsToSupportUrl(
         baseUrl || DEFAULT_CTA_BASE_URL,
         tracking,
+        numArticles,
         countryCode,
     );
     return (

--- a/packages/modules/src/modules/header/HeaderWrapper.tsx
+++ b/packages/modules/src/modules/header/HeaderWrapper.tsx
@@ -26,9 +26,15 @@ export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<Hea
         tracking,
         countryCode,
         submitComponentEvent,
+        numArticles,
     }) => {
         const buildEnrichedCta = (cta: HeaderCta): HeaderEnrichedCta => ({
-            ctaUrl: addRegionIdAndTrackingParamsToSupportUrl(cta.url, tracking, countryCode),
+            ctaUrl: addRegionIdAndTrackingParamsToSupportUrl(
+                cta.url,
+                tracking,
+                numArticles,
+                countryCode,
+            ),
             ctaText: cta.text,
         });
 

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -352,6 +352,7 @@ export const buildHeaderData = async (
                         content: variant.content,
                         tracking: { ...pageTracking, ...testTracking },
                         countryCode: targeting.countryCode,
+                        numArticles: targeting.numArticles,
                     },
                 },
                 meta: testTracking,

--- a/packages/shared/src/lib/tracking.test.ts
+++ b/packages/shared/src/lib/tracking.test.ts
@@ -19,10 +19,12 @@ describe('addTrackingParams', () => {
         });
         const buttonBaseUrl = 'https://support.theguardian.com/contribute/climate-pledge-2019';
 
-        const got = addTrackingParams(buttonBaseUrl, trackingData);
+        const numArticles = 88;
+
+        const got = addTrackingParams(buttonBaseUrl, trackingData, numArticles);
 
         const want =
-            'https://support.theguardian.com/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D';
+            'https://support.theguardian.com/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=88';
         expect(got).toEqual(want);
     });
     it('should return a correctly formatted URL when the base URL already has a query string', () => {
@@ -39,10 +41,12 @@ describe('addTrackingParams', () => {
         const buttonBaseUrl =
             'https://support.theguardian.com/contribute/climate-pledge-2019?foo=bar';
 
-        const got = addTrackingParams(buttonBaseUrl, trackingData);
+        const numArticles = 88;
+
+        const got = addTrackingParams(buttonBaseUrl, trackingData, numArticles);
 
         const want =
-            'https://support.theguardian.com/contribute/climate-pledge-2019?foo=bar&REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D';
+            'https://support.theguardian.com/contribute/climate-pledge-2019?foo=bar&REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=88';
         expect(got).toEqual(want);
     });
 });
@@ -78,16 +82,18 @@ describe('addRegionIdAndTrackingParamsToSupportUrl', () => {
                 'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
         });
         const buttonBaseUrl = 'https://support.theguardian.com/contribute/climate-pledge-2019';
+        const numArticles = 88;
         const countryCode = 'GB';
 
         const got = addRegionIdAndTrackingParamsToSupportUrl(
             buttonBaseUrl,
             trackingData,
+            numArticles,
             countryCode,
         );
 
         const want =
-            'https://support.theguardian.com/uk/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D';
+            'https://support.theguardian.com/uk/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=88';
         expect(got).toEqual(want);
     });
 });

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -14,7 +14,7 @@ type LinkParams = {
 export const addTrackingParams = (
     baseUrl: string,
     params: Tracking,
-    numArticles: number,
+    numArticles?: number,
 ): string => {
     const acquisitionData = encodeURIComponent(
         JSON.stringify({

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -8,9 +8,14 @@ type LinkParams = {
     REFPVID: string;
     INTCMP: string;
     acquisitionData: string;
+    numArticles: number;
 };
 
-export const addTrackingParams = (baseUrl: string, params: Tracking): string => {
+export const addTrackingParams = (
+    baseUrl: string,
+    params: Tracking,
+    numArticles: number,
+): string => {
     const acquisitionData = encodeURIComponent(
         JSON.stringify({
             source: params.platformId,
@@ -32,9 +37,12 @@ export const addTrackingParams = (baseUrl: string, params: Tracking): string => 
         REFPVID: params.ophanPageId || 'not_found',
         INTCMP: params.campaignCode || '',
         acquisitionData: acquisitionData,
+        numArticles,
     };
 
-    const queryString = Object.entries(trackingLinkParams).map(([key, value]) => `${key}=${value}`);
+    const queryString = Object.entries(trackingLinkParams)
+        .filter(([, value]) => value !== undefined)
+        .map(([key, value]) => `${key}=${value}`);
     const alreadyHasQueryString = baseUrl.includes('?');
 
     return `${baseUrl}${alreadyHasQueryString ? '&' : '?'}${queryString.join('&')}`;
@@ -43,12 +51,13 @@ export const addTrackingParams = (baseUrl: string, params: Tracking): string => 
 export const addRegionIdAndTrackingParamsToSupportUrl = (
     baseUrl: string,
     tracking: Tracking,
+    numArticles?: number,
     countryCode?: string,
 ): string => {
     const isSupportUrl = /\bsupport\./.test(baseUrl);
 
     return isSupportUrl
-        ? addTrackingParams(addRegionIdToSupportUrl(baseUrl, countryCode), tracking)
+        ? addTrackingParams(addRegionIdToSupportUrl(baseUrl, countryCode), tracking, numArticles)
         : baseUrl;
 };
 

--- a/packages/shared/src/types/header.ts
+++ b/packages/shared/src/types/header.ts
@@ -30,6 +30,7 @@ export interface HeaderProps {
     tracking: Tracking;
     countryCode?: string;
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
+    numArticles?: number;
 }
 
 export interface HeaderTestSelection {
@@ -46,4 +47,5 @@ export interface HeaderTargeting {
     modulesVersion?: string;
     mvtId: number;
     lastOneOffContributionDate?: string;
+    numArticles?: number;
 }


### PR DESCRIPTION
## What does this change?
- We are working on a test to add article count to the contributions landing page and we've decided to use header / banner / epic ctas to pass a user's article count to support-frontend as a temporary solution while we work out how to use iFrame.
- This PR adds article count to the cta url (`addRegionIdAndTrackingParamsToSupportUrl` in tracking)
- We've added article count to the header and banner props and leveraged the existing article count prop in the epic.