### PR TITLE
set cors origin

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -35,13 +35,20 @@ const app = express();
 app.use(express.json({ limit: '50mb' }));
 app.use(compression());
 
-const corsOptions = isProd
-    ? {
-          origin: 'https://www.theguardian.com',
-      }
-    : {
-          origin: '*',
-      };
+const corsOrigin = () => {
+    switch (process.env.stage) {
+        case 'PROD':
+            return 'https://www.theguardian.com';
+        case 'CODE':
+            return 'https://m.code.dev-theguardian.com';
+        default:
+            return '*';
+    }
+};
+
+const corsOptions = {
+    origin: corsOrigin(),
+};
 app.use(cors(corsOptions));
 
 app.use(loggingMiddleware);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -35,9 +35,14 @@ const app = express();
 app.use(express.json({ limit: '50mb' }));
 app.use(compression());
 
-// Note allows *all* cors. We may want to tighten this later.
-app.use(cors());
-app.options('*', [cors()]);
+const corsOptions = isProd
+    ? {
+          origin: 'https://www.theguardian.com',
+      }
+    : {
+          origin: '*',
+      };
+app.use(cors(corsOptions));
 
 app.use(loggingMiddleware);
 


### PR DESCRIPTION
Currently the `Access-Control-Allow-Origin` header is a wildcard (`*`)
We're seeing some failed cors requests from the Apple Mail browser, so let's see if setting an origin helps.