### PR TITLE
Update showing subscribe button in header logic

### DIFF
--- a/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
@@ -8,8 +8,9 @@ import { brand } from '@guardian/src-foundations';
 const givingTuesdayStart = new Date('2021-11-29T17:00:00'); //remove "Subscribe" Monday 12:00 PM EST
 const givingTuesdayEnd = new Date('2021-11-01T09:00:00'); //re-add "Subscribe" on Wednesday morning GMT
 const currentDateTime = new Date();
-const shouldShowSubscribeButton =
-    givingTuesdayStart <= currentDateTime && currentDateTime <= givingTuesdayEnd;
+const shouldShowSubscribeButton = !(
+    currentDateTime >= givingTuesdayStart && currentDateTime <= givingTuesdayEnd
+);
 
 export const props: HeaderProps = {
     content: {

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.stories.tsx
@@ -6,7 +6,7 @@ import { css } from '@emotion/core';
 import { brand } from '@guardian/src-foundations';
 
 const givingTuesdayStart = new Date('2021-11-29T17:00:00'); //remove "Subscribe" Monday 12:00 PM EST
-const givingTuesdayEnd = new Date('2021-11-01T09:00:00'); //re-add "Subscribe" on Wednesday morning GMT
+const givingTuesdayEnd = new Date('2021-12-01T09:00:00'); //re-add "Subscribe" on Wednesday morning GMT
 const currentDateTime = new Date();
 const shouldShowSubscribeButton = !(
     currentDateTime >= givingTuesdayStart && currentDateTime <= givingTuesdayEnd

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -31,8 +31,9 @@ const nonSupportersTestUS = (): HeaderTest => {
     const givingTuesdayStart = new Date('2021-11-29T17:00:00'); //remove "Subscribe" Monday 12:00 PM EST
     const givingTuesdayEnd = new Date('2021-11-01T09:00:00'); //re-add "Subscribe" on Wednesday morning GMT
     const currentDateTime = new Date();
-    const shouldShowSubscribeButton =
-        givingTuesdayStart <= currentDateTime && currentDateTime <= givingTuesdayEnd;
+    const shouldShowSubscribeButton = !(
+        currentDateTime >= givingTuesdayStart && currentDateTime <= givingTuesdayEnd
+    );
 
     return {
         name: 'RemoteRrHeaderLinksTest__USEOY',

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -29,7 +29,7 @@ const nonSupportersTestNonUK: HeaderTest = {
 
 const nonSupportersTestUS = (): HeaderTest => {
     const givingTuesdayStart = new Date('2021-11-29T17:00:00'); //remove "Subscribe" Monday 12:00 PM EST
-    const givingTuesdayEnd = new Date('2021-11-01T09:00:00'); //re-add "Subscribe" on Wednesday morning GMT
+    const givingTuesdayEnd = new Date('2021-12-01T09:00:00'); //re-add "Subscribe" on Wednesday morning GMT
     const currentDateTime = new Date();
     const shouldShowSubscribeButton = !(
         currentDateTime >= givingTuesdayStart && currentDateTime <= givingTuesdayEnd


### PR DESCRIPTION
Co-authored-by: Samantha Gottlieb <samanthagottlieb@users.noreply.github.com>

## What does this change?
This PR updates the conditional logic to hide the subscribe button in the US header for Giving Tuesday.
