### PR TITLE
Improve test variant allocation

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,6 +23,7 @@
     "@types/node": "^14.14.25",
     "@types/node-fetch": "^2.5.4",
     "@types/supertest": "^2.0.8",
+    "@types/seedrandom": "^3.0.1",
     "concurrently": "^6.2.0",
     "fetch-mock": "^8.3.1",
     "fishery": "^0.3.0",
@@ -51,6 +52,7 @@
     "lodash.debounce": "^4.0.8",
     "log4js": "^6.3.0",
     "node-fetch": "^2.6.1",
+    "seedrandom": "^3.0.5",
     "zod": "^3.2.0"
   }
 }

--- a/packages/server/src/lib/ab.test.ts
+++ b/packages/server/src/lib/ab.test.ts
@@ -1,8 +1,8 @@
 import { EpicTest } from '@sdc/shared/types';
-import { selectVariant, withinRange } from './ab';
+import { selectVariant, withinRange, selectWithSeed } from './ab';
 
 const test: EpicTest = {
-    name: 'example-1',
+    name: 'example-1', // note - changing this name will change the results of the tests, as it's used for the seed
     isOn: true,
     locations: [],
     tagIds: [],
@@ -44,12 +44,12 @@ const controlProportionSettings = {
 
 describe('selectVariant', () => {
     it('should select control (no controlProportion)', () => {
-        const variant = selectVariant(test, 0);
+        const variant = selectVariant(test, 4);
         expect(variant.name).toBe('control');
     });
 
     it('should select variant (no controlProportion)', () => {
-        const variant = selectVariant(test, 1);
+        const variant = selectVariant(test, 2);
         expect(variant.name).toBe('v1');
     });
 
@@ -110,5 +110,22 @@ describe('withinRange', () => {
 
     it('should return false if above upper and below lower (wrap)', () => {
         expect(withinRange(999990, 0.1, 99990)).toBe(false);
+    });
+});
+
+describe('selectWithSeed', () => {
+    it('should evenly distribute to the variants', () => {
+        const variantCounts: { [key: string]: number } = {
+            control: 0,
+            v1: 0,
+        };
+
+        for (let mvt = 0; mvt < 5000; mvt++) {
+            const variant = selectWithSeed(mvt, 'testName', test.variants);
+            variantCounts[variant.name]++;
+        }
+
+        // Uses pseudorandom generator so they may not match precisely
+        expect(Math.abs(variantCounts.control - variantCounts.v1)).toBeLessThan(10);
     });
 });

--- a/packages/server/src/lib/ab.ts
+++ b/packages/server/src/lib/ab.ts
@@ -1,4 +1,5 @@
 import { Test, Variant } from '@sdc/shared/types';
+import seedrandom from 'seedrandom';
 
 const maxMvt = 1000000;
 
@@ -11,6 +12,15 @@ export const withinRange = (lower: number, proportion: number, mvtId: number): b
     } else {
         return mvtId >= lower && mvtId < upper;
     }
+};
+
+export const selectWithSeed = <V extends Variant>(
+    mvtId: number,
+    seed: string,
+    variants: V[],
+): V => {
+    const n: number = Math.abs(seedrandom(mvtId + seed).int32());
+    return variants[n % variants.length];
 };
 
 /**
@@ -32,11 +42,11 @@ export const selectVariant = <V extends Variant, T extends Test<V>>(test: T, mvt
         } else {
             const otherVariants = test.variants.filter(v => v.name.toLowerCase() !== 'control');
             if (otherVariants.length > 0) {
-                return otherVariants[mvtId % otherVariants.length];
+                return selectWithSeed(mvtId, test.name, otherVariants);
             }
             return control;
         }
     }
 
-    return test.variants[mvtId % test.variants.length];
+    return selectWithSeed(mvtId, test.name, test.variants);
 };

--- a/packages/server/src/lib/ab.ts
+++ b/packages/server/src/lib/ab.ts
@@ -19,6 +19,11 @@ export const selectWithSeed = <V extends Variant>(
     seed: string,
     variants: V[],
 ): V => {
+    if (variants.length === 1) {
+        // optimisation as it's common for a 'test' to have a single variant
+        return variants[0];
+    }
+
     const n: number = Math.abs(seedrandom(mvtId + seed).int32());
     return variants[n % variants.length];
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3455,6 +3455,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/seedrandom@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-3.0.1.tgz#1254750a4fec4aff2ebec088ccd0bb02e91fedb4"
+  integrity sha512-giB9gzDeiCeloIXDgzFBCgjj1k4WxcDrZtGl6h1IqmUPlxF+Nx8Ve+96QCyDZ/HseB/uvDsKbpib9hU5cU53pw==
+
 "@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
@@ -12932,6 +12937,11 @@ schema-utils@^3.0.0, schema-utils@^3.1.0:
     "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
+
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
 
 semver-diff@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
This changes the logic for assigning a browser's mvt value to a variant.
It's based on the long-standing [logic in support-frontend](https://github.com/guardian/support-frontend/blob/9c7649f7758f68541ff3d292fe515fc02665d229/support-frontend/assets/helpers/abTests/abtest.js#L217), which uses a seed value for each test to keep tests independent.
It uses the [seedrandom](https://github.com/davidbau/seedrandom) library.

This will help us to run concurrent independent tests on dotcom, e.g. a banner message test + a banner targeting test.