### PR TITLE
Add visually hidden legends to epic choice cards

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -4,6 +4,7 @@ import { ChoiceCardAmounts, ContributionFrequency, OphanComponentEvent } from '@
 import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib/geolocation';
 import { css } from '@emotion/react';
 import { until } from '@guardian/src-foundations/mq';
+import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { countryCodeToCountryGroupId } from '@sdc/shared/lib';
 
 const frequencyChoiceCardGroupOverrides = css`
@@ -21,14 +22,7 @@ const frequencyChoiceCardGroupOverrides = css`
 
 const hideChoiceCardGroupLegend = css`
     legend {
-        border: 0;
-        clip: rect(0 0 0 0);
-        height: 1px;
-        margin: -1px;
-        overflow: hidden;
-        padding: 0;
-        position: absolute;
-        width: 1px;
+        ${visuallyHidden};
     }
 `;
 

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -19,6 +19,19 @@ const frequencyChoiceCardGroupOverrides = css`
     }
 `;
 
+const hideChoiceCardGroupLegend = css`
+    legend {
+        border: 0;
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+    }
+`;
+
 // This `position: relative` is necessary to stop it jumping to the top of the page when a button is clicked
 const container = css`
     position: relative;
@@ -90,7 +103,8 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
             <ChoiceCardGroup
                 name="contribution-frequency"
                 columns={3}
-                css={frequencyChoiceCardGroupOverrides}
+                css={[frequencyChoiceCardGroupOverrides, hideChoiceCardGroupLegend]}
+                label="Contribution frequency"
             >
                 <ChoiceCard
                     label="Single"
@@ -115,7 +129,11 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
                 />
             </ChoiceCardGroup>
             <br />
-            <ChoiceCardGroup name="contribution-amount">
+            <ChoiceCardGroup
+                name="contribution-amount"
+                label="Contribution amount"
+                css={hideChoiceCardGroupLegend}
+            >
                 <ChoiceCard
                     value="first"
                     label={`${currencySymbol}${


### PR DESCRIPTION
## What does this change?
This adds visually hidden legends to epic choice cards to improve accessibility for screen readers and add context to the radio buttons

This approach will be updated once the `hideLabel` prop is [available to use in source](https://github.com/guardian/source/pull/1147)