### PR TITLE
Epic article count by tag test

### DIFF
--- a/packages/modules/src/lib/replaceArticleCount.tsx
+++ b/packages/modules/src/lib/replaceArticleCount.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ArticleCountOptOutPopup, OphanTracking } from '../modules/shared/ArticleCountOptOutPopup';
 import { ArticleCountOptOutType } from '../modules/shared/ArticleCountOptOutPopup';
 
-export const replaceArticleCount = (
+export const replaceArticleCountWithLink = (
     text: string,
     numArticles: number,
     articleCountOptOutType: ArticleCountOptOutType,
@@ -36,4 +36,17 @@ export const replaceArticleCount = (
     );
 
     return elements;
+};
+
+export const replaceArticleCount = (
+    text: string,
+    numArticles: number,
+    articleCountOptOutType: ArticleCountOptOutType,
+    tracking?: OphanTracking,
+    optOutLink: boolean = true,
+): Array<JSX.Element> | JSX.Element => {
+    if (optOutLink) {
+        return replaceArticleCountWithLink(text, numArticles, articleCountOptOutType, tracking);
+    }
+    return <>{text.replace(/%%ARTICLE_COUNT%%/, `${numArticles}`)}</>;
 };

--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -36,7 +36,7 @@ export interface ContributionsReminderTracking {
 export interface BannerRenderedContent {
     heading: JSX.Element | JSX.Element[] | null;
     messageText: JSX.Element | JSX.Element[];
-    highlightedText?: JSX.Element[] | null;
+    highlightedText?: JSX.Element | JSX.Element[] | null;
     primaryCta: BannerEnrichedCta | null;
     secondaryCta: BannerEnrichedSecondaryCta | null;
 }

--- a/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerBody.tsx
+++ b/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerBody.tsx
@@ -30,8 +30,8 @@ const styles = {
 interface InvestigationsMomentBannerBodyProps {
     messageText: JSX.Element | JSX.Element[];
     mobileMessageText: JSX.Element | JSX.Element[] | null;
-    highlightedText: JSX.Element[] | null;
-    mobileHighlightedText: JSX.Element[] | null;
+    highlightedText: JSX.Element | JSX.Element[] | null;
+    mobileHighlightedText: JSX.Element | JSX.Element[] | null;
 }
 
 export function InvestigationsMomentBannerBody({

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -252,10 +252,9 @@ const EpicBody: React.FC<BodyProps> = ({
     );
 };
 
-// TODO: We'll have to turn this into a function that returns an Epic
-// e.g https://github.com/guardian/support-dotcom-components/pull/456/files#diff-ac06266d74967899108118ed90d5ad5bd8bf6f6ea351b83740679543bb591788R194
-// because the 3rd variant will need to be a new module
-const ContributionsEpic: React.FC<EpicProps> = ({
+export const getContributionsEpic: (
+    aboveArticleCountByTag: boolean,
+) => React.FC<EpicProps> = aboveArticleCountByTag => ({
     variant,
     tracking,
     countryCode,
@@ -351,6 +350,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                         onArticleCountOptIn={onArticleCountOptIn}
                         openCmp={openCmp}
                         submitComponentEvent={submitComponentEvent}
+                        aboveArticleCountByTag={aboveArticleCountByTag}
                     />
                 </div>
             )}
@@ -452,5 +452,6 @@ const validate = (props: unknown): props is EpicProps => {
     return result.success;
 };
 
-const validatedEpic = withParsedProps(ContributionsEpic, validate);
-export { validatedEpic as ContributionsEpic, ContributionsEpic as ContributionsEpicUnvalidated };
+const validatedEpic = withParsedProps(getContributionsEpic(false), validate);
+const unValidatedEpic = getContributionsEpic(false);
+export { validatedEpic as ContributionsEpic, unValidatedEpic as ContributionsEpicUnvalidated };

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -123,6 +123,7 @@ type HighlightedProps = {
     countryCode?: string;
     numArticles: number;
     tracking?: OphanTracking;
+    showAboveArticleCount: boolean;
 };
 
 type BodyProps = {
@@ -131,6 +132,7 @@ type BodyProps = {
     countryCode?: string;
     numArticles: number;
     tracking?: OphanTracking;
+    showAboveArticleCount: boolean;
 };
 
 interface OnReminderOpen {
@@ -141,14 +143,22 @@ interface EpicHeaderProps {
     text: string;
     numArticles: number;
     tracking?: OphanTracking;
+    showAboveArticleCount: boolean;
 }
 
 const EpicHeader: React.FC<EpicHeaderProps> = ({
     text,
     numArticles,
     tracking,
+    showAboveArticleCount,
 }: EpicHeaderProps) => {
-    const elements = replaceArticleCount(text, numArticles, 'epic', tracking);
+    const elements = replaceArticleCount(
+        text,
+        numArticles,
+        'epic',
+        tracking,
+        !showAboveArticleCount,
+    );
     return <h2 css={headingStyles}>{elements}</h2>;
 };
 
@@ -156,8 +166,15 @@ const Highlighted: React.FC<HighlightedProps> = ({
     highlightedText,
     numArticles,
     tracking,
+    showAboveArticleCount,
 }: HighlightedProps) => {
-    const elements = replaceArticleCount(highlightedText, numArticles, 'epic', tracking);
+    const elements = replaceArticleCount(
+        highlightedText,
+        numArticles,
+        'epic',
+        tracking,
+        !showAboveArticleCount,
+    );
 
     return (
         <strong css={highlightWrapperStyles}>
@@ -172,6 +189,7 @@ interface EpicBodyParagraphProps {
     numArticles: number;
     highlighted: JSX.Element | null;
     tracking?: OphanTracking;
+    showAboveArticleCount: boolean;
 }
 
 const EpicBodyParagraph: React.FC<EpicBodyParagraphProps> = ({
@@ -179,8 +197,15 @@ const EpicBodyParagraph: React.FC<EpicBodyParagraphProps> = ({
     numArticles,
     highlighted,
     tracking,
+    showAboveArticleCount,
 }: EpicBodyParagraphProps) => {
-    const elements = replaceArticleCount(paragraph, numArticles, 'epic', tracking);
+    const elements = replaceArticleCount(
+        paragraph,
+        numArticles,
+        'epic',
+        tracking,
+        !showAboveArticleCount,
+    );
 
     return (
         <p css={bodyStyles}>
@@ -196,6 +221,7 @@ const EpicBody: React.FC<BodyProps> = ({
     paragraphs,
     highlightedText,
     tracking,
+    showAboveArticleCount,
 }: BodyProps) => {
     return (
         <>
@@ -211,10 +237,12 @@ const EpicBody: React.FC<BodyProps> = ({
                                     highlightedText={highlightedText}
                                     countryCode={countryCode}
                                     numArticles={numArticles}
+                                    showAboveArticleCount={showAboveArticleCount}
                                 />
                             ) : null
                         }
                         tracking={tracking}
+                        showAboveArticleCount={showAboveArticleCount}
                     />
                 );
 
@@ -308,9 +336,13 @@ const ContributionsEpic: React.FC<EpicProps> = ({
         componentType: 'ACQUISITIONS_EPIC',
     };
 
+    const showAboveArticleCount = !!(
+        variant.separateArticleCount?.type === 'above' && hasConsentForArticleCount
+    );
+
     return (
         <section ref={setNode} css={wrapperStyles}>
-            {variant.separateArticleCount?.type === 'above' && hasConsentForArticleCount && (
+            {showAboveArticleCount && (
                 <div css={articleCountAboveContainerStyles}>
                     <ContributionsEpicArticleCountAboveWithOptOut
                         numArticles={articleCounts.for52Weeks}
@@ -346,6 +378,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                     text={cleanHeading}
                     numArticles={articleCounts.forTargetedWeeks}
                     tracking={ophanTracking}
+                    showAboveArticleCount={showAboveArticleCount}
                 />
             )}
 
@@ -355,6 +388,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 countryCode={countryCode}
                 numArticles={articleCounts.forTargetedWeeks}
                 tracking={ophanTracking}
+                showAboveArticleCount={showAboveArticleCount}
             />
             {variant.showSignInLink && <ContributionsEpicSignInCta />}
 

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -344,7 +344,7 @@ export const getContributionsEpic: (
             {showAboveArticleCount && (
                 <div css={articleCountAboveContainerStyles}>
                     <ContributionsEpicArticleCountAboveWithOptOut
-                        numArticles={articleCounts.for52Weeks}
+                        articleCounts={articleCounts}
                         isArticleCountOn={!hasOptedOut}
                         onArticleCountOptOut={onArticleCountOptOut}
                         onArticleCountOptIn={onArticleCountOptIn}

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -447,7 +447,7 @@ export const getContributionsEpic: (
     );
 };
 
-const validate = (props: unknown): props is EpicProps => {
+export const validate = (props: unknown): props is EpicProps => {
     const result = epicPropsSchema.safeParse(props);
     return result.success;
 };

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -224,6 +224,9 @@ const EpicBody: React.FC<BodyProps> = ({
     );
 };
 
+// TODO: We'll have to turn this into a function that returns an Epic
+// e.g https://github.com/guardian/support-dotcom-components/pull/456/files#diff-ac06266d74967899108118ed90d5ad5bd8bf6f6ea351b83740679543bb591788R194
+// because the 3rd variant will need to be a new module
 const ContributionsEpic: React.FC<EpicProps> = ({
     variant,
     tracking,

--- a/packages/modules/src/modules/epics/ContributionsEpicACByTag.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicACByTag.tsx
@@ -1,4 +1,8 @@
-import { getContributionsEpic } from './ContributionsEpic';
+import { getContributionsEpic, validate } from './ContributionsEpic';
 import { EpicProps } from '@sdc/shared/dist/types';
+import { withParsedProps } from '../shared/ModuleWrapper';
 
-export const ContributionsEpic: React.FC<EpicProps> = getContributionsEpic(true);
+export const ContributionsEpic: React.FC<EpicProps> = withParsedProps(
+    getContributionsEpic(true),
+    validate,
+);

--- a/packages/modules/src/modules/epics/ContributionsEpicACByTag.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicACByTag.tsx
@@ -1,0 +1,4 @@
+import { getContributionsEpic } from './ContributionsEpic';
+import { EpicProps } from '@sdc/shared/dist/types';
+
+export const ContributionsEpic: React.FC<EpicProps> = getContributionsEpic(true);

--- a/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.stories.tsx
@@ -32,5 +32,8 @@ ArticleCountOff.args = {
 };
 
 ArticleCountOnBelow5.args = {
-    numArticles: 1,
+    articleCounts: {
+        forTargetedWeeks: 5,
+        for52Weeks: 10,
+    },
 };

--- a/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
@@ -6,7 +6,7 @@ import { palette, space } from '@guardian/src-foundations';
 import { Button } from '@guardian/src-button';
 import { ButtonLink } from '@guardian/src-link';
 import { css } from '@emotion/core';
-import { OphanComponentEvent } from '@sdc/shared/types';
+import { ArticleCounts, OphanComponentEvent } from '@sdc/shared/types';
 import {
     OPHAN_COMPONENT_ARTICLE_COUNT_OPT_OUT_OPEN,
     OPHAN_COMPONENT_ARTICLE_COUNT_OPT_OUT_CLOSE,
@@ -222,14 +222,14 @@ const caretStyles = css`
 `;
 
 interface ArticleCountWithToggleProps {
-    numArticles: number;
+    articleCounts: ArticleCounts;
     isArticleCountOn: boolean;
     onToggleClick: () => void;
     aboveArticleCountByTag: boolean;
 }
 
 export interface ContributionsEpicArticleCountAboveWithOptOutProps {
-    numArticles: number;
+    articleCounts: ArticleCounts;
     isArticleCountOn: boolean;
     onArticleCountOptOut: () => void;
     onArticleCountOptIn: () => void;
@@ -242,11 +242,16 @@ export interface ContributionsEpicArticleCountAboveWithOptOutProps {
 
 const ArticleCountWithToggle: React.FC<ArticleCountWithToggleProps> = ({
     isArticleCountOn,
-    numArticles,
+    articleCounts,
     onToggleClick,
     aboveArticleCountByTag,
 }: ArticleCountWithToggleProps) => {
-    if (isArticleCountOn && numArticles >= 5) {
+    // By default we display the 52-week count
+    const articleCount = aboveArticleCountByTag
+        ? articleCounts.forTargetedWeeks
+        : articleCounts.for52Weeks;
+
+    if (isArticleCountOn && articleCount >= 5) {
         const timeWindowCopy = aboveArticleCountByTag ? (
             <span>
                 about the
@@ -259,10 +264,10 @@ const ArticleCountWithToggle: React.FC<ArticleCountWithToggleProps> = ({
         return (
             <div css={articleCountOnHeaderContainerStyles}>
                 <div css={articleCountAboveContainerStyles}>
-                    {numArticles >= 5 && (
+                    {articleCount >= 5 && (
                         <>
                             You&apos;ve read{' '}
-                            <span css={optOutContainer}>{numArticles} articles</span>{' '}
+                            <span css={optOutContainer}>{articleCount} articles</span>{' '}
                             {timeWindowCopy}
                         </>
                     )}
@@ -300,7 +305,7 @@ const ArticleCountWithToggle: React.FC<ArticleCountWithToggleProps> = ({
 };
 
 export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<ContributionsEpicArticleCountAboveWithOptOutProps> = ({
-    numArticles,
+    articleCounts,
     isArticleCountOn,
     onArticleCountOptOut,
     onArticleCountOptIn,
@@ -346,7 +351,7 @@ export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<Contribution
         <div css={topContainer}>
             <ArticleCountWithToggle
                 isArticleCountOn={isArticleCountOn}
-                numArticles={numArticles}
+                articleCounts={articleCounts}
                 onToggleClick={onToggleClick}
                 aboveArticleCountByTag={aboveArticleCountByTag}
             />

--- a/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
@@ -50,14 +50,14 @@ const articleCountOnHeaderContainerStyles = css`
 
     ${from.tablet} {
         flex-direction: row;
-        align-items: center;
+        align-items: flex-start;
     }
 `;
 
 const articleCountWrapperStyles = css`
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: flex-start;
     margin-right: ${space[2]}px;
     margin-bottom: ${space[2]}px;
     justify-content: start;
@@ -225,6 +225,7 @@ interface ArticleCountWithToggleProps {
     numArticles: number;
     isArticleCountOn: boolean;
     onToggleClick: () => void;
+    aboveArticleCountByTag: boolean;
 }
 
 export interface ContributionsEpicArticleCountAboveWithOptOutProps {
@@ -234,6 +235,7 @@ export interface ContributionsEpicArticleCountAboveWithOptOutProps {
     onArticleCountOptIn: () => void;
     openCmp?: () => void;
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
+    aboveArticleCountByTag: boolean;
 }
 
 // -- Components -- //
@@ -242,16 +244,26 @@ const ArticleCountWithToggle: React.FC<ArticleCountWithToggleProps> = ({
     isArticleCountOn,
     numArticles,
     onToggleClick,
+    aboveArticleCountByTag,
 }: ArticleCountWithToggleProps) => {
     if (isArticleCountOn && numArticles >= 5) {
+        const timeWindowCopy = aboveArticleCountByTag ? (
+            <span>
+                about the
+                <br />
+                climate crisis in the last six weeks
+            </span>
+        ) : (
+            'in the last year'
+        );
         return (
             <div css={articleCountOnHeaderContainerStyles}>
                 <div css={articleCountAboveContainerStyles}>
                     {numArticles >= 5 && (
                         <>
                             You&apos;ve read{' '}
-                            <span css={optOutContainer}>{numArticles} articles</span> in the last
-                            year
+                            <span css={optOutContainer}>{numArticles} articles</span>{' '}
+                            {timeWindowCopy}
                         </>
                     )}
                 </div>
@@ -294,6 +306,7 @@ export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<Contribution
     onArticleCountOptIn,
     openCmp,
     submitComponentEvent,
+    aboveArticleCountByTag,
 }: ContributionsEpicArticleCountAboveWithOptOutProps) => {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -335,6 +348,7 @@ export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<Contribution
                 isArticleCountOn={isArticleCountOn}
                 numArticles={numArticles}
                 onToggleClick={onToggleClick}
+                aboveArticleCountByTag={aboveArticleCountByTag}
             />
 
             {isOpen && (

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -1,16 +1,30 @@
 import {
     ArticleCounts,
     ArticlesViewedSettings,
+    ArticlesViewedByTagSettings,
     WeeklyArticleHistory,
     WeeklyArticleLog,
 } from '@sdc/shared/types';
 
+// From https://github.com/guardian/automat-client-v2/blob/master/src/contributions/lib/dates.ts#L4
 export const getMondayFromDate = (date: Date): number => {
-    const day = date.getDay() || 7;
-    if (day !== 1) {
-        date.setHours(-24 * (day - 1));
-    }
-    return Math.floor(date.getTime() / 86400000);
+    const day = date.getDay() || 7; // Sunday is 0, so set it to 7
+    const time = Date.UTC(date.getFullYear(), date.getMonth(), date.getDate() - (day - 1));
+    return time / 86400000;
+};
+
+const getWeeksInWindow = (
+    history: WeeklyArticleHistory = [],
+    weeks = 52,
+    rightNow: Date = new Date(),
+): WeeklyArticleLog[] => {
+    const mondayThisWeek = getMondayFromDate(rightNow);
+    const cutOffWeek = mondayThisWeek - weeks * 7;
+
+    // Filter only weeks within cutoff period
+    return history.filter(
+        (weeklyArticleLog: WeeklyArticleLog) => weeklyArticleLog.week >= cutOffWeek,
+    );
 };
 
 export const getArticleViewCountForWeeks = (
@@ -18,18 +32,26 @@ export const getArticleViewCountForWeeks = (
     weeks = 52,
     rightNow: Date = new Date(),
 ): number => {
-    const mondayThisWeek = getMondayFromDate(rightNow);
-    const cutOffWeek = mondayThisWeek - weeks * 7;
-
-    // Filter only weeks within cutoff period
-    const weeksInWindow = history.filter(
-        (weeklyArticleLog: WeeklyArticleLog) => weeklyArticleLog.week >= cutOffWeek,
-    );
+    const weeksInWindow = getWeeksInWindow(history, weeks, rightNow);
 
     return weeksInWindow.reduce(
-        (accumulator: number, currentValue: WeeklyArticleLog) => currentValue.count + accumulator,
+        (accumulator: number, articleLog: WeeklyArticleLog) => articleLog.count + accumulator,
         0,
     );
+};
+
+export const getArticleViewCountByTagForWeeks = (
+    tagId: string,
+    history: WeeklyArticleHistory = [],
+    weeks = 52,
+    rightNow: Date = new Date(),
+): number => {
+    const weeksInWindow = getWeeksInWindow(history, weeks, rightNow);
+
+    return weeksInWindow.reduce((accumulator: number, articleLog: WeeklyArticleLog) => {
+        const countForTag = articleLog.tags ? articleLog.tags[tagId] : 0;
+        return accumulator + countForTag;
+    }, 0);
 };
 
 export const getArticleViewCounts = (
@@ -63,4 +85,24 @@ export const historyWithinArticlesViewedSettings = (
     const maxViewsOk = maxViews ? viewCountForWeeks <= maxViews : true;
 
     return minViewsOk && maxViewsOk;
+};
+
+export const historyWithinArticlesViewedSettingsByTag = (
+    articlesViewedSettings?: ArticlesViewedByTagSettings,
+    history: WeeklyArticleHistory = [],
+    now: Date = new Date(),
+): boolean => {
+    if (!articlesViewedSettings) {
+        return true;
+    }
+
+    // At least one of the tags must match
+    return Object.entries(articlesViewedSettings).some(([tagId, settings]) => {
+        const { minViews, maxViews, periodInWeeks } = settings;
+        const count = getArticleViewCountByTagForWeeks(tagId, history, periodInWeeks, now);
+        const minViewsOk = minViews ? count >= minViews : true;
+        const maxViewsOk = maxViews ? count <= maxViews : true;
+
+        return minViewsOk && maxViewsOk;
+    });
 };

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -64,15 +64,8 @@ export const getArticleViewCounts = (
 
     const getCountForTargetingWeeks = (): number => {
         if (articlesViewedByTagSettings) {
-            // Sum the counts for each tag
-            return articlesViewedByTagSettings.tagIds.reduce((sum, tagId) => {
-                const countForTag = getArticleViewCountByTagForWeeks(
-                    tagId,
-                    history,
-                    articlesViewedByTagSettings.periodInWeeks,
-                );
-                return sum + countForTag;
-            }, 0);
+            const { tagId, periodInWeeks } = articlesViewedByTagSettings;
+            return getArticleViewCountByTagForWeeks(tagId, history, periodInWeeks);
         }
         return weeks === 52 ? for52Weeks : getArticleViewCountForWeeks(history, weeks);
     };
@@ -111,10 +104,7 @@ export const historyWithinArticlesViewedSettingsByTag = (
         return true;
     }
 
-    const { minViews, periodInWeeks } = articlesViewedSettings;
-    // At least one of the tags must match
-    return articlesViewedSettings.tagIds.some(tagId => {
-        const count = getArticleViewCountByTagForWeeks(tagId, history, periodInWeeks, now);
-        return count >= minViews;
-    });
+    const { tagId, minViews, periodInWeeks } = articlesViewedSettings;
+    const count = getArticleViewCountByTagForWeeks(tagId, history, periodInWeeks, now);
+    return count >= minViews;
 };

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -49,7 +49,7 @@ export const getArticleViewCountByTagForWeeks = (
     const weeksInWindow = getWeeksInWindow(history, weeks, rightNow);
 
     return weeksInWindow.reduce((accumulator: number, articleLog: WeeklyArticleLog) => {
-        const countForTag = articleLog.tags ? articleLog.tags[tagId] : 0;
+        const countForTag = articleLog.tags && articleLog.tags[tagId] ? articleLog.tags[tagId] : 0;
         return accumulator + countForTag;
     }, 0);
 };
@@ -65,7 +65,7 @@ export const getArticleViewCounts = (
     const getCountForTargetingWeeks = (): number => {
         if (articlesViewedByTagSettings) {
             // Sum the counts for each tag
-            articlesViewedByTagSettings.tagIds.reduce((sum, tagId) => {
+            return articlesViewedByTagSettings.tagIds.reduce((sum, tagId) => {
                 const countForTag = getArticleViewCountByTagForWeeks(
                     tagId,
                     history,

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -49,7 +49,7 @@ export const getArticleViewCountByTagForWeeks = (
     const weeksInWindow = getWeeksInWindow(history, weeks, rightNow);
 
     return weeksInWindow.reduce((accumulator: number, articleLog: WeeklyArticleLog) => {
-        const countForTag = articleLog.tags && articleLog.tags[tagId] ? articleLog.tags[tagId] : 0;
+        const countForTag = articleLog.tags?.[tagId] ?? 0;
         return accumulator + countForTag;
     }, 0);
 };

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -36,7 +36,10 @@ import { fallbackEpicTest } from './tests/epics/fallback';
 import { selectHeaderTest } from './tests/header/headerSelection';
 import { logWarn } from './utils/logging';
 import { cachedChoiceCardAmounts } from './choiceCardAmounts';
-import { epicArticleCountByTagTest } from './tests/epics/articleCountByTagTest';
+import {
+    epicArticleCountByTagTestGlobal,
+    epicArticleCountByTagTestUS,
+} from './tests/epics/articleCountByTagTest';
 
 interface EpicDataResponse {
     data?: {
@@ -120,7 +123,9 @@ const getArticleEpicTests = async (
             fetchConfiguredArticleEpicHoldbackTestsCached(),
         ]);
 
-        const hardcodedTests = enableHardcodedEpicTests ? [epicArticleCountByTagTest] : [];
+        const hardcodedTests = enableHardcodedEpicTests
+            ? [epicArticleCountByTagTestUS, epicArticleCountByTagTestGlobal]
+            : [];
 
         if (isForcingTest) {
             return [...hardcodedTests, ...regular, ...holdback, fallbackEpicTest];

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -207,6 +207,7 @@ export const buildEpicData = async (
         tracking: { ...pageTracking, ...testTracking },
         articleCounts: getArticleViewCounts(
             targeting.weeklyArticleHistory,
+            test.articlesViewedByTagSettings,
             test.articlesViewedSettings?.periodInWeeks,
         ),
         countryCode: targeting.countryCode,

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -36,6 +36,7 @@ import { fallbackEpicTest } from './tests/epics/fallback';
 import { selectHeaderTest } from './tests/header/headerSelection';
 import { logWarn } from './utils/logging';
 import { cachedChoiceCardAmounts } from './choiceCardAmounts';
+import { epicArticleCountByTagTest } from './tests/epics/articleCountByTagTest';
 
 interface EpicDataResponse {
     data?: {
@@ -119,7 +120,7 @@ const getArticleEpicTests = async (
             fetchConfiguredArticleEpicHoldbackTestsCached(),
         ]);
 
-        const hardcodedTests = enableHardcodedEpicTests ? [] : [];
+        const hardcodedTests = enableHardcodedEpicTests ? [epicArticleCountByTagTest] : [];
 
         if (isForcingTest) {
             return [...hardcodedTests, ...regular, ...holdback, fallbackEpicTest];

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -75,13 +75,8 @@ export const epicArticleCountByTagTest: EpicTest = {
         periodInWeeks: 52,
     },
     articlesViewedByTagSettings: {
-        'environment/climate-change': {
-            minViews: 5,
-            periodInWeeks: 52,
-        },
-        'environment/environment': {
-            minViews: 5,
-            periodInWeeks: 52,
-        },
+        minViews: 5,
+        periodInWeeks: 6,
+        tagIds: ['environment/climate-change', 'environment/environment'],
     },
 };

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -2,7 +2,7 @@ import { EpicTest } from '@sdc/shared/types';
 import { epic } from '@sdc/shared/config';
 import { CTA, HIGHLIGHTED_TEXT, PARAGRAPHS } from './articleCountByTagTestData';
 
-export const ARTICLE_COUNT_BY_TAG_TEST_NAME = 'EpicArticleCountByTagTest';
+export const ARTICLE_COUNT_BY_TAG_TEST_NAME = '2021-11-05_EpicArticleCountByTagTest';
 
 export enum EpicArticleCountByTagTestVariants {
     control = 'control',

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -53,6 +53,7 @@ export const epicArticleCountByTagTest: EpicTest = {
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,
             separateArticleCount: { type: 'above' },
+            showChoiceCards: true,
         },
         {
             name: EpicArticleCountByTagTestVariants.v1,
@@ -61,6 +62,7 @@ export const epicArticleCountByTagTest: EpicTest = {
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,
             separateArticleCount: { type: 'above' },
+            showChoiceCards: true,
         },
         {
             name: EpicArticleCountByTagTestVariants.v2,
@@ -69,6 +71,7 @@ export const epicArticleCountByTagTest: EpicTest = {
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,
             separateArticleCount: { type: 'above' },
+            showChoiceCards: true,
         },
     ],
     highPriority: true,

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -1,5 +1,5 @@
 import { EpicTest } from '@sdc/shared/types';
-import { epic } from '@sdc/shared/config';
+import { epic, epicACByTag } from '@sdc/shared/config';
 import {
     CTA,
     HIGHLIGHTED_TEXT,
@@ -48,7 +48,6 @@ export const epicArticleCountByTagTest: EpicTest = {
         {
             name: EpicArticleCountByTagTestVariants.control,
             modulePathBuilder: epic.endpointPathBuilder,
-            // TODO: Replace with proper copy
             paragraphs: CONTROL_PARAGRAPHS,
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,
@@ -57,7 +56,6 @@ export const epicArticleCountByTagTest: EpicTest = {
         {
             name: EpicArticleCountByTagTestVariants.v1,
             modulePathBuilder: epic.endpointPathBuilder,
-            // TODO: Replace with proper copy
             paragraphs: [
                 '… and in the last six weeks alone, %%ARTICLE_COUNT%% of these were about the climate crisis. Thank you for turning to the Guardian.',
                 ...VARIANT_PARAGRAPHS,
@@ -68,9 +66,7 @@ export const epicArticleCountByTagTest: EpicTest = {
         },
         {
             name: EpicArticleCountByTagTestVariants.v2,
-            // TODO: This one will actually have to be the new epic modules e.g epicWithClimateAC
-            modulePathBuilder: epic.endpointPathBuilder,
-            // TODO: Replace with proper copy
+            modulePathBuilder: epicACByTag.endpointPathBuilder,
             paragraphs: ['… thank you for turning to the Guardian.', ...VARIANT_PARAGRAPHS],
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -21,9 +21,10 @@ export enum EpicArticleCountByTagTestVariants {
 const buildEpicArticleCountByTagTest = (
     highlightedText: string,
     countries: CountryGroupId[],
+    suffix: string,
 ): EpicTest => ({
-    name: ARTICLE_COUNT_BY_TAG_TEST_NAME,
-    campaignId: ARTICLE_COUNT_BY_TAG_TEST_NAME,
+    name: `${ARTICLE_COUNT_BY_TAG_TEST_NAME}__${suffix}`,
+    campaignId: `${ARTICLE_COUNT_BY_TAG_TEST_NAME}__${suffix}`,
     hasArticleCountInCopy: false,
     isOn: true,
     locations: countries,
@@ -87,7 +88,10 @@ const buildEpicArticleCountByTagTest = (
 export const epicArticleCountByTagTestGlobal = buildEpicArticleCountByTagTest(
     GLOBAL_HIGHLIGHTED_TEXT,
     ['Canada', 'AUDCountries', 'NZDCountries', 'GBPCountries', 'EURCountries', 'International'],
+    'Global',
 );
-export const epicArticleCountByTagTestUS = buildEpicArticleCountByTagTest(US_HIGHLIGHTED_TEXT, [
-    'UnitedStates',
-]);
+export const epicArticleCountByTagTestUS = buildEpicArticleCountByTagTest(
+    US_HIGHLIGHTED_TEXT,
+    ['UnitedStates'],
+    'US',
+);

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -4,7 +4,8 @@ import {
     CTA,
     HIGHLIGHTED_TEXT,
     CONTROL_PARAGRAPHS,
-    VARIANT_PARAGRAPHS,
+    VARIANT1_PARAGRAPHS,
+    VARIANT2_PARAGRAPHS,
 } from './articleCountByTagTestData';
 
 export const ARTICLE_COUNT_BY_TAG_TEST_NAME = '2021-11-05_EpicArticleCountByTagTest';
@@ -56,10 +57,7 @@ export const epicArticleCountByTagTest: EpicTest = {
         {
             name: EpicArticleCountByTagTestVariants.v1,
             modulePathBuilder: epic.endpointPathBuilder,
-            paragraphs: [
-                '… and in the last six weeks alone, %%ARTICLE_COUNT%% of these were about the climate crisis. Thank you for turning to the Guardian.',
-                ...VARIANT_PARAGRAPHS,
-            ],
+            paragraphs: VARIANT1_PARAGRAPHS,
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,
             separateArticleCount: { type: 'above' },
@@ -67,7 +65,7 @@ export const epicArticleCountByTagTest: EpicTest = {
         {
             name: EpicArticleCountByTagTestVariants.v2,
             modulePathBuilder: epicACByTag.endpointPathBuilder,
-            paragraphs: ['… thank you for turning to the Guardian.', ...VARIANT_PARAGRAPHS],
+            paragraphs: VARIANT2_PARAGRAPHS,
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,
             separateArticleCount: { type: 'above' },

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -10,7 +10,7 @@ import {
 } from './articleCountByTagTestData';
 import { CountryGroupId } from '@sdc/shared/lib';
 
-export const ARTICLE_COUNT_BY_TAG_TEST_NAME = '2021-11-05_EpicArticleCountByTagTest';
+export const ARTICLE_COUNT_BY_TAG_TEST_NAME = '2021-11-09_EpicArticleCountByTagTest';
 
 export enum EpicArticleCountByTagTestVariants {
     control = 'control',
@@ -33,13 +33,12 @@ const buildEpicArticleCountByTagTest = (
     sections: [],
     excludedTagIds: [],
     excludedSections: [],
-    // alwaysAsk: false,
-    alwaysAsk: true,
-    // maxViews: {
-    //     maxViewsCount: 4,
-    //     maxViewsDays: 30,
-    //     minDaysBetweenViews: 0,
-    // },
+    alwaysAsk: false,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
     userCohort: 'AllNonSupporters',
     isLiveBlog: false,
     hasCountryName: true,

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -1,0 +1,77 @@
+import { EpicTest } from '@sdc/shared/types';
+import { epic } from '@sdc/shared/config';
+import { CTA, HIGHLIGHTED_TEXT, PARAGRAPHS } from './articleCountByTagTestData';
+
+export const ARTICLE_COUNT_BY_TAG_TEST_NAME = 'EpicArticleCountByTagTest';
+
+export enum EpicArticleCountByTagTestVariants {
+    control = 'control',
+    v1 = 'v1',
+    v2 = 'v2',
+}
+
+export const epicArticleCountByTagTest: EpicTest = {
+    name: ARTICLE_COUNT_BY_TAG_TEST_NAME,
+    campaignId: ARTICLE_COUNT_BY_TAG_TEST_NAME,
+    hasArticleCountInCopy: false,
+    isOn: true,
+    locations: [
+        'UnitedStates',
+        'Canada',
+        'AUDCountries',
+        'NZDCountries',
+        'GBPCountries',
+        'EURCountries',
+        'International',
+    ],
+    audience: 1,
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: false,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
+    userCohort: 'AllNonSupporters',
+    isLiveBlog: false,
+    hasCountryName: true,
+    variants: [
+        {
+            name: EpicArticleCountByTagTestVariants.control,
+            modulePathBuilder: epic.endpointPathBuilder,
+            // TODO: Replace with proper copy
+            paragraphs: PARAGRAPHS,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
+            separateArticleCount: { type: 'above' },
+        },
+        {
+            name: EpicArticleCountByTagTestVariants.v1,
+            modulePathBuilder: epic.endpointPathBuilder,
+            // TODO: Replace with proper copy
+            paragraphs: PARAGRAPHS,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
+            separateArticleCount: { type: 'above' },
+        },
+        {
+            name: EpicArticleCountByTagTestVariants.v2,
+            // TODO: This one will actually have to be the new epic modules e.g epicWithClimateAC
+            modulePathBuilder: epic.endpointPathBuilder,
+            // TODO: Replace with proper copy
+            paragraphs: PARAGRAPHS,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
+            separateArticleCount: { type: 'above' },
+        },
+    ],
+    highPriority: true,
+    useLocalViewLog: true,
+    articlesViewedSettings: {
+        minViews: 5,
+        periodInWeeks: 52,
+    },
+};

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -2,11 +2,13 @@ import { EpicTest } from '@sdc/shared/types';
 import { epic, epicACByTag } from '@sdc/shared/config';
 import {
     CTA,
-    HIGHLIGHTED_TEXT,
+    GLOBAL_HIGHLIGHTED_TEXT,
+    US_HIGHLIGHTED_TEXT,
     CONTROL_PARAGRAPHS,
     VARIANT1_PARAGRAPHS,
     VARIANT2_PARAGRAPHS,
 } from './articleCountByTagTestData';
+import { CountryGroupId } from '@sdc/shared/lib';
 
 export const ARTICLE_COUNT_BY_TAG_TEST_NAME = '2021-11-05_EpicArticleCountByTagTest';
 
@@ -16,20 +18,15 @@ export enum EpicArticleCountByTagTestVariants {
     v2 = 'v2',
 }
 
-export const epicArticleCountByTagTest: EpicTest = {
+const buildEpicArticleCountByTagTest = (
+    highlightedText: string,
+    countries: CountryGroupId[],
+): EpicTest => ({
     name: ARTICLE_COUNT_BY_TAG_TEST_NAME,
     campaignId: ARTICLE_COUNT_BY_TAG_TEST_NAME,
     hasArticleCountInCopy: false,
     isOn: true,
-    locations: [
-        'UnitedStates',
-        'Canada',
-        'AUDCountries',
-        'NZDCountries',
-        'GBPCountries',
-        'EURCountries',
-        'International',
-    ],
+    locations: countries,
     audience: 1,
     tagIds: [],
     sections: [],
@@ -50,7 +47,7 @@ export const epicArticleCountByTagTest: EpicTest = {
             name: EpicArticleCountByTagTestVariants.control,
             modulePathBuilder: epic.endpointPathBuilder,
             paragraphs: CONTROL_PARAGRAPHS,
-            highlightedText: HIGHLIGHTED_TEXT,
+            highlightedText,
             cta: CTA,
             separateArticleCount: { type: 'above' },
             showChoiceCards: true,
@@ -59,7 +56,7 @@ export const epicArticleCountByTagTest: EpicTest = {
             name: EpicArticleCountByTagTestVariants.v1,
             modulePathBuilder: epic.endpointPathBuilder,
             paragraphs: VARIANT1_PARAGRAPHS,
-            highlightedText: HIGHLIGHTED_TEXT,
+            highlightedText,
             cta: CTA,
             separateArticleCount: { type: 'above' },
             showChoiceCards: true,
@@ -68,7 +65,7 @@ export const epicArticleCountByTagTest: EpicTest = {
             name: EpicArticleCountByTagTestVariants.v2,
             modulePathBuilder: epicACByTag.endpointPathBuilder,
             paragraphs: VARIANT2_PARAGRAPHS,
-            highlightedText: HIGHLIGHTED_TEXT,
+            highlightedText,
             cta: CTA,
             separateArticleCount: { type: 'above' },
             showChoiceCards: true,
@@ -85,4 +82,12 @@ export const epicArticleCountByTagTest: EpicTest = {
         periodInWeeks: 6,
         tagIds: ['environment/climate-change', 'environment/environment'],
     },
-};
+});
+
+export const epicArticleCountByTagTestGlobal = buildEpicArticleCountByTagTest(
+    GLOBAL_HIGHLIGHTED_TEXT,
+    ['Canada', 'AUDCountries', 'NZDCountries', 'GBPCountries', 'EURCountries', 'International'],
+);
+export const epicArticleCountByTagTestUS = buildEpicArticleCountByTagTest(US_HIGHLIGHTED_TEXT, [
+    'UnitedStates',
+]);

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -80,7 +80,7 @@ const buildEpicArticleCountByTagTest = (
     articlesViewedByTagSettings: {
         minViews: 5,
         periodInWeeks: 6,
-        tagIds: ['environment/climate-change', 'environment/environment'],
+        tagId: 'environment/climate-crisis',
     },
 });
 

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -1,6 +1,11 @@
 import { EpicTest } from '@sdc/shared/types';
 import { epic } from '@sdc/shared/config';
-import { CTA, HIGHLIGHTED_TEXT, PARAGRAPHS } from './articleCountByTagTestData';
+import {
+    CTA,
+    HIGHLIGHTED_TEXT,
+    CONTROL_PARAGRAPHS,
+    VARIANT_PARAGRAPHS,
+} from './articleCountByTagTestData';
 
 export const ARTICLE_COUNT_BY_TAG_TEST_NAME = '2021-11-05_EpicArticleCountByTagTest';
 
@@ -29,12 +34,13 @@ export const epicArticleCountByTagTest: EpicTest = {
     sections: [],
     excludedTagIds: [],
     excludedSections: [],
-    alwaysAsk: false,
-    maxViews: {
-        maxViewsCount: 4,
-        maxViewsDays: 30,
-        minDaysBetweenViews: 0,
-    },
+    // alwaysAsk: false,
+    alwaysAsk: true,
+    // maxViews: {
+    //     maxViewsCount: 4,
+    //     maxViewsDays: 30,
+    //     minDaysBetweenViews: 0,
+    // },
     userCohort: 'AllNonSupporters',
     isLiveBlog: false,
     hasCountryName: true,
@@ -43,7 +49,7 @@ export const epicArticleCountByTagTest: EpicTest = {
             name: EpicArticleCountByTagTestVariants.control,
             modulePathBuilder: epic.endpointPathBuilder,
             // TODO: Replace with proper copy
-            paragraphs: PARAGRAPHS,
+            paragraphs: CONTROL_PARAGRAPHS,
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,
             separateArticleCount: { type: 'above' },
@@ -52,7 +58,10 @@ export const epicArticleCountByTagTest: EpicTest = {
             name: EpicArticleCountByTagTestVariants.v1,
             modulePathBuilder: epic.endpointPathBuilder,
             // TODO: Replace with proper copy
-            paragraphs: PARAGRAPHS,
+            paragraphs: [
+                '… and in the last six weeks alone, %%ARTICLE_COUNT%% of these were about the climate crisis. Thank you for turning to the Guardian.',
+                ...VARIANT_PARAGRAPHS,
+            ],
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,
             separateArticleCount: { type: 'above' },
@@ -62,7 +71,7 @@ export const epicArticleCountByTagTest: EpicTest = {
             // TODO: This one will actually have to be the new epic modules e.g epicWithClimateAC
             modulePathBuilder: epic.endpointPathBuilder,
             // TODO: Replace with proper copy
-            paragraphs: PARAGRAPHS,
+            paragraphs: ['… thank you for turning to the Guardian.', ...VARIANT_PARAGRAPHS],
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,
             separateArticleCount: { type: 'above' },

--- a/packages/server/src/tests/epics/articleCountByTagTest.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTest.ts
@@ -74,4 +74,14 @@ export const epicArticleCountByTagTest: EpicTest = {
         minViews: 5,
         periodInWeeks: 52,
     },
+    articlesViewedByTagSettings: {
+        'environment/climate-change': {
+            minViews: 5,
+            periodInWeeks: 52,
+        },
+        'environment/environment': {
+            minViews: 5,
+            periodInWeeks: 52,
+        },
+    },
 };

--- a/packages/server/src/tests/epics/articleCountByTagTestData.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTestData.ts
@@ -22,8 +22,11 @@ export const VARIANT2_PARAGRAPHS = [
     ...otherParagraphs,
 ];
 
-export const HIGHLIGHTED_TEXT =
+export const GLOBAL_HIGHLIGHTED_TEXT =
     'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.';
+
+export const US_HIGHLIGHTED_TEXT =
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.';
 
 export const CTA = {
     text: 'Support the Guardian',

--- a/packages/server/src/tests/epics/articleCountByTagTestData.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTestData.ts
@@ -1,10 +1,15 @@
 // TODO: Replace all of these with the proper copy & we'll need different copy for different variants!
-export const PARAGRAPHS = [
+export const CONTROL_PARAGRAPHS = [
     '… we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
     'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
     'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
     "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
     'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+];
+
+export const VARIANT_PARAGRAPHS = [
+    'Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+    'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.,'
 ];
 
 export const HIGHLIGHTED_TEXT =

--- a/packages/server/src/tests/epics/articleCountByTagTestData.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTestData.ts
@@ -1,0 +1,16 @@
+// TODO: Replace all of these with the proper copy & we'll need different copy for different variants!
+export const PARAGRAPHS = [
+    '… we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+    'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+    'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+    "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+    'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+];
+
+export const HIGHLIGHTED_TEXT =
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.';
+
+export const CTA = {
+    text: 'Support the Guardian',
+    baseUrl: 'https://support.theguardian.com/contribute',
+};

--- a/packages/server/src/tests/epics/articleCountByTagTestData.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTestData.ts
@@ -1,15 +1,25 @@
-// TODO: Replace all of these with the proper copy & we'll need different copy for different variants!
-export const CONTROL_PARAGRAPHS = [
-    '... we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+const firstParagraph =
+    'Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.';
+const otherParagraphs = [
     'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
     'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
     "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
     'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
 ];
 
-export const VARIANT_PARAGRAPHS = [
-    'Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
-    'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.,',
+export const CONTROL_PARAGRAPHS = [
+    `... we have a small favour to ask. ${firstParagraph}`,
+    ...otherParagraphs,
+];
+
+export const VARIANT1_PARAGRAPHS = [
+    `… and in the last six weeks alone, %%ARTICLE_COUNT%% of these were about the climate crisis. Thank you for turning to the Guardian. ${firstParagraph}`,
+    ...otherParagraphs,
+];
+
+export const VARIANT2_PARAGRAPHS = [
+    `… thank you for turning to the Guardian. ${firstParagraph}`,
+    ...otherParagraphs,
 ];
 
 export const HIGHLIGHTED_TEXT =

--- a/packages/server/src/tests/epics/articleCountByTagTestData.ts
+++ b/packages/server/src/tests/epics/articleCountByTagTestData.ts
@@ -1,6 +1,6 @@
 // TODO: Replace all of these with the proper copy & we'll need different copy for different variants!
 export const CONTROL_PARAGRAPHS = [
-    '… we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+    '... we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
     'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
     'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
     "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
@@ -9,7 +9,7 @@ export const CONTROL_PARAGRAPHS = [
 
 export const VARIANT_PARAGRAPHS = [
     'Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
-    'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.,'
+    'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.,',
 ];
 
 export const HIGHLIGHTED_TEXT =

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -631,14 +631,9 @@ describe('withinArticleViewedSettings filter', () => {
 describe('withinArticleViewedByTagSettings filter', () => {
     const now = new Date('2020-03-31T12:30:00');
     const articlesViewedByTagSettings: ArticlesViewedByTagSettings = {
-        'environment/climate-change': {
-            minViews: 5,
-            periodInWeeks: 52,
-        },
-        'science/science': {
-            minViews: 5,
-            periodInWeeks: 52,
-        },
+        minViews: 5,
+        periodInWeeks: 52,
+        tagIds: ['environment/climate-change', 'science/science'],
     };
 
     it('should pass when no articlesViewedByTagSettings', () => {

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -1,4 +1,4 @@
-import { SecondaryCtaType } from '@sdc/shared/types';
+import { ArticlesViewedByTagSettings, SecondaryCtaType } from '@sdc/shared/types';
 import { EpicTargeting, EpicTest } from '@sdc/shared/types';
 import { SuperModeArticle } from '../../lib/superMode';
 import { withNowAs } from '../../utils/withNowAs';
@@ -14,6 +14,7 @@ import {
     matchesCountryGroups,
     userInTest,
     withinArticleViewedSettings,
+    withinArticleViewedByTagSettings,
     withinMaxViews,
 } from './epicSelection';
 
@@ -622,6 +623,77 @@ describe('withinArticleViewedSettings filter', () => {
         const filter = withinArticleViewedSettings(history, now);
 
         const got = filter.test(test, targeting);
+
+        expect(got).toBe(true);
+    });
+});
+
+describe('withinArticleViewedByTagSettings filter', () => {
+    const now = new Date('2020-03-31T12:30:00');
+    const articlesViewedByTagSettings: ArticlesViewedByTagSettings = {
+        'environment/climate-change': {
+            minViews: 5,
+            periodInWeeks: 52,
+        },
+        'science/science': {
+            minViews: 5,
+            periodInWeeks: 52,
+        },
+    };
+
+    it('should pass when no articlesViewedByTagSettings', () => {
+        const history = [{ week: 18330, count: 2500 }];
+        const targeting: EpicTargeting = {
+            ...targetingDefault,
+            weeklyArticleHistory: history,
+        };
+        const filter = withinArticleViewedByTagSettings(history, now);
+
+        const got = filter.test({ ...testDefault }, targeting);
+
+        expect(got).toBe(true);
+    });
+
+    it('should fail when below min articles viewed for any tag', () => {
+        const history = [
+            {
+                week: 18330,
+                count: 5,
+                tags: {
+                    'environment/climate-change': 1,
+                    'science/science': 2,
+                },
+            },
+        ];
+        const targeting: EpicTargeting = {
+            ...targetingDefault,
+            weeklyArticleHistory: history,
+        };
+        const filter = withinArticleViewedByTagSettings(history, now);
+
+        const got = filter.test({ ...testDefault, articlesViewedByTagSettings }, targeting);
+
+        expect(got).toBe(false);
+    });
+
+    it('should succeed when above min articles viewed for any tag', () => {
+        const history = [
+            {
+                week: 18330,
+                count: 5,
+                tags: {
+                    'environment/climate-change': 5,
+                    'science/science': 2,
+                },
+            },
+        ];
+        const targeting: EpicTargeting = {
+            ...targetingDefault,
+            weeklyArticleHistory: history,
+        };
+        const filter = withinArticleViewedByTagSettings(history, now);
+
+        const got = filter.test({ ...testDefault, articlesViewedByTagSettings }, targeting);
 
         expect(got).toBe(true);
     });

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -633,7 +633,7 @@ describe('withinArticleViewedByTagSettings filter', () => {
     const articlesViewedByTagSettings: ArticlesViewedByTagSettings = {
         minViews: 5,
         periodInWeeks: 52,
-        tagIds: ['environment/climate-change', 'science/science'],
+        tagId: 'environment/climate-change',
     };
 
     it('should pass when no articlesViewedByTagSettings', () => {

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -15,6 +15,7 @@ import { TestVariant } from '../../lib/params';
 import { SuperModeArticle } from '../../lib/superMode';
 import { isInSuperMode, superModeify } from '../../lib/superMode';
 import { shouldNotRenderEpic, shouldThrottle, userIsInTest } from '../../lib/targeting';
+import { ARTICLE_COUNT_BY_TAG_TEST_NAME } from './articleCountByTagTest';
 
 interface Filter {
     id: string;
@@ -179,6 +180,18 @@ export const respectArticleCountOptOut: Filter = {
     },
 };
 
+const applyArticleCountByTagFilterToHardCodedTest: Filter = {
+    id: 'applyArticleCountByTagFilterToHardCodedTests',
+    test: (test, targeting) => {
+        if (test.name !== ARTICLE_COUNT_BY_TAG_TEST_NAME) {
+            // We only want to apply filtering logic when it's the hardcoded test
+            return true;
+        }
+        // TODO: here we need to do some logic e.g check the targeting to find out ac by tag count in last X weeks and see if it's over the threshold
+        return false;
+    },
+};
+
 type FilterResults = Record<string, boolean>;
 
 export type Debug = Record<string, FilterResults>;
@@ -218,6 +231,7 @@ export const findTestAndVariant = (
             ...(isSuperModePass ? [] : [withinMaxViews(targeting.epicViewLog || [])]),
             withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
             respectArticleCountOptOut,
+            applyArticleCountByTagFilterToHardCodedTest,
         ];
     };
 

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -18,7 +18,10 @@ export const getDefaultModuleInfo = (name: string, path: string): ModuleInfo => 
 
 export const epic: ModuleInfo = getDefaultModuleInfo('epic', 'epics/ContributionsEpic');
 
-// TODO: add the new epic module here
+export const epicACByTag: ModuleInfo = getDefaultModuleInfo(
+    'epicACByTag',
+    'epics/ContributionsEpicACByTag',
+);
 
 export const liveblogEpic: ModuleInfo = getDefaultModuleInfo(
     'liveblog-epic',
@@ -64,6 +67,7 @@ export const header: ModuleInfo = getDefaultModuleInfo('header', 'header/Header'
 
 export const moduleInfos: ModuleInfo[] = [
     epic,
+    epicACByTag,
     liveblogEpic,
     contributionsBanner,
     contributionsBannerWithSignIn,

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -18,6 +18,8 @@ export const getDefaultModuleInfo = (name: string, path: string): ModuleInfo => 
 
 export const epic: ModuleInfo = getDefaultModuleInfo('epic', 'epics/ContributionsEpic');
 
+// TODO: add the new epic module here
+
 export const liveblogEpic: ModuleInfo = getDefaultModuleInfo(
     'liveblog-epic',
     'epics/ContributionsLiveblogEpic',

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -15,6 +15,7 @@ import {
     PageTracking,
     trackingSchema,
     secondaryCtaSchema,
+    ArticlesViewedByTagSettings,
 } from './shared';
 import { ReminderFields, CountryGroupId } from '../lib';
 import { z } from 'zod';
@@ -226,6 +227,7 @@ export interface EpicTest extends Test<EpicVariant> {
     highPriority: boolean;
     useLocalViewLog: boolean;
     articlesViewedSettings?: ArticlesViewedSettings;
+    articlesViewedByTagSettings?: ArticlesViewedByTagSettings;
     hasArticleCountInCopy: boolean;
 
     audience?: number;

--- a/packages/shared/src/types/shared.ts
+++ b/packages/shared/src/types/shared.ts
@@ -125,9 +125,14 @@ export interface ChoiceCardSettings {
     showChoiceCards: boolean;
 }
 
+export type TagCounts = {
+    [tag: string]: number;
+};
+
 export type WeeklyArticleLog = {
     week: number;
     count: number;
+    tags?: TagCounts;
 };
 
 export type WeeklyArticleHistory = WeeklyArticleLog[];

--- a/packages/shared/src/types/shared.ts
+++ b/packages/shared/src/types/shared.ts
@@ -144,7 +144,7 @@ export interface ArticlesViewedSettings {
 }
 
 export interface ArticlesViewedByTagSettings {
-    tagIds: string[];
+    tagId: string;
     minViews: number;
     periodInWeeks: number;
 }

--- a/packages/shared/src/types/shared.ts
+++ b/packages/shared/src/types/shared.ts
@@ -143,6 +143,10 @@ export interface ArticlesViewedSettings {
     periodInWeeks: number;
 }
 
+export type ArticlesViewedByTagSettings = {
+    [tag: string]: ArticlesViewedSettings;
+};
+
 export interface ControlProportionSettings {
     proportion: number;
     offset: number;

--- a/packages/shared/src/types/shared.ts
+++ b/packages/shared/src/types/shared.ts
@@ -143,9 +143,11 @@ export interface ArticlesViewedSettings {
     periodInWeeks: number;
 }
 
-export type ArticlesViewedByTagSettings = {
-    [tag: string]: ArticlesViewedSettings;
-};
+export interface ArticlesViewedByTagSettings {
+    tagIds: string[];
+    minViews: number;
+    periodInWeeks: number;
+}
 
 export interface ControlProportionSettings {
     proportion: number;


### PR DESCRIPTION
Co-authored-by: Tom Pretty TomPretty@users.noreply.github.com

A hardcoded epic test for users who have read at least 5 climate crisis articles in the last 6 weeks. We started counting AC by tag on Sept 16th.

### Control
52-week AC above:
![Screen Shot 2021-11-08 at 14 24 50](https://user-images.githubusercontent.com/1513454/140760138-b9803e1d-fe38-46bc-bf3c-18941194a88b.png)

### V1
52-week AC above, climate AC in the body:
![Screen Shot 2021-11-08 at 14 41 06](https://user-images.githubusercontent.com/1513454/140761990-5cc9568a-927e-4371-a341-4de6cfa9be9e.png)


### V2
Climate AC above:
![Screen Shot 2021-11-08 at 14 40 28](https://user-images.githubusercontent.com/1513454/140762003-2020faa2-2c15-4bd6-a7b7-1edfa96ea230.png)


## Details

- Added a new `Filter` to epicSelection.tsx, `withinArticleViewedByTagSettings`. This ensures a user has viewed enough articles of a given tag.
- Changed the in-body AC to _not_ be an opt-out link if there's also AC above.
- Added a new epic module (`ContributionsEpicACByTag`), because V2 requires different client-side logic.