### PR TITLE
Add the option to show a sign in link to the epic

### DIFF
--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerSignInCta.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerSignInCta.tsx
@@ -5,7 +5,7 @@ import { Link } from '@guardian/src-link';
 
 // TODO: replace with correct UTM parameters
 const signInUrl =
-    'https://profile.theguardian.com/signin??utm_source=gdnwb&utm_medium=banner&utm_campaign=SigninContributionsBanner_Exisitng&CMP_TU=mrtn&CMP_BUNIT=subs';
+    'https://profile.theguardian.com/signin??utm_source=gdnwb&utm_medium=banner&utm_campaign=SigninContributionsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs';
 
 const boldText = css`
     font-family: inherit;

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -582,3 +582,27 @@ WithChoiceCards.args = {
         },
     },
 };
+
+export const WithSignInLink = Template.bind({});
+WithSignInLink.args = {
+    variant: {
+        ...props.variant,
+        showSignInLink: true,
+    },
+};
+
+export const WithReminderAndSignInLink = Template.bind({});
+WithReminder.args = {
+    variant: {
+        ...props.variant,
+        showSignInLink: true,
+        secondaryCta: {
+            type: SecondaryCtaType.ContributionsReminder,
+        },
+        showReminderFields: {
+            reminderCta: 'Remind me in May',
+            reminderPeriod: '2020-05-01',
+            reminderLabel: 'May',
+        },
+    },
+};

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -592,7 +592,7 @@ WithSignInLink.args = {
 };
 
 export const WithReminderAndSignInLink = Template.bind({});
-WithReminder.args = {
+WithReminderAndSignInLink.args = {
     variant: {
         ...props.variant,
         showSignInLink: true,

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -19,6 +19,7 @@ import { HasBeenSeen, useHasBeenSeen } from '../../hooks/useHasBeenSeen';
 import { isProd } from '../shared/helpers/stage';
 import { withParsedProps } from '../shared/ModuleWrapper';
 import { ChoiceCardSelection, ContributionsEpicChoiceCards } from './ContributionsEpicChoiceCards';
+import { ContributionsEpicSignInCta } from './ContributionsEpicSignInCta';
 import { countryCodeToCountryGroupId } from '@sdc/shared/lib';
 
 const sendEpicViewEvent = (url: string, countryCode?: string, stage?: Stage): void => {
@@ -329,6 +330,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 numArticles={articleCounts.forTargetedWeeks}
                 tracking={ophanTracking}
             />
+            {variant.showSignInLink && <ContributionsEpicSignInCta />}
 
             {showChoiceCards && choiceCardSelection && choiceCardAmounts && (
                 <ContributionsEpicChoiceCards

--- a/packages/modules/src/modules/epics/ContributionsEpicSignInCta.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicSignInCta.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { Link } from '@guardian/src-link';
+import { body } from '@guardian/src-foundations/typography';
+import { neutral } from '@guardian/src-foundations';
+
+const signInLink = css`
+    margin: 0;
+    border-top: 1px solid ${neutral[0]};
+`;
+
+const signInLinkText = css`
+    ${body.medium({ fontWeight: 'bold' })};
+`;
+
+// TODO: replace with correct UTM parameters
+const signInUrl =
+    'https://profile.theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs';
+
+export const ContributionsEpicSignInCta: React.FC = () => {
+    return (
+        <p css={[signInLink, signInLinkText]}>
+            Already a supporter?{' '}
+            <Link href={signInUrl} priority="secondary" cssOverrides={signInLinkText}>
+                Sign in
+            </Link>{' '}
+            and we promise to ask you less.
+        </p>
+    );
+};

--- a/packages/modules/src/modules/epics/ContributionsEpicSignInCta.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicSignInCta.tsx
@@ -16,7 +16,7 @@ const signInLinkText = css`
 `;
 
 const signInUrl =
-    'https://profile.theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SigninEPIC_Exisitng&CMP_TU=mrtn&CMP_BUNIT=subs';
+    'https://profile.theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SigninEPIC_Existing&CMP_TU=mrtn&CMP_BUNIT=subs';
 
 interface ContributionsEpicSignInProps {
     submitComponentEvent?: (event: OphanComponentEvent) => void;

--- a/packages/modules/src/modules/epics/ContributionsEpicSignInCta.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicSignInCta.tsx
@@ -3,6 +3,8 @@ import { css } from '@emotion/react';
 import { Link } from '@guardian/src-link';
 import { body } from '@guardian/src-foundations/typography';
 import { neutral } from '@guardian/src-foundations';
+import { OphanComponentEvent } from '@sdc/shared/types';
+import { OPHAN_COMPONENT_SIGN_IN } from './utils/ophan';
 
 const signInLink = css`
     margin: 0;
@@ -13,15 +15,31 @@ const signInLinkText = css`
     ${body.medium({ fontWeight: 'bold' })};
 `;
 
-// TODO: replace with correct UTM parameters
 const signInUrl =
     'https://profile.theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SigninEPIC_Exisitng&CMP_TU=mrtn&CMP_BUNIT=subs';
 
-export const ContributionsEpicSignInCta: React.FC = () => {
+interface ContributionsEpicSignInProps {
+    submitComponentEvent?: (event: OphanComponentEvent) => void;
+}
+
+export const ContributionsEpicSignInCta: React.FC<ContributionsEpicSignInProps> = ({
+    submitComponentEvent,
+}: ContributionsEpicSignInProps) => {
+    const onSignInClick = () => {
+        if (submitComponentEvent) {
+            submitComponentEvent(OPHAN_COMPONENT_SIGN_IN);
+        }
+    };
+
     return (
         <p css={[signInLink, signInLinkText]}>
             Already a supporter?{' '}
-            <Link href={signInUrl} priority="secondary" cssOverrides={signInLinkText}>
+            <Link
+                onClick={onSignInClick}
+                href={signInUrl}
+                priority="secondary"
+                cssOverrides={signInLinkText}
+            >
                 Sign in
             </Link>{' '}
             and we promise to ask you less.

--- a/packages/modules/src/modules/epics/ContributionsEpicSignInCta.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicSignInCta.tsx
@@ -15,7 +15,7 @@ const signInLinkText = css`
 
 // TODO: replace with correct UTM parameters
 const signInUrl =
-    'https://profile.theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs';
+    'https://profile.theguardian.com/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SigninEPIC_Exisitng&CMP_TU=mrtn&CMP_BUNIT=subs';
 
 export const ContributionsEpicSignInCta: React.FC = () => {
     return (

--- a/packages/modules/src/modules/epics/utils/ophan.ts
+++ b/packages/modules/src/modules/epics/utils/ophan.ts
@@ -11,6 +11,7 @@ const OPHAN_COMPONENT_ID_ARTICLE_COUNT_STAY_IN = 'contributions-epic-article-cou
 const OPHAN_COMPONENT_ID_ARTICLE_COUNT_OPT_OUT = 'contributions-epic-article-count-opt-out';
 const OPHAN_COMPONENT_ID_ARTICLE_COUNT_STAY_OUT = 'contributions-epic-article-count-stay-out';
 const OPHAN_COMPONENT_ID_ARTICLE_COUNT_OPT_IN = 'contributions-epic-article-count-opt-in';
+const OPHAN_COMPONENT_ID_SIGN_IN = 'contributions-epic-sign-in';
 
 export const getReminderViewEvent = (isSignedIn: boolean): OphanComponentEvent => ({
     component: {
@@ -97,6 +98,14 @@ export const OPHAN_COMPONENT_ARTICLE_COUNT_OPT_IN: OphanComponentEvent = {
     component: {
         componentType: 'ACQUISITIONS_OTHER',
         id: OPHAN_COMPONENT_ID_ARTICLE_COUNT_OPT_IN,
+    },
+    action: 'CLICK',
+};
+
+export const OPHAN_COMPONENT_SIGN_IN: OphanComponentEvent = {
+    component: {
+        componentType: 'ACQUISITIONS_OTHER',
+        id: OPHAN_COMPONENT_ID_SIGN_IN,
     },
     action: 'CLICK',
 };

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -124,6 +124,7 @@ export interface EpicVariant extends Variant {
     // the test + variant. This means users **wont** fall through to a test
     // with lower priority.
     maxViews?: MaxViews;
+    showSignInLink?: boolean;
 }
 
 const variantSchema = z.object({
@@ -139,6 +140,7 @@ const variantSchema = z.object({
     showReminderFields: reminderFieldsSchema.optional(),
     separateArticleCount: separateArticleCountSchema.optional(),
     maxViews: maxViewsSchema.optional(),
+    showSignInLink: z.boolean().optional(),
 });
 
 export type EpicProps = {


### PR DESCRIPTION
## What does this change?
This adds a sign-in link to the epic, controlled by a prop for the variant. This is to enable an A/B test on impact of including a sign in option. See also #539. 

## Images

**Desktop**
![Screenshot 2021-10-15 at 14-26-36 Britain was led by Churchill then – it’s led by a Churchill tribute act now](https://user-images.githubusercontent.com/29146931/137522132-f8fe4ec9-43c7-47b9-8b85-6d84c5d5dcf6.png)

**Tablet**
![Screenshot 2021-10-15 at 14 49 03](https://user-images.githubusercontent.com/29146931/137522674-6973dec3-025b-4880-8c9c-66cb653df1a6.png)

**Mobile**
![Screenshot 2021-10-15 at 14 58 31](https://user-images.githubusercontent.com/29146931/137522726-6d76d9df-842d-459f-83d1-f586f4a3780c.png)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [x] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [x] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [x] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
