### PR TITLE
Use port 8082 when run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ yarn server start
 
 This will start `tsc` in `watch` mode to recompile on file changes and `nodemon` to run the resulting javascript and restart after recompilation.
 
+The server runs on port 8082 locally.
+
 #### DCR
 
 A local instance of DCR will use the `SDC_URL` environment variable to get the url for requests to SDC. To point DCR at a local instance of SDC we can therefore run DCR like
 
 ```bash
-SDC_URL=http://localhost:<SDC_PORT> make dev
+SDC_URL=http://localhost:8082 make dev
 ```
-
-Where the default value for `<SDC_PORT>` is `8082`.
 
 ### Modules
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
     "build": "webpack --config webpack.prod.js",
     "prestart": "webpack --config webpack.dev.js",
     "start-watch": "webpack --config webpack.dev.js --watch",
-    "start-server": "stage=DEV nodemon dist/server.js",
+    "start-server": "stage=DEV PORT=8082 nodemon dist/server.js",
     "start": "concurrently --kill-others \"yarn start-watch\" \"yarn start-server\"",
     "test": "jest"
   },


### PR DESCRIPTION
this seems to be the convention, to avoid clashing with DCR locally.
So now we can just run `yarn server start`.
Does not affect CODE/PROD