### PR TITLE
Fix default value in epic when default frequency is set

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -9,7 +9,7 @@ import {
     createViewEventFromTracking,
     replaceNonArticleCountPlaceholders,
 } from '@sdc/shared/lib';
-import { EpicProps, epicPropsSchema, Stage } from '@sdc/shared/types';
+import { ContributionFrequency, EpicProps, epicPropsSchema, Stage } from '@sdc/shared/types';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { ContributionsEpicTicker } from './ContributionsEpicTicker';
@@ -268,10 +268,14 @@ export const getContributionsEpic: (
     stage,
 }: EpicProps) => {
     const countryGroupId = countryCodeToCountryGroupId(countryCode || 'GBPCountries');
+    const defaultFrequency: ContributionFrequency = variant.defaultChoiceCardFrequency || 'MONTHLY';
     const [choiceCardSelection, setChoiceCardSelection] = useState<ChoiceCardSelection | undefined>(
         variant.choiceCardAmounts && {
-            frequency: variant.defaultChoiceCardFrequency || 'MONTHLY',
-            amount: variant.choiceCardAmounts[countryGroupId]['control']['MONTHLY']['amounts'][1],
+            frequency: defaultFrequency,
+            amount:
+                variant.choiceCardAmounts[countryGroupId]['control'][defaultFrequency][
+                    'amounts'
+                ][1],
         },
     );
 


### PR DESCRIPTION
we can now set the default frequency per variant: https://github.com/guardian/support-dotcom-components/pull/545/files#diff-f61d94af1bff9403a86eff24d9e0740db6b9d1cf3607a47286ddc847dc1af6aaR273

But this currently breaks selection of the default amount.

With this PR, it now correctly selects a default amount for single:
![Screen Shot 2021-11-25 at 16 32 14](https://user-images.githubusercontent.com/1513454/143476896-fadc4c1f-59cb-490d-b870-dba617de7077.png)
