### PR TITLE
In Epic checkout + draft test

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpicWithCheckout.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicWithCheckout.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { ContributionsEpicUnvalidated as ContributionsEpic } from './ContributionsEpicWithCheckout';
+import { props } from './utils/storybook';
+import { EpicProps, SecondaryCtaType } from '@sdc/shared/types';
+import { EpicDecorator } from './ContributionsEpic.stories';
+
+export default {
+    component: ContributionsEpic,
+    title: 'Epics/ContributionsWithCheckout',
+    args: props,
+    decorators: [EpicDecorator],
+    excludeStories: /.*Decorator$/,
+} as Meta;
+
+const Template: Story<EpicProps> = (props: EpicProps) => <ContributionsEpic {...props} />;
+
+export const Default = Template.bind({});
+Default.args = {
+    countryCode: 'GB',
+    variant: {
+        ...props.variant,
+        secondaryCta: { type: SecondaryCtaType.ContributionsReminder },
+        showReminderFields: {
+            reminderCta: 'Remind me in May',
+            reminderPeriod: '2020-05-01',
+            reminderLabel: 'May',
+        },
+    },
+};

--- a/packages/modules/src/modules/epics/ContributionsEpicWithCheckout.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicWithCheckout.tsx
@@ -1,0 +1,7 @@
+import { withParsedProps } from '../shared/ModuleWrapper';
+import { getContributionsEpic, InEpicPaymentVariant, validate } from './ContributionsEpic';
+
+const ContributionsEpic = getContributionsEpic(InEpicPaymentVariant.Variant);
+const validatedEpic = withParsedProps(ContributionsEpic, validate);
+const unValidatedEpic = ContributionsEpic;
+export { validatedEpic as ContributionsEpic, unValidatedEpic as ContributionsEpicUnvalidated };

--- a/packages/modules/src/modules/epics/checkout/ContributionsEpicCheckout.tsx
+++ b/packages/modules/src/modules/epics/checkout/ContributionsEpicCheckout.tsx
@@ -1,0 +1,79 @@
+import { css } from '@emotion/react';
+import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/lib';
+import { Tracking } from '@sdc/shared/src/types';
+import React, { RefObject } from 'react';
+
+const styles = {
+    iframeContainer: css`
+        border: none;
+        width: 100%;
+    `,
+};
+
+// Currently components don't know if they're in DEV/CODE/PROD
+// hence why we hardcode urls to PROD. For convenience for future
+// dev work we've left in the CODE and DEV urls below.
+const BASE_URL = 'https://support.theguardian.com/contribute-in-epic';
+// const BASE_URL = 'https://support.code.dev-theguardian.com/contribute-in-epic';
+// const BASE_URL = 'https://support.thegulocal.com/contribute-in-epic';
+
+interface ContributionsEpicCheckoutProps {
+    iframeRef: RefObject<HTMLIFrameElement>;
+    iframeHeight: number;
+    tracking: Tracking;
+    onReminderClicked: () => void;
+    numArticles?: number;
+    countryCode?: string;
+    reminderCta?: string;
+}
+
+export function ContributionsEpicCheckout({
+    iframeRef,
+    iframeHeight,
+    tracking,
+    numArticles,
+    countryCode,
+    reminderCta,
+}: ContributionsEpicCheckoutProps): JSX.Element {
+    const iframeUrl = getIframeUrl(tracking, numArticles, countryCode, reminderCta);
+
+    return (
+        <div>
+            <iframe
+                ref={iframeRef}
+                src={iframeUrl}
+                css={styles.iframeContainer}
+                style={{ height: iframeHeight }}
+                allow="payment *"
+                scrolling="no"
+            />
+        </div>
+    );
+}
+
+// ---- Helpers ---- //
+
+function getIframeUrl(
+    tracking: Tracking,
+    numArticles?: number,
+    countryCode?: string,
+    reminderCta?: string,
+) {
+    return addRegionIdAndTrackingParamsToSupportUrl(
+        addReminderCtaToUrl(BASE_URL, reminderCta),
+        tracking,
+        numArticles,
+        countryCode,
+    );
+}
+
+function addReminderCtaToUrl(urlString: string, reminderCta?: string) {
+    if (!reminderCta) {
+        return urlString;
+    }
+
+    const url = new URL(urlString);
+    url.searchParams.append('reminderCta', reminderCta);
+
+    return url.toString();
+}

--- a/packages/modules/src/modules/epics/checkout/useIframedCheckout.ts
+++ b/packages/modules/src/modules/epics/checkout/useIframedCheckout.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { useEffect, useRef, useState, RefObject } from 'react';
+
+interface IframedCheckout {
+    iframeRef: RefObject<HTMLIFrameElement>;
+    iframeHeight: number;
+    postReminderClosedMessage: () => void;
+}
+
+export function useIframedCheckout(onReminderClicked: () => void): IframedCheckout {
+    const [iframeHeight, setIframeHeight] = useState(0);
+    const iframeRef = useRef<HTMLIFrameElement>(null);
+
+    useEffect(() => {
+        const handler = (ev: MessageEvent<unknown>) => {
+            const result = messageSchema.safeParse(ev.data);
+
+            if (!result.success) {
+                return;
+            }
+
+            const message = result.data;
+            if (message.type === 'IFRAME_HEIGHT') {
+                setIframeHeight(message.height);
+            } else if (message.type === 'REMINDER_CTA_CLICKED') {
+                onReminderClicked();
+            }
+        };
+
+        window.addEventListener('message', handler);
+
+        return () => window.removeEventListener('message', handler);
+    }, []);
+
+    function postReminderClosedMessage() {
+        iframeRef.current?.contentWindow?.postMessage({ type: 'REMINDER_CLOSE_CLICKED' }, '*');
+    }
+
+    return { iframeRef, iframeHeight, postReminderClosedMessage };
+}
+
+// ---- Utils ---- //
+
+const contentSizeMessageSchema = z.object({
+    type: z.literal('IFRAME_HEIGHT'),
+    height: z.number(),
+});
+
+const reminderCtaClickedMessageSchema = z.object({
+    type: z.literal('REMINDER_CTA_CLICKED'),
+});
+
+const messageSchema = z.union([contentSizeMessageSchema, reminderCtaClickedMessageSchema]);

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -34,6 +34,7 @@ import { getCachedTests } from './tests/banners/bannerTests';
 import { Debug, findForcedTestAndVariant, findTestAndVariant } from './tests/epics/epicSelection';
 import { fallbackEpicTest } from './tests/epics/fallback';
 import { selectHeaderTest } from './tests/header/headerSelection';
+import { inEpicPaymentTestDraft } from './tests/epics/inEpicPaymentTest';
 import { logWarn } from './utils/logging';
 import { cachedChoiceCardAmounts } from './choiceCardAmounts';
 
@@ -126,7 +127,13 @@ const getArticleEpicTests = async (
         const hardcodedTests = enableHardcodedEpicTests ? hardcodedEpicTests : [];
 
         if (isForcingTest) {
-            return [...hardcodedTests, ...regular, ...holdback, fallbackEpicTest];
+            return [
+                inEpicPaymentTestDraft,
+                ...hardcodedTests,
+                ...regular,
+                ...holdback,
+                fallbackEpicTest,
+            ];
         }
 
         const shouldHoldBack = mvtId % 100 === 0; // holdback 1% of the audience

--- a/packages/server/src/tests/epics/inEpicPaymentTest.ts
+++ b/packages/server/src/tests/epics/inEpicPaymentTest.ts
@@ -1,0 +1,60 @@
+import { EpicTest, SecondaryCtaType } from '@sdc/shared/types';
+import { epic, epicWithCheckout } from '@sdc/shared/config';
+import { CTA, HIGHLIGHTED_TEXT, PARAGRAPHS } from './inEpicPaymentTestData';
+
+export const inEpicPaymentTestDraft: EpicTest = {
+    name: 'InEpicPaymentTestDraft',
+    campaignId: 'InEpicPaymentTestDraft',
+    hasArticleCountInCopy: false,
+    isOn: true,
+    locations: [
+        'GBPCountries',
+        'EURCountries',
+        'UnitedStates',
+        'Canada',
+        'AUDCountries',
+        'NZDCountries',
+        'International',
+    ],
+    audience: 1,
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: false,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
+    userCohort: 'AllNonSupporters',
+    isLiveBlog: false,
+    hasCountryName: true,
+    variants: [
+        {
+            name: 'control',
+            modulePathBuilder: epic.endpointPathBuilder,
+            paragraphs: PARAGRAPHS,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
+            secondaryCta: { type: SecondaryCtaType.ContributionsReminder },
+            separateArticleCount: { type: 'above' },
+            showChoiceCards: true,
+        },
+        {
+            name: 'variant',
+            modulePathBuilder: epicWithCheckout.endpointPathBuilder,
+            paragraphs: PARAGRAPHS,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
+            secondaryCta: { type: SecondaryCtaType.ContributionsReminder },
+            separateArticleCount: { type: 'above' },
+        },
+    ],
+    highPriority: true,
+    useLocalViewLog: true,
+    articlesViewedSettings: {
+        minViews: 5,
+        periodInWeeks: 52,
+    },
+};

--- a/packages/server/src/tests/epics/inEpicPaymentTestData.ts
+++ b/packages/server/src/tests/epics/inEpicPaymentTestData.ts
@@ -1,0 +1,15 @@
+export const PARAGRAPHS = [
+    '... we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s high-impact journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million readers, from 180 countries, have recently taken the step to support us financially – keeping us open to all, and fiercely independent.',
+    'With no shareholders or billionaire owner, we can set our own agenda and provide trustworthy journalism that’s free from commercial and political influence, offering a counterweight to the spread of misinformation. When it’s never mattered more, we can investigate and challenge without fear or favour.',
+    'Unlike many others, Guardian journalism is available for everyone to read, regardless of what they can afford to pay. We do this because we believe in information equality. Greater numbers of people can keep track of global events, understand their impact on people and communities, and become inspired to take meaningful action.',
+    "We aim to offer readers a comprehensive, international perspective on critical events shaping our world – from the Black Lives Matter movement, to the new American administration, Brexit, and the world's slow emergence from a global pandemic. We are committed to upholding our reputation for urgent, powerful reporting on the climate emergency, and made the decision to reject advertising from fossil fuel companies, divest from the oil and gas industries, and set a course to achieve net zero emissions by 2030.",
+    'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+];
+
+export const HIGHLIGHTED_TEXT =
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.';
+
+export const CTA = {
+    text: 'Support the Guardian',
+    baseUrl: 'https://support.theguardian.com/contribute',
+};

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -17,6 +17,10 @@ export const getDefaultModuleInfo = (name: string, path: string): ModuleInfo => 
 });
 
 export const epic: ModuleInfo = getDefaultModuleInfo('epic', 'epics/ContributionsEpic');
+export const epicWithCheckout: ModuleInfo = getDefaultModuleInfo(
+    'epic',
+    'epics/ContributionsEpicWithCheckout',
+);
 
 export const liveblogEpic: ModuleInfo = getDefaultModuleInfo(
     'liveblog-epic',
@@ -77,6 +81,7 @@ export const header: ModuleInfo = getDefaultModuleInfo('header', 'header/Header'
 
 export const moduleInfos: ModuleInfo[] = [
     epic,
+    epicWithCheckout,
     liveblogEpic,
     contributionsBanner,
     contributionsBannerWithSignIn,

--- a/packages/shared/src/lib/geolocation.ts
+++ b/packages/shared/src/lib/geolocation.ts
@@ -431,7 +431,7 @@ export const addRegionIdToSupportUrl = (originalUrl: string, countryCode?: strin
         const supportRegionId = countryCodeToSupportRegionId(countryCode);
         if (supportRegionId) {
             return originalUrl.replace(
-                /(support.theguardian.com)\/(contribute|subscribe)/,
+                /(support.theguardian.com)\/(contribute-in-epic|contribute|subscribe)/,
                 (_, domain, path) => `${domain}/${supportRegionId.toLowerCase()}/${path}`,
             );
         }


### PR DESCRIPTION
## What does this change?

Add support to the Epic for embedding the new `contribute-in-checkout` checkout page from the support site. Additionally, it adds a "draft" test that is only viewable by forcing with a query parameter. This way we can do some testing in PROD before going live with the actual test (will be a follow up PR).

We have a [go-live plan](https://docs.google.com/document/d/1FbnjdkntdUhvYNOP8VLYdWaHNSFV0tOKsjSOjipr5nE/edit#) for releasing the A/B test. The first stage involves merging the [support site PR](https://github.com/guardian/support-frontend/pull/3403). After that is live and tested, we can merge this PR and then do some further testing.

## Images

### With payment request button

![Screenshot 2022-02-02 at 10 55 55](https://user-images.githubusercontent.com/17720442/152141167-a25c1791-b932-4de5-9358-c239b988a77f.png)

### With fallback

![Screenshot 2022-02-02 at 10 56 18](https://user-images.githubusercontent.com/17720442/152141186-2349c722-c992-4d5b-acae-7997a53647b0.png)

