### PR TITLE
Investigations banner tweaks

### DIFF
--- a/packages/modules/src/modules/banners/investigationsMoment/InvestigationsMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/investigationsMoment/InvestigationsMomentBanner.tsx
@@ -33,8 +33,20 @@ const styles = {
         justify-content: flex-end;
         top: 0;
         right: 0;
-        width: 100px;
+        width: 150px;
         height: 80px;
+
+        ${from.mobileMedium} {
+            width: 200px;
+        }
+
+        ${from.mobileLandscape} {
+            width: 300px;
+        }
+
+        ${from.phablet} {
+            width: 475px;
+        }
 
         ${from.tablet} {
             bottom: 0;
@@ -165,10 +177,34 @@ function InvestigationsMomentBanner({
                 </section>
             </div>
 
-            <Hide above="tablet">
+            <Hide above="mobileMedium">
                 <div css={styles.desktopShadowRight}>
-                    <svg viewBox="0 0 100 80" xmlns="http://www.w3.org/2000/svg">
-                        <polygon points="0 0, 100 0, 100 80" />
+                    <svg viewBox="0 0 150 80" xmlns="http://www.w3.org/2000/svg">
+                        <polygon points="0 0, 150 0, 150 80" />
+                    </svg>
+                </div>
+            </Hide>
+
+            <Hide below="mobileMedium" above="mobileLandscape">
+                <div css={styles.desktopShadowRight}>
+                    <svg viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+                        <polygon points="0 0, 200 0, 200 80" />
+                    </svg>
+                </div>
+            </Hide>
+
+            <Hide below="mobileLandscape" above="phablet">
+                <div css={styles.desktopShadowRight}>
+                    <svg viewBox="0 0 300 80" xmlns="http://www.w3.org/2000/svg">
+                        <polygon points="0 0, 300 0, 300 80" />
+                    </svg>
+                </div>
+            </Hide>
+
+            <Hide below="phablet" above="tablet">
+                <div css={styles.desktopShadowRight}>
+                    <svg viewBox="0 0 475 80" xmlns="http://www.w3.org/2000/svg">
+                        <polygon points="0 0, 475 0, 475 80" />
                     </svg>
                 </div>
             </Hide>

--- a/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerCtas.tsx
@@ -177,7 +177,7 @@ const buttonWithPaymentIconStyles = {
             width: auto;
 
             ${from.tablet} {
-                height: 17px;
+                height: 20px;
             }
         }
     `,


### PR DESCRIPTION
## What does this change?
Just a couple of tweaks for the banner as requested by Ellen:

1. Tweak top right shadow across mobile breakpoints
2. Make payment icons 20px at tablet+

## Images
<img width="333" alt="Screenshot 2021-09-28 at 14 18 55" src="https://user-images.githubusercontent.com/17720442/135095144-a804afdd-1910-4c07-85f2-6471650ba88b.png">
<img width="387" alt="Screenshot 2021-09-28 at 14 19 06" src="https://user-images.githubusercontent.com/17720442/135095153-f80566d2-0084-413c-9195-78de6c8e08e8.png">
<img width="492" alt="Screenshot 2021-09-28 at 14 19 17" src="https://user-images.githubusercontent.com/17720442/135095161-38bec52f-5346-47d7-8276-b8f5ec533997.png">
<img width="670" alt="Screenshot 2021-09-28 at 14 19 30" src="https://user-images.githubusercontent.com/17720442/135095163-f513f7d4-990c-4035-94c1-100c81b0731a.png">

