### PR TITLE
fix cta on single contributor test

### DIFF
--- a/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
+++ b/packages/server/src/tests/epics/singleContributorPropensityTest/singleContributorPropensityTest.ts
@@ -57,7 +57,7 @@ const singleContributorPropensityTest = (
             highlightedText: VARIANT_HIGHLIGHTED_TEXT,
             cta: {
                 baseUrl:
-                    'https://support.theguardian.com/contribute?selected-contribution-type=ONE_OFF',
+                    'https://support.theguardian.com/contribute',
                 text: 'Continue',
             },
             secondaryCta: {


### PR DESCRIPTION
this querystring is not required, as the choice cards add it