### PR TITLE
Clip US EOY banner image overflow

### DIFF
--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerVisual.tsx
@@ -9,6 +9,8 @@ const container = css`
     position: relative;
     float: right;
     overflow-y: clip;
+    clip-path: inset(0% -100% 0% -100%);
+    -webkit-clip-path: inset(0% -100% 0% -100%);
 
     ${from.mobileMedium} {
         padding-top: 40%;
@@ -30,6 +32,8 @@ const container = css`
         bottom: 0;
         right: 0;
         width: 42%;
+        clip-path: none;
+        -webkit-clip-path: none;
     }
 
     ${from.desktop} {


### PR DESCRIPTION
## What does this change?
This PR adds a clip path rule to the us eoy banner image to prevent the image overflowing its container on devices which do not support the `overflow: clip` property.