### PR TITLE
Fix US EOY copy start date

### DIFF
--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -123,7 +123,7 @@ const supportersTestUS: HeaderTest = {
     ],
 };
 
-const usEoyPeriodStart = new Date(2021, 11, 22);
+const usEoyPeriodStart = new Date(2021, 10, 22);
 const usEoyPeriodEnd = new Date(2022, 1, 1);
 
 const isInUsEoyPeriod = (date: Date): boolean => {


### PR DESCRIPTION
## What does this change?

This fixes an issue with the start date for the special end-of-year copy being in December rather than November.