### PR TITLE
Resume subs banner deploy frequency test

### DIFF
--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -1,4 +1,34 @@
 import { TargetingTest } from '../../lib/targetingTesting';
 import { BannerTargeting } from '@sdc/shared/types';
 
-export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [];
+export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
+    {
+        name: '2021-12-22_BannerTargeting_SubsOncePerWeek',
+        canInclude: () => true,
+        variants: [
+            {
+                name: 'control',
+                canShow: () => true,
+            },
+            {
+                name: 'variant',
+                canShow: () => true,
+                // Subs Saturday, Contribs Monday
+                deploySchedule: {
+                    contributions: [
+                        {
+                            dayOfWeek: 1,
+                            hour: 9,
+                        },
+                    ],
+                    subscriptions: [
+                        {
+                            dayOfWeek: 6,
+                            hour: 8,
+                        },
+                    ],
+                },
+            },
+        ],
+    },
+];


### PR DESCRIPTION
I ended this earlier in the week because it was again performing poorly.
But I just looked again with Jesse and May and while total £AV was down, the £AV/impression isn't too bad. We've decided to give this test more time now that things have returned to normal after christmas. We're also interested to see how it performs in the US, where subs performs worse.