### PR TITLE
Set module publicReadAcl to true

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,6 +9,7 @@ deployments:
             prefixStack: false
             cacheControl: max-age=300
             surrogateControl: max-age=300
+            publicReadAcl: true
 
     dotcom-components-cloudformation:
         type: cloud-formation


### PR DESCRIPTION
The riffraff default is changing to false - see https://github.com/guardian/riff-raff/pull/664.

The modules need to be publically readable in S3