### PR TITLE
Update logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ This repo consists of 3 packages, managed by [yarn workspaces](https://classic.y
 To ssh onto an instance use:
 `ssm ssh --profile <aws profile> -x --ssm-tunnel -i <instance ID>`
 
+## Logging
+
+When running locally a simple `console.log` is all you need. However, if you want to produce logs that can be viewed in kibana the simplest way to go is to use the `logInfo`/`logWarn`/`logError` functions exported from `logging.ts`. These take a `message` string that you can search for under the `message` field in kibana. If you want additional flexibility, you can use the `logger.info`/`logger.warn`/`logger.error` methods on the exported `logger` object instead. These methods take an object with any key/values that will appear as top level keys in kibana. However, getting the types wrong (e.g if you did `logger.info({ message: ["foo", "bar"]}))` would result in kibana silently rejecting the log and it therefore not being searchable (as `message` must be a string).
+
 ## Module versions
 
 We use versioning on the modules for backwards-incompatible upgrades. For example when we need to upgrade the emotion dependency, which the platforms (DCR+frontend) must also have.

--- a/packages/server/src/lib/cache.ts
+++ b/packages/server/src/lib/cache.ts
@@ -1,4 +1,4 @@
-import { logger } from '../utils/logging';
+import { logWarn } from '../utils/logging';
 
 type Cache = Record<string, unknown>;
 const cache: Cache = {};
@@ -34,7 +34,7 @@ export const cacheAsync = <T>(
                 cache[key] = result;
                 return Promise.resolve(result);
             } catch (err) {
-                logger.warn(`Failed to make initial request for ${key}: ${err}`);
+                logWarn(`Failed to make initial request for ${key}: ${err}`);
                 return Promise.reject(
                     new Error(`Failed to make initial request for ${key}: ${err}`),
                 );
@@ -45,7 +45,7 @@ export const cacheAsync = <T>(
                             cache[key] = await fn();
                             scheduleRefresh(ttlSec * 1000);
                         } catch (err) {
-                            logger.warn(`Error refreshing cached value for key ${key}: ${err}`);
+                            logWarn(`Error refreshing cached value for key ${key}: ${err}`);
                             scheduleRefresh(retryIntervalMs);
                         }
                     }, ms);

--- a/packages/server/src/lib/superMode.ts
+++ b/packages/server/src/lib/superMode.ts
@@ -3,7 +3,7 @@ import { isProd } from './env';
 import { addDays, format } from 'date-fns';
 import { EpicTest } from '@sdc/shared/types';
 import { CountryGroupId } from '@sdc/shared/lib';
-import { logger } from '../utils/logging';
+import { logInfo } from '../utils/logging';
 
 const docClient = new AWS.DynamoDB.DocumentClient({ region: 'eu-west-1' });
 const stage = isProd ? 'PROD' : 'CODE';
@@ -16,7 +16,7 @@ export interface SuperModeArticle {
 export const fetchSuperModeArticles = async (): Promise<SuperModeArticle[]> => {
     const records = await queryActiveArticles(stage, docClient);
 
-    logger.info(`Got super mode articles from dynamo, number of records: ${records.length}`);
+    logInfo(`Got super mode articles from dynamo, number of records: ${records.length}`);
 
     return records.map(record => ({
         url: record.url,

--- a/packages/server/src/middleware/errorHandling.ts
+++ b/packages/server/src/middleware/errorHandling.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { logger } from '../utils/logging';
+import { logInfo } from '../utils/logging';
 
 export const errorHandling = (
     error: Error,
@@ -14,5 +14,5 @@ export const errorHandling = (
 
     res.status(500).send({ error: message });
 
-    logger.error('Something went wrong: ', message);
+    logInfo('Something went wrong: ' + message);
 };

--- a/packages/server/src/middleware/logging.ts
+++ b/packages/server/src/middleware/logging.ts
@@ -9,7 +9,7 @@ export const logging = (
     next: express.NextFunction,
 ): void => {
     res.on('finish', () =>
-        logger.info(RequestLogName, {
+        logger.info({
             status: res.statusCode,
             method: req.method,
             path: req.path,

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -34,7 +34,7 @@ import { getCachedTests } from './tests/banners/bannerTests';
 import { Debug, findForcedTestAndVariant, findTestAndVariant } from './tests/epics/epicSelection';
 import { fallbackEpicTest } from './tests/epics/fallback';
 import { selectHeaderTest } from './tests/header/headerSelection';
-import { logger } from './utils/logging';
+import { logWarn } from './utils/logging';
 import { cachedChoiceCardAmounts } from './choiceCardAmounts';
 
 interface EpicDataResponse {
@@ -132,7 +132,7 @@ const getArticleEpicTests = async (
 
         return [...hardcodedTests, ...regular, fallbackEpicTest];
     } catch (err) {
-        logger.warn(`Error getting article epic tests: ${err}`);
+        logWarn(`Error getting article epic tests: ${err}`);
 
         return [fallbackEpicTest];
     }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -23,7 +23,7 @@ import {
 import { buildBannerData, buildEpicData, buildHeaderData, buildPuzzlesData } from './payloads';
 import { ampEpic } from './tests/amp/ampEpic';
 import { getAmpExperimentData } from './tests/amp/ampEpicTests';
-import { logger } from './utils/logging';
+import { logInfo } from './utils/logging';
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -233,7 +233,7 @@ app.post('/epic/compare-variant-decision', async (req: express.Request, res: exp
         gotCampaignId !== expectedCampaignId;
 
     if (notBothFalsy && notTheSame) {
-        logger.info(
+        logInfo(
             'comparison failed with data: ' +
                 JSON.stringify({
                     status: 'comparison failed',

--- a/packages/server/src/tests/banners/bannerDeployCache.ts
+++ b/packages/server/src/tests/banners/bannerDeployCache.ts
@@ -1,7 +1,7 @@
 import { BannerChannel } from '@sdc/shared/types';
 import { cacheAsync } from '../../lib/cache';
 import { isProd } from '../../lib/env';
-import { logger } from '../../utils/logging';
+import { logInfo } from '../../utils/logging';
 import { fetchS3Data } from '../../utils/S3';
 
 export type ReaderRevenueRegion =
@@ -27,7 +27,7 @@ const fetchBannerDeployTimes = (bannerChannel: BannerChannel) => (): Promise<Ban
                     RestOfWorld: new Date(data.RestOfWorld.timestamp),
                     EuropeanUnion: new Date(data.EuropeanUnion.timestamp),
                 };
-                logger.info(`Got banner deploy times for ${channel}`, times);
+                logInfo(`Got banner deploy times for ${channel}, times: ${JSON.stringify(times)}`);
                 return times;
             })
     );

--- a/packages/server/src/utils/logging.ts
+++ b/packages/server/src/utils/logging.ts
@@ -2,14 +2,12 @@ import path from 'path';
 import { Configuration, LoggingEvent } from 'log4js';
 import { addLayout, configure, getLogger } from 'log4js';
 import { isDev, isProd } from '../lib/env';
-import { RequestLogName } from '../middleware/logging';
 
 const logLocation = !isDev
     ? '/var/log/dotcom-components/dotcom-components.log'
     : `${path.resolve('logs')}/dotcom-components.log`;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const logFields = (logEvent: LoggingEvent): any => {
+const logFields = (logEvent: LoggingEvent) => {
     const fields = {
         stack: 'support',
         app: 'dotcom-components',
@@ -18,18 +16,12 @@ const logFields = (logEvent: LoggingEvent): any => {
         level: logEvent.level.levelStr,
         level_value: logEvent.level.level,
     };
+    const data = logEvent.data[0];
 
-    if (logEvent.data[0] === RequestLogName && typeof logEvent.data[1] === 'object') {
-        return {
-            ...fields,
-            ...logEvent.data[1],
-        };
-    } else {
-        return {
-            ...fields,
-            message: logEvent.data,
-        };
-    }
+    return {
+        ...fields,
+        ...data,
+    };
 };
 
 addLayout('json', () => {
@@ -61,3 +53,15 @@ const log4jConfig = (layout: string): Configuration => ({
 configure(log4jConfig('json'));
 export const logger = getLogger(process.env.NODE_ENV);
 logger.info('Created log4j logger');
+
+export function logInfo(message: string): void {
+    logger.info({ message });
+}
+
+export function logError(message: string): void {
+    logger.error({ message });
+}
+
+export function logWarn(message: string): void {
+    logger.warn({ message });
+}


### PR DESCRIPTION
## What does this change?
Makes a few changes to how logging currently works: 

1. Add new helpers (e.g `logInfo`) for logging a `string`. This ensures we only ever send strings as the `message` field to kibana. Currently it is silently rejecting logs that are non-strings.
2. Simplify the logic in the custom `logger` layout. Now the input to e.g `logger.info` should be an object consisting of keys that appear as top level fields in kibana.
