### PR TITLE
Update US EOY header and overfunded ticker

### DIFF
--- a/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.stories.tsx
@@ -51,7 +51,7 @@ WithoutArticleCount.args = {
             goalReachedSecondary: "It's not too late to give!",
         },
         tickerData: {
-            total: 120000,
+            total: 200000,
             goal: 150000,
         },
     },

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerTicker.tsx
@@ -179,7 +179,7 @@ const UsEoyMomentBannerTicker: React.FC<UsEoyMomentBannerTickerProps> = ({
                     <div css={totalCountStyles}>
                         {currencySymbol}
                         {isGoalReached
-                            ? `${runningTotal.toLocaleString()} goal reached`
+                            ? `${goal.toLocaleString()} goal reached`
                             : goal.toLocaleString()}
                     </div>
                     <div css={countLabelStyles(isGoalReached, true)}>

--- a/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/components/UsEoyMomentBannerTicker.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { neutral, palette } from '@guardian/src-foundations';
+import { neutral, news, palette, space } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import { TickerSettings } from '@sdc/shared/types';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
@@ -16,6 +16,7 @@ const rootStyles = css`
     position: relative;
     height: 65px;
     line-height: 18px;
+    overflow: hidden;
 `;
 
 const totalCountStyles = css`
@@ -39,10 +40,12 @@ const soFarCountStyles = css`
     }
 `;
 
-const countLabelStyles = css`
-    ${textSans.xsmall()};
+const countLabelStyles = (isGoalReached: boolean, goalText: boolean): SerializedStyles => css`
+    ${isGoalReached && goalText
+        ? `${textSans.xsmall({ fontWeight: 'bold' })}`
+        : `${textSans.xsmall()}`};
     font-size: 13px;
-    color: ${neutral[0]};
+    color: ${isGoalReached && goalText ? `${news[400]}` : `${neutral[0]}`};
     line-height: 1.3;
 
     ${from.desktop} {
@@ -82,7 +85,7 @@ const progressBarTransform = (end: number, runningTotal: number, total: number):
         return 'translateX(-100%)';
     }
 
-    const percentage = (total / end) * 100 - 100;
+    const percentage = (total / end) * 100 - 95;
 
     return `translate3d(${percentage >= 0 ? 0 : percentage}%, 0, 0)`;
 };
@@ -104,37 +107,24 @@ const filledProgressStyles = (
         background-color: ${colour};
     `;
 
-const goalContainerStyles = css`
+const goalContainerStyles = (isGoalReached: boolean) => css`
     position: absolute;
     right: 0;
     bottom: ${progressBarHeight + 5}px;
     text-align: right;
-`;
+    margin-right: ${isGoalReached ? '12%' : 0};
 
-const goalMarkerStyles = (transform: string): SerializedStyles => css`
-    border-right: 2px solid ${palette.neutral[7]};
-    content: ' ';
-    display: block;
-    height: 12px;
-    margin-top: -2px;
-    transform: ${transform};
-`;
-
-type MarkerProps = {
-    goal: number;
-    end: number;
-};
-
-const Marker: React.FC<MarkerProps> = ({ goal, end }: MarkerProps) => {
-    if (end > goal) {
-        const markerTranslate = (goal / end) * 100 - 100;
-        const markerTransform = `translate3d(${markerTranslate}%, 0, 0)`;
-
-        return <div css={goalMarkerStyles(markerTransform)} />;
-    } else {
-        return null;
+    &::after {
+        content: '';
+        width: 0;
+        height: 150%;
+        z-index: 1;
+        margin-left: ${space[1]}px;
+        position: absolute;
+        border: 1px solid black;
+        top: 0;
     }
-};
+`;
 
 type UsEoyMomentBannerTickerProps = {
     tickerSettings: TickerSettings;
@@ -177,25 +167,23 @@ const UsEoyMomentBannerTicker: React.FC<UsEoyMomentBannerTickerProps> = ({
             <div>
                 <div css={soFarContainerStyles}>
                     <div css={soFarCountStyles}>
-                        {!isGoalReached && currencySymbol}
-                        {isGoalReached
-                            ? tickerSettings.copy.goalReachedPrimary
-                            : runningTotal.toLocaleString()}
+                        {currencySymbol}
+                        {runningTotal.toLocaleString()}
                     </div>
-                    <div css={countLabelStyles}>
-                        {isGoalReached
-                            ? tickerSettings.copy.goalReachedSecondary
-                            : tickerSettings.copy.countLabel}
+                    <div css={countLabelStyles(isGoalReached, false)}>
+                        {tickerSettings.copy.countLabel}
                     </div>
                 </div>
 
-                <div css={goalContainerStyles}>
+                <div css={goalContainerStyles(isGoalReached)}>
                     <div css={totalCountStyles}>
                         {currencySymbol}
-                        {isGoalReached ? runningTotal.toLocaleString() : goal.toLocaleString()}
+                        {isGoalReached
+                            ? `${runningTotal.toLocaleString()} goal reached`
+                            : goal.toLocaleString()}
                     </div>
-                    <div css={countLabelStyles}>
-                        {isGoalReached ? tickerSettings.copy.countLabel : 'our goal'}
+                    <div css={countLabelStyles(isGoalReached, true)}>
+                        {isGoalReached ? "But it's not too late to give" : 'our goal'}
                     </div>
                 </div>
             </div>
@@ -204,7 +192,6 @@ const UsEoyMomentBannerTicker: React.FC<UsEoyMomentBannerTickerProps> = ({
                 <div css={progressBarStyles}>
                     <div css={filledProgressStyles(end, runningTotal, total, accentColour)}></div>
                 </div>
-                <Marker goal={goal} end={end} />
             </div>
         </div>
     );

--- a/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/core';
-import { from, until } from '@guardian/src-foundations/mq';
+import { between, from, until } from '@guardian/src-foundations/mq';
 import { brandAlt, brandText } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonReaderRevenueBrand } from '@guardian/src-button';
@@ -17,10 +17,13 @@ const containerStyles = css`
 const messageStyles = css`
     color: ${brandAlt[400]};
     ${headline.xxsmall({ fontWeight: 'bold' })};
-    margin-bottom: 3px;
 
     ${until.tablet} {
         ${textSans.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })}
+    }
+
+    ${between.tablet.and.leftCol} {
+        ${headline.xxxsmall({ fontWeight: 'bold', lineHeight: 'tight' })}
     }
 
     ${from.leftCol} {
@@ -48,9 +51,10 @@ const linkStyles = css`
 `;
 
 const mobileLinkStyles = css`
+    font-weight: bold;
     &,
     &:hover {
-        ${textSans.xsmall({ lineHeight: 'tight' })}
+        ${textSans.xsmall({ lineHeight: 'tight', fontWeight: 'bold' })}
         color: ${brandAlt[400]};
         line-height: 1.15;
     }
@@ -59,7 +63,6 @@ const mobileLinkStyles = css`
 const subMessageStyles = css`
     color: ${brandText.primary};
     ${textSans.medium()};
-    margin: 5px 0;
 `;
 
 const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {


### PR DESCRIPTION
## What does this change?
This PR updates the existing overfunded ticker UI in line with the approved design as well as the US EOY header following a design review.

## Images
Header
| mobileMedium (Default) | Desktop (Default) | mobileMedium (Supporters) | Desktop (Supporters) |
|------------------------|-------------------|---------------------------|------------|
|  <img width="170" alt="Screenshot 2021-12-03 at 17 08 45" src="https://user-images.githubusercontent.com/44685872/144644926-296fd1ec-70d1-4789-a004-cb6f2f35bb20.png">   |  <img width="294" alt="Screenshot 2021-12-03 at 17 09 03" src="https://user-images.githubusercontent.com/44685872/144645013-c9d5b13c-e202-4428-8725-fab8c16d1732.png">   |    <img width="143" alt="Screenshot 2021-12-03 at 17 09 32" src="https://user-images.githubusercontent.com/44685872/144645087-75d56276-e244-4dec-a232-0b4ccf8b13ac.png">    | <img width="294" alt="Screenshot 2021-12-03 at 17 09 15" src="https://user-images.githubusercontent.com/44685872/144645184-3ce348d6-78f0-4ed1-b54e-2c17be1f325e.png">   |

Overfunded Ticker
| mobileMedium | Desktop |
|--------------|---------|
 |<img width="322" alt="Screenshot 2021-12-03 at 17 07 49" src="https://user-images.githubusercontent.com/44685872/144645346-9684b412-e1e0-4377-8646-71ef0605fa8e.png"> | <img width="980" alt="Screenshot 2021-12-03 at 17 07 33" src="https://user-images.githubusercontent.com/44685872/144645369-8edabb65-a191-41d8-a481-a1ae87e1ed05.png">   |