### PR TITLE
Targeting tests for banners

### DIFF
--- a/packages/server/src/lib/targetingTesting.test.ts
+++ b/packages/server/src/lib/targetingTesting.test.ts
@@ -43,8 +43,10 @@ describe('selectTargetingTest', () => {
         const decision = selectTargetingTest(2, targeting, bannerTargetingTests);
         expect(decision).toEqual({
             canShow: true,
-            testName: 'BannerTargetingTest',
-            variantName: 'Control',
+            test: {
+                testName: 'BannerTargetingTest',
+                variantName: 'Control',
+            },
         });
     });
 
@@ -52,8 +54,10 @@ describe('selectTargetingTest', () => {
         const decision = selectTargetingTest(1, targeting, bannerTargetingTests);
         expect(decision).toEqual({
             canShow: false,
-            testName: 'BannerTargetingTest',
-            variantName: 'Variant',
+            test: {
+                testName: 'BannerTargetingTest',
+                variantName: 'Variant',
+            },
         });
     });
 
@@ -65,8 +69,10 @@ describe('selectTargetingTest', () => {
         );
         expect(decision).toEqual({
             canShow: true,
-            testName: 'BannerTargetingTest',
-            variantName: 'Variant',
+            test: {
+                testName: 'BannerTargetingTest',
+                variantName: 'Variant',
+            },
         });
     });
 });

--- a/packages/server/src/lib/targetingTesting.test.ts
+++ b/packages/server/src/lib/targetingTesting.test.ts
@@ -1,0 +1,72 @@
+import { selectTargetingTest, TargetingTest } from './targetingTesting';
+import { BannerTargeting } from '@sdc/shared/types';
+
+const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
+    {
+        name: 'BannerTargetingTest',
+        canInclude: (targeting: BannerTargeting) => targeting.countryCode === 'GB',
+        variants: [
+            {
+                name: 'Control',
+                canShow: () => true,
+            },
+            {
+                name: 'Variant',
+                canShow: (targeting: BannerTargeting) => targeting.alreadyVisitedCount >= 5,
+            },
+        ],
+    },
+];
+
+const targeting: BannerTargeting = {
+    alreadyVisitedCount: 2,
+    shouldHideReaderRevenue: false,
+    isPaidContent: false,
+    showSupportMessaging: true,
+    mvtId: 1,
+    countryCode: 'GB',
+    weeklyArticleHistory: [],
+    hasOptedOutOfArticleCount: false,
+};
+
+describe('selectTargetingTest', () => {
+    it('should exclude user from a targeting test', () => {
+        const decision = selectTargetingTest(
+            1,
+            { ...targeting, countryCode: 'US' },
+            bannerTargetingTests,
+        );
+        expect(decision).toBe(null);
+    });
+
+    it('should include user in a targeting test and return Control', () => {
+        const decision = selectTargetingTest(2, targeting, bannerTargetingTests);
+        expect(decision).toEqual({
+            canShow: true,
+            testName: 'BannerTargetingTest',
+            variantName: 'Control',
+        });
+    });
+
+    it('should include user in a targeting test and return Variant, with canShow of false', () => {
+        const decision = selectTargetingTest(1, targeting, bannerTargetingTests);
+        expect(decision).toEqual({
+            canShow: false,
+            testName: 'BannerTargetingTest',
+            variantName: 'Variant',
+        });
+    });
+
+    it('should include user in a targeting test and return Variant, with canShow of true', () => {
+        const decision = selectTargetingTest(
+            1,
+            { ...targeting, alreadyVisitedCount: 5 },
+            bannerTargetingTests,
+        );
+        expect(decision).toEqual({
+            canShow: true,
+            testName: 'BannerTargetingTest',
+            variantName: 'Variant',
+        });
+    });
+});

--- a/packages/server/src/lib/targetingTesting.ts
+++ b/packages/server/src/lib/targetingTesting.ts
@@ -1,8 +1,9 @@
 import { TargetingAbTest, Test, Variant } from '@sdc/shared/types';
 import { selectVariant } from './ab';
 
-type TargetingTestDecision = TargetingAbTest & {
+type TargetingTestDecision = {
     canShow: boolean;
+    test: TargetingAbTest;
 };
 
 interface TargetingTestVariant<T> extends Variant {
@@ -35,8 +36,10 @@ export const selectTargetingTest = <T>(
         const variant: TargetingTestVariant<T> = selectVariant(test, mvtId);
         return {
             canShow: variant.canShow(targeting),
-            testName: test.name,
-            variantName: variant.name,
+            test: {
+                testName: test.name,
+                variantName: variant.name,
+            },
         };
     } else {
         return null;

--- a/packages/server/src/lib/targetingTesting.ts
+++ b/packages/server/src/lib/targetingTesting.ts
@@ -1,7 +1,7 @@
-import { SecondaryAbTest, Test, Variant } from '@sdc/shared/types';
+import { TargetingAbTest, Test, Variant } from '@sdc/shared/types';
 import { selectVariant } from './ab';
 
-type TargetingTestDecision = SecondaryAbTest & {
+type TargetingTestDecision = TargetingAbTest & {
     canShow: boolean;
 };
 

--- a/packages/server/src/lib/targetingTesting.ts
+++ b/packages/server/src/lib/targetingTesting.ts
@@ -10,6 +10,12 @@ interface TargetingTestVariant<T> extends Variant {
     canShow: (targeting: T) => boolean; // Can a message be shown?
 }
 
+/**
+ * A targeting test seeks to understand the impact of changes to targeting rules.
+ * A user is assigned to a variant in a targeting test in the usual way.
+ * But the variant then determines if the user should see a message at all, based on the user's targeting data.
+ * Each variant in a TargetingTest has a `canShow` function. This decides if the user can be put into a message test.
+ */
 export interface TargetingTest<T> extends Test<TargetingTestVariant<T>> {
     name: string;
     variants: TargetingTestVariant<T>[];

--- a/packages/server/src/lib/targetingTesting.ts
+++ b/packages/server/src/lib/targetingTesting.ts
@@ -1,0 +1,38 @@
+import { SecondaryAbTest, Test, Variant } from '@sdc/shared/types';
+import { selectVariant } from './ab';
+
+type TargetingTestDecision = SecondaryAbTest & {
+    canShow: boolean;
+};
+
+interface TargetingTestVariant<T> extends Variant {
+    name: string;
+    canShow: (targeting: T) => boolean; // Can a message be shown?
+}
+
+export interface TargetingTest<T> extends Test<TargetingTestVariant<T>> {
+    name: string;
+    variants: TargetingTestVariant<T>[];
+    canInclude: (targeting: T) => boolean; // Can browser be included in this targeting test?
+}
+
+export const selectTargetingTest = <T>(
+    mvtId: number,
+    targeting: T,
+    targetingTests: TargetingTest<T>[],
+): TargetingTestDecision | null => {
+    const test: TargetingTest<T> | undefined = targetingTests.find(test =>
+        test.canInclude(targeting),
+    );
+
+    if (test) {
+        const variant: TargetingTestVariant<T> = selectVariant(test, mvtId);
+        return {
+            canShow: variant.canShow(targeting),
+            testName: test.name,
+            variantName: variant.name,
+        };
+    } else {
+        return null;
+    }
+};

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -251,14 +251,14 @@ export const buildBannerData = async (
     );
 
     if (selectedTest) {
-        const { test, variant, moduleUrl, moduleName, secondaryAbTest } = selectedTest;
+        const { test, variant, moduleUrl, moduleName, targetingAbTest } = selectedTest;
 
         const testTracking: TestTracking = {
             abTestName: test.name,
             abTestVariant: variant.name,
             campaignCode: buildBannerCampaignCode(test, variant),
             componentType: variant.componentType,
-            secondaryAbTest,
+            targetingAbTest,
             ...(variant.products && { products: variant.products }),
         };
 

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -251,13 +251,14 @@ export const buildBannerData = async (
     );
 
     if (selectedTest) {
-        const { test, variant, moduleUrl, moduleName } = selectedTest;
+        const { test, variant, moduleUrl, moduleName, secondaryAbTest } = selectedTest;
 
         const testTracking: TestTracking = {
             abTestName: test.name,
             abTestVariant: variant.name,
             campaignCode: buildBannerCampaignCode(test, variant),
             componentType: variant.componentType,
+            secondaryAbTest,
             ...(variant.products && { products: variant.products }),
         };
 

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -146,7 +146,7 @@ export const selectBannerTest = async (
                 variant,
                 moduleUrl: `${baseUrl}/${variant.modulePathBuilder(targeting.modulesVersion)}`,
                 moduleName: variant.moduleName,
-                secondaryAbTest: targetingTest ? targetingTest : undefined,
+                targetingAbTest: targetingTest ? targetingTest : undefined,
             };
 
             return Promise.resolve(bannerTestSelection);

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -13,6 +13,7 @@ import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { TestVariant } from '../../lib/params';
 import { userIsInTest } from '../../lib/targeting';
 import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
+import { selectTargetingTest, TargetingTest } from '../../lib/targetingTesting';
 
 export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
     switch (true) {
@@ -100,6 +101,8 @@ const getForcedVariant = (
     return null;
 };
 
+const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [];
+
 export const selectBannerTest = async (
     targeting: BannerTargeting,
     pageTracking: PageTracking,
@@ -113,6 +116,11 @@ export const selectBannerTest = async (
 
     if (forcedTestVariant) {
         return Promise.resolve(getForcedVariant(forcedTestVariant, tests, baseUrl, targeting));
+    }
+
+    const targetingTest = selectTargetingTest(targeting.mvtId, targeting, bannerTargetingTests);
+    if (targetingTest && !targetingTest.canShow) {
+        return Promise.resolve(null);
     }
 
     for (const test of tests) {
@@ -138,6 +146,7 @@ export const selectBannerTest = async (
                 variant,
                 moduleUrl: `${baseUrl}/${variant.modulePathBuilder(targeting.modulesVersion)}`,
                 moduleName: variant.moduleName,
+                secondaryAbTest: targetingTest ? targetingTest : undefined,
             };
 
             return Promise.resolve(bannerTestSelection);

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -146,7 +146,7 @@ export const selectBannerTest = async (
                 variant,
                 moduleUrl: `${baseUrl}/${variant.modulePathBuilder(targeting.modulesVersion)}`,
                 moduleName: variant.moduleName,
-                targetingAbTest: targetingTest ? targetingTest : undefined,
+                targetingAbTest: targetingTest ? targetingTest.test : undefined,
             };
 
             return Promise.resolve(bannerTestSelection);

--- a/packages/shared/src/lib/tracking.test.ts
+++ b/packages/shared/src/lib/tracking.test.ts
@@ -14,6 +14,10 @@ describe('addTrackingParams', () => {
             campaignId: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
             abTestName: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
             abTestVariant: 'v2_stay_quiet',
+            targetingAbTest: {
+                testName: 'my-tracking-test',
+                variantName: 'control',
+            },
             referrerUrl:
                 'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
         });
@@ -24,7 +28,8 @@ describe('addTrackingParams', () => {
         const got = addTrackingParams(buttonBaseUrl, trackingData, numArticles);
 
         const want =
-            'https://support.theguardian.com/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=88';
+            'https://support.theguardian.com/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTests%22%3A%5B%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%7B%22name%22%3A%22my-tracking-test%22%2C%22variant%22%3A%22control%22%7D%5D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=88';
+
         expect(got).toEqual(want);
     });
     it('should return a correctly formatted URL when the base URL already has a query string', () => {
@@ -46,7 +51,7 @@ describe('addTrackingParams', () => {
         const got = addTrackingParams(buttonBaseUrl, trackingData, numArticles);
 
         const want =
-            'https://support.theguardian.com/contribute/climate-pledge-2019?foo=bar&REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=88';
+            'https://support.theguardian.com/contribute/climate-pledge-2019?foo=bar&REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTests%22%3A%5B%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%5D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=88';
         expect(got).toEqual(want);
     });
 });
@@ -93,7 +98,7 @@ describe('addRegionIdAndTrackingParamsToSupportUrl', () => {
         );
 
         const want =
-            'https://support.theguardian.com/uk/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTest%22%3A%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=88';
+            'https://support.theguardian.com/uk/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTests%22%3A%5B%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%5D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=88';
         expect(got).toEqual(want);
     });
 });

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -26,7 +26,7 @@ export const addTrackingParams = (
                 name: params.abTestName,
                 variant: params.abTestVariant,
             },
-            secondaryAbTest: params.secondaryAbTest,
+            targetingAbTest: params.targetingAbTest,
             referrerPageviewId: params.ophanPageId,
             referrerUrl: params.referrerUrl,
             isRemote: true, // Temp param to indicate served by remote service

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -93,6 +93,13 @@ const createEventFromTracking = (action: OphanAction) => {
                   }
                 : null;
 
+        const targetingAbTest = tracking.targetingAbTest
+            ? {
+                  name: tracking.targetingAbTest.testName,
+                  variant: tracking.targetingAbTest.variantName,
+              }
+            : null;
+
         return {
             component: {
                 componentType,
@@ -101,6 +108,7 @@ const createEventFromTracking = (action: OphanAction) => {
                 id: componentId,
             },
             ...(abTest ? { abTest } : {}),
+            ...(targetingAbTest ? { targetingAbTest } : {}),
             action,
         };
     };

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -26,6 +26,7 @@ export const addTrackingParams = (
                 name: params.abTestName,
                 variant: params.abTestVariant,
             },
+            secondaryAbTest: params.secondaryAbTest,
             referrerPageviewId: params.ophanPageId,
             referrerUrl: params.referrerUrl,
             isRemote: true, // Temp param to indicate served by remote service

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -35,7 +35,7 @@ export const addTrackingParams = (
             componentId: params.campaignCode,
             componentType: params.componentType,
             campaignCode: params.campaignCode,
-            abTests: abTests,
+            abTests,
             referrerPageviewId: params.ophanPageId,
             referrerUrl: params.referrerUrl,
             isRemote: true, // Temp param to indicate served by remote service

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -16,17 +16,26 @@ export const addTrackingParams = (
     params: Tracking,
     numArticles?: number,
 ): string => {
+    const abTests = [
+        {
+            name: params.abTestName,
+            variant: params.abTestVariant,
+        },
+    ];
+    if (params.targetingAbTest) {
+        abTests.push({
+            name: params.targetingAbTest.testName,
+            variant: params.targetingAbTest.variantName,
+        });
+    }
+
     const acquisitionData = encodeURIComponent(
         JSON.stringify({
             source: params.platformId,
             componentId: params.campaignCode,
             componentType: params.componentType,
             campaignCode: params.campaignCode,
-            abTest: {
-                name: params.abTestName,
-                variant: params.abTestVariant,
-            },
-            targetingAbTest: params.targetingAbTest,
+            abTests: abTests,
             referrerPageviewId: params.ophanPageId,
             referrerUrl: params.referrerUrl,
             isRemote: true, // Temp param to indicate served by remote service

--- a/packages/shared/src/types/banner.ts
+++ b/packages/shared/src/types/banner.ts
@@ -17,7 +17,7 @@ import {
     Tracking,
     PageTracking,
     trackingSchema,
-    SecondaryAbTest,
+    TargetingAbTest,
 } from './shared';
 
 export type BannerTargeting = {
@@ -105,7 +105,7 @@ export interface BannerTestSelection {
     variant: BannerVariant;
     moduleUrl: string;
     moduleName: string;
-    secondaryAbTest?: SecondaryAbTest;
+    targetingAbTest?: TargetingAbTest;
 }
 
 export interface BannerProps {

--- a/packages/shared/src/types/banner.ts
+++ b/packages/shared/src/types/banner.ts
@@ -17,6 +17,7 @@ import {
     Tracking,
     PageTracking,
     trackingSchema,
+    SecondaryAbTest,
 } from './shared';
 
 export type BannerTargeting = {
@@ -104,6 +105,7 @@ export interface BannerTestSelection {
     variant: BannerVariant;
     moduleUrl: string;
     moduleName: string;
+    secondaryAbTest?: SecondaryAbTest;
 }
 
 export interface BannerProps {

--- a/packages/shared/src/types/ophan.ts
+++ b/packages/shared/src/types/ophan.ts
@@ -29,13 +29,16 @@ export type OphanComponent = {
     labels?: string[];
 };
 
+interface OphanAbTest {
+    name: string;
+    variant: string;
+}
+
 export type OphanComponentEvent = {
     component: OphanComponent;
     action: OphanAction;
     value?: string;
     id?: string;
-    abTest?: {
-        name: string;
-        variant: string;
-    };
+    abTest?: OphanAbTest;
+    targetingAbTest?: OphanAbTest;
 };

--- a/packages/shared/src/types/shared.ts
+++ b/packages/shared/src/types/shared.ts
@@ -145,6 +145,16 @@ export interface ControlProportionSettings {
 
 export type Stage = 'PROD' | 'CODE' | 'DEV';
 
+/**
+ * Secondary tests are for experimenting with targeting, e.g. measuring the impact of not showing banners on certain sections.
+ * It is not a message test and should not affect what the user sees once they're in a test.
+ * But we do need to carry the test/variant names through in the tracking.
+ */
+export interface SecondaryAbTest {
+    testName: string;
+    variantName: string;
+}
+
 export type TestTracking = {
     abTestName: string;
     abTestVariant: string;
@@ -153,6 +163,7 @@ export type TestTracking = {
     componentType: OphanComponentType;
     products?: OphanProduct[];
     labels?: string[];
+    secondaryAbTest?: SecondaryAbTest;
 };
 
 export type PageTracking = {

--- a/packages/shared/src/types/shared.ts
+++ b/packages/shared/src/types/shared.ts
@@ -150,7 +150,7 @@ export type Stage = 'PROD' | 'CODE' | 'DEV';
  * It is not a message test and should not affect what the user sees once they're in a test.
  * But we do need to carry the test/variant names through in the tracking.
  */
-export interface SecondaryAbTest {
+export interface TargetingAbTest {
     testName: string;
     variantName: string;
 }
@@ -163,7 +163,7 @@ export type TestTracking = {
     componentType: OphanComponentType;
     products?: OphanProduct[];
     labels?: string[];
-    secondaryAbTest?: SecondaryAbTest;
+    targetingAbTest?: TargetingAbTest;
 };
 
 export type PageTracking = {

--- a/packages/shared/src/types/shared.ts
+++ b/packages/shared/src/types/shared.ts
@@ -146,7 +146,7 @@ export interface ControlProportionSettings {
 export type Stage = 'PROD' | 'CODE' | 'DEV';
 
 /**
- * Secondary tests are for experimenting with targeting.
+ * Targeting tests are for experimenting with targeting rules.
  * It is not a message test and should not affect what the user sees once they're in a test.
  * But we do need to carry the test/variant names through in the tracking.
  */

--- a/packages/shared/src/types/shared.ts
+++ b/packages/shared/src/types/shared.ts
@@ -146,7 +146,7 @@ export interface ControlProportionSettings {
 export type Stage = 'PROD' | 'CODE' | 'DEV';
 
 /**
- * Secondary tests are for experimenting with targeting, e.g. measuring the impact of not showing banners on certain sections.
+ * Secondary tests are for experimenting with targeting.
  * It is not a message test and should not affect what the user sees once they're in a test.
  * But we do need to carry the test/variant names through in the tracking.
  */


### PR DESCRIPTION
A targeting test seeks to understand the impact of changes to targeting rules.
E.g. a targeting test could measure the impact of:
- not displaying banners on certain sections
- only displaying banners on a page view after finishing an article

They should be independent of _messaging_ AB tests, though they will determine whether a user can actually be put in any message test.

In the past it has been difficult to run these types of tests, and they block our ability to run message tests. But we now have [the ability to run independent tests concurrently](https://github.com/guardian/support-dotcom-components/pull/540).

This PR introduces the `TargetingTest` type, initially just for use with the banner.
A user is assigned to a variant in a targeting test in the usual way. But the variant then determines if the user should see a message at all, based on the user's targeting data.
Each variant in a `TargetingTest` has a function, `canShow: (targeting: T) => boolean`. This decides if the user can be put into a message test.

The response to the client now includes a `targetingAbTest` value if the user is in a targeting test, in addition to the standard messaging AB test/variant names.
We'll need to track this `targetingAbTest` in views/conversions, to measure a test's impact on views and conversion rates.

Response from SDC with the new `targetingAbTest` field:
![Screen Shot 2021-10-18 at 16 28 54](https://user-images.githubusercontent.com/1513454/137762373-90c8cde9-cd7a-4824-b446-a990bdd98c1b.png)

Test info carries through to support-frontend via the url querystring:
![Screen Shot 2021-10-21 at 09 05 00](https://user-images.githubusercontent.com/1513454/138236985-57b112fc-858c-49db-9a8b-037b796af453.png)



#### Still TODO:

- [x] Enable tracking of channel targeting tests in ophan component events