### PR TITLE
Fix AMP epic choice cards bug

### DIFF
--- a/packages/server/src/tests/amp/ampEpicTests.ts
+++ b/packages/server/src/tests/amp/ampEpicTests.ts
@@ -104,7 +104,7 @@ export const selectAmpEpicTestAndVariant = async (
                     componentId: campaignCode,
                     campaignCode: campaignCode,
                 },
-                choiceCards: variant.showChoiceCards,
+                showChoiceCards: variant.showChoiceCards,
             };
 
             if (variant.tickerSettings) {


### PR DESCRIPTION
Fixes a typo that causes fallback AMP epic to be served instead of tests