### PR TITLE
Exclude US from scheduled banner deploys

### DIFF
--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -56,7 +56,9 @@ export const redeployedSinceLastClosed = (
         );
         const lastClosed = new Date(lastClosedRaw);
         return (
-            lastManualDeploy > lastClosed || lastScheduledDeploy[bannerChannel](now) > lastClosed
+            lastManualDeploy > lastClosed ||
+            // Exclude US from scheduled deploys
+            (targeting.countryCode !== 'US' && lastScheduledDeploy[bannerChannel](now) > lastClosed)
         );
     };
 


### PR DESCRIPTION
because of the EOY campaign. This will last until the new year