### PR TITLE
Remove the "6 for 6" Guardian Weekly offer

### DIFF
--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -33,10 +33,10 @@ const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
 const mobileAndDesktopImg =
-    'https://i.guim.co.uk/img/media/d544f4e24e4275d3434e6465d8676d2b5bcd0851/128_122_3218_1543/500.png?quality=85&s=718ce35eab4f021fcba8893be654cfda';
+    'https://i.guim.co.uk/img/media/0682b069cf2e32b987ddcfbb2b549a93be61ae36/0_0_500_240/500.png?quality=85&s=1bf9bd8af343813bd6db3f009fccf385';
 
 const tabletImage =
-    'https://i.guim.co.uk/img/media/a213adf3f68f788b3f9434a1e88787fce1fa10bd/322_0_2430_1632/500.png?quality=85&s=70749c1c97ffaac614c1e357d3e7f616';
+    'https://i.guim.co.uk/img/media/6d601169360b35c705412fbfa163c15f140efc2f/0_0_500_336/500.png?quality=85&s=21fb33ade343b7db222823c4d3160b7f';
 
 // Responsive image props
 const baseImg = {


### PR DESCRIPTION
## What does this change?
This PR accompanies the PR 3316 in support-frontend - [A/B test to remove the "6 for 6" Guardian Weekly offer](https://github.com/guardian/support-frontend/pull/3316).

Specifically, this PR changes a single image that appears in the Guardian Weekly banner promoting the 6-for-6 offer in the Europe region, which included the '6 for 6' copy in the image

### Desktop:
<img width="1664" alt="Screen Shot 2021-11-01 at 09 50 09" src="https://user-images.githubusercontent.com/1513454/139653674-3740e7a1-4bea-4cd8-82d9-33f68105bad8.png">


### Tablet:
<img width="758" alt="Screen Shot 2021-11-01 at 09 48 49" src="https://user-images.githubusercontent.com/1513454/139653586-a6455597-db19-4bf1-bfdb-b392204b65d1.png">
