### PR TITLE
Make heading text in header more semantic

### DIFF
--- a/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
+++ b/packages/modules/src/modules/header/EoYUSMomentHeader.tsx
@@ -65,6 +65,12 @@ const subMessageStyles = css`
     ${textSans.medium()};
 `;
 
+// override user agent styles
+const headingStyles = css`
+    font-size: 100%;
+    margin: 0;
+`;
+
 const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
     const { heading, subheading, primaryCta, secondaryCta } = props.content;
     const mobileContent = props.mobileContent;
@@ -75,7 +81,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
         <div css={containerStyles}>
             <Hide below="tablet">
                 <div css={messageStyles}>
-                    <span>{heading}</span>
+                    <h2 css={headingStyles}>{heading}</h2>
                 </div>
 
                 {subheading && (

--- a/packages/modules/src/modules/header/Header.tsx
+++ b/packages/modules/src/modules/header/Header.tsx
@@ -46,6 +46,12 @@ const subMessageStyles = css`
     margin: 5px 0;
 `;
 
+// override user agent styles
+const headingStyles = css`
+    margin: 0;
+    font-size: 100%;
+`;
+
 const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
     const { heading, subheading, primaryCta, secondaryCta } = props.content;
 
@@ -53,7 +59,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
         <div>
             <Hide below="tablet">
                 <div css={messageStyles(false)}>
-                    <span>{heading}</span>
+                    <h2 css={headingStyles}>{heading}</h2>
                 </div>
 
                 <div css={subMessageStyles}>

--- a/packages/modules/src/modules/header/HeaderSupportAgain.tsx
+++ b/packages/modules/src/modules/header/HeaderSupportAgain.tsx
@@ -15,6 +15,7 @@ const supportAgainHeadingStyles = css`
     ${textSans.small({ fontWeight: 'bold' })}
     color: ${brandAlt[400]};
     font-size: 14px;
+    margin: 0;
 
     ${from.tablet} {
         ${headline.xxsmall({ fontWeight: 'bold' })};
@@ -63,7 +64,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
     return (
         <div>
             <div>
-                <div css={supportAgainHeadingStyles}>{heading}</div>
+                <h2 css={supportAgainHeadingStyles}>{heading}</h2>
 
                 <Hide below="tablet">
                     <div css={supportAgainSubheadingStyles}>{subheading}</div>


### PR DESCRIPTION
## What does this change?

Make the heading text into `h2` in the following components:

- Header
- HeaderSupportAgain
- EOYUSMoment

## How can we measure success?

Screen reader users are able to discover the "Support" and "Thank you" messaging in the list of headings

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [x] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
