### PR TITLE
Re-enable html in messages

### DIFF
--- a/packages/modules/src/lib/replaceArticleCount.tsx
+++ b/packages/modules/src/lib/replaceArticleCount.tsx
@@ -48,5 +48,11 @@ export const replaceArticleCount = (
     if (optOutLink) {
         return replaceArticleCountWithLink(text, numArticles, articleCountOptOutType, tracking);
     }
-    return <>{text.replace(/%%ARTICLE_COUNT%%/, `${numArticles}`)}</>;
+    return (
+        <span
+            dangerouslySetInnerHTML={{
+                __html: text.replace(/%%ARTICLE_COUNT%%/, `${numArticles}`),
+            }}
+        />
+    );
 };


### PR DESCRIPTION
This was broken here: https://github.com/guardian/support-dotcom-components/pull/557/files#diff-21fed3afe7c219869438ed4902474a49427cf7ab5f0f4355f3ad8eb0d27d847fR51

Support for html in these messages was always a bit of an accidental 'feature'. The tools should offer proper support for creating links, but for now this PR will make it behave as before.

![Screen Shot 2021-11-10 at 09 29 21](https://user-images.githubusercontent.com/1513454/141087049-42289979-36fe-408c-b76f-925ccc61a777.png)
