### PR TITLE
Make selectVariant safer

### DIFF
--- a/packages/server/src/lib/ab.test.ts
+++ b/packages/server/src/lib/ab.test.ts
@@ -72,6 +72,15 @@ describe('selectVariant', () => {
         const variant = selectVariant({ ...test, controlProportionSettings }, 600000);
         expect(variant.name).toBe('v1');
     });
+
+    it('should select control if no variants', () => {
+        const controlOnly = {
+            ...test,
+            variants: [test.variants[0]],
+        };
+        const variant = selectVariant({ ...controlOnly, controlProportionSettings }, 600000);
+        expect(variant.name).toBe('control');
+    });
 });
 
 describe('withinRange', () => {

--- a/packages/server/src/lib/ab.ts
+++ b/packages/server/src/lib/ab.ts
@@ -31,7 +31,10 @@ export const selectVariant = <V extends Variant, T extends Test<V>>(test: T, mvt
             return control;
         } else {
             const otherVariants = test.variants.filter(v => v.name.toLowerCase() !== 'control');
-            return otherVariants[mvtId % otherVariants.length];
+            if (otherVariants.length > 0) {
+                return otherVariants[mvtId % otherVariants.length];
+            }
+            return control;
         }
     }
 


### PR DESCRIPTION
We had a couple of tests come through with only a control, but with `controlProportionSettings` set. This broke variant allocation.
This change ensures we have other variants.
We also need to change the epic tool to prevent this from happening.