### PR TITLE
enable strong html tag in global new year banner copy

### DIFF
--- a/packages/modules/src/modules/banners/globalNewYear/GlobalNewYearBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/globalNewYear/GlobalNewYearBanner.stories.tsx
@@ -16,20 +16,20 @@ export const WithoutArticleCount = Template.bind({});
 WithoutArticleCount.args = {
     ...props,
     content: {
-        heading: 'Will you please help carry us into 2022...',
+        heading: 'As 2022 begins, will you support us?',
         messageText:
             'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations. We do not shy away. And we provide all this for free, for everyone. <strong>Show your support today from just $1, or sustain us long term with a little more. Thank you.</strong>',
         cta: {
             text: 'Support the Guardian',
             baseUrl: 'https://support.theguardian.com/contribute',
         },
-        secondaryCta: {
-            type: SecondaryCtaType.Custom,
-            cta: {
-                text: 'Hear from our editor',
-                baseUrl: 'https://theguardian.com',
-            },
-        },
+        // secondaryCta: {
+        //     type: SecondaryCtaType.Custom,
+        //     cta: {
+        //         text: 'Hear from our editor',
+        //         baseUrl: 'https://theguardian.com',
+        //     },
+        // },
     },
     numArticles: 0,
 };

--- a/packages/modules/src/modules/banners/globalNewYear/GlobalNewYearBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/globalNewYear/GlobalNewYearBanner.stories.tsx
@@ -23,13 +23,13 @@ WithoutArticleCount.args = {
             text: 'Support the Guardian',
             baseUrl: 'https://support.theguardian.com/contribute',
         },
-        // secondaryCta: {
-        //     type: SecondaryCtaType.Custom,
-        //     cta: {
-        //         text: 'Hear from our editor',
-        //         baseUrl: 'https://theguardian.com',
-        //     },
-        // },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Hear from our editor',
+                baseUrl: 'https://theguardian.com',
+            },
+        },
     },
     numArticles: 0,
 };

--- a/packages/modules/src/modules/banners/globalNewYear/GlobalNewYearBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/globalNewYear/GlobalNewYearBanner.stories.tsx
@@ -18,7 +18,7 @@ WithoutArticleCount.args = {
     content: {
         heading: 'Will you please help carry us into 2022...',
         messageText:
-            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations. We do not shy away. And we provide all this for free, for everyone. Show your support today from just $1, or sustain us long term with a little more. Thank you.',
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations. We do not shy away. And we provide all this for free, for everyone. <strong>Show your support today from just $1, or sustain us long term with a little more. Thank you.</strong>',
         cta: {
             text: 'Support the Guardian',
             baseUrl: 'https://support.theguardian.com/contribute',

--- a/packages/modules/src/modules/banners/globalNewYear/components/GlobalNewYearBannerBody.tsx
+++ b/packages/modules/src/modules/banners/globalNewYear/components/GlobalNewYearBannerBody.tsx
@@ -23,6 +23,10 @@ const styles = {
         p {
             margin: 0;
         }
+
+        strong {
+            font-weight: bold;
+        }
     `,
     highlightedTextContainer: css`
         font-weight: bold;

--- a/packages/modules/src/modules/banners/globalNewYear/components/getGlobalNewYearBanner.tsx
+++ b/packages/modules/src/modules/banners/globalNewYear/components/getGlobalNewYearBanner.tsx
@@ -54,11 +54,6 @@ const styles = {
             max-width: 70%;
             font-size: 50px;
         }
-
-        ${from.wide} {
-            max-width: 74%;
-            font-size: 50px;
-        }
     `,
     horizontalRule: css`
         clear: both;


### PR DESCRIPTION
## What does this PR do?
Enables bold text in Global New Year Moment banner copy, configurable in RRCP by wrapping in `<strong>` tags.

## Screenshot
_Example_
<img width="1440" alt="Screenshot 2022-01-11 at 16 33 29" src="https://user-images.githubusercontent.com/25020231/148983037-8ed28874-02d6-44d9-b6fd-10e861cbfc38.png">
