### PR TITLE
Fix banner deploy bug

### DIFF
--- a/packages/server/src/tests/banners/bannerDeploySchedule.test.ts
+++ b/packages/server/src/tests/banners/bannerDeploySchedule.test.ts
@@ -1,4 +1,4 @@
-import { previousScheduledDate } from './bannerDeploySchedule';
+import { lastScheduledDeploy, previousScheduledDate } from './bannerDeploySchedule';
 
 const days = {
     sunday: 0,
@@ -32,15 +32,20 @@ describe('previousScheduledDate', () => {
     });
 });
 
-// describe('lastScheduledDeploy, subscriptions', () => {
-//     it('returns previous monday if currently tuesday', () => {
-//         const date = new Date('2021-11-09 09:00:00');
-//         const result = lastScheduledDeploy.subscriptions(date);
-//         expect(result).toEqual(new Date('2021-11-08 08:00:00'));
-//     });
-//
-//     it('returns previous friday if currently sunday', () => {
-//         const result = lastScheduledDeploy.subscriptions(new Date('2021-11-07 09:00:00'));
-//         expect(result).toEqual(new Date('2021-11-05 08:00:00'));
-//     });
-// });
+describe('lastScheduledDeploy, subscriptions', () => {
+    it('returns previous monday if currently tuesday', () => {
+        const date = new Date('2021-11-09 09:00:00');
+        const result = lastScheduledDeploy.subscriptions(date);
+        expect(result).toEqual(new Date('2021-11-08 08:00:00'));
+    });
+
+    it('returns previous friday if currently sunday', () => {
+        const result = lastScheduledDeploy.subscriptions(new Date('2021-11-07 09:00:00'));
+        expect(result).toEqual(new Date('2021-11-05 08:00:00'));
+    });
+
+    it('returns today (friday) if currently friday and within an hour of the last deploy', () => {
+        const result = lastScheduledDeploy.subscriptions(new Date('2021-11-26 08:30:00'));
+        expect(result).toEqual(new Date('2021-11-26 08:00:00'));
+    });
+});

--- a/packages/server/src/tests/banners/bannerDeploySchedule.ts
+++ b/packages/server/src/tests/banners/bannerDeploySchedule.ts
@@ -1,4 +1,4 @@
-import { compareDesc, setHours, subDays } from 'date-fns';
+import { compareDesc, set, subDays } from 'date-fns';
 
 /**
  * Banner deploy schedule -
@@ -11,21 +11,21 @@ interface ScheduledBannerDeploy {
 }
 
 const channel1Schedule: ScheduledBannerDeploy[] = [
-    // {
-    //     dayOfWeek: 0,
-    //     hour: 9,
-    // },
+    {
+        dayOfWeek: 0,
+        hour: 9,
+    },
 ];
 
 const channel2Schedule: ScheduledBannerDeploy[] = [
-    // {
-    //     dayOfWeek: 1,
-    //     hour: 8,
-    // },
-    // {
-    //     dayOfWeek: 5,
-    //     hour: 8,
-    // },
+    {
+        dayOfWeek: 1,
+        hour: 8,
+    },
+    {
+        dayOfWeek: 5,
+        hour: 8,
+    },
 ];
 
 const previousDay = (date: Date, dayOfWeek: number): Date =>
@@ -43,7 +43,11 @@ export const previousScheduledDate = (now: Date, dayOfWeek: number, hour: number
             ? subDays(now, 1) // scheduled for later today, so go back to previous week
             : now;
 
-    return setHours(previousDay(date, dayOfWeek), hour);
+    return set(previousDay(date, dayOfWeek), {
+        hours: hour,
+        minutes: 0,
+        seconds: 0,
+    });
 };
 
 const getLastScheduledDeploy = (date: Date, scheduledDeploys: ScheduledBannerDeploy[]): Date => {


### PR DESCRIPTION
For the first hour after a scheduled banner deploy, users will keep seeing a banner.
This is because the `previousDay` function does not set the minutes + seconds to 0.

E.g.
- the last redeploy was 2021-11-26 08:00:00
- the user last closed the banner at 2021-11-26 08:30:00
Currently this function returns 2021-11-26 08:30:00, when it should return 2021-11-26 08:00:00.
I've added a test case to cover this.