### PR TITLE
enable default choice card frequency to work with amp epic

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -346,6 +346,7 @@ app.get(
             const choiceCardAmounts = await cachedChoiceCardAmounts();
             const ampVariantAssignments = getAmpVariantAssignments(req);
             const epic = await ampEpic(ampVariantAssignments, countryCode);
+            const defaultChoiceCardFrequency = epic.defaultChoiceCardFrequency || 'MONTHLY';
             const acquisitionData = {
                 source: 'GOOGLE_AMP',
                 componentType: 'ACQUISITIONS_EPIC',
@@ -373,10 +374,11 @@ app.get(
                 choiceCards: epic.showChoiceCards
                     ? {
                           choiceCardSelection: {
-                              frequency: 'MONTHLY',
+                              frequency: defaultChoiceCardFrequency,
                               amount:
-                                  choiceCardAmounts[countryGroupId]['control']['MONTHLY']
-                                      .amounts[1],
+                                  choiceCardAmounts[countryGroupId]['control'][
+                                      defaultChoiceCardFrequency
+                                  ].amounts[1],
                           },
                           amounts: {
                               ONE_OFF: choiceCardAmounts[countryGroupId]['control'][

--- a/packages/server/src/tests/amp/ampEpicModels.ts
+++ b/packages/server/src/tests/amp/ampEpicModels.ts
@@ -1,5 +1,5 @@
 import { CountryGroupId } from '@sdc/shared/lib';
-import { Cta, TickerSettings } from '@sdc/shared/types';
+import { Cta, TickerSettings, ContributionFrequency } from '@sdc/shared/types';
 import { AMPTicker } from './ampTicker';
 
 /**
@@ -21,6 +21,7 @@ export interface AMPEpic {
     cta: AMPCta;
     ticker?: AMPTicker;
     showChoiceCards?: boolean;
+    defaultChoiceCardFrequency?: ContributionFrequency;
 }
 
 /**
@@ -34,6 +35,7 @@ export interface AmpEpicTestVariant {
     cta?: Cta;
     tickerSettings?: TickerSettings;
     showChoiceCards?: boolean;
+    defaultChoiceCardFrequency?: ContributionFrequency;
 }
 
 export interface AmpEpicTest {

--- a/packages/server/src/tests/amp/ampEpicTests.ts
+++ b/packages/server/src/tests/amp/ampEpicTests.ts
@@ -105,6 +105,7 @@ export const selectAmpEpicTestAndVariant = async (
                     campaignCode: campaignCode,
                 },
                 showChoiceCards: variant.showChoiceCards,
+                defaultChoiceCardFrequency: variant.defaultChoiceCardFrequency,
             };
 
             if (variant.tickerSettings) {


### PR DESCRIPTION
## What does this change?
Allows per variant configuration of default contribution amount choice card.