### PR TITLE
Any cta closes the banner

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -149,32 +149,26 @@ const withBannerData = (
         };
     };
 
-    const clickHandlerFor = (componentId: string) => {
+    const clickHandlerFor = (componentId: string, close: boolean) => {
         return (): void => {
             const componentClickEvent = createClickEventFromTracking(tracking, componentId);
             if (submitComponentEvent) {
                 submitComponentEvent(componentClickEvent);
             }
+            if (close) {
+                onClose();
+            }
         };
     };
 
-    const onCtaClick = clickHandlerFor(componentIds.cta);
-    const onSecondaryCtaClick = clickHandlerFor(componentIds.secondaryCta);
-    const onReminderCtaClick = clickHandlerFor(componentIds.reminderCta);
-    const onReminderSetClick = clickHandlerFor(componentIds.reminderSet);
-    const onReminderCloseClick = clickHandlerFor(componentIds.reminderClose);
-
-    const onCloseClick = (): void => {
-        clickHandlerFor(componentIds.close)();
-        onClose();
-    };
-
-    const onNotNowClick = (): void => {
-        clickHandlerFor(componentIds.notNow)();
-        onClose();
-    };
-
-    const onSignInClick = clickHandlerFor(componentIds.signIn);
+    const onCtaClick = clickHandlerFor(componentIds.cta, true);
+    const onSecondaryCtaClick = clickHandlerFor(componentIds.secondaryCta, true);
+    const onReminderCtaClick = clickHandlerFor(componentIds.reminderCta, false);
+    const onReminderSetClick = clickHandlerFor(componentIds.reminderSet, false);
+    const onReminderCloseClick = clickHandlerFor(componentIds.reminderClose, false);
+    const onCloseClick = clickHandlerFor(componentIds.close, true);
+    const onNotNowClick = clickHandlerFor(componentIds.notNow, true);
+    const onSignInClick = clickHandlerFor(componentIds.signIn, false);
 
     try {
         const renderedContent = content && buildRenderedContent(content);


### PR DESCRIPTION
Currently if a user clicks the primary or secondary cta (which typically take them to the support site or an article), the banner is not dismissed. This means they'll still see it on subsequent page views, which is a poor user experience.

With this PR any primary or secondary cta click will also dismiss the banner, meaning the user will not see it again until the next banner redeploy.