### PR TITLE
Remove AC-by-tag epic

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -252,9 +252,7 @@ const EpicBody: React.FC<BodyProps> = ({
     );
 };
 
-export const getContributionsEpic: (
-    aboveArticleCountByTag: boolean,
-) => React.FC<EpicProps> = aboveArticleCountByTag => ({
+const ContributionsEpic: React.FC<EpicProps> = ({
     variant,
     tracking,
     countryCode,
@@ -354,7 +352,7 @@ export const getContributionsEpic: (
                         onArticleCountOptIn={onArticleCountOptIn}
                         openCmp={openCmp}
                         submitComponentEvent={submitComponentEvent}
-                        aboveArticleCountByTag={aboveArticleCountByTag}
+                        aboveArticleCountByTag={false}
                     />
                 </div>
             )}
@@ -455,6 +453,6 @@ export const validate = (props: unknown): props is EpicProps => {
     return result.success;
 };
 
-const validatedEpic = withParsedProps(getContributionsEpic(false), validate);
-const unValidatedEpic = getContributionsEpic(false);
+const validatedEpic = withParsedProps(ContributionsEpic, validate);
+const unValidatedEpic = ContributionsEpic;
 export { validatedEpic as ContributionsEpic, unValidatedEpic as ContributionsEpicUnvalidated };

--- a/packages/modules/src/modules/epics/ContributionsEpicACByTag.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicACByTag.tsx
@@ -1,8 +1,0 @@
-import { getContributionsEpic, validate } from './ContributionsEpic';
-import { EpicProps } from '@sdc/shared/dist/types';
-import { withParsedProps } from '../shared/ModuleWrapper';
-
-export const ContributionsEpic: React.FC<EpicProps> = withParsedProps(
-    getContributionsEpic(true),
-    validate,
-);

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -18,11 +18,6 @@ export const getDefaultModuleInfo = (name: string, path: string): ModuleInfo => 
 
 export const epic: ModuleInfo = getDefaultModuleInfo('epic', 'epics/ContributionsEpic');
 
-export const epicACByTag: ModuleInfo = getDefaultModuleInfo(
-    'epicACByTag',
-    'epics/ContributionsEpicACByTag',
-);
-
 export const liveblogEpic: ModuleInfo = getDefaultModuleInfo(
     'liveblog-epic',
     'epics/ContributionsLiveblogEpic',
@@ -82,7 +77,6 @@ export const header: ModuleInfo = getDefaultModuleInfo('header', 'header/Header'
 
 export const moduleInfos: ModuleInfo[] = [
     epic,
-    epicACByTag,
     liveblogEpic,
     contributionsBanner,
     contributionsBannerWithSignIn,


### PR DESCRIPTION
Remove the `ContributionsEpicACByTag` module. This was recently used in an AB test, and the variant was not significant.

I've left the `aboveArticleCountByTag` functionality in for now, I suspect we'll be revisiting this in some form later