### PR TITLE
Turn off NYE reminder (MERGE ON 30th DEC)

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -3,7 +3,6 @@ import {
     createClickEventFromTracking,
     createInsertEventFromTracking,
     createViewEventFromTracking,
-    NYE_REMINDER_FIELDS,
 } from '@sdc/shared/lib';
 import React, { useEffect } from 'react';
 import {
@@ -95,7 +94,7 @@ const withBannerData = (
 
             return {
                 type: SecondaryCtaType.ContributionsReminder,
-                reminderFields: countryCode === 'US' ? NYE_REMINDER_FIELDS : buildReminderFields(),
+                reminderFields: buildReminderFields(),
             };
         };
 

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -185,7 +185,7 @@ export const buildEpicData = async (
 
     const choiceCardAmounts = await cachedChoiceCardAmounts();
     const tickerSettings = await getTickerSettings(variant);
-    const showReminderFields = getReminderFields(variant, targeting.countryCode);
+    const showReminderFields = getReminderFields(variant);
 
     const propsVariant = {
         ...variant,

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -29,18 +29,6 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-export const NYE_REMINDER_FIELDS: ReminderFields = {
-    reminderCta: "Remind me on New Year's Eve",
-    reminderPeriod: '2021-12-01',
-    reminderLabel: "on New Year's Eve",
-    reminderOption: 'nye-2021',
-};
-
-export const getReminderFields = (
-    variant: EpicVariant,
-    countryCode?: string,
-): ReminderFields | undefined => {
-    return variant.showReminderFields ?? countryCode === 'US'
-        ? NYE_REMINDER_FIELDS
-        : buildReminderFields();
+export const getReminderFields = (variant: EpicVariant): ReminderFields | undefined => {
+    return variant.showReminderFields ?? buildReminderFields();
 };


### PR DESCRIPTION
## What does this change?

Turn off NYE reminder sign up from the US TY page.

**NB: Merge this on the 30th**

[**Trello Card**](https://trello.com/c/Z9QdKsbu/215-revert-new-years-eve-reminder-ctas-in-the-us-to-the-standard-reminder-cta-before-nye)
