### PR TITLE
Hide subscribe in header on Giving Tuesday

### DIFF
--- a/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
@@ -4,6 +4,23 @@ import { HeaderProps } from '@sdc/shared/types';
 import { Header } from './EoYUSMomentHeader';
 import { css } from '@emotion/core';
 import { brand } from '@guardian/src-foundations';
+import { isAfter, isBefore } from 'date-fns';
+
+const givingTuesdayStart = new Date(2021, 11, 29, 17, 0); //remove "Subscribe" Monday 12:00 PM EST
+const givingTuesdayEnd = new Date(2021, 12, 1, 9, 0); //re-add "Subscribe" on Wednesday morning GMT
+
+const isGivingTuesday = (date: Date): boolean => {
+    return isAfter(date, givingTuesdayStart) && isBefore(date, givingTuesdayEnd);
+};
+
+const maybeSecondaryCta = isGivingTuesday(new Date())
+    ? undefined
+    : {
+          secondaryCta: {
+              url: 'https://support.theguardian.com/subscribe',
+              text: 'Subscribe',
+          },
+      };
 
 export const props: HeaderProps = {
     content: {
@@ -13,10 +30,7 @@ export const props: HeaderProps = {
             url: 'https://support.theguardian.com/contribute',
             text: 'Contribute',
         },
-        secondaryCta: {
-            url: 'https://support.theguardian.com/subscribe',
-            text: 'Subscribe',
-        },
+        ...maybeSecondaryCta,
     },
     mobileContent: {
         heading: '',

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
@@ -6,8 +6,8 @@ import { css } from '@emotion/core';
 import { brand } from '@guardian/src-foundations';
 import { isAfter, isBefore } from 'date-fns';
 
-const givingTuesdayStart = new Date(2021, 11, 29, 17, 0); //remove "Subscribe" Monday 12:00 PM EST
-const givingTuesdayEnd = new Date(2021, 12, 1, 9, 0); //re-add "Subscribe" on Wednesday morning GMT
+const givingTuesdayStart = new Date(2021, 10, 29, 17, 0); //remove "Subscribe" Monday 12:00 PM EST
+const givingTuesdayEnd = new Date(2021, 11, 1, 9, 0); //re-add "Subscribe" on Wednesday morning GMT
 
 const isGivingTuesday = (date: Date): boolean => {
     return isAfter(date, givingTuesdayStart) && isBefore(date, givingTuesdayEnd);

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
@@ -4,23 +4,12 @@ import { HeaderProps } from '@sdc/shared/types';
 import { Header } from './EoYUSMomentHeader';
 import { css } from '@emotion/core';
 import { brand } from '@guardian/src-foundations';
-import { isAfter, isBefore } from 'date-fns';
 
-const givingTuesdayStart = new Date(2021, 10, 29, 17, 0); //remove "Subscribe" Monday 12:00 PM EST
-const givingTuesdayEnd = new Date(2021, 11, 1, 9, 0); //re-add "Subscribe" on Wednesday morning GMT
-
-const isGivingTuesday = (date: Date): boolean => {
-    return isAfter(date, givingTuesdayStart) && isBefore(date, givingTuesdayEnd);
-};
-
-const maybeSecondaryCta = isGivingTuesday(new Date())
-    ? undefined
-    : {
-          secondaryCta: {
-              url: 'https://support.theguardian.com/subscribe',
-              text: 'Subscribe',
-          },
-      };
+const givingTuesdayStart = new Date('2021-11-29T17:00:00'); //remove "Subscribe" Monday 12:00 PM EST
+const givingTuesdayEnd = new Date('2021-11-01T09:00:00'); //re-add "Subscribe" on Wednesday morning GMT
+const currentDateTime = new Date();
+const shouldShowSubscribeButton =
+    givingTuesdayStart <= currentDateTime && currentDateTime <= givingTuesdayEnd;
 
 export const props: HeaderProps = {
     content: {
@@ -30,7 +19,12 @@ export const props: HeaderProps = {
             url: 'https://support.theguardian.com/contribute',
             text: 'Contribute',
         },
-        ...maybeSecondaryCta,
+        ...(shouldShowSubscribeButton && {
+            secondaryCta: {
+                url: 'https://support.theguardian.com/subscribe',
+                text: 'Subscribe',
+            },
+        }),
     },
     mobileContent: {
         heading: '',

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
@@ -10,6 +10,10 @@ import { SvgArrowRightStraight } from '@guardian/src-icons';
 import { HeaderRenderProps, headerWrapper } from './HeaderWrapper';
 import { Link } from '@guardian/src-link';
 
+const containerStyles = css`
+    line-height: 1.15;
+`;
+
 const messageStyles = css`
     color: ${brandAlt[400]};
     ${headline.xxsmall({ fontWeight: 'bold' })};
@@ -65,7 +69,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
     const mobileCta = mobileContent?.primaryCta ?? primaryCta;
 
     return (
-        <div>
+        <div css={containerStyles}>
             <Hide below="tablet">
                 <div css={messageStyles}>
                     <span>{heading}</span>

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -28,21 +28,11 @@ const nonSupportersTestNonUK: HeaderTest = {
 };
 
 const nonSupportersTestUS = (): HeaderTest => {
-    const givingTuesdayStart = new Date(2021, 10, 29, 17, 0); //remove "Subscribe" Monday 12:00 PM EST
-    const givingTuesdayEnd = new Date(2021, 11, 1, 9, 0); //re-add "Subscribe" on Wednesday morning GMT
-
-    const isGivingTuesday = (date: Date): boolean => {
-        return isAfter(date, givingTuesdayStart) && isBefore(date, givingTuesdayEnd);
-    };
-
-    const maybeSecondaryCta = isGivingTuesday(new Date())
-        ? undefined
-        : {
-              secondaryCta: {
-                  url: 'https://support.theguardian.com/subscribe',
-                  text: 'Subscribe',
-              },
-          };
+    const givingTuesdayStart = new Date('2021-11-29T17:00:00'); //remove "Subscribe" Monday 12:00 PM EST
+    const givingTuesdayEnd = new Date('2021-11-01T09:00:00'); //re-add "Subscribe" on Wednesday morning GMT
+    const currentDateTime = new Date();
+    const shouldShowSubscribeButton =
+        givingTuesdayStart <= currentDateTime && currentDateTime <= givingTuesdayEnd;
 
     return {
         name: 'RemoteRrHeaderLinksTest__USEOY',
@@ -58,7 +48,12 @@ const nonSupportersTestUS = (): HeaderTest => {
                         url: 'https://support.theguardian.com/contribute',
                         text: 'Contribute',
                     },
-                    ...maybeSecondaryCta,
+                    ...(shouldShowSubscribeButton && {
+                        secondaryCta: {
+                            url: 'https://support.theguardian.com/subscribe',
+                            text: 'Subscribe',
+                        },
+                    }),
                 },
                 mobileContent: {
                     heading: '',

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -28,8 +28,8 @@ const nonSupportersTestNonUK: HeaderTest = {
 };
 
 const nonSupportersTestUS = (): HeaderTest => {
-    const givingTuesdayStart = new Date(2021, 11, 29, 17, 0); //remove "Subscribe" Monday 12:00 PM EST
-    const givingTuesdayEnd = new Date(2021, 12, 1, 9, 0); //re-add "Subscribe" on Wednesday morning GMT
+    const givingTuesdayStart = new Date(2021, 10, 29, 17, 0); //remove "Subscribe" Monday 12:00 PM EST
+    const givingTuesdayEnd = new Date(2021, 11, 1, 9, 0); //re-add "Subscribe" on Wednesday morning GMT
 
     const isGivingTuesday = (date: Date): boolean => {
         return isAfter(date, givingTuesdayStart) && isBefore(date, givingTuesdayEnd);

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -27,35 +27,50 @@ const nonSupportersTestNonUK: HeaderTest = {
     ],
 };
 
-const nonSupportersTestUS: HeaderTest = {
-    name: 'RemoteRrHeaderLinksTest__USEOY',
-    audience: 'AllNonSupporters',
-    variants: [
-        {
-            name: 'remote',
-            modulePathBuilder: usEOYHeader.endpointPathBuilder,
-            content: {
-                heading: 'Support the Guardian',
-                subheading: 'Make a year-end gift',
-                primaryCta: {
-                    url: 'https://support.theguardian.com/contribute',
-                    text: 'Contribute',
+const nonSupportersTestUS = (): HeaderTest => {
+    const givingTuesdayStart = new Date(2021, 11, 29, 17, 0); //remove "Subscribe" Monday 12:00 PM EST
+    const givingTuesdayEnd = new Date(2021, 12, 1, 9, 0); //re-add "Subscribe" on Wednesday morning GMT
+
+    const isGivingTuesday = (date: Date): boolean => {
+        return isAfter(date, givingTuesdayStart) && isBefore(date, givingTuesdayEnd);
+    };
+
+    const maybeSecondaryCta = isGivingTuesday(new Date())
+        ? undefined
+        : {
+              secondaryCta: {
+                  url: 'https://support.theguardian.com/subscribe',
+                  text: 'Subscribe',
+              },
+          };
+
+    return {
+        name: 'RemoteRrHeaderLinksTest__USEOY',
+        audience: 'AllNonSupporters',
+        variants: [
+            {
+                name: 'remote',
+                modulePathBuilder: usEOYHeader.endpointPathBuilder,
+                content: {
+                    heading: 'Support the Guardian',
+                    subheading: 'Make a year-end gift',
+                    primaryCta: {
+                        url: 'https://support.theguardian.com/contribute',
+                        text: 'Contribute',
+                    },
+                    ...maybeSecondaryCta,
                 },
-                secondaryCta: {
-                    url: 'https://support.theguardian.com/subscribe',
-                    text: 'Subscribe',
+                mobileContent: {
+                    heading: '',
+                    subheading: '',
+                    primaryCta: {
+                        url: 'https://support.theguardian.com/contribute',
+                        text: 'Make a year-end gift',
+                    },
                 },
             },
-            mobileContent: {
-                heading: '',
-                subheading: '',
-                primaryCta: {
-                    url: 'https://support.theguardian.com/contribute',
-                    text: 'Make a year-end gift',
-                },
-            },
-        },
-    ],
+        ],
+    };
 };
 
 const nonSupportersTestUK: HeaderTest = {
@@ -145,7 +160,7 @@ const getNonSupportersTest = (edition: Edition): HeaderTest => {
         return nonSupportersTestUK;
     }
     if (edition === 'US' && isInUsEoyPeriod(new Date())) {
-        return nonSupportersTestUS;
+        return nonSupportersTestUS();
     }
     return nonSupportersTestNonUK;
 };


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR hides the Subscribe CTA on Giving Tuesday. This change only affects breakpoints above Phablet as the Subscribe CTA doesn't appear below this.

This also adds a line-height to the container for the header, to attempt to override the base styling on dotcom.

[**Trello Card**](https://trello.com/c/YxjXnb0R/157-%E2%9A%A1-remove-subscriptions-from-the-us-header-on-giving-tuesday)

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run Storybook locally.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

Outside of Giving Tuesday:
![Screenshot 2021-11-26 at 10 41 06](https://user-images.githubusercontent.com/7883129/143568813-340c69ff-406c-4d71-a63d-523a8555e929.png)

On Giving Tuesday:
![Screenshot 2021-11-26 at 10 42 20](https://user-images.githubusercontent.com/7883129/143568824-d40925fb-66fa-4a2b-9e0f-687a13127608.png)

