### PR TITLE
AB test showing subs banner once per week

### DIFF
--- a/packages/server/src/lib/targetingTesting.ts
+++ b/packages/server/src/lib/targetingTesting.ts
@@ -1,14 +1,17 @@
 import { TargetingAbTest, Test, Variant } from '@sdc/shared/types';
 import { selectVariant } from './ab';
+import { ScheduledBannerDeploys } from '../tests/banners/bannerDeploySchedule';
 
 type TargetingTestDecision = {
     canShow: boolean;
+    deploySchedule?: ScheduledBannerDeploys;
     test: TargetingAbTest;
 };
 
 interface TargetingTestVariant<T> extends Variant {
     name: string;
     canShow: (targeting: T) => boolean; // Can a message be shown?
+    deploySchedule?: ScheduledBannerDeploys;
 }
 
 /**
@@ -36,6 +39,7 @@ export const selectTargetingTest = <T>(
         const variant: TargetingTestVariant<T> = selectVariant(test, mvtId);
         return {
             canShow: variant.canShow(targeting),
+            deploySchedule: variant.deploySchedule,
             test: {
                 testName: test.name,
                 variantName: variant.name,

--- a/packages/server/src/lib/targetingTesting.ts
+++ b/packages/server/src/lib/targetingTesting.ts
@@ -11,7 +11,7 @@ type TargetingTestDecision = {
 interface TargetingTestVariant<T> extends Variant {
     name: string;
     canShow: (targeting: T) => boolean; // Can a message be shown?
-    deploySchedule?: ScheduledBannerDeploys;
+    deploySchedule?: ScheduledBannerDeploys; // Overrides default deploy schedule
 }
 
 /**

--- a/packages/server/src/tests/banners/bannerDeploySchedule.test.ts
+++ b/packages/server/src/tests/banners/bannerDeploySchedule.test.ts
@@ -1,4 +1,8 @@
-import { lastScheduledDeploy, previousScheduledDate } from './bannerDeploySchedule';
+import {
+    defaultDeploySchedule,
+    getLastScheduledDeploy,
+    previousScheduledDate,
+} from './bannerDeploySchedule';
 
 const days = {
     sunday: 0,
@@ -34,18 +38,26 @@ describe('previousScheduledDate', () => {
 
 describe('lastScheduledDeploy, subscriptions', () => {
     it('returns previous monday if currently tuesday', () => {
-        const date = new Date('2021-11-09 09:00:00');
-        const result = lastScheduledDeploy.subscriptions(date);
+        const result = getLastScheduledDeploy(
+            new Date('2021-11-09 09:00:00'),
+            defaultDeploySchedule.subscriptions,
+        );
         expect(result).toEqual(new Date('2021-11-08 08:00:00'));
     });
 
     it('returns previous friday if currently sunday', () => {
-        const result = lastScheduledDeploy.subscriptions(new Date('2021-11-07 09:00:00'));
+        const result = getLastScheduledDeploy(
+            new Date('2021-11-07 09:00:00'),
+            defaultDeploySchedule.subscriptions,
+        );
         expect(result).toEqual(new Date('2021-11-05 08:00:00'));
     });
 
     it('returns today (friday) if currently friday and within an hour of the last deploy', () => {
-        const result = lastScheduledDeploy.subscriptions(new Date('2021-11-26 08:30:00'));
+        const result = getLastScheduledDeploy(
+            new Date('2021-11-26 08:30:00'),
+            defaultDeploySchedule.subscriptions,
+        );
         expect(result).toEqual(new Date('2021-11-26 08:00:00'));
     });
 });

--- a/packages/server/src/tests/banners/bannerDeploySchedule.ts
+++ b/packages/server/src/tests/banners/bannerDeploySchedule.ts
@@ -58,6 +58,11 @@ const getLastScheduledDeploy = (date: Date, scheduledDeploys: ScheduledBannerDep
     return sorted[0];
 };
 
+export interface ScheduledBannerDeploys {
+    contributions: ScheduledBannerDeploy[];
+    subscriptions: ScheduledBannerDeploy[];
+}
+
 export const lastScheduledDeploy = {
     contributions: (date: Date): Date => getLastScheduledDeploy(date, channel1Schedule),
     subscriptions: (date: Date): Date => getLastScheduledDeploy(date, channel2Schedule),

--- a/packages/server/src/tests/banners/bannerDeploySchedule.ts
+++ b/packages/server/src/tests/banners/bannerDeploySchedule.ts
@@ -10,23 +10,29 @@ interface ScheduledBannerDeploy {
     hour: number; // 0-23
 }
 
-const channel1Schedule: ScheduledBannerDeploy[] = [
-    {
-        dayOfWeek: 0,
-        hour: 9,
-    },
-];
+export interface ScheduledBannerDeploys {
+    contributions: ScheduledBannerDeploy[];
+    subscriptions: ScheduledBannerDeploy[];
+}
 
-const channel2Schedule: ScheduledBannerDeploy[] = [
-    {
-        dayOfWeek: 1,
-        hour: 8,
-    },
-    {
-        dayOfWeek: 5,
-        hour: 8,
-    },
-];
+export const defaultDeploySchedule: ScheduledBannerDeploys = {
+    contributions: [
+        {
+            dayOfWeek: 0,
+            hour: 9,
+        },
+    ],
+    subscriptions: [
+        {
+            dayOfWeek: 1,
+            hour: 8,
+        },
+        {
+            dayOfWeek: 5,
+            hour: 8,
+        },
+    ],
+};
 
 const previousDay = (date: Date, dayOfWeek: number): Date =>
     subDays(date, (date.getDay() + 7 - dayOfWeek) % 7);
@@ -50,20 +56,13 @@ export const previousScheduledDate = (now: Date, dayOfWeek: number, hour: number
     });
 };
 
-const getLastScheduledDeploy = (date: Date, scheduledDeploys: ScheduledBannerDeploy[]): Date => {
+export const getLastScheduledDeploy = (
+    date: Date,
+    scheduledDeploys: ScheduledBannerDeploy[],
+): Date => {
     const deployDateTimes = scheduledDeploys.map(deploy =>
         previousScheduledDate(date, deploy.dayOfWeek, deploy.hour),
     );
     const sorted = deployDateTimes.sort(compareDesc);
     return sorted[0];
-};
-
-export interface ScheduledBannerDeploys {
-    contributions: ScheduledBannerDeploy[];
-    subscriptions: ScheduledBannerDeploy[];
-}
-
-export const lastScheduledDeploy = {
-    contributions: (date: Date): Date => getLastScheduledDeploy(date, channel1Schedule),
-    subscriptions: (date: Date): Date => getLastScheduledDeploy(date, channel2Schedule),
 };

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -12,7 +12,7 @@ const exclusions: SectionAndTagExclusions = {
     travel: [],
 };
 
-// TODO - remove?
+// TODO - remove or use this logic. We're still waiting for full results from this test to become available
 export const variantCanShow = (targeting: BannerTargeting): boolean => {
     const { sectionId, tagIds } = targeting;
 
@@ -30,7 +30,7 @@ export const variantCanShow = (targeting: BannerTargeting): boolean => {
 
 export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
     {
-        name: '2021-11-26_BannerTargeting_DeploySchedule',
+        name: '2021-12-02_BannerTargeting_SubsOncePerWeek',
         canInclude: (targeting: BannerTargeting) => targeting.countryCode !== 'US',
         variants: [
             {

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -42,4 +42,18 @@ export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
             },
         ],
     },
+    {
+        name: '2021-11-26_BannerTargeting_DeploySchedule',
+        canInclude: () => true,
+        variants: [
+            {
+                name: 'control',
+                canShow: () => true,
+            },
+            {
+                name: 'variant',
+                canShow: variantCanShow,
+            },
+        ],
+    },
 ];

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -29,22 +29,8 @@ export const variantCanShow = (targeting: BannerTargeting): boolean => {
 
 export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
     {
-        name: '2021-11-04_BannerTargeting_SectionExclusions',
-        canInclude: () => true,
-        variants: [
-            {
-                name: 'control',
-                canShow: () => true,
-            },
-            {
-                name: 'variant',
-                canShow: variantCanShow,
-            },
-        ],
-    },
-    {
         name: '2021-11-26_BannerTargeting_DeploySchedule',
-        canInclude: () => true,
+        canInclude: (targeting: BannerTargeting) => targeting.countryCode !== 'US',
         variants: [
             {
                 name: 'control',
@@ -52,7 +38,21 @@ export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
             },
             {
                 name: 'variant',
-                canShow: variantCanShow,
+                canShow: () => true,
+                deploySchedule: {
+                    contributions: [
+                        {
+                            dayOfWeek: 0,
+                            hour: 9,
+                        },
+                    ],
+                    subscriptions: [
+                        {
+                            dayOfWeek: 5,
+                            hour: 8,
+                        },
+                    ],
+                },
             },
         ],
     },

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -12,6 +12,7 @@ const exclusions: SectionAndTagExclusions = {
     travel: [],
 };
 
+// TODO - remove?
 export const variantCanShow = (targeting: BannerTargeting): boolean => {
     const { sectionId, tagIds } = targeting;
 

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -40,6 +40,7 @@ export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
             {
                 name: 'variant',
                 canShow: () => true,
+                // Only deploy the subs banner on a Monday
                 deploySchedule: {
                     contributions: [
                         {
@@ -49,7 +50,7 @@ export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
                     ],
                     subscriptions: [
                         {
-                            dayOfWeek: 5,
+                            dayOfWeek: 1,
                             hour: 8,
                         },
                     ],


### PR DESCRIPTION
Does showing the subs banner less often impact conversions?

Control: the subs banner is deployed on monday and friday (existing behaviour).
Variant: the subs banner is deployed on monday only.

If overall conversions are not significantly lower then we can improve user experience on the site without harming revenue.
We should run this test for at least a month. The US is currently excluded from auto deploys.

This PR ends the `2021-11-04_BannerTargeting_SectionExclusions` targeting test. We're still waiting for a Data Tech change before impressions become available, so we don't yet know if this logic will become a permanent part of banner targeting.

### Implementation
It's a bit clunky, but I've added a `deploySchedule` field to the `TargetingTestVariant` type. This means a variant can override the default deploy schedule.

Note - this test doesn't affect contributions, which is deployed once per week. If we want to deploy less frequently, e.g. every 2 weeks, then the logic would have to be quite a bit more complicated. It would need a start date from which to count weeks.