### PR TITLE
US end-of-year campaign header

### DIFF
--- a/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { HeaderProps } from '@sdc/shared/types';
+import { Header } from './EoYUSMomentHeader';
+import { css } from '@emotion/core';
+import { brand } from '@guardian/src-foundations';
+
+export const props: HeaderProps = {
+    content: {
+        heading: 'Support the Guardian',
+        subheading: 'Make a year-end gift',
+        primaryCta: {
+            url: 'https://support.theguardian.com/contribute',
+            text: 'Contribute',
+        },
+        secondaryCta: {
+            url: '',
+            text: 'Subscribe',
+        },
+    },
+    tracking: {
+        ophanPageId: 'pvid',
+        platformId: 'GUARDIAN_WEB',
+        referrerUrl: 'https://theguardian.com/uk',
+        clientName: 'dcr',
+        abTestName: 'test-name',
+        abTestVariant: 'variant-name',
+        campaignCode: 'campaign-code',
+        componentType: 'ACQUISITIONS_HEADER',
+    },
+    countryCode: 'GB',
+};
+
+const background = css`
+    background-color: ${brand[400]};
+    padding: 10px;
+`;
+
+export const HeaderDecorator = (Story: Story): JSX.Element => (
+    <div css={background}>
+        <Story />
+    </div>
+);
+
+export default {
+    component: Header,
+    title: 'Header/EOYUSMoment',
+    args: props,
+    decorators: [HeaderDecorator],
+    excludeStories: ['props', 'HeaderDecorator'],
+} as Meta;
+
+const Template: Story<HeaderProps> = (props: HeaderProps) => <Header {...props} />;
+
+export const DefaultHeader = Template.bind({});

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
@@ -14,8 +14,16 @@ export const props: HeaderProps = {
             text: 'Contribute',
         },
         secondaryCta: {
-            url: '',
+            url: 'https://support.theguardian.com/subscribe',
             text: 'Subscribe',
+        },
+    },
+    mobileContent: {
+        heading: '',
+        subheading: '',
+        primaryCta: {
+            url: 'https://support.theguardian.com/contribute',
+            text: 'Make a year-end gift',
         },
     },
     tracking: {
@@ -53,3 +61,23 @@ export default {
 const Template: Story<HeaderProps> = (props: HeaderProps) => <Header {...props} />;
 
 export const DefaultHeader = Template.bind({});
+
+export const SupportersHeader = Template.bind({});
+SupportersHeader.args = {
+    content: {
+        heading: 'Thank you for supporting us',
+        subheading: '',
+        primaryCta: {
+            url: 'https://support.theguardian.com/subscribe',
+            text: 'Make an extra contribution',
+        },
+    },
+    mobileContent: {
+        heading: 'Thank you for your support',
+        subheading: '',
+        primaryCta: {
+            url: 'https://support.theguardian.com/subscribe',
+            text: 'Contribute again',
+        },
+    },
+};

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
@@ -73,7 +73,7 @@ SupportersHeader.args = {
         },
     },
     mobileContent: {
-        heading: 'Thank you for your support',
+        heading: 'Thank you',
         subheading: '',
         primaryCta: {
             url: 'https://support.theguardian.com/subscribe',

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import { from } from '@guardian/src-foundations/mq';
+import { brandAlt, brandText } from '@guardian/src-foundations';
+import { headline, textSans } from '@guardian/src-foundations/typography';
+import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
+import { Hide } from '@guardian/src-layout';
+import { ThemeProvider } from '@emotion/react';
+import { SvgArrowRightStraight } from '@guardian/src-icons';
+import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
+import { Link } from '@guardian/src-link';
+
+const messageStyles = (isThankYouMessage: boolean) => css`
+    color: ${brandAlt[400]};
+    ${headline.xxsmall({ fontWeight: 'bold' })};
+    margin-bottom: 3px;
+
+    ${from.desktop} {
+        ${headline.xsmall({ fontWeight: 'bold' })}
+    }
+
+    ${from.leftCol} {
+        ${isThankYouMessage
+            ? headline.small({ fontWeight: 'bold' })
+            : headline.medium({ fontWeight: 'bold' })}
+    }
+`;
+
+const linkStyles = css`
+    height: 32px;
+    min-height: 32px;
+    ${textSans.small({ fontWeight: 'bold' })};
+    border-radius: 16px;
+    padding: 0 12px 0 12px;
+    line-height: 18px;
+    margin-right: 10px;
+    margin-bottom: 6px;
+
+    svg {
+        width: 24px;
+    }
+`;
+
+const mobileLinkStyles = css`
+    &,
+    &:hover {
+        color: ${brandAlt[400]};
+        line-height: 1.15;
+    }
+`;
+
+const subMessageStyles = css`
+    color: ${brandText.primary};
+    ${textSans.medium()};
+    margin: 5px 0;
+`;
+
+const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
+    const { heading, subheading, primaryCta, secondaryCta } = props.content;
+
+    return (
+        <div>
+            <Hide below="tablet">
+                <div css={messageStyles(false)}>
+                    <span>{heading}</span>
+                </div>
+
+                <div css={subMessageStyles}>
+                    <div>{subheading}</div>
+                </div>
+            </Hide>
+
+            {primaryCta && (
+                <>
+                    <Hide below="tablet">
+                        <ThemeProvider theme={buttonReaderRevenueBrand}>
+                            <LinkButton
+                                priority="primary"
+                                href={primaryCta.ctaUrl}
+                                icon={<SvgArrowRightStraight />}
+                                iconSide="right"
+                                nudgeIcon={true}
+                                css={linkStyles}
+                            >
+                                {primaryCta.ctaText}
+                            </LinkButton>
+                        </ThemeProvider>
+                    </Hide>
+                    <Hide above="tablet">
+                        <Link priority="primary" href={primaryCta.ctaUrl} css={mobileLinkStyles}>
+                            Make a year-end gift
+                        </Link>
+                    </Hide>
+                </>
+            )}
+
+            {secondaryCta && (
+                <Hide below="tablet">
+                    <ThemeProvider theme={buttonReaderRevenueBrand}>
+                        <LinkButton
+                            priority="primary"
+                            href={secondaryCta.ctaUrl}
+                            icon={<SvgArrowRightStraight />}
+                            iconSide="right"
+                            nudgeIcon={true}
+                            css={linkStyles}
+                        >
+                            {secondaryCta.ctaText}
+                        </LinkButton>
+                    </ThemeProvider>
+                </Hide>
+            )}
+        </div>
+    );
+};
+const wrapped = headerWrapper(Header);
+export { wrapped as Header };

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
@@ -15,9 +15,14 @@ const messageStyles = css`
     ${headline.xxsmall({ fontWeight: 'bold' })};
     margin-bottom: 3px;
 
-    ${until.tablet} {
+    ${until.mobileLandscape} {
         margin-bottom: 0;
         ${textSans.xxsmall({ fontWeight: 'bold' })}
+    }
+
+    ${until.tablet} {
+        margin-bottom: 0;
+        ${textSans.xsmall({ fontWeight: 'bold' })}
     }
 
     ${from.leftCol} {
@@ -47,7 +52,11 @@ const linkStyles = css`
 const mobileLinkStyles = css`
     &,
     &:hover {
-        ${textSans.xxsmall()}
+        ${until.mobileLandscape} {
+            ${textSans.xxsmall()}
+
+        }
+        ${textSans.xsmall()}
         color: ${brandAlt[400]};
         line-height: 1.15;
     }

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
@@ -10,23 +10,18 @@ import { SvgArrowRightStraight } from '@guardian/src-icons';
 import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
 import { Link } from '@guardian/src-link';
 
-const messageStyles = (isThankYouMessage: boolean) => css`
-    ${until.tablet} {
-        ${textSans.xsmall({ fontWeight: 'bold' })}
-    }
-
+const messageStyles = css`
     color: ${brandAlt[400]};
     ${headline.xxsmall({ fontWeight: 'bold' })};
     margin-bottom: 3px;
 
-    ${from.desktop} {
-        ${headline.xsmall({ fontWeight: 'bold' })}
+    ${until.tablet} {
+        margin-bottom: 0;
+        ${textSans.xxsmall({ fontWeight: 'bold' })}
     }
 
     ${from.leftCol} {
-        ${isThankYouMessage
-            ? headline.small({ fontWeight: 'bold' })
-            : headline.medium({ fontWeight: 'bold' })}
+        ${headline.xsmall({ fontWeight: 'bold' })}
     }
 `;
 
@@ -39,7 +34,10 @@ const linkStyles = css`
     line-height: 18px;
     margin-right: 10px;
     margin-bottom: 6px;
-    margin-top: 12px;
+
+    ${from.tablet} {
+        margin-top: 12px;
+    }
 
     svg {
         width: 24px;
@@ -49,7 +47,7 @@ const linkStyles = css`
 const mobileLinkStyles = css`
     &,
     &:hover {
-        ${textSans.xsmall()}
+        ${textSans.xxsmall()}
         color: ${brandAlt[400]};
         line-height: 1.15;
     }
@@ -70,7 +68,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
     return (
         <div>
             <Hide below="tablet">
-                <div css={messageStyles(false)}>
+                <div css={messageStyles}>
                     <span>{heading}</span>
                 </div>
 
@@ -82,7 +80,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
             </Hide>
             {mobileContent?.heading && (
                 <Hide above="tablet">
-                    <div css={messageStyles(false)}>
+                    <div css={messageStyles}>
                         <span>{mobileContent.heading}</span>
                     </div>
                 </Hide>

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
@@ -15,14 +15,8 @@ const messageStyles = css`
     ${headline.xxsmall({ fontWeight: 'bold' })};
     margin-bottom: 3px;
 
-    ${until.mobileLandscape} {
-        margin-bottom: 0;
-        ${textSans.xxsmall({ fontWeight: 'bold' })}
-    }
-
     ${until.tablet} {
-        margin-bottom: 0;
-        ${textSans.xsmall({ fontWeight: 'bold' })}
+        ${textSans.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })}
     }
 
     ${from.leftCol} {
@@ -52,11 +46,7 @@ const linkStyles = css`
 const mobileLinkStyles = css`
     &,
     &:hover {
-        ${until.mobileLandscape} {
-            ${textSans.xxsmall()}
-
-        }
-        ${textSans.xsmall()}
+        ${textSans.xsmall({ lineHeight: 'tight' })}
         color: ${brandAlt[400]};
         line-height: 1.15;
     }

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
@@ -88,7 +88,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                 )}
             </Hide>
             {mobileContent?.heading && (
-                <Hide above="tablet">
+                <Hide above="tablet" below="mobileMedium">
                     <div css={messageStyles}>
                         <span>{mobileContent.heading}</span>
                     </div>
@@ -111,7 +111,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                             </LinkButton>
                         </ThemeProvider>
                     </Hide>
-                    <Hide above="tablet">
+                    <Hide above="tablet" below="mobileMedium">
                         <Link priority="primary" href={mobileCta?.ctaUrl} css={mobileLinkStyles}>
                             {mobileCta?.ctaText}
                         </Link>

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/core';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { brandAlt, brandText } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
@@ -11,6 +11,10 @@ import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
 import { Link } from '@guardian/src-link';
 
 const messageStyles = (isThankYouMessage: boolean) => css`
+    ${until.tablet} {
+        ${textSans.xsmall({ fontWeight: 'bold' })}
+    }
+
     color: ${brandAlt[400]};
     ${headline.xxsmall({ fontWeight: 'bold' })};
     margin-bottom: 3px;
@@ -35,6 +39,7 @@ const linkStyles = css`
     line-height: 18px;
     margin-right: 10px;
     margin-bottom: 6px;
+    margin-top: 12px;
 
     svg {
         width: 24px;
@@ -44,6 +49,7 @@ const linkStyles = css`
 const mobileLinkStyles = css`
     &,
     &:hover {
+        ${textSans.xsmall()}
         color: ${brandAlt[400]};
         line-height: 1.15;
     }
@@ -57,6 +63,9 @@ const subMessageStyles = css`
 
 const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
     const { heading, subheading, primaryCta, secondaryCta } = props.content;
+    const mobileContent = props.mobileContent;
+
+    const mobileCta = mobileContent?.primaryCta ?? primaryCta;
 
     return (
         <div>
@@ -65,10 +74,19 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                     <span>{heading}</span>
                 </div>
 
-                <div css={subMessageStyles}>
-                    <div>{subheading}</div>
-                </div>
+                {subheading && (
+                    <div css={subMessageStyles}>
+                        <div>{subheading}</div>
+                    </div>
+                )}
             </Hide>
+            {mobileContent?.heading && (
+                <Hide above="tablet">
+                    <div css={messageStyles(false)}>
+                        <span>{mobileContent.heading}</span>
+                    </div>
+                </Hide>
+            )}
 
             {primaryCta && (
                 <>
@@ -87,8 +105,8 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                         </ThemeProvider>
                     </Hide>
                     <Hide above="tablet">
-                        <Link priority="primary" href={primaryCta.ctaUrl} css={mobileLinkStyles}>
-                            Make a year-end gift
+                        <Link priority="primary" href={mobileCta?.ctaUrl} css={mobileLinkStyles}>
+                            {mobileCta?.ctaText}
                         </Link>
                     </Hide>
                 </>

--- a/packages/modules/src/modules/header/HeaderWrapper.tsx
+++ b/packages/modules/src/modules/header/HeaderWrapper.tsx
@@ -51,11 +51,11 @@ export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<Hea
         };
 
         const mobilePrimaryCta = mobileContent?.primaryCta
-            ? buildEnrichedCta(mobileContent?.primaryCta)
+            ? buildEnrichedCta(mobileContent.primaryCta)
             : primaryCta;
 
         const mobileSecondaryCta = mobileContent?.secondaryCta
-            ? buildEnrichedCta(mobileContent?.secondaryCta)
+            ? buildEnrichedCta(mobileContent.secondaryCta)
             : secondaryCta;
 
         const renderedMobileContent = mobileContent

--- a/packages/modules/src/modules/header/HeaderWrapper.tsx
+++ b/packages/modules/src/modules/header/HeaderWrapper.tsx
@@ -18,11 +18,13 @@ export interface HeaderRenderedContent {
 
 export interface HeaderRenderProps {
     content: HeaderRenderedContent;
+    mobileContent?: HeaderRenderedContent;
 }
 
 export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<HeaderProps> => {
     const Wrapped: React.FC<HeaderProps> = ({
         content,
+        mobileContent,
         tracking,
         countryCode,
         submitComponentEvent,
@@ -47,6 +49,23 @@ export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<Hea
             primaryCta,
             secondaryCta,
         };
+
+        const mobilePrimaryCta = mobileContent?.primaryCta
+            ? buildEnrichedCta(mobileContent?.primaryCta)
+            : primaryCta;
+
+        const mobileSecondaryCta = mobileContent?.secondaryCta
+            ? buildEnrichedCta(mobileContent?.secondaryCta)
+            : secondaryCta;
+
+        const renderedMobileContent = mobileContent
+            ? ({
+                  heading: mobileContent.heading,
+                  subheading: mobileContent.subheading,
+                  primaryCta: mobilePrimaryCta,
+                  secondaryCta: mobileSecondaryCta,
+              } as HeaderRenderedContent)
+            : undefined;
 
         const { abTestName, abTestVariant, componentType, campaignCode } = tracking;
 
@@ -84,7 +103,7 @@ export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<Hea
 
         return (
             <div ref={setNode}>
-                <Header content={renderedContent} />
+                <Header content={renderedContent} mobileContent={renderedMobileContent} />
             </div>
         );
     };

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -360,6 +360,7 @@ export const buildHeaderData = async (
                     name: header.name,
                     props: {
                         content: variant.content,
+                        mobileContent: variant.mobileContent,
                         tracking: { ...pageTracking, ...testTracking },
                         countryCode: targeting.countryCode,
                         numArticles: targeting.numArticles,

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -111,7 +111,7 @@ const supportersTestUS: HeaderTest = {
                 },
             },
             mobileContent: {
-                heading: 'Thank you for your support',
+                heading: 'Thank you',
                 subheading: '',
                 primaryCta: {
                     url: 'https://support.theguardian.com/subscribe',

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -1,5 +1,5 @@
 import { header } from '@sdc/shared/config';
-import { HeaderTargeting, HeaderTest, HeaderTestSelection } from '@sdc/shared/types';
+import { Edition, HeaderTargeting, HeaderTest, HeaderTestSelection } from '@sdc/shared/types';
 
 const modulePathBuilder = header.endpointPathBuilder;
 
@@ -13,6 +13,29 @@ const nonSupportersTestNonUK: HeaderTest = {
             content: {
                 heading: 'Support the Guardian',
                 subheading: 'Available for everyone, funded by readers',
+                primaryCta: {
+                    url: 'https://support.theguardian.com/contribute',
+                    text: 'Contribute',
+                },
+                secondaryCta: {
+                    url: 'https://support.theguardian.com/subscribe',
+                    text: 'Subscribe',
+                },
+            },
+        },
+    ],
+};
+
+const nonSupportersTestUS: HeaderTest = {
+    name: 'RemoteRrHeaderLinksTest__US',
+    audience: 'AllNonSupporters',
+    variants: [
+        {
+            name: 'remote',
+            modulePathBuilder,
+            content: {
+                heading: 'Support the Guardian',
+                subheading: 'Make a year-end gift',
                 primaryCta: {
                     url: 'https://support.theguardian.com/contribute',
                     text: 'Contribute',
@@ -64,8 +87,37 @@ const supportersTest: HeaderTest = {
     ],
 };
 
-const getNonSupportersTest = (edition: string): HeaderTest =>
-    edition === 'UK' ? nonSupportersTestUK : nonSupportersTestNonUK;
+const supportersTestUS: HeaderTest = {
+    name: 'header-supporter',
+    audience: 'AllExistingSupporters',
+    variants: [
+        {
+            name: 'control',
+            modulePathBuilder,
+            content: {
+                heading: 'Thank you',
+                subheading: 'Your support powers our independent journalism',
+            },
+        },
+    ],
+};
+
+const getNonSupportersTest = (edition: Edition): HeaderTest => {
+    if (edition === 'UK') {
+        return nonSupportersTestUK;
+    }
+    if (edition === 'US') {
+        return nonSupportersTestUS;
+    }
+    return nonSupportersTestNonUK;
+};
+
+const getSupportersTest = (edition: Edition): HeaderTest => {
+    if (edition === 'US') {
+        return supportersTestUS;
+    }
+    return supportersTest;
+};
 
 export const selectHeaderTest = (
     targeting: HeaderTargeting,
@@ -74,7 +126,7 @@ export const selectHeaderTest = (
         if (targeting.showSupportMessaging) {
             return getNonSupportersTest(targeting.edition);
         } else {
-            return supportersTest;
+            return getSupportersTest(targeting.edition);
         }
     };
 

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -27,7 +27,7 @@ const nonSupportersTestNonUK: HeaderTest = {
 };
 
 const nonSupportersTestUS: HeaderTest = {
-    name: 'RemoteRrHeaderLinksTest__US',
+    name: 'RemoteRrHeaderLinksTest__USEOY',
     audience: 'AllNonSupporters',
     variants: [
         {
@@ -43,6 +43,14 @@ const nonSupportersTestUS: HeaderTest = {
                 secondaryCta: {
                     url: 'https://support.theguardian.com/subscribe',
                     text: 'Subscribe',
+                },
+            },
+            mobileContent: {
+                heading: '',
+                subheading: '',
+                primaryCta: {
+                    url: 'https://support.theguardian.com/contribute',
+                    text: 'Make a year-end gift',
                 },
             },
         },
@@ -88,15 +96,27 @@ const supportersTest: HeaderTest = {
 };
 
 const supportersTestUS: HeaderTest = {
-    name: 'header-supporter',
+    name: 'header-supporter__USEOY',
     audience: 'AllExistingSupporters',
     variants: [
         {
             name: 'control',
             modulePathBuilder,
             content: {
-                heading: 'Thank you',
-                subheading: 'Your support powers our independent journalism',
+                heading: 'Thank you for supporting us',
+                subheading: '',
+                primaryCta: {
+                    url: 'https://support.theguardian.com/subscribe',
+                    text: 'Make an extra contribution',
+                },
+            },
+            mobileContent: {
+                heading: 'Thank you for your support',
+                subheading: '',
+                primaryCta: {
+                    url: 'https://support.theguardian.com/subscribe',
+                    text: 'Contribute again',
+                },
             },
         },
     ],

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -1,4 +1,4 @@
-import { header } from '@sdc/shared/config';
+import { header, usEOYHeader } from '@sdc/shared/config';
 import { Edition, HeaderTargeting, HeaderTest, HeaderTestSelection } from '@sdc/shared/types';
 
 const modulePathBuilder = header.endpointPathBuilder;
@@ -32,7 +32,7 @@ const nonSupportersTestUS: HeaderTest = {
     variants: [
         {
             name: 'remote',
-            modulePathBuilder,
+            modulePathBuilder: usEOYHeader.endpointPathBuilder,
             content: {
                 heading: 'Support the Guardian',
                 subheading: 'Make a year-end gift',
@@ -101,7 +101,7 @@ const supportersTestUS: HeaderTest = {
     variants: [
         {
             name: 'control',
-            modulePathBuilder,
+            modulePathBuilder: usEOYHeader.endpointPathBuilder,
             content: {
                 heading: 'Thank you for supporting us',
                 subheading: '',

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -1,5 +1,6 @@
 import { header, usEOYHeader } from '@sdc/shared/config';
 import { Edition, HeaderTargeting, HeaderTest, HeaderTestSelection } from '@sdc/shared/types';
+import { isAfter, isBefore } from 'date-fns';
 
 const modulePathBuilder = header.endpointPathBuilder;
 
@@ -122,18 +123,25 @@ const supportersTestUS: HeaderTest = {
     ],
 };
 
+const usEoyPeriodStart = new Date(2021, 11, 22);
+const usEoyPeriodEnd = new Date(2022, 1, 1);
+
+const isInUsEoyPeriod = (date: Date): boolean => {
+    return isAfter(date, usEoyPeriodStart) && isBefore(date, usEoyPeriodEnd);
+};
+
 const getNonSupportersTest = (edition: Edition): HeaderTest => {
     if (edition === 'UK') {
         return nonSupportersTestUK;
     }
-    if (edition === 'US') {
+    if (edition === 'US' && isInUsEoyPeriod(new Date())) {
         return nonSupportersTestUS;
     }
     return nonSupportersTestNonUK;
 };
 
 const getSupportersTest = (edition: Edition): HeaderTest => {
-    if (edition === 'US') {
+    if (edition === 'US' && isInUsEoyPeriod(new Date())) {
         return supportersTestUS;
     }
     return supportersTest;

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -65,6 +65,8 @@ export const puzzlesBanner: ModuleInfo = getDefaultModuleInfo(
 
 export const header: ModuleInfo = getDefaultModuleInfo('header', 'header/Header');
 
+export const usEOYHeader: ModuleInfo = getDefaultModuleInfo('header', 'header/EoYUSMomentHeader');
+
 export const moduleInfos: ModuleInfo[] = [
     epic,
     epicACByTag,
@@ -77,4 +79,5 @@ export const moduleInfos: ModuleInfo[] = [
     guardianWeekly,
     puzzlesBanner,
     header,
+    usEOYHeader,
 ];

--- a/packages/shared/src/types/header.ts
+++ b/packages/shared/src/types/header.ts
@@ -16,6 +16,7 @@ interface HeaderContent {
 interface HeaderVariant extends Variant {
     name: string;
     content: HeaderContent;
+    mobileContent?: HeaderContent;
     modulePathBuilder: (version?: string) => string;
 }
 
@@ -28,6 +29,7 @@ export interface HeaderTest extends Test<HeaderVariant> {
 export interface HeaderProps {
     content: HeaderContent;
     tracking: Tracking;
+    mobileContent?: HeaderContent;
     countryCode?: string;
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
     numArticles?: number;

--- a/packages/shared/src/types/header.ts
+++ b/packages/shared/src/types/header.ts
@@ -40,9 +40,11 @@ export interface HeaderTestSelection {
     moduleName: string;
 }
 
+export type Edition = 'UK' | 'US' | 'AU' | 'INT';
+
 export interface HeaderTargeting {
     showSupportMessaging: boolean;
-    edition: string;
+    edition: Edition;
     countryCode: string;
     modulesVersion?: string;
     mvtId: number;


### PR DESCRIPTION
## What does this change?

This adds a variant of the header for the US end-of-year campaign, with specific text for both supporters and non-supporters.

## Images

**Non-supporters**

![Screenshot 2021-11-22 at 11 17 47](https://user-images.githubusercontent.com/29146931/142853104-686af4e5-026b-490c-84d2-0561ef426da3.png)

![Screenshot 2021-11-22 at 11 17 56](https://user-images.githubusercontent.com/29146931/142853107-e9cf1082-22f9-4774-86c8-c2e3e486281f.png)

**Existing supporters**

![Screenshot 2021-11-22 at 11 18 22](https://user-images.githubusercontent.com/29146931/142853148-e291bfc2-04a0-405a-ad4c-95755ee7b4d8.png)

![Screenshot 2021-11-22 at 11 18 06](https://user-images.githubusercontent.com/29146931/142853157-957394a0-ad47-43ed-a667-da708059ec49.png)
