### PR TITLE
Add US End Of Year banner

### DIFF
--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -8,7 +8,8 @@ export type BannerId =
     | 'investigations-moment-banner'
     | 'environment-moment-banner'
     | 'subscription-banner'
-    | 'weekly-banner';
+    | 'weekly-banner'
+    | 'us-eoy-moment-banner';
 
 export interface BannerEnrichedCta {
     ctaUrl: string;

--- a/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.stories.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { UsEoyMomentBanner as UsEoyMoment } from './UsEoyMomentBanner';
+import { props } from '../utils/storybook';
+import { BannerProps, SecondaryCtaType, TickerCountType, TickerEndType } from '@sdc/shared/types';
+
+export default {
+    component: UsEoyMoment,
+    title: 'Banners/UsEoyMoment',
+    args: props,
+} as Meta;
+
+const Template: Story<BannerProps> = (props: BannerProps) => <UsEoyMoment {...props} />;
+
+export const WithoutArticleCount = Template.bind({});
+WithoutArticleCount.args = {
+    ...props,
+    mobileContent: {
+        heading: 'Join us in the fight for America’s future',
+        messageText:
+            'One year ago, we outlined our plans to confront the escalating climate crisis. We promised to report with authority on the defining issue of our lifetime',
+        cta: {
+            text: 'Support The Guardian',
+            baseUrl: 'https://support.theguardian.com/contribute',
+        },
+    },
+    content: {
+        heading: 'Join us in the fight for America’s future',
+        messageText:
+            'One year ago, we outlined our plans to confront the escalating climate crisis. We promised to report with authority on the defining issue of our lifetime – giving it the sustained attention it demands. Then came the global pandemic. Today we want to update you on our progress, and assure you that the Guardian will not sideline the climate emergency in 2020, or in the years to come. Generosity from supporters like you sustains our open, independent',
+        cta: {
+            text: 'Support the Guardian',
+            baseUrl: 'https://support.theguardian.com/contribute',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Hear from our editor',
+                baseUrl: 'https://theguardian.com',
+            },
+        },
+    },
+    numArticles: 0,
+    tickerSettings: {
+        countType: TickerCountType.money,
+        endType: TickerEndType.hardstop,
+        currencySymbol: '$',
+        copy: {
+            countLabel: 'contributed',
+            goalReachedPrimary: "We've met our goal - thank you!",
+            goalReachedSecondary: "It's not too late to give!",
+        },
+        tickerData: {
+            total: 180000,
+            goal: 150000,
+        },
+    },
+};
+
+export const WithArticleCount = Template.bind({});
+WithArticleCount.args = {
+    ...WithoutArticleCount.args,
+    numArticles: 321,
+};

--- a/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.stories.tsx
@@ -51,7 +51,7 @@ WithoutArticleCount.args = {
             goalReachedSecondary: "It's not too late to give!",
         },
         tickerData: {
-            total: 180000,
+            total: 120000,
             goal: 150000,
         },
     },

--- a/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { neutral, news, space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { Container } from '@guardian/src-layout';
+import { BannerRenderProps } from '../common/types';
+import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
+import { UsEoyMomentBannerHeader } from './components/UsEoyMomentBannerHeader';
+import { UsEoyMomentBannerArticleCount } from './components/UsEoyMomentBannerArticleCount';
+import { UsEoyMomentBannerBody } from './components/UsEoyMomentBannerBody';
+import { UsEoyMomentBannerCtas } from './components/UsEoyMomentBannerCtas';
+import { UsEoyMomentBannerCloseButton } from './components/UsEoyMomentBannerCloseButton';
+import UsEoyMomentBannerTicker from './components/UsEoyMomentBannerTicker';
+import UsEoyMomentBannerVisual from './components/UsEoyMomentBannerVisual';
+
+const styles = {
+    outerContainer: css`
+        background: #fdefe0;
+        border-top: 1px solid ${news[400]};
+    `,
+    container: css`
+        position: relative;
+        overflow: hidden;
+        max-width: 1300px;
+        margin: 0 auto;
+
+        * {
+            box-sizing: border-box;
+        }
+
+        ${from.tablet} {
+            background: #fdefe0;
+        }
+
+        ${from.wide} {
+            border-right: 1px solid #707070;
+            border-left: 1px solid #707070;
+        }
+    `,
+    headerContainer: css`
+        margin: 0 -${space[3]}px;
+        display: inline-block;
+
+        ${from.mobileLandscape} {
+            margin: 0 -${space[5]}px;
+        }
+
+        ${from.tablet} {
+            margin: 0;
+        }
+    `,
+    horizontalRule: css`
+        clear: both;
+        margin: 0 -${space[3]}px 0 0;
+        background-color: ${neutral[20]};
+        height: 1px;
+        border-width: 0;
+
+        ${from.mobileLandscape} {
+            margin-right: -${space[5]}px;
+        }
+
+        ${from.tablet} {
+            display: none;
+        }
+    `,
+    bottomContainer: css`
+        padding-bottom: ${space[6]}px;
+
+        ${from.tablet} {
+            max-width: 58%;
+        }
+
+        ${from.desktop} {
+            max-width: 66%;
+        }
+
+        ${from.leftCol} {
+            max-width: 64%;
+        }
+
+        ${from.leftCol} {
+            max-width: 68%;
+        }
+    `,
+    bodyContainer: css`
+        margin-top: ${space[1]}px;
+    `,
+    ctasContainer: css`
+        display: flex;
+        flex-direction: row;
+        margin-top: ${space[4]}px;
+
+        ${from.tablet} {
+            margin-top: ${space[6]}px;
+            margin-right: -65px;
+        }
+    `,
+    closeButtonContainer: css`
+        position: absolute;
+        top: ${space[2]}px;
+        right: ${space[4]}px;
+
+        ${from.leftCol} {
+            top: ${space[3]}px;
+            right: ${space[5]}px;
+        }
+    `,
+};
+
+function UsEoyMomentBanner({
+    content,
+    onCloseClick,
+    numArticles,
+    onCtaClick,
+    onSecondaryCtaClick,
+    tickerSettings,
+}: BannerRenderProps) {
+    return (
+        <div css={styles.outerContainer}>
+            <Container cssOverrides={styles.container}>
+                <div css={styles.headerContainer}>
+                    <UsEoyMomentBannerHeader
+                        heading={content.mainContent.heading}
+                        mobileHeading={content.mobileContent?.heading ?? null}
+                    />
+                </div>
+
+                <UsEoyMomentBannerVisual />
+                <hr css={styles.horizontalRule} />
+
+                <div css={styles.bottomContainer}>
+                    {numArticles !== undefined && numArticles > 5 && (
+                        <section>
+                            <UsEoyMomentBannerArticleCount numArticles={numArticles} />
+                        </section>
+                    )}
+
+                    {tickerSettings?.tickerData && (
+                        <UsEoyMomentBannerTicker
+                            tickerSettings={tickerSettings}
+                            accentColour={news[400]}
+                        />
+                    )}
+
+                    <section css={styles.bodyContainer}>
+                        <UsEoyMomentBannerBody
+                            messageText={content.mainContent.messageText}
+                            mobileMessageText={content.mobileContent?.messageText ?? null}
+                            highlightedText={content.mainContent.highlightedText ?? null}
+                            mobileHighlightedText={content.mobileContent?.highlightedText ?? null}
+                        />
+                    </section>
+
+                    <section css={styles.ctasContainer}>
+                        <UsEoyMomentBannerCtas
+                            desktopCtas={{
+                                primary: content.mainContent.primaryCta,
+                                secondary: content.mainContent.secondaryCta,
+                            }}
+                            mobileCtas={
+                                content.mobileContent
+                                    ? {
+                                          primary: content.mobileContent.primaryCta,
+                                          secondary: null,
+                                      }
+                                    : null
+                            }
+                            onPrimaryCtaClick={onCtaClick}
+                            onSecondaryCtaClick={onSecondaryCtaClick}
+                        />
+                    </section>
+                </div>
+                <div css={styles.closeButtonContainer}>
+                    <UsEoyMomentBannerCloseButton onCloseClick={onCloseClick} />
+                </div>
+            </Container>
+        </div>
+    );
+}
+
+const unvalidated = bannerWrapper(UsEoyMomentBanner, 'us-eoy-moment-banner');
+const validated = validatedBannerWrapper(UsEoyMomentBanner, 'us-eoy-moment-banner');
+
+export { validated as UsEoyMomentBanner, unvalidated as UsEoyMomentBannerUnvalidated };

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerArticleCount.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { neutral, space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { headline } from '@guardian/src-foundations/typography';
+import { ArticleCountOptOutPopup } from '../../../shared/ArticleCountOptOutPopup';
+import { Hide } from '@guardian/src-layout';
+
+const styles = {
+    container: css`
+        ${headline.xxxsmall({ fontWeight: 'bold' })}
+        font-size: 15px;
+        color: ${neutral[20]};
+        margin: 0 0 ${space[3]}px;
+
+        ${from.tablet} {
+            font-size: 17px;
+            color: #707070;
+        }
+
+        ${from.desktop} {
+            font-size: 20px;
+        }
+
+        ${from.leftCol} {
+            font-size: 24px;
+        }
+    `,
+};
+
+interface UsEoyMomentBannerArticleCountProps {
+    numArticles: number;
+}
+
+export function UsEoyMomentBannerArticleCount({
+    numArticles,
+}: UsEoyMomentBannerArticleCountProps): JSX.Element {
+    return (
+        <p css={styles.container}>
+            You&apos;ve read{' '}
+            <Hide above="tablet">
+                <ArticleCountOptOutPopup
+                    numArticles={numArticles}
+                    nextWord=" articles"
+                    type="us-eoy-moment-banner"
+                />
+            </Hide>
+            <Hide below="tablet">
+                <ArticleCountOptOutPopup
+                    numArticles={numArticles}
+                    nextWord=" articles"
+                    type="us-eoy-moment-banner"
+                />
+            </Hide>{' '}
+            in the last year
+        </p>
+    );
+}

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerArticleCount.tsx
@@ -11,11 +11,10 @@ const styles = {
         ${headline.xxxsmall({ fontWeight: 'bold' })}
         font-size: 15px;
         color: ${neutral[20]};
-        margin: 0 0 ${space[3]}px;
+        margin: 0 0 ${space[6]}px;
 
         ${from.tablet} {
             font-size: 17px;
-            color: #707070;
         }
 
         ${from.desktop} {

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerBody.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerBody.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { neutral } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { Hide } from '@guardian/src-layout';
+import { body } from '@guardian/src-foundations/typography';
+
+const styles = {
+    container: css`
+        ${body.small()}
+        color: ${neutral[0]};
+
+        p {
+            margin: 0;
+        }
+
+        ${from.tablet} {
+            color: ${neutral[0]};
+            font-size: 17px;
+        }
+    `,
+    highlightedTextContainer: css`
+        font-weight: bold;
+    `,
+};
+
+interface UsEoyMomentBannerBodyProps {
+    messageText: JSX.Element | JSX.Element[];
+    mobileMessageText: JSX.Element | JSX.Element[] | null;
+    highlightedText: JSX.Element | JSX.Element[] | null;
+    mobileHighlightedText: JSX.Element | JSX.Element[] | null;
+}
+
+export function UsEoyMomentBannerBody({
+    messageText,
+    mobileMessageText,
+    highlightedText,
+    mobileHighlightedText,
+}: UsEoyMomentBannerBodyProps): JSX.Element {
+    return (
+        <div css={styles.container}>
+            <p>
+                <span>
+                    <Hide above="desktop">{mobileMessageText ?? messageText}</Hide>
+                    <Hide below="desktop">{messageText}</Hide>
+                </span>{' '}
+                <span css={styles.highlightedTextContainer}>
+                    <Hide above="tablet">{mobileHighlightedText ?? highlightedText}</Hide>
+
+                    <Hide below="tablet">{highlightedText}</Hide>
+                </span>
+            </p>
+        </div>
+    );
+}

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerCloseButton.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { brand, neutral, space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { SvgCross } from '@guardian/src-icons';
+import { Button } from '@guardian/src-button';
+import { Hide } from '@guardian/src-layout';
+import { SvgRoundelBrand } from '@guardian/src-brand';
+
+const styles = {
+    container: css`
+        display: flex;
+    `,
+    roundelContainer: css`
+        height: 36px;
+        width: 36px;
+        margin-right: ${space[1]}px;
+
+        svg {
+            display: block;
+        }
+    `,
+    closeButton: css`
+        background-color: ${brand[400]};
+        color: ${neutral[100]};
+
+        &:hover {
+            background-color: ${neutral[0]};
+            color: ${neutral[100]};
+        }
+
+        ${from.tablet} {
+            &:hover {
+                background-color: #234b8a;
+            }
+        }
+    `,
+};
+
+interface InvestigationsMomentBannerCloseButtonProps {
+    onCloseClick: () => void;
+}
+
+export function UsEoyMomentBannerCloseButton({
+    onCloseClick,
+}: InvestigationsMomentBannerCloseButtonProps): JSX.Element {
+    return (
+        <div css={styles.container}>
+            <Hide above="tablet">
+                <Button
+                    onClick={onCloseClick}
+                    cssOverrides={styles.closeButton}
+                    icon={<SvgCross />}
+                    size="xsmall"
+                    hideLabel
+                >
+                    Close
+                </Button>
+            </Hide>
+
+            <Hide below="tablet">
+                <div css={styles.roundelContainer}>
+                    <SvgRoundelBrand />
+                </div>
+            </Hide>
+
+            <Hide below="tablet">
+                <div>
+                    <Button
+                        onClick={onCloseClick}
+                        cssOverrides={styles.closeButton}
+                        icon={<SvgCross />}
+                        size="small"
+                        hideLabel
+                    >
+                        Close
+                    </Button>
+                </div>
+            </Hide>
+        </div>
+    );
+}

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerCtas.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { space } from '@guardian/src-foundations';
+import { Hide } from '@guardian/src-layout';
+import { LinkButton } from '@guardian/src-button';
+import { SecondaryCtaType } from '@sdc/shared/types';
+import { BannerEnrichedCta, BannerEnrichedSecondaryCta } from '../../common/types';
+import { SvgArrowRightStraight } from '@guardian/src-icons';
+
+const styles = {
+    container: css`
+        display: flex;
+        flex-direction: row;
+
+        & > * + * {
+            margin-left: ${space[3]}px;
+        }
+    `,
+};
+
+interface BreakpointCtas {
+    primary: BannerEnrichedCta | null;
+    secondary: BannerEnrichedSecondaryCta | null;
+}
+
+interface UsEoyMomentBannerCtasProps {
+    mobileCtas: BreakpointCtas | null;
+    desktopCtas: BreakpointCtas;
+    onPrimaryCtaClick: () => void;
+    onSecondaryCtaClick: () => void;
+}
+
+export function UsEoyMomentBannerCtas({
+    desktopCtas,
+    mobileCtas: maybeMobileCtas,
+    onPrimaryCtaClick,
+    onSecondaryCtaClick,
+}: UsEoyMomentBannerCtasProps): JSX.Element {
+    const mobileCtas = maybeMobileCtas ?? desktopCtas;
+
+    return (
+        <div css={styles.container}>
+            <div>
+                {mobileCtas.primary && (
+                    <Hide above="tablet">
+                        <LinkButton
+                            href={mobileCtas.primary.ctaUrl}
+                            onClick={onPrimaryCtaClick}
+                            size="small"
+                            priority="primary"
+                            icon={<SvgArrowRightStraight />}
+                            iconSide="right"
+                        >
+                            {mobileCtas.primary.ctaText}
+                        </LinkButton>
+                    </Hide>
+                )}
+
+                {desktopCtas.primary && (
+                    <Hide below="tablet">
+                        <LinkButton
+                            href={desktopCtas.primary.ctaUrl}
+                            onClick={onPrimaryCtaClick}
+                            size="small"
+                            priority="primary"
+                        >
+                            {desktopCtas.primary.ctaText}
+                        </LinkButton>
+                    </Hide>
+                )}
+            </div>
+
+            <div>
+                {desktopCtas.secondary?.type === SecondaryCtaType.Custom && (
+                    <Hide below="tablet">
+                        <LinkButton
+                            href={desktopCtas.secondary.cta.ctaUrl}
+                            onClick={onSecondaryCtaClick}
+                            size="small"
+                            priority="tertiary"
+                        >
+                            {desktopCtas.secondary.cta.ctaText}
+                        </LinkButton>
+                    </Hide>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerHeader.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { news, space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { headline } from '@guardian/src-foundations/typography';
+
+const styles = {
+    container: css`
+        position: relative;
+    `,
+    header: css`
+        padding: ${space[2]}px ${space[3]}px;
+        margin: 0;
+
+        h2 {
+            ${headline.xsmall({ fontWeight: 'bold' })}
+            max-width: 150px;
+            margin: 0;
+            color: ${news[400]};
+            width: max-content;
+
+            ${from.mobileLandscape} {
+                max-width: 210px;
+            }
+
+            ${from.phablet} {
+                max-width: 300px;
+                font-size: 34px;
+            }
+
+            ${from.tablet} {
+                max-width: 400px;
+                font-size: 34px;
+            }
+
+            ${from.desktop} {
+                max-width: none;
+            }
+
+            ${from.leftCol} {
+                max-width: none;
+                font-size: 38px;
+            }
+        }
+
+        ${from.mobileLandscape} {
+            padding: ${space[2]}px ${space[5]}px;
+        }
+
+        ${from.tablet} {
+            padding: ${space[2]}px 0;
+        }
+    `,
+};
+
+interface UsEoyMomentBannerHeaderProps {
+    heading: JSX.Element | JSX.Element[] | null;
+    mobileHeading: JSX.Element | JSX.Element[] | null;
+}
+
+export function UsEoyMomentBannerHeader({
+    heading,
+    mobileHeading,
+}: UsEoyMomentBannerHeaderProps): JSX.Element {
+    return (
+        <div css={styles.container}>
+            <header css={styles.header}>
+                <h2>{mobileHeading ?? heading}</h2>
+            </header>
+        </div>
+    );
+}

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerTicker.tsx
@@ -32,6 +32,7 @@ const soFarCountStyles = css`
     ${textSans.xsmall({ fontWeight: 'bold' })};
     font-size: 13px;
     color: ${neutral[0]};
+    line-height: 1.3;
 
     ${from.desktop} {
         font-size: 17px;
@@ -40,6 +41,13 @@ const soFarCountStyles = css`
 
 const countLabelStyles = css`
     ${textSans.xsmall()};
+    font-size: 13px;
+    color: ${neutral[0]};
+    line-height: 1.3;
+
+    ${from.desktop} {
+        font-size: 17px;
+    }
 `;
 
 const progressBarHeight = 12;

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerTicker.tsx
@@ -1,0 +1,205 @@
+import React, { useState, useEffect } from 'react';
+import { css, SerializedStyles } from '@emotion/react';
+import { neutral, palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
+import { TickerSettings } from '@sdc/shared/types';
+import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
+import useTicker from '../../../../hooks/useTicker';
+import { from } from '@guardian/src-foundations/mq';
+
+// This ticker component provides an animated progress bar and counter for the
+// epic. It mirrors the behaviour of the "unlimited" ticker type from frontend.
+// The "hardstop" type is not supported. The differences between the two relate
+// to behaviour once the goal has been reached.
+
+const rootStyles = css`
+    position: relative;
+    height: 65px;
+    line-height: 18px;
+`;
+
+const totalCountStyles = css`
+    ${textSans.xsmall({ fontWeight: 'bold' })};
+    font-size: 13px;
+    color: ${neutral[0]};
+
+    ${from.desktop} {
+        font-size: 17px;
+    }
+`;
+
+const soFarCountStyles = css`
+    ${textSans.xsmall({ fontWeight: 'bold' })};
+    font-size: 13px;
+    color: ${neutral[0]};
+
+    ${from.desktop} {
+        font-size: 17px;
+    }
+`;
+
+const countLabelStyles = css`
+    ${textSans.xsmall()};
+`;
+
+const progressBarHeight = 12;
+
+const progressBarContainerStyles = css`
+    width: 100%;
+    height: ${progressBarHeight}px;
+    background-color: ${palette.neutral[86]};
+    position: absolute;
+    bottom: 0;
+    margin-top: 40px;
+`;
+
+const progressBarStyles = css`
+    overflow: hidden;
+    width: 100%;
+    background: #dda7a1;
+    height: ${progressBarHeight}px;
+    position: absolute;
+`;
+
+const soFarContainerStyles = css`
+    position: absolute;
+    left: 0;
+    bottom: ${progressBarHeight + 5}px;
+`;
+
+const progressBarTransform = (end: number, runningTotal: number, total: number): string => {
+    const haveStartedAnimating = runningTotal > 0;
+
+    if (!haveStartedAnimating) {
+        return 'translateX(-100%)';
+    }
+
+    const percentage = (total / end) * 100 - 100;
+
+    return `translate3d(${percentage >= 0 ? 0 : percentage}%, 0, 0)`;
+};
+
+const filledProgressStyles = (
+    end: number,
+    runningTotal: number,
+    total: number,
+    colour: string,
+): SerializedStyles =>
+    css`
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        transform: ${progressBarTransform(end, runningTotal, total)};
+        transition: transform 3s cubic-bezier(0.25, 0.55, 0.2, 0.85);
+        background-color: ${colour};
+    `;
+
+const goalContainerStyles = css`
+    position: absolute;
+    right: 0;
+    bottom: ${progressBarHeight + 5}px;
+    text-align: right;
+`;
+
+const goalMarkerStyles = (transform: string): SerializedStyles => css`
+    border-right: 2px solid ${palette.neutral[7]};
+    content: ' ';
+    display: block;
+    height: 12px;
+    margin-top: -2px;
+    transform: ${transform};
+`;
+
+type MarkerProps = {
+    goal: number;
+    end: number;
+};
+
+const Marker: React.FC<MarkerProps> = ({ goal, end }: MarkerProps) => {
+    if (end > goal) {
+        const markerTranslate = (goal / end) * 100 - 100;
+        const markerTransform = `translate3d(${markerTranslate}%, 0, 0)`;
+
+        return <div css={goalMarkerStyles(markerTransform)} />;
+    } else {
+        return null;
+    }
+};
+
+type UsEoyMomentBannerTickerProps = {
+    tickerSettings: TickerSettings;
+    accentColour: string;
+};
+
+const UsEoyMomentBannerTicker: React.FC<UsEoyMomentBannerTickerProps> = ({
+    tickerSettings: tickerSettings,
+    accentColour,
+}: UsEoyMomentBannerTickerProps) => {
+    const [readyToAnimate, setReadyToAnimate] = useState(false);
+
+    const debounce = true;
+    const [hasBeenSeen, setNode] = useHasBeenSeen(
+        {
+            rootMargin: '-18px',
+            threshold: 0,
+        },
+        debounce,
+    ) as HasBeenSeen;
+
+    useEffect(() => {
+        if (hasBeenSeen) {
+            setTimeout(() => setReadyToAnimate(true), 500);
+        }
+    }, [hasBeenSeen]);
+
+    const total = tickerSettings.tickerData?.total || 1;
+    const goal = tickerSettings.tickerData?.goal || 1;
+    const isGoalReached = total >= goal;
+    const runningTotal = useTicker(total, readyToAnimate);
+    const currencySymbol =
+        tickerSettings.countType === 'money' ? tickerSettings.currencySymbol : '';
+
+    // If we've exceeded the goal then extend the bar 15% beyond the total
+    const end = isGoalReached ? total + total * 0.15 : goal;
+
+    return (
+        <div ref={setNode} css={rootStyles}>
+            <div>
+                <div css={soFarContainerStyles}>
+                    <div css={soFarCountStyles}>
+                        {!isGoalReached && currencySymbol}
+                        {isGoalReached
+                            ? tickerSettings.copy.goalReachedPrimary
+                            : runningTotal.toLocaleString()}
+                    </div>
+                    <div css={countLabelStyles}>
+                        {isGoalReached
+                            ? tickerSettings.copy.goalReachedSecondary
+                            : tickerSettings.copy.countLabel}
+                    </div>
+                </div>
+
+                <div css={goalContainerStyles}>
+                    <div css={totalCountStyles}>
+                        {currencySymbol}
+                        {isGoalReached ? runningTotal.toLocaleString() : goal.toLocaleString()}
+                    </div>
+                    <div css={countLabelStyles}>
+                        {isGoalReached ? tickerSettings.copy.countLabel : 'our goal'}
+                    </div>
+                </div>
+            </div>
+
+            <div css={progressBarContainerStyles}>
+                <div css={progressBarStyles}>
+                    <div css={filledProgressStyles(end, runningTotal, total, accentColour)}></div>
+                </div>
+                <Marker goal={goal} end={end} />
+            </div>
+        </div>
+    );
+};
+
+export default UsEoyMomentBannerTicker;

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerVisual.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { from } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
+
+const container = css`
+    width: 40%;
+    padding-top: 45%;
+    position: relative;
+    float: right;
+    overflow-y: clip;
+
+    ${from.mobileMedium} {
+        padding-top: 40%;
+        width: 43%;
+    }
+
+    ${from.mobileLandscape} {
+        padding-top: 30%;
+    }
+
+    ${from.phablet} {
+        padding-top: 25%;
+    }
+
+    ${from.tablet} {
+        padding-top: 0;
+        height: 100%;
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        width: 42%;
+    }
+
+    ${from.desktop} {
+        width: 34%;
+    }
+
+    ${from.desktop} {
+        width: 36%;
+        right: -2%;
+    }
+
+    ${from.leftCol} {
+        width: 34%;
+    }
+`;
+
+const imageContainer = css`
+    margin-right: -${space[3]}px;
+    margin-left: -32px;
+
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+
+    ${from.mobileMedium} {
+        bottom: -11%;
+    }
+
+    ${from.mobileLandscape} {
+        margin-right: -${space[5]}px;
+        bottom: -40%;
+    }
+
+    ${from.phablet} {
+        bottom: -55%;
+    }
+
+    ${from.tablet} {
+        margin-left: 0;
+        margin-right: 0;
+        bottom: 0%;
+        padding-left: 3%;
+    }
+
+    ${from.desktop} {
+        bottom: 0%;
+        padding-left: 5%;
+    }
+
+    ${from.leftCol} {
+        right: -25%;
+        bottom: -10%;
+    }
+
+    ${from.wide} {
+        bottom: -25%;
+    }
+
+    img {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+`;
+
+const UsEoyMomentBannerVisual = (): JSX.Element => (
+    <div css={container}>
+        <div css={imageContainer}>
+            <picture>
+                <source
+                    media="(max-width: 979px)"
+                    srcSet="https://media.guim.co.uk/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/414.jpg"
+                />
+                <source
+                    media="(max-width: 1299px)"
+                    srcSet="https://media.guim.co.uk/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/600.jpg"
+                />
+                <source srcSet="https://media.guim.co.uk/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/600.jpg" />
+                <img src="https://media.guim.co.uk/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/414.jpg" />
+            </picture>
+        </div>
+    </div>
+);
+
+export default UsEoyMomentBannerVisual;

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerVisual.tsx
@@ -81,12 +81,7 @@ const imageContainer = css`
     }
 
     ${from.leftCol} {
-        right: -25%;
-        bottom: -10%;
-    }
-
-    ${from.wide} {
-        bottom: -25%;
+        right: -5%;
     }
 
     img {
@@ -103,7 +98,7 @@ const UsEoyMomentBannerVisual = (): JSX.Element => (
             <picture>
                 <source
                     media="(max-width: 979px)"
-                    srcSet="hhttps://i.guim.co.uk/img/media/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/414.jpg?width=414&quality=85&s=d1aa5690af8abb2c696c528eb44e5ca5"
+                    srcSet="https://i.guim.co.uk/img/media/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/414.jpg?width=414&quality=85&s=d1aa5690af8abb2c696c528eb44e5ca5"
                 />
                 <source
                     media="(max-width: 1299px)"

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerVisual.tsx
@@ -103,14 +103,15 @@ const UsEoyMomentBannerVisual = (): JSX.Element => (
             <picture>
                 <source
                     media="(max-width: 979px)"
-                    srcSet="https://media.guim.co.uk/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/414.jpg"
+                    srcSet="hhttps://i.guim.co.uk/img/media/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/414.jpg?width=414&quality=85&s=d1aa5690af8abb2c696c528eb44e5ca5"
                 />
                 <source
                     media="(max-width: 1299px)"
-                    srcSet="https://media.guim.co.uk/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/600.jpg"
+                    srcSet="
+                    https://i.guim.co.uk/img/media/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/600.jpg?width=600&quality=85&s=2859c5b61e0b033bfe458b32d29fdc7e"
                 />
-                <source srcSet="https://media.guim.co.uk/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/600.jpg" />
-                <img src="https://media.guim.co.uk/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/414.jpg" />
+                <source srcSet="https://i.guim.co.uk/img/media/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/600.jpg?width=600&quality=85&s=2859c5b61e0b033bfe458b32d29fdc7e" />
+                <img src="https://i.guim.co.uk/img/media/fb8279054062d480d5f14c7098accc980fb5dd45/0_0_600_724/414.jpg?width=414&quality=85&s=d1aa5690af8abb2c696c528eb44e5ca5" />
             </picture>
         </div>
     </div>

--- a/packages/modules/src/modules/shared/ArticleCountOptOutOverlay.tsx
+++ b/packages/modules/src/modules/shared/ArticleCountOptOutOverlay.tsx
@@ -5,6 +5,7 @@ import {
     brandAltBackground,
     brandAltLine,
     brandAltText,
+    culture,
     neutral,
 } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -21,24 +22,28 @@ const COLOURS = {
     epic: 'white',
     banner: brandAltText.primary,
     ['investigations-moment-banner']: neutral[0],
+    ['us-eoy-moment-banner']: neutral[0],
 };
 
 const BACKGROUND_COLOURS = {
     epic: brand[400],
     banner: brandAltBackground.primary,
     ['investigations-moment-banner']: neutral[100],
+    ['us-eoy-moment-banner']: '#FFEEDB',
 };
 
 const BORDER_COLOURS = {
     epic: 'transparent',
     banner: brandAltLine.primary,
     ['investigations-moment-banner']: neutral[0],
+    ['us-eoy-moment-banner']: neutral[0],
 };
 
 const BUTTON_THEMES = {
     epic: brandTheme,
     banner: brandAltTheme,
     ['investigations-moment-banner']: buttonDefaultTheme,
+    ['us-eoy-moment-banner']: buttonDefaultTheme,
 };
 
 const overlayContainer = (type: ArticleCountOptOutType): SerializedStyles => css`
@@ -86,6 +91,7 @@ const NOTE_LINK_COLOURS = {
     epic: neutral[100],
     banner: brandAltText.primary,
     ['investigations-moment-banner']: neutral[0],
+    ['us-eoy-moment-banner']: neutral[0],
 };
 
 const BUTTON_OVERRIDES = {
@@ -98,6 +104,16 @@ const BUTTON_OVERRIDES = {
 
         &:hover {
             background-color: ${neutral[86]};
+        }
+    `,
+    ['us-eoy-moment-banner']: css`
+        color: ${neutral[7]};
+        border: 1px solid ${neutral[7]};
+
+        &:hover {
+            background-color: ${culture[350]};
+            color: ${neutral[100]};
+            border: 1px solid ${culture[350]};
         }
     `,
 };
@@ -113,6 +129,17 @@ const PRIMARY_BUTTON_OVERRIDES = {
         &:hover {
             background-color: ${neutral[46]};
             border-color: ${neutral[46]};
+        }
+    `,
+    ['us-eoy-moment-banner']: css`
+        background-color: ${neutral[7]};
+        color: ${neutral[100]};
+        border: 1px solid ${neutral[7]};
+
+        &:hover {
+            background-color: ${culture[350]};
+            color: ${neutral[100]};
+            border: 1px solid ${culture[350]};
         }
     `,
 };

--- a/packages/modules/src/modules/shared/ArticleCountOptOutPopup.tsx
+++ b/packages/modules/src/modules/shared/ArticleCountOptOutPopup.tsx
@@ -17,9 +17,13 @@ import {
     removeArticleCountFromLocalStorage,
 } from './helpers/articleCountOptOut';
 
-export type ArticleCountOptOutType = 'epic' | 'banner' | 'investigations-moment-banner';
+export type ArticleCountOptOutType =
+    | 'epic'
+    | 'banner'
+    | 'investigations-moment-banner'
+    | 'us-eoy-moment-banner';
 const isBanner = (type: ArticleCountOptOutType): boolean =>
-    type === 'banner' || type === 'investigations-moment-banner';
+    type === 'banner' || type === 'investigations-moment-banner' || type === 'us-eoy-moment-banner';
 
 const optOutContainer = (type: ArticleCountOptOutType): SerializedStyles => css`
     display: inline-block;

--- a/packages/server/src/tests/banners/ChannelBannerTests.ts
+++ b/packages/server/src/tests/banners/ChannelBannerTests.ts
@@ -16,6 +16,8 @@ import {
     OphanProduct,
     RawTestParams,
     RawVariantParams,
+    TickerCountType,
+    TickerEndType,
 } from '@sdc/shared/types';
 import { BannerTemplate } from '@sdc/shared/types';
 import { isProd } from '../../lib/env';
@@ -70,7 +72,19 @@ const BannerVariantFromParams = (forChannel: BannerChannel) => {
             }
         };
 
-        const tickerSettings = undefined;
+        const tickerSettings =
+            variant.template === BannerTemplate.UsEoyMomentBanner
+                ? {
+                      countType: TickerCountType.money,
+                      endType: TickerEndType.unlimited,
+                      currencySymbol: '$',
+                      copy: {
+                          countLabel: 'contributions',
+                          goalReachedPrimary: "We've hit our goal!",
+                          goalReachedSecondary: 'but you can still support us',
+                      },
+                  }
+                : undefined;
 
         return {
             name: variant.name,

--- a/packages/server/src/tests/banners/ChannelBannerTests.ts
+++ b/packages/server/src/tests/banners/ChannelBannerTests.ts
@@ -79,7 +79,7 @@ const BannerVariantFromParams = (forChannel: BannerChannel) => {
                       endType: TickerEndType.unlimited,
                       currencySymbol: '$',
                       copy: {
-                          countLabel: 'contributions',
+                          countLabel: 'contributed',
                           goalReachedPrimary: "We've hit our goal!",
                           goalReachedSecondary: 'but you can still support us',
                       },

--- a/packages/server/src/tests/banners/ChannelBannerTests.ts
+++ b/packages/server/src/tests/banners/ChannelBannerTests.ts
@@ -5,6 +5,7 @@ import {
     environmentMomentBanner,
     guardianWeekly,
     investigationsMomentBanner,
+    usEoyMomentBanner,
 } from '@sdc/shared/config';
 import {
     BannerChannel,
@@ -33,6 +34,7 @@ export const BannerPaths: {
         contributionsBannerWithSignIn.endpointPathBuilder,
     [BannerTemplate.InvestigationsMomentBanner]: investigationsMomentBanner.endpointPathBuilder,
     [BannerTemplate.EnvironmentMomentBanner]: environmentMomentBanner.endpointPathBuilder,
+    [BannerTemplate.UsEoyMomentBanner]: usEoyMomentBanner.endpointPathBuilder,
     [BannerTemplate.DigitalSubscriptionsBanner]: digiSubs.endpointPathBuilder,
     [BannerTemplate.GuardianWeeklyBanner]: guardianWeekly.endpointPathBuilder,
 };

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -48,6 +48,11 @@ export const environmentMomentBanner: ModuleInfo = getDefaultModuleInfo(
     'banners/environmentMoment/EnvironmentMomentBanner',
 );
 
+export const usEoyMomentBanner: ModuleInfo = getDefaultModuleInfo(
+    'us-eoy-banner',
+    'banners/usEoyMoment/USEoyMomentBanner',
+);
+
 export const digiSubs: ModuleInfo = getDefaultModuleInfo(
     'digital-subscriptions-banner',
     'banners/digitalSubscriptions/DigitalSubscriptionsBanner',
@@ -73,6 +78,7 @@ export const moduleInfos: ModuleInfo[] = [
     contributionsBannerWithSignIn,
     investigationsMomentBanner,
     environmentMomentBanner,
+    usEoyMomentBanner,
     digiSubs,
     guardianWeekly,
     puzzlesBanner,

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -50,7 +50,7 @@ export const environmentMomentBanner: ModuleInfo = getDefaultModuleInfo(
 
 export const usEoyMomentBanner: ModuleInfo = getDefaultModuleInfo(
     'us-eoy-banner',
-    'banners/usEoyMoment/USEoyMomentBanner',
+    'banners/usEoyMoment/UsEoyMomentBanner',
 );
 
 export const digiSubs: ModuleInfo = getDefaultModuleInfo(

--- a/packages/shared/src/types/banner.ts
+++ b/packages/shared/src/types/banner.ts
@@ -66,6 +66,7 @@ export enum BannerTemplate {
     EnvironmentMomentBanner = 'EnvironmentMomentBanner',
     DigitalSubscriptionsBanner = 'DigitalSubscriptionsBanner',
     GuardianWeeklyBanner = 'GuardianWeeklyBanner',
+    UsEoyMomentBanner = 'UsEoyMomentBanner',
 }
 
 export interface BannerVariant extends Variant {


### PR DESCRIPTION
## What does this change?
This adds the US EOY moment banner ready for the upcoming moment, we're currently hooking it up the RRCP

## Images
| mobile | mobileMedium | tablet | desktop | leftCol | Wide |
|--------|--------------|--------|---------|---------|------|
| <img width="240" alt="Screenshot 2021-11-19 at 11 24 39" src="https://user-images.githubusercontent.com/44685872/142615237-02bf184e-91e4-4951-a3b0-63a4696fd02a.png"> | <img width="281" alt="Screenshot 2021-11-19 at 11 26 25" src="https://user-images.githubusercontent.com/44685872/142615364-04d82f3b-5494-4e78-87d1-ca99be427253.png"> | <img width="555" alt="Screenshot 2021-11-19 at 11 27 35" src="https://user-images.githubusercontent.com/44685872/142615498-9e3ec2d6-6479-4245-a0e6-d2b2f92da907.png"> | <img width="735" alt="Screenshot 2021-11-19 at 11 28 55" src="https://user-images.githubusercontent.com/44685872/142615713-6d5d9af2-cb7b-4196-ab0e-d2a222bfb90c.png"> | <img width="571" alt="Screenshot 2021-11-19 at 15 46 28" src="https://user-images.githubusercontent.com/44685872/142650935-30ed7e2a-2f70-4101-95e4-ad6a393546ad.png"> | <img width="650" alt="Screenshot 2021-11-19 at 15 45 32" src="https://user-images.githubusercontent.com/44685872/142650816-b78aa214-be43-4e19-afcb-c8aece3e2bf8.png">  |








