### PR TITLE
Give the yellow banner a font colour

### DIFF
--- a/packages/modules/src/modules/banners/contributions/ContributionsBanner.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBanner.tsx
@@ -20,6 +20,7 @@ const styles = {
         overflow: hidden;
         width: 100%;
         background-color: ${brandAlt[400]};
+        color: ${neutral[7]};
         ${from.tablet} {
             border-top: 1px solid ${neutral[7]};
             padding-bottom: 0;


### PR DESCRIPTION
## What does this change?
This gives a baseline `color` value for the yellow contributions banner. Previously the font colour was inherited from the `body` element on the page, but this was causing an issue with special articles which override the defaults on the body, such as https://www.theguardian.com/environment/ng-interactive/2021/oct/14/climate-change-happening-now-stats-graphs-maps-cop26

<img width="1663" alt="Screenshot 2021-10-18 at 12 23 47" src="https://user-images.githubusercontent.com/29146931/137723310-a406893e-fb99-4685-9c69-8adba82d3cec.png">

This change means the basic font colour will always have the appropriate contrast against the yellow background.

## Images

**With fix applied**
<img width="1600" alt="Screenshot 2021-10-18 at 12 38 32" src="https://user-images.githubusercontent.com/29146931/137723542-90ed6238-5308-4741-99dc-6487ba5d0b8c.png">