### PR TITLE
Subs banner deploy test v2

### DIFF
--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -30,7 +30,7 @@ export const variantCanShow = (targeting: BannerTargeting): boolean => {
 
 export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
     {
-        name: '2021-12-02_BannerTargeting_SubsOncePerWeek',
+        name: '2021-12-22_BannerTargeting_SubsOncePerWeek',
         canInclude: (targeting: BannerTargeting) => targeting.countryCode !== 'US',
         variants: [
             {

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -40,17 +40,17 @@ export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
             {
                 name: 'variant',
                 canShow: () => true,
-                // Only deploy the subs banner on a Monday
+                // Subs Saturday, Contribs Monday
                 deploySchedule: {
                     contributions: [
                         {
-                            dayOfWeek: 0,
+                            dayOfWeek: 1,
                             hour: 9,
                         },
                     ],
                     subscriptions: [
                         {
-                            dayOfWeek: 1,
+                            dayOfWeek: 6,
                             hour: 8,
                         },
                     ],


### PR DESCRIPTION
We think the existing test is really testing day-of-week + proximity to the contributions banner deploy. We know the subs banner performs well at weekends, and in the variant we only deploy at the start of the week, close to the contribs banner.
What happens if we change it to:
- Sat morning subs
- Mon morning contribs

In general, decoupling frequency of banner views and day of the week is tricky. In future we could change the logic to deploy every N days, per user. Though this all becomes simpler when we eventually move away from having 2 banners...