### PR TITLE
update epic ticker styling for us eoy appeal

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpicTicker.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicTicker.tsx
@@ -75,7 +75,7 @@ const filledProgressStyles = (end: number, runningTotal: number, total: number):
         bottom: 0;
         transform: ${progressBarTransform(end, runningTotal, total)};
         transition: transform 3s cubic-bezier(0.25, 0.55, 0.2, 0.85);
-        background-color: #c70000;
+        background-color: ${palette.news[400]};
     `;
 
 const goalContainerStyles: SerializedStyles = css`

--- a/packages/modules/src/modules/epics/ContributionsEpicTicker.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicTicker.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
 import { palette } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/typography';
+import { textSans } from '@guardian/src-foundations/typography';
 import { useHasBeenSeen, HasBeenSeen } from '../../hooks/useHasBeenSeen';
 import useTicker from '../../hooks/useTicker';
 import { TickerSettings } from '@sdc/shared/types';
@@ -19,15 +19,15 @@ const rootStyles = css`
 `;
 
 const totalCountStyles = css`
-    ${headline.xxxsmall({ fontWeight: 'bold' })};
+    ${textSans.medium({ fontWeight: 'bold' })}
 `;
 
 const soFarCountStyles = css`
-    ${headline.xsmall({ fontWeight: 'bold' })};
+    ${textSans.medium({ fontWeight: 'bold' })}
 `;
 
 const countLabelStyles = css`
-    ${headline.xxxsmall({ fontStyle: 'italic' })};
+    ${textSans.medium()}
 `;
 
 const progressBarHeight = 10;
@@ -35,7 +35,7 @@ const progressBarHeight = 10;
 const progressBarContainerStyles = css`
     width: 100%;
     height: ${progressBarHeight}px;
-    background-color: ${palette.neutral[86]};
+    background-color: #dda7a1;
     position: absolute;
     bottom: 0;
     margin-top: 40px;
@@ -75,7 +75,7 @@ const filledProgressStyles = (end: number, runningTotal: number, total: number):
         bottom: 0;
         transform: ${progressBarTransform(end, runningTotal, total)};
         transition: transform 3s cubic-bezier(0.25, 0.55, 0.2, 0.85);
-        background-color: ${palette.brandAlt[400]};
+        background-color: #c70000;
     `;
 
 const goalContainerStyles: SerializedStyles = css`


### PR DESCRIPTION
## What does this do?
Updates styling on epic ticker for US end of year appeal.

## Screenshot
<img width="544" alt="Screenshot 2021-11-21 at 21 59 59" src="https://user-images.githubusercontent.com/25020231/142780496-9d146cea-90b8-4d64-a1de-2a7ebb8b8a4b.png">

