### PR TITLE
use correct port in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Which need the `@sdc/shared` package to have been built.
 To start the server run
 
 ```bash
-yarn server start
+NODE_OPTIONS="--max-old-space-size=80000" AWS_PROFILE=membership PORT=8082 yarn server start
 ```
 
 This will start `tsc` in `watch` mode to recompile on file changes and `nodemon` to run the resulting javascript and restart after recompilation.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Which need the `@sdc/shared` package to have been built.
 To start the server run
 
 ```bash
-NODE_OPTIONS="--max-old-space-size=80000" AWS_PROFILE=membership PORT=8082 yarn server start
+NODE_OPTIONS="--max-old-space-size=80000" AWS_PROFILE=membership yarn server start
 ```
 
 This will start `tsc` in `watch` mode to recompile on file changes and `nodemon` to run the resulting javascript and restart after recompilation.

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -75,7 +75,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
         ];
 
         const ec2App = new GuEc2App(this, {
-            applicationPort: 3030,
+            applicationPort: 8082,
             app: appName,
             access: { scope: AccessScope.PUBLIC },
             certificateProps: {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -479,7 +479,7 @@ app.post('/puzzles', async (req: express.Request, res: express.Response) => {
 
 app.use(errorHandlingMiddleware);
 
-const PORT = process.env.PORT || 3030;
+const PORT = process.env.PORT || 8082;
 
 app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
 


### PR DESCRIPTION
It seems to try to use 3030 which classes with dotcom rendering.  This shows the command that seems to work, as I used that last time.