### PR TITLE
Single contributor model epic test

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1022,7 +1022,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
                       Object {
                         "Ref": "Stage",
                       },
-                      "/single-contributor-propensity-test",
+                      "/single-contributor-propensity-test/*",
                     ],
                   ],
                 },

--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1014,6 +1014,18 @@ chown -R dotcom-components:support /var/log/dotcom-components
                     ],
                   ],
                 },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:s3:::support-admin-console/",
+                      Object {
+                        "Ref": "Stage",
+                      },
+                      "/single-contributor-propensity-test",
+                    ],
+                  ],
+                },
               ],
             },
           ],

--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -239,7 +239,7 @@ export base_url=",
 mkdir /var/log/dotcom-components
 chown -R dotcom-components:support /var/log/dotcom-components
 
-/usr/local/node/pm2 start --uid dotcom-components --gid support server.js --max-memory-restart 3000M
+/usr/local/node/pm2 start --uid dotcom-components --gid support server.js
 
 /opt/aws-kinesis-agent/configure-aws-kinesis-agent ",
                 Object {

--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -239,7 +239,7 @@ export base_url=",
 mkdir /var/log/dotcom-components
 chown -R dotcom-components:support /var/log/dotcom-components
 
-/usr/local/node/pm2 start --uid dotcom-components --gid support server.js
+/usr/local/node/pm2 start --uid dotcom-components --gid support server.js --max-memory-restart 3000M
 
 /opt/aws-kinesis-agent/configure-aws-kinesis-agent ",
                 Object {

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -59,6 +59,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
                     `${this.stage}/banner-deploy/*`,
                     `${this.stage}/channel-switches.json`,
                     `${this.stage}/configured-amounts.json`,
+                    `${this.stage}/single-contributor-propensity-test`,
                 ],
             }),
             new GuGetS3ObjectsPolicy(this, 'S3ReadPolicyGuContributionsPublic', {

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -46,7 +46,7 @@ export base_url=${baseUrl.valueAsString}
 mkdir /var/log/dotcom-components
 chown -R dotcom-components:support /var/log/dotcom-components
 
-/usr/local/node/pm2 start --uid dotcom-components --gid support server.js
+/usr/local/node/pm2 start --uid dotcom-components --gid support server.js --max-memory-restart 3000M
 
 /opt/aws-kinesis-agent/configure-aws-kinesis-agent ${this.region} ${
             elkStream.valueAsString

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -46,7 +46,7 @@ export base_url=${baseUrl.valueAsString}
 mkdir /var/log/dotcom-components
 chown -R dotcom-components:support /var/log/dotcom-components
 
-/usr/local/node/pm2 start --uid dotcom-components --gid support server.js --max-memory-restart 3000M
+/usr/local/node/pm2 start --uid dotcom-components --gid support server.js
 
 /opt/aws-kinesis-agent/configure-aws-kinesis-agent ${this.region} ${
             elkStream.valueAsString

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -59,7 +59,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
                     `${this.stage}/banner-deploy/*`,
                     `${this.stage}/channel-switches.json`,
                     `${this.stage}/configured-amounts.json`,
-                    `${this.stage}/single-contributor-propensity-test`,
+                    `${this.stage}/single-contributor-propensity-test/*`,
                 ],
             }),
             new GuGetS3ObjectsPolicy(this, 'S3ReadPolicyGuContributionsPublic', {

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -270,7 +270,7 @@ export const getContributionsEpic: (
     const countryGroupId = countryCodeToCountryGroupId(countryCode || 'GBPCountries');
     const [choiceCardSelection, setChoiceCardSelection] = useState<ChoiceCardSelection | undefined>(
         variant.choiceCardAmounts && {
-            frequency: 'MONTHLY',
+            frequency: variant.defaultChoiceCardFrequency || 'MONTHLY',
             amount: variant.choiceCardAmounts[countryGroupId]['control']['MONTHLY']['amounts'][1],
         },
     );

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -40,6 +40,7 @@ import {
     epicArticleCountByTagTestGlobal,
     epicArticleCountByTagTestUS,
 } from './tests/epics/articleCountByTagTest';
+import { singleContributorPropensityTest } from './tests/epics/singleContributorPropensityTest/singleContributorPropensityTest';
 
 interface EpicDataResponse {
     data?: {
@@ -124,7 +125,11 @@ const getArticleEpicTests = async (
         ]);
 
         const hardcodedTests = enableHardcodedEpicTests
-            ? [epicArticleCountByTagTestUS, epicArticleCountByTagTestGlobal]
+            ? [
+                  singleContributorPropensityTest,
+                  epicArticleCountByTagTestUS,
+                  epicArticleCountByTagTestGlobal,
+              ]
             : [];
 
         if (isForcingTest) {

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -40,7 +40,7 @@ import {
     epicArticleCountByTagTestGlobal,
     epicArticleCountByTagTestUS,
 } from './tests/epics/articleCountByTagTest';
-import { singleContributorPropensityTest } from './tests/epics/singleContributorPropensityTest/singleContributorPropensityTest';
+import { singleContributorPropensityTests } from './tests/epics/singleContributorPropensityTest/singleContributorPropensityTest';
 
 interface EpicDataResponse {
     data?: {
@@ -126,7 +126,7 @@ const getArticleEpicTests = async (
 
         const hardcodedTests = enableHardcodedEpicTests
             ? [
-                  singleContributorPropensityTest,
+                  ...singleContributorPropensityTests,
                   epicArticleCountByTagTestUS,
                   epicArticleCountByTagTestGlobal,
               ]

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -51,6 +51,12 @@ jest.mock('./channelSwitches', () => {
         ),
     };
 });
+jest.mock('./tests/epics/singleContributorPropensityTest/singleContributorPropensityData', () => {
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        fetchSingleContributorPropensityIds: jest.fn().mockImplementation(() => {}),
+    };
+});
 jest.mock('./choiceCardAmounts', () => {
     return {
         cachedChoiceCardAmounts: jest.fn().mockImplementation(() =>

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -97,6 +97,11 @@ export const isOn: Filter = {
     test: (test): boolean => test.isOn,
 };
 
+export const canShow = (targeting: EpicTargeting): Filter => ({
+    id: 'canShow',
+    test: (test): boolean => (test.canShow ? test.canShow(targeting) : true),
+});
+
 export const userInTest = (mvtId: number): Filter => ({
     id: 'userInTest',
     test: (test: EpicTest): boolean => userIsInTest(test, mvtId),
@@ -218,6 +223,7 @@ export const findTestAndVariant = (
         return [
             shouldNotRender(epicType),
             isOn,
+            canShow(targeting),
             isNotExpired(),
             hasSectionOrTags,
             userInTest(targeting.mvtId || 1),

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
@@ -4,14 +4,18 @@ import { logger } from '../../../utils/logging';
 
 const singleContributorPropensityIds: Set<string> = new Set<string>();
 
-logger.info('Loading singleContributorPropensityIds...');
-streamS3DataByLine(
-    'support-admin-console',
-    `${isProd ? 'PROD' : 'CODE'}/single-contributor-propensity-test/ids.txt`,
-    line => singleContributorPropensityIds.add(line),
-    () =>
-        logger.info(`Loaded ${singleContributorPropensityIds.size} singleContributorPropensityIds`),
-);
+const fetchSingleContributorPropensityIds = (): void => {
+    logger.info('Loading singleContributorPropensityIds...');
+    streamS3DataByLine(
+        'support-admin-console',
+        `${isProd ? 'PROD' : 'CODE'}/single-contributor-propensity-test/ids.txt`,
+        line => singleContributorPropensityIds.add(line),
+        () =>
+            logger.info(`Loaded ${singleContributorPropensityIds.size} singleContributorPropensityIds`),
+    );
+};
+
+fetchSingleContributorPropensityIds();
 
 export const inSingleContributorPropensityTest = (id: string): boolean =>
     singleContributorPropensityIds.has(id);

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
@@ -1,0 +1,17 @@
+import { isProd } from '../../../lib/env';
+import { streamS3DataByLine } from '../../../utils/S3';
+import { logger } from '../../../utils/logging';
+
+const singleContributorPropensityIds: Set<string> = new Set<string>();
+
+logger.info('Loading singleContributorPropensityIds...');
+streamS3DataByLine(
+    'support-admin-console',
+    `${isProd ? 'PROD' : 'CODE'}/single-contributor-propensity-test/ids.txt`,
+    line => singleContributorPropensityIds.add(line),
+    () =>
+        logger.info(`Loaded ${singleContributorPropensityIds.size} singleContributorPropensityIds`),
+);
+
+export const inSingleContributorPropensityTest = (id: string): boolean =>
+    singleContributorPropensityIds.has(id);

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
@@ -6,7 +6,7 @@ const singleContributorPropensityIds: Set<string> = new Set<string>();
 
 const fetchSingleContributorPropensityIds = (): void => {
     logInfo('Loading singleContributorPropensityIds...');
-    console.log('MEMORY1', process.memoryUsage().heapUsed / 1024 / 1024);
+    logInfo(`MEMORY1: ${process.memoryUsage().heapUsed / 1024 / 1024}`);
     streamS3DataByLine(
         'support-admin-console',
         `${isProd ? 'PROD' : 'CODE'}/single-contributor-propensity-test/ids.txt`,
@@ -20,7 +20,7 @@ const fetchSingleContributorPropensityIds = (): void => {
         },
         () => {
             logInfo(`Loaded ${singleContributorPropensityIds.size} singleContributorPropensityIds`);
-            console.log('MEMORY2', process.memoryUsage().heapUsed / 1024 / 1024);
+            logInfo(`MEMORY2: ${process.memoryUsage().heapUsed / 1024 / 1024}`);
         },
     );
 };

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
@@ -6,12 +6,22 @@ const singleContributorPropensityIds: Set<string> = new Set<string>();
 
 const fetchSingleContributorPropensityIds = (): void => {
     logInfo('Loading singleContributorPropensityIds...');
+    console.log('MEMORY1', process.memoryUsage().heapUsed / 1024 / 1024);
     streamS3DataByLine(
         'support-admin-console',
         `${isProd ? 'PROD' : 'CODE'}/single-contributor-propensity-test/ids.txt`,
-        line => singleContributorPropensityIds.add(line),
-        () =>
-            logInfo(`Loaded ${singleContributorPropensityIds.size} singleContributorPropensityIds`),
+        line => {
+            if (singleContributorPropensityIds.size % 10000 === 0) {
+                logInfo(
+                    `...got ${singleContributorPropensityIds.size} singleContributorPropensityIds`,
+                );
+            }
+            singleContributorPropensityIds.add(line);
+        },
+        () => {
+            logInfo(`Loaded ${singleContributorPropensityIds.size} singleContributorPropensityIds`);
+            console.log('MEMORY2', process.memoryUsage().heapUsed / 1024 / 1024);
+        },
     );
 };
 

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
@@ -6,21 +6,12 @@ const singleContributorPropensityIds: Set<string> = new Set<string>();
 
 const fetchSingleContributorPropensityIds = (): void => {
     logInfo('Loading singleContributorPropensityIds...');
-    logInfo(`MEMORY1: ${process.memoryUsage().heapUsed / 1024 / 1024}`);
     streamS3DataByLine(
         'support-admin-console',
         `${isProd ? 'PROD' : 'CODE'}/single-contributor-propensity-test/ids.txt`,
-        line => {
-            if (singleContributorPropensityIds.size % 10000 === 0) {
-                logInfo(
-                    `...got ${singleContributorPropensityIds.size} singleContributorPropensityIds`,
-                );
-            }
-            singleContributorPropensityIds.add(line);
-        },
+        line => singleContributorPropensityIds.add(line),
         () => {
             logInfo(`Loaded ${singleContributorPropensityIds.size} singleContributorPropensityIds`);
-            logInfo(`MEMORY2: ${process.memoryUsage().heapUsed / 1024 / 1024}`);
         },
     );
 };

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
@@ -1,19 +1,17 @@
 import { isProd } from '../../../lib/env';
 import { streamS3DataByLine } from '../../../utils/S3';
-import { logger } from '../../../utils/logging';
+import { logInfo } from '../../../utils/logging';
 
 const singleContributorPropensityIds: Set<string> = new Set<string>();
 
 const fetchSingleContributorPropensityIds = (): void => {
-    logger.info('Loading singleContributorPropensityIds...');
+    logInfo('Loading singleContributorPropensityIds...');
     streamS3DataByLine(
         'support-admin-console',
         `${isProd ? 'PROD' : 'CODE'}/single-contributor-propensity-test/ids.txt`,
         line => singleContributorPropensityIds.add(line),
         () =>
-            logger.info(
-                `Loaded ${singleContributorPropensityIds.size} singleContributorPropensityIds`,
-            ),
+            logInfo(`Loaded ${singleContributorPropensityIds.size} singleContributorPropensityIds`),
     );
 };
 

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityData.ts
@@ -11,7 +11,9 @@ const fetchSingleContributorPropensityIds = (): void => {
         `${isProd ? 'PROD' : 'CODE'}/single-contributor-propensity-test/ids.txt`,
         line => singleContributorPropensityIds.add(line),
         () =>
-            logger.info(`Loaded ${singleContributorPropensityIds.size} singleContributorPropensityIds`),
+            logger.info(
+                `Loaded ${singleContributorPropensityIds.size} singleContributorPropensityIds`,
+            ),
     );
 };
 

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
@@ -37,6 +37,24 @@ export const singleContributorPropensityTest: EpicTest = {
                 type: SecondaryCtaType.ContributionsReminder,
             },
         },
+        {
+            name: 'variant',
+            paragraphs: [
+                '… we have a small favour to ask. Millions are turning to the Guardian for open, independent, quality news every day, and readers in 180 countries around the world now support us financially.',
+                'We believe everyone deserves access to information that’s grounded in science and truth, and analysis rooted in authority and integrity. That’s why we made a different choice: to keep our reporting open for all readers, regardless of where they live or what they can afford to pay. This means more people can be better informed, united, and inspired to take meaningful action.',
+                'In these perilous times, a truth-seeking global news organisation like the Guardian is essential. We have no shareholders or billionaire owner, meaning our journalism is free from commercial and political influence – this makes us different. When it’s never been more important, our independence allows us to fearlessly investigate, challenge and expose those in power.',
+            ],
+            highlightedText:
+                'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+            cta: {
+                baseUrl:
+                    'https://support.theguardian.com/contribute?selected-contribution-type=ONE_OFF',
+                text: 'Support the Guardian',
+            },
+            secondaryCta: {
+                type: SecondaryCtaType.ContributionsReminder,
+            },
+        },
     ],
     highPriority: false,
     useLocalViewLog: false,

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
@@ -1,4 +1,4 @@
-import { Cta, EpicTargeting, EpicTest, SecondaryCta, SecondaryCtaType } from '@sdc/shared/types';
+import { EpicTargeting, EpicTest, SecondaryCtaType } from '@sdc/shared/types';
 import { inSingleContributorPropensityTest } from './singleContributorPropensityData';
 import {
     GLOBAL_PARAGRAPHS,
@@ -8,14 +8,6 @@ import {
     VARIANT_HIGHLIGHTED_TEXT,
 } from './singleContributorPropensityTestCopy';
 import { CountryGroupId } from '@sdc/shared/dist/lib';
-
-const cta: Cta = {
-    baseUrl: 'https://support.theguardian.com/contribute',
-    text: 'Support the Guardian',
-};
-const secondaryCta: SecondaryCta = {
-    type: SecondaryCtaType.ContributionsReminder,
-};
 
 const singleContributorPropensityTest = (
     suffix: string,
@@ -46,8 +38,13 @@ const singleContributorPropensityTest = (
             name: 'control',
             paragraphs,
             highlightedText: controlHighlightedText,
-            cta,
-            secondaryCta,
+            cta: {
+                baseUrl: 'https://support.theguardian.com/contribute',
+                text: 'Support the Guardian',
+            },
+            secondaryCta: {
+                type: SecondaryCtaType.ContributionsReminder,
+            },
             separateArticleCount: {
                 type: 'above',
             },
@@ -56,8 +53,14 @@ const singleContributorPropensityTest = (
             name: 'variant',
             paragraphs,
             highlightedText: VARIANT_HIGHLIGHTED_TEXT,
-            cta,
-            secondaryCta,
+            cta: {
+                baseUrl:
+                    'https://support.theguardian.com/contribute?selected-contribution-type=ONE_OFF',
+                text: 'Support the Guardian',
+            },
+            secondaryCta: {
+                type: SecondaryCtaType.ContributionsReminder,
+            },
             separateArticleCount: {
                 type: 'above',
             },

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
@@ -49,6 +49,7 @@ const singleContributorPropensityTest = (
                 type: 'above',
             },
             showChoiceCards: true,
+            defaultChoiceCardFrequency: 'MONTHLY',
         },
         {
             name: 'variant',
@@ -66,6 +67,7 @@ const singleContributorPropensityTest = (
                 type: 'above',
             },
             showChoiceCards: true,
+            defaultChoiceCardFrequency: 'ONE_OFF',
         },
     ],
     highPriority: false,

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
@@ -40,7 +40,7 @@ const singleContributorPropensityTest = (
             highlightedText: controlHighlightedText,
             cta: {
                 baseUrl: 'https://support.theguardian.com/contribute',
-                text: 'Support the Guardian',
+                text: 'Continue',
             },
             secondaryCta: {
                 type: SecondaryCtaType.ContributionsReminder,
@@ -58,7 +58,7 @@ const singleContributorPropensityTest = (
             cta: {
                 baseUrl:
                     'https://support.theguardian.com/contribute?selected-contribution-type=ONE_OFF',
-                text: 'Support the Guardian',
+                text: 'Continue',
             },
             secondaryCta: {
                 type: SecondaryCtaType.ContributionsReminder,

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
@@ -1,10 +1,31 @@
-import { EpicTargeting, EpicTest, SecondaryCtaType } from '@sdc/shared/types';
+import { Cta, EpicTargeting, EpicTest, SecondaryCta, SecondaryCtaType } from '@sdc/shared/types';
 import { inSingleContributorPropensityTest } from './singleContributorPropensityData';
+import {
+    GLOBAL_PARAGRAPHS,
+    HIGHLIGHTED_TEXT,
+    UK_AU_US_PARAGRAPHS,
+    US_HIGHLIGHTED_TEXT,
+} from './singleContributorPropensityTestCopy';
+import { CountryGroupId } from '@sdc/shared/dist/lib';
 
-export const singleContributorPropensityTest: EpicTest = {
-    name: '2021-10-18_SingleContributorPropensityTest',
+const cta: Cta = {
+    baseUrl: 'https://support.theguardian.com/contribute',
+    text: 'Support the Guardian',
+};
+const secondaryCta: SecondaryCta = {
+    type: SecondaryCtaType.ContributionsReminder,
+};
+
+const singleContributorPropensityTest = (
+    suffix: string,
+    paragraphs: string[],
+    highlightedText: string,
+    hasCountryName: boolean,
+    locations: CountryGroupId[],
+): EpicTest => ({
+    name: `2021-10-18_SingleContributorPropensityTest__${suffix}`,
     isOn: true,
-    locations: [],
+    locations,
     audience: 1,
     tagIds: [],
     sections: [],
@@ -22,37 +43,22 @@ export const singleContributorPropensityTest: EpicTest = {
     variants: [
         {
             name: 'control',
-            paragraphs: [
-                '… we have a small favour to ask. Millions are turning to the Guardian for open, independent, quality news every day, and readers in 180 countries around the world now support us financially.',
-                'We believe everyone deserves access to information that’s grounded in science and truth, and analysis rooted in authority and integrity. That’s why we made a different choice: to keep our reporting open for all readers, regardless of where they live or what they can afford to pay. This means more people can be better informed, united, and inspired to take meaningful action.',
-                'In these perilous times, a truth-seeking global news organisation like the Guardian is essential. We have no shareholders or billionaire owner, meaning our journalism is free from commercial and political influence – this makes us different. When it’s never been more important, our independence allows us to fearlessly investigate, challenge and expose those in power.',
-            ],
-            highlightedText:
-                'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
-            cta: {
-                baseUrl: 'https://support.theguardian.com/contribute',
-                text: 'Support the Guardian',
-            },
-            secondaryCta: {
-                type: SecondaryCtaType.ContributionsReminder,
+            paragraphs,
+            highlightedText,
+            cta,
+            secondaryCta,
+            separateArticleCount: {
+                type: 'above',
             },
         },
         {
             name: 'variant',
-            paragraphs: [
-                '… we have a small favour to ask. Millions are turning to the Guardian for open, independent, quality news every day, and readers in 180 countries around the world now support us financially.',
-                'We believe everyone deserves access to information that’s grounded in science and truth, and analysis rooted in authority and integrity. That’s why we made a different choice: to keep our reporting open for all readers, regardless of where they live or what they can afford to pay. This means more people can be better informed, united, and inspired to take meaningful action.',
-                'In these perilous times, a truth-seeking global news organisation like the Guardian is essential. We have no shareholders or billionaire owner, meaning our journalism is free from commercial and political influence – this makes us different. When it’s never been more important, our independence allows us to fearlessly investigate, challenge and expose those in power.',
-            ],
-            highlightedText:
-                'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
-            cta: {
-                baseUrl:
-                    'https://support.theguardian.com/contribute?selected-contribution-type=ONE_OFF',
-                text: 'Support the Guardian',
-            },
-            secondaryCta: {
-                type: SecondaryCtaType.ContributionsReminder,
+            paragraphs,
+            highlightedText,
+            cta,
+            secondaryCta,
+            separateArticleCount: {
+                type: 'above',
             },
         },
     ],
@@ -63,4 +69,15 @@ export const singleContributorPropensityTest: EpicTest = {
         targeting.showSupportMessaging &&
         !!targeting.browserId &&
         inSingleContributorPropensityTest(targeting.browserId),
-};
+});
+
+export const singleContributorPropensityTests = [
+    singleContributorPropensityTest('US', UK_AU_US_PARAGRAPHS, US_HIGHLIGHTED_TEXT, false, [
+        'UnitedStates',
+    ]),
+    singleContributorPropensityTest('UK_AUS', UK_AU_US_PARAGRAPHS, HIGHLIGHTED_TEXT, false, [
+        'GBPCountries',
+        'AUDCountries',
+    ]),
+    singleContributorPropensityTest('GLOBAL', GLOBAL_PARAGRAPHS, HIGHLIGHTED_TEXT, true, []),
+];

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
@@ -5,6 +5,7 @@ import {
     HIGHLIGHTED_TEXT,
     UK_AU_US_PARAGRAPHS,
     US_HIGHLIGHTED_TEXT,
+    VARIANT_HIGHLIGHTED_TEXT,
 } from './singleContributorPropensityTestCopy';
 import { CountryGroupId } from '@sdc/shared/dist/lib';
 
@@ -19,7 +20,7 @@ const secondaryCta: SecondaryCta = {
 const singleContributorPropensityTest = (
     suffix: string,
     paragraphs: string[],
-    highlightedText: string,
+    controlHighlightedText: string,
     hasCountryName: boolean,
     locations: CountryGroupId[],
 ): EpicTest => ({
@@ -44,7 +45,7 @@ const singleContributorPropensityTest = (
         {
             name: 'control',
             paragraphs,
-            highlightedText,
+            highlightedText: controlHighlightedText,
             cta,
             secondaryCta,
             separateArticleCount: {
@@ -54,7 +55,7 @@ const singleContributorPropensityTest = (
         {
             name: 'variant',
             paragraphs,
-            highlightedText,
+            highlightedText: VARIANT_HIGHLIGHTED_TEXT,
             cta,
             secondaryCta,
             separateArticleCount: {

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
@@ -1,0 +1,48 @@
+import { EpicTargeting, EpicTest, SecondaryCtaType } from '@sdc/shared/types';
+import { inSingleContributorPropensityTest } from './singleContributorPropensityData';
+
+export const singleContributorPropensityTest: EpicTest = {
+    name: '2021-10-18_SingleContributorPropensityTest',
+    isOn: true,
+    locations: [],
+    audience: 1,
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: false,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
+    userCohort: 'AllNonSupporters',
+    isLiveBlog: false,
+    hasCountryName: false,
+    variants: [
+        {
+            name: 'control',
+            paragraphs: [
+                '… we have a small favour to ask. Millions are turning to the Guardian for open, independent, quality news every day, and readers in 180 countries around the world now support us financially.',
+                'We believe everyone deserves access to information that’s grounded in science and truth, and analysis rooted in authority and integrity. That’s why we made a different choice: to keep our reporting open for all readers, regardless of where they live or what they can afford to pay. This means more people can be better informed, united, and inspired to take meaningful action.',
+                'In these perilous times, a truth-seeking global news organisation like the Guardian is essential. We have no shareholders or billionaire owner, meaning our journalism is free from commercial and political influence – this makes us different. When it’s never been more important, our independence allows us to fearlessly investigate, challenge and expose those in power.',
+            ],
+            highlightedText:
+                'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+            cta: {
+                baseUrl: 'https://support.theguardian.com/contribute',
+                text: 'Support the Guardian',
+            },
+            secondaryCta: {
+                type: SecondaryCtaType.ContributionsReminder,
+            },
+        },
+    ],
+    highPriority: false,
+    useLocalViewLog: false,
+    hasArticleCountInCopy: false,
+    canShow: (targeting: EpicTargeting): boolean =>
+        targeting.showSupportMessaging &&
+        !!targeting.browserId &&
+        inSingleContributorPropensityTest(targeting.browserId),
+};

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
@@ -48,6 +48,7 @@ const singleContributorPropensityTest = (
             separateArticleCount: {
                 type: 'above',
             },
+            showChoiceCards: true,
         },
         {
             name: 'variant',
@@ -64,6 +65,7 @@ const singleContributorPropensityTest = (
             separateArticleCount: {
                 type: 'above',
             },
+            showChoiceCards: true,
         },
     ],
     highPriority: false,

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTestCopy.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTestCopy.ts
@@ -1,0 +1,17 @@
+const paragraphs = (firstLine: string): string[] => [
+    `${firstLine} Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.`,
+    'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+    'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+    "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+    'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+];
+
+export const UK_AU_US_PARAGRAPHS = paragraphs('… we have a small favour to ask.');
+export const GLOBAL_PARAGRAPHS = paragraphs(
+    "… as you're joining us today from %%COUNTRY_NAME%%, we have a small favour to ask.",
+);
+
+export const US_HIGHLIGHTED_TEXT =
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.';
+export const HIGHLIGHTED_TEXT =
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.';

--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTestCopy.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTestCopy.ts
@@ -15,3 +15,5 @@ export const US_HIGHLIGHTED_TEXT =
     'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.';
 export const HIGHLIGHTED_TEXT =
     'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.';
+export const VARIANT_HIGHLIGHTED_TEXT =
+    'You can make a contribution from as little as %%CURRENCY_SYMBOL%%1 – a quick, flexible way to show your support for Guardian journalism, and help sustain our future. Thank you.';

--- a/packages/server/src/utils/S3.ts
+++ b/packages/server/src/utils/S3.ts
@@ -49,7 +49,5 @@ export const streamS3DataByLine = (
     if (onComplete) {
         stream.on('close', onComplete);
     }
-    stream.on('error', error =>
-        logError(`Error streaming from S3 for ${bucket}/${key}: ${error}`),
-    );
+    stream.on('error', error => logError(`Error streaming from S3 for ${bucket}/${key}: ${error}`));
 };

--- a/packages/server/src/utils/S3.ts
+++ b/packages/server/src/utils/S3.ts
@@ -2,7 +2,7 @@ import AWS from 'aws-sdk';
 import { GetObjectOutput } from 'aws-sdk/clients/s3';
 import readline from 'readline';
 import { isDev } from '../lib/env';
-import { logger } from './logging';
+import { logError } from './logging';
 
 if (isDev) {
     AWS.config.credentials = new AWS.SharedIniFileCredentials({
@@ -50,6 +50,6 @@ export const streamS3DataByLine = (
         stream.on('close', onComplete);
     }
     stream.on('error', error =>
-        logger.error(`Error streaming from S3 for ${bucket}/${key}: ${error}`),
+        logError(`Error streaming from S3 for ${bucket}/${key}: ${error}`),
     );
 };

--- a/packages/server/src/utils/S3.ts
+++ b/packages/server/src/utils/S3.ts
@@ -1,6 +1,8 @@
 import AWS from 'aws-sdk';
 import { GetObjectOutput } from 'aws-sdk/clients/s3';
+import readline from 'readline';
 import { isDev } from '../lib/env';
+import { logger } from './logging';
 
 if (isDev) {
     AWS.config.credentials = new AWS.SharedIniFileCredentials({
@@ -25,4 +27,29 @@ export const fetchS3Data = (bucket: string, key: string): Promise<string> => {
             }
         })
         .catch(err => Promise.reject(`Failed to fetch S3 object ${bucket}/${key}: ${err}`));
+};
+
+export const streamS3DataByLine = (
+    bucket: string,
+    key: string,
+    onLine: (line: string) => void,
+    onComplete?: () => void,
+): void => {
+    const input = S3.getObject({
+        Bucket: bucket,
+        Key: key,
+    }).createReadStream();
+
+    const stream = readline.createInterface({
+        input,
+        terminal: false,
+    });
+
+    stream.on('line', onLine);
+    if (onComplete) {
+        stream.on('close', onComplete);
+    }
+    stream.on('error', error =>
+        logger.error(`Error streaming from S3 for ${bucket}/${key}: ${error}`),
+    );
 };

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -112,6 +112,7 @@ export interface EpicVariant extends Variant {
     separateArticleCount?: SeparateArticleCount;
     showChoiceCards?: boolean;
     choiceCardAmounts?: ChoiceCardAmounts;
+    defaultChoiceCardFrequency?: ContributionFrequency;
 
     // Variant level maxViews are for special targeting tests. These
     // are handled differently to our usual copy/design tests. To

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -51,7 +51,7 @@ export type EpicTargeting = {
     lastOneOffContributionDate?: number; // Platform to send undefined or a timestamp date
     modulesVersion?: string;
     url?: string;
-    browserId?: string;
+    browserId?: string; // Only present if the user has consented to browserId-based targeting
 };
 
 export type EpicPayload = {

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -46,16 +46,12 @@ export type EpicTargeting = {
     countryCode?: string;
     weeklyArticleHistory?: WeeklyArticleHistory;
     hasOptedOutOfArticleCount: boolean;
-
-    // Note, it turns out that showSupportMessaging (defined in the Members Data
-    // API) does not capture every case of recurring contributors or last
-    // contributions (i.e. the latter two are not simply a subset of the first -
-    // we need all three!).
     showSupportMessaging: boolean;
     isRecurringContributor: boolean;
     lastOneOffContributionDate?: number; // Platform to send undefined or a timestamp date
     modulesVersion?: string;
     url?: string;
+    browserId?: string;
 };
 
 export type EpicPayload = {
@@ -240,4 +236,5 @@ export interface EpicTest extends Test<EpicVariant> {
     controlProportionSettings?: ControlProportionSettings;
 
     isSuperMode?: boolean;
+    canShow?: (targeting: EpicTargeting) => boolean;
 }


### PR DESCRIPTION
We've used a _single contributor rules-based model_ to produce a list of browser IDs which are likely to favour single contributions.
This is a hardcoded AB test to use that list. We hope to measure 2 things:
1. £AV/impression (is the variant better at making money?)
2. Number of targetable browsers (how useful is browser ID based data?)

The list of IDs has been manually uploaded to S3. Each SDC instance loads the list into memory on startup.
If a client request contains a browserId, and it appears in the list, then they are put into the test.
DCR will send the browserId if the user has consented: https://github.com/guardian/dotcom-rendering/pull/3545

I tested this in CODE with 3m (fake) browserIds and the t4g.small still has plenty of spare memory, so no need to change the instance type.


### Control (UK/AUS)
![Screen Shot 2021-11-18 at 13 34 15](https://user-images.githubusercontent.com/1513454/142424948-8e3e5693-0db6-4dd4-abd0-3d3c66c9ead3.png)


### Variant (UK/AUS)
Has different highlighted text and defaults to single:
![Screen Shot 2021-11-18 at 13 50 15](https://user-images.githubusercontent.com/1513454/142427739-cb854ea7-4dd3-4938-b367-661902a62a08.png)

### EU/ROW has different first sentence
![Screen Shot 2021-11-18 at 11 46 57](https://user-images.githubusercontent.com/1513454/142410019-35c1a85b-01aa-4604-a743-73e3caefffcc.png)

### US has different highlighted text in the control only
![Screen Shot 2021-11-18 at 13 52 29](https://user-images.githubusercontent.com/1513454/142428122-1f21eec7-cac8-47bd-ae56-0a62d1b21688.png)


