### PR TITLE
Update US reminders

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -3,7 +3,7 @@ import {
     createClickEventFromTracking,
     createInsertEventFromTracking,
     createViewEventFromTracking,
-    GIVING_TUESDAY_REMINDER_FIELDS,
+    NYE_REMINDER_FIELDS,
 } from '@sdc/shared/lib';
 import React, { useEffect } from 'react';
 import {
@@ -95,8 +95,7 @@ const withBannerData = (
 
             return {
                 type: SecondaryCtaType.ContributionsReminder,
-                reminderFields:
-                    countryCode === 'US' ? GIVING_TUESDAY_REMINDER_FIELDS : buildReminderFields(),
+                reminderFields: countryCode === 'US' ? NYE_REMINDER_FIELDS : buildReminderFields(),
             };
         };
 

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -29,11 +29,11 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-export const GIVING_TUESDAY_REMINDER_FIELDS: ReminderFields = {
-    reminderCta: `Remind me on Giving Tuesday`,
-    reminderPeriod: `2021-11-01`,
-    reminderLabel: 'on Giving Tuesday',
-    reminderOption: 'giving-tuesday-2021',
+export const NYE_REMINDER_FIELDS: ReminderFields = {
+    reminderCta: "Remind me on New Year's Eve",
+    reminderPeriod: '2021-12-01',
+    reminderLabel: "on New Year's Eve",
+    reminderOption: 'nye-2021',
 };
 
 export const getReminderFields = (
@@ -41,6 +41,6 @@ export const getReminderFields = (
     countryCode?: string,
 ): ReminderFields | undefined => {
     return variant.showReminderFields ?? countryCode === 'US'
-        ? GIVING_TUESDAY_REMINDER_FIELDS
+        ? NYE_REMINDER_FIELDS
         : buildReminderFields();
 };


### PR DESCRIPTION
## What does this change?

Updating the US reminder in the Epic & Banner from Giving Tuesday (today) -> to NYE.

## Images

### Banner
![Screenshot 2021-11-30 at 09 28 18](https://user-images.githubusercontent.com/17720442/144022195-0d775b78-6228-4e38-9be3-cf1fc6cbb744.png)

### Epic
![Screenshot 2021-11-30 at 09 28 47](https://user-images.githubusercontent.com/17720442/144022211-61d7f2a5-37e3-454b-afee-c1d19f2651f1.png)
![Screenshot 2021-11-30 at 09 28 55](https://user-images.githubusercontent.com/17720442/144022215-0b62c0c3-9c32-4d4e-97f0-89d97f732c6b.png)

