### PR TITLE
Test suppressing banner on some sections

### DIFF
--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -13,7 +13,8 @@ import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { TestVariant } from '../../lib/params';
 import { userIsInTest } from '../../lib/targeting';
 import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
-import { selectTargetingTest, TargetingTest } from '../../lib/targetingTesting';
+import { selectTargetingTest } from '../../lib/targetingTesting';
+import { bannerTargetingTests } from './bannerTargetingTests';
 
 export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
     switch (true) {
@@ -100,8 +101,6 @@ const getForcedVariant = (
     }
     return null;
 };
-
-const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [];
 
 export const selectBannerTest = async (
     targeting: BannerTargeting,

--- a/packages/server/src/tests/banners/bannerTargetingTests.test.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.test.ts
@@ -1,0 +1,53 @@
+import { variantCanShow } from './bannerTargetingTests';
+import { BannerTargeting } from '@sdc/shared/types';
+
+const targeting: BannerTargeting = {
+    alreadyVisitedCount: 3,
+    shouldHideReaderRevenue: false,
+    isPaidContent: false,
+    showSupportMessaging: true,
+    mvtId: 3,
+    countryCode: 'GB',
+    hasOptedOutOfArticleCount: false,
+};
+
+describe('Section exclusions', () => {
+    it('returns true if no section', () => {
+        const canShow = variantCanShow(targeting);
+        expect(canShow).toBe(true);
+    });
+
+    it('returns true if politics', () => {
+        const canShow = variantCanShow({
+            ...targeting,
+            section: 'politics',
+        });
+        expect(canShow).toBe(true);
+    });
+
+    it('returns false if fashion', () => {
+        const canShow = variantCanShow({
+            ...targeting,
+            section: 'fashion',
+        });
+        expect(canShow).toBe(false);
+    });
+
+    it('returns false if football match report', () => {
+        const canShow = variantCanShow({
+            ...targeting,
+            section: 'football',
+            tags: ['tone/matchreports'],
+        });
+        expect(canShow).toBe(false);
+    });
+
+    it('returns true if football but not match report', () => {
+        const canShow = variantCanShow({
+            ...targeting,
+            section: 'football',
+            tags: ['tone/features'],
+        });
+        expect(canShow).toBe(true);
+    });
+});

--- a/packages/server/src/tests/banners/bannerTargetingTests.test.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.test.ts
@@ -20,7 +20,7 @@ describe('Section exclusions', () => {
     it('returns true if politics', () => {
         const canShow = variantCanShow({
             ...targeting,
-            section: 'politics',
+            sectionId: 'politics',
         });
         expect(canShow).toBe(true);
     });
@@ -28,7 +28,7 @@ describe('Section exclusions', () => {
     it('returns false if fashion', () => {
         const canShow = variantCanShow({
             ...targeting,
-            section: 'fashion',
+            sectionId: 'fashion',
         });
         expect(canShow).toBe(false);
     });
@@ -36,8 +36,8 @@ describe('Section exclusions', () => {
     it('returns false if football match report', () => {
         const canShow = variantCanShow({
             ...targeting,
-            section: 'football',
-            tags: ['tone/matchreports'],
+            sectionId: 'football',
+            tagIds: ['tone/matchreports'],
         });
         expect(canShow).toBe(false);
     });
@@ -45,8 +45,8 @@ describe('Section exclusions', () => {
     it('returns true if football but not match report', () => {
         const canShow = variantCanShow({
             ...targeting,
-            section: 'football',
-            tags: ['tone/features'],
+            sectionId: 'football',
+            tagIds: ['tone/features'],
         });
         expect(canShow).toBe(true);
     });

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -1,21 +1,28 @@
 import { TargetingTest } from '../../lib/targetingTesting';
 import { BannerTargeting } from '@sdc/shared/types';
 
-const isFootballMatch = (targeting: BannerTargeting): boolean => {
-    if (targeting.sectionId === 'football' && targeting.tagIds) {
-        return !!targeting.tagIds.find(
-            tag => tag === 'tone/minutebyminute' || tag === 'tone/matchreports',
-        );
-    }
-    return false;
+type SectionAndTagExclusions = {
+    [sectionId: string]: string[];
+};
+
+const exclusions: SectionAndTagExclusions = {
+    football: ['tone/minutebyminute', 'tone/matchreports'],
+    fashion: [],
+    'tv-and-radio': [],
+    travel: [],
 };
 
 export const variantCanShow = (targeting: BannerTargeting): boolean => {
-    if (targeting.sectionId) {
-        return (
-            !['fashion', 'tv-and-radio', 'travel'].includes(targeting.sectionId) &&
-            !isFootballMatch(targeting)
-        );
+    const { sectionId, tagIds } = targeting;
+
+    if (sectionId && !!exclusions[sectionId]) {
+        const excludedTagIds = exclusions[sectionId];
+        if (!excludedTagIds.length) {
+            return false;
+        }
+
+        const foundTagId = (tagIds || []).some(tag => excludedTagIds.includes(tag));
+        return !foundTagId;
     }
     return true;
 };

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -1,0 +1,38 @@
+import { TargetingTest } from '../../lib/targetingTesting';
+import { BannerTargeting } from '@sdc/shared/types';
+
+const isFootballMatch = (targeting: BannerTargeting): boolean => {
+    if (targeting.section === 'football' && targeting.tags) {
+        return !!targeting.tags.find(
+            tag => tag === 'tone/minutebyminute' || tag === 'tone/matchreports',
+        );
+    }
+    return false;
+};
+
+export const variantCanShow = (targeting: BannerTargeting): boolean => {
+    if (targeting.section) {
+        return (
+            !['fashion', 'tv-and-radio', 'travel'].includes(targeting.section) &&
+            !isFootballMatch(targeting)
+        );
+    }
+    return true;
+};
+
+export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
+    {
+        name: '2021-10-29_BannerTargeting_SectionExclusions',
+        canInclude: () => true,
+        variants: [
+            {
+                name: 'control',
+                canShow: () => true,
+            },
+            {
+                name: 'variant',
+                canShow: variantCanShow,
+            },
+        ],
+    },
+];

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -22,7 +22,7 @@ export const variantCanShow = (targeting: BannerTargeting): boolean => {
 
 export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
     {
-        name: '2021-10-29_BannerTargeting_SectionExclusions',
+        name: '2021-11-04_BannerTargeting_SectionExclusions',
         canInclude: () => true,
         variants: [
             {

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -2,8 +2,8 @@ import { TargetingTest } from '../../lib/targetingTesting';
 import { BannerTargeting } from '@sdc/shared/types';
 
 const isFootballMatch = (targeting: BannerTargeting): boolean => {
-    if (targeting.section === 'football' && targeting.tags) {
-        return !!targeting.tags.find(
+    if (targeting.sectionId === 'football' && targeting.tagIds) {
+        return !!targeting.tagIds.find(
             tag => tag === 'tone/minutebyminute' || tag === 'tone/matchreports',
         );
     }
@@ -11,9 +11,9 @@ const isFootballMatch = (targeting: BannerTargeting): boolean => {
 };
 
 export const variantCanShow = (targeting: BannerTargeting): boolean => {
-    if (targeting.section) {
+    if (targeting.sectionId) {
         return (
-            !['fashion', 'tv-and-radio', 'travel'].includes(targeting.section) &&
+            !['fashion', 'tv-and-radio', 'travel'].includes(targeting.sectionId) &&
             !isFootballMatch(targeting)
         );
     }

--- a/packages/shared/src/types/banner.ts
+++ b/packages/shared/src/types/banner.ts
@@ -32,8 +32,8 @@ export type BannerTargeting = {
     weeklyArticleHistory?: WeeklyArticleHistory;
     hasOptedOutOfArticleCount: boolean;
     modulesVersion?: string;
-    section?: string;
-    tags?: string[];
+    sectionId?: string;
+    tagIds?: string[];
 };
 
 export type BannerDataRequestPayload = {

--- a/packages/shared/src/types/banner.ts
+++ b/packages/shared/src/types/banner.ts
@@ -32,6 +32,8 @@ export type BannerTargeting = {
     weeklyArticleHistory?: WeeklyArticleHistory;
     hasOptedOutOfArticleCount: boolean;
     modulesVersion?: string;
+    section?: string;
+    tags?: string[];
 };
 
 export type BannerDataRequestPayload = {


### PR DESCRIPTION
Co-authored-by: Rik Roots KaliedaRik@users.noreply.github.com

This is a targeting test. We want to measure the impact of not displaying the banner on some low performing sections.

Dotcom must now send sectionId and tagIds:
https://github.com/guardian/frontend/pull/24325
https://github.com/guardian/dotcom-rendering/pull/3574