### PR TITLE
Use sectionId for epic targeting

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsLiveblogEpic.testData.ts
+++ b/packages/modules/src/modules/epics/ContributionsLiveblogEpic.testData.ts
@@ -36,7 +36,7 @@ const tracking: Tracking = {
 
 const targeting: EpicTargeting = {
     contentType: 'Article',
-    sectionName: 'environment',
+    sectionId: 'environment',
     shouldHideReaderRevenue: false,
     isMinuteArticle: false,
     isPaidContent: false,

--- a/packages/server/src/factories/targeting.ts
+++ b/packages/server/src/factories/targeting.ts
@@ -3,7 +3,7 @@ import { Factory } from 'fishery';
 
 export default Factory.define<EpicTargeting>(() => ({
     contentType: 'Article',
-    sectionName: 'culture',
+    sectionId: 'culture',
     shouldHideReaderRevenue: false,
     isMinuteArticle: false,
     isPaidContent: false,

--- a/packages/server/src/lib/targeting.test.ts
+++ b/packages/server/src/lib/targeting.test.ts
@@ -15,7 +15,7 @@ describe('shouldNotRenderEpic', () => {
     });
 
     it('returns true for blacklisted section', () => {
-        const data = factories.targeting.build({ sectionName: 'careers' });
+        const data = factories.targeting.build({ sectionId: 'careers' });
         const got = shouldNotRenderEpic(data, 'ARTICLE');
         expect(got).toBe(true);
     });

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -39,9 +39,8 @@ export const shouldThrottle = (
 };
 
 export const shouldNotRenderEpic = (meta: EpicTargeting, epicType: EpicType): boolean => {
-    const isLowValueSection = lowValueSections.some(
-        id => id === meta.sectionId || meta.sectionName,
-    );
+    const section = meta.sectionId || meta.sectionName;
+    const isLowValueSection = !!section && lowValueSections.includes(section);
     const isLowValueTag = lowValueTags.some(id => meta.tags.some(pageTag => pageTag.id === id));
 
     return (

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -1,5 +1,5 @@
 import { EpicTargeting, EpicType, ViewLog } from '@sdc/shared/types';
-import { daysSince } from '../lib/dates';
+import { daysSince } from './dates';
 
 const lowValueSections = ['money', 'education', 'games', 'teacher-network', 'careers'];
 
@@ -39,7 +39,9 @@ export const shouldThrottle = (
 };
 
 export const shouldNotRenderEpic = (meta: EpicTargeting, epicType: EpicType): boolean => {
-    const isLowValueSection = lowValueSections.some(id => id === meta.sectionName);
+    const isLowValueSection = lowValueSections.some(
+        id => id === meta.sectionId || meta.sectionName,
+    );
     const isLowValueTag = lowValueTags.some(id => meta.tags.some(pageTag => pageTag.id === id));
 
     return (

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -505,7 +505,7 @@ describe('POST /epic', () => {
     it('should return epic data', async () => {
         const targeting = factories.targeting.build({
             contentType: 'Article',
-            sectionName: 'environment',
+            sectionId: 'environment',
             shouldHideReaderRevenue: false,
             isMinuteArticle: false,
             isPaidContent: false,

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -71,7 +71,7 @@ const testDefault: EpicTest = {
 
 const targetingDefault: EpicTargeting = {
     contentType: 'Article',
-    sectionName: 'environment',
+    sectionId: 'environment',
     shouldHideReaderRevenue: false,
     isMinuteArticle: false,
     isPaidContent: false,
@@ -121,7 +121,7 @@ describe('findTestAndVariant', () => {
     it('should return undefined when no matching test variant', () => {
         const test = { ...testDefault, excludedSections: ['news'] };
         const tests = [test];
-        const targeting = { ...targetingDefault, sectionName: 'news' };
+        const targeting = { ...targetingDefault, sectionId: 'news' };
         const epicType = 'ARTICLE';
 
         const got = findTestAndVariant(tests, targeting, superModeArticles, epicType);
@@ -321,7 +321,7 @@ describe('hasSectionOrTags filter', () => {
         };
         const targeting: EpicTargeting = {
             ...targetingDefault,
-            sectionName: 'environment',
+            sectionId: 'environment',
         };
 
         const got = hasSectionOrTags.test(test, targeting);
@@ -336,7 +336,7 @@ describe('hasSectionOrTags filter', () => {
         };
         const targeting: EpicTargeting = {
             ...targetingDefault,
-            sectionName: 'business',
+            sectionId: 'business',
         };
 
         const got = hasSectionOrTags.test(test, targeting);
@@ -358,7 +358,7 @@ describe('hasSectionOrTags filter', () => {
         };
         const targeting: EpicTargeting = {
             ...targetingDefault,
-            sectionName: 'business',
+            sectionId: 'business',
             tags: tags,
         };
 
@@ -381,7 +381,7 @@ describe('hasSectionOrTags filter', () => {
         };
         const targeting: EpicTargeting = {
             ...targetingDefault,
-            sectionName: 'business',
+            sectionId: 'business',
             tags: [
                 {
                     id: 'business/some-business-tag',
@@ -403,7 +403,7 @@ describe('hasSectionOrTags filter', () => {
         };
         const targeting: EpicTargeting = {
             ...targetingDefault,
-            sectionName: 'business',
+            sectionId: 'business',
         };
 
         const got = hasSectionOrTags.test(test, targeting);
@@ -420,7 +420,7 @@ describe('excludeSection filter', () => {
         };
         const targeting: EpicTargeting = {
             ...targetingDefault,
-            sectionName: 'football',
+            sectionId: 'football',
         };
 
         const got = excludeSection.test(test, targeting);
@@ -435,7 +435,7 @@ describe('excludeSection filter', () => {
         };
         const targeting: EpicTargeting = {
             ...targetingDefault,
-            sectionName: 'environment',
+            sectionId: 'environment',
         };
 
         const got = excludeSection.test(test, targeting);

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -68,7 +68,7 @@ export const hasSectionOrTags: Filter = {
             targeting.tags.map(tag => tag.id).includes(tagId),
         );
 
-        const hasSection = test.sections.includes(targeting.sectionName);
+        const hasSection = test.sections.includes(targeting.sectionId || targeting.sectionName);
         const hasTags = intersectingTags.length > 0;
 
         return hasSection || hasTags;
@@ -77,7 +77,8 @@ export const hasSectionOrTags: Filter = {
 
 export const excludeSection: Filter = {
     id: 'excludeSection',
-    test: (test, targeting) => !test.excludedSections.includes(targeting.sectionName),
+    test: (test, targeting) =>
+        !test.excludedSections.includes(targeting.sectionId || targeting.sectionName),
 };
 
 export const excludeTags: Filter = {

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -68,7 +68,8 @@ export const hasSectionOrTags: Filter = {
             targeting.tags.map(tag => tag.id).includes(tagId),
         );
 
-        const hasSection = test.sections.includes(targeting.sectionId || targeting.sectionName);
+        const section = targeting.sectionId || targeting.sectionName;
+        const hasSection = !!section && test.sections.includes(section);
         const hasTags = intersectingTags.length > 0;
 
         return hasSection || hasTags;
@@ -77,8 +78,13 @@ export const hasSectionOrTags: Filter = {
 
 export const excludeSection: Filter = {
     id: 'excludeSection',
-    test: (test, targeting) =>
-        !test.excludedSections.includes(targeting.sectionId || targeting.sectionName),
+    test: (test, targeting) => {
+        const section = targeting.sectionId || targeting.sectionName;
+        if (section) {
+            return !test.excludedSections.includes(section);
+        }
+        return true;
+    },
 };
 
 export const excludeTags: Filter = {

--- a/packages/shared/src/factories/targeting.ts
+++ b/packages/shared/src/factories/targeting.ts
@@ -3,7 +3,7 @@ import { Factory } from 'fishery';
 
 export default Factory.define<EpicTargeting>(() => ({
     contentType: 'Article',
-    sectionName: 'culture',
+    sectionId: 'culture',
     shouldHideReaderRevenue: false,
     isMinuteArticle: false,
     isPaidContent: false,

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -33,7 +33,7 @@ export type ViewLog = View[];
 
 export type EpicTargeting = {
     contentType: string;
-    sectionName: string; // Deprecated - use sectionId
+    sectionName?: string; // Deprecated - use sectionId
     sectionId?: string;
     shouldHideReaderRevenue: boolean;
 

--- a/packages/shared/src/types/epic.ts
+++ b/packages/shared/src/types/epic.ts
@@ -33,7 +33,8 @@ export type ViewLog = View[];
 
 export type EpicTargeting = {
     contentType: string;
-    sectionName: string;
+    sectionName: string; // Deprecated - use sectionId
+    sectionId?: string;
     shouldHideReaderRevenue: boolean;
 
     // TODO let's replace these with Design Type/a single property after migration


### PR DESCRIPTION
Currently we target by tag ID, but section name. This is inconsistent, and likely to lead to mistakes.
It's actually also a bug because frontend does send sectionId! But I think it hasn't really been an issue because the name and id are often the same, e.g. `environment`.

This PR changes the backend to support both section name and section id. This is temporary while we migrate the clients.
For now, both sectionName and sectionId are optional fields, because for a time clients may be sending either. A follow up PR can remove sectionName and make sectionId mandatory.

TODO:

- [ ] Update DCR to send `sectionId` field
- [ ] Update frontend to send `sectionId` field