### PR TITLE
Update GW banner images

### DIFF
--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -33,25 +33,36 @@ const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
 const mobileAndDesktopImg =
-    'https://i.guim.co.uk/img/media/670c3033e71f48296798480ac22a1123602e8466/0_0_500_240/500.png?quality=85&s=c1456ddb21a061ac1a199670637b5c5a';
+    'https://i.guim.co.uk/img/media/0682b069cf2e32b987ddcfbb2b549a93be61ae36/0_0_500_240/500.png?quality=85&s=1bf9bd8af343813bd6db3f009fccf385';
 
 const tabletImage =
+    'https://i.guim.co.uk/img/media/6d601169360b35c705412fbfa163c15f140efc2f/0_0_500_336/500.png?quality=85&s=21fb33ade343b7db222823c4d3160b7f';
+
+const mobileAndDesktopImgJan22 =
+    'https://i.guim.co.uk/img/media/670c3033e71f48296798480ac22a1123602e8466/0_0_500_240/500.png?quality=85&s=c1456ddb21a061ac1a199670637b5c5a';
+
+const tabletImageJan22 =
     'https://i.guim.co.uk/img/media/8d1fea851030b24328e05267fdb9bcd767248aeb/0_0_500_336/500.png?quality=85&s=102abc54f37796d6f668416bdbb993f1';
+
+const bannerMobileAndDesktopImg =
+    new Date() >= new Date('2022-01-24T08:00:00') ? mobileAndDesktopImgJan22 : mobileAndDesktopImg;
+const bannerTabletImageJan22 =
+    new Date() >= new Date('2022-01-24T08:00:00') ? tabletImageJan22 : tabletImage;
 
 // Responsive image props
 const baseImg = {
-    url: mobileAndDesktopImg,
+    url: bannerMobileAndDesktopImg,
     media: '(min-width: 980px)',
     alt: 'The Guardian Weekly magazine',
 };
 
 const images = [
     {
-        url: mobileAndDesktopImg,
+        url: bannerMobileAndDesktopImg,
         media: '(max-width: 739px)',
     },
     {
-        url: tabletImage,
+        url: bannerTabletImageJan22,
         media: '(min-width: 740px) and (max-width: 979px)',
     },
     baseImg,

--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -33,10 +33,10 @@ const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
 const mobileAndDesktopImg =
-    'https://i.guim.co.uk/img/media/0682b069cf2e32b987ddcfbb2b549a93be61ae36/0_0_500_240/500.png?quality=85&s=1bf9bd8af343813bd6db3f009fccf385';
+    'https://i.guim.co.uk/img/media/670c3033e71f48296798480ac22a1123602e8466/0_0_500_240/500.png?quality=85&s=c1456ddb21a061ac1a199670637b5c5a';
 
 const tabletImage =
-    'https://i.guim.co.uk/img/media/6d601169360b35c705412fbfa163c15f140efc2f/0_0_500_336/500.png?quality=85&s=21fb33ade343b7db222823c4d3160b7f';
+    'https://i.guim.co.uk/img/media/8d1fea851030b24328e05267fdb9bcd767248aeb/0_0_500_336/500.png?quality=85&s=102abc54f37796d6f668416bdbb993f1';
 
 // Responsive image props
 const baseImg = {

--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -46,7 +46,7 @@ const tabletImageJan22 =
 
 const bannerMobileAndDesktopImg =
     new Date() >= new Date('2022-01-24T08:00:00') ? mobileAndDesktopImgJan22 : mobileAndDesktopImg;
-const bannerTabletImageJan22 =
+const bannerTabletImg =
     new Date() >= new Date('2022-01-24T08:00:00') ? tabletImageJan22 : tabletImage;
 
 // Responsive image props
@@ -62,7 +62,7 @@ const images = [
         media: '(max-width: 739px)',
     },
     {
-        url: bannerTabletImageJan22,
+        url: bannerTabletImg,
         media: '(min-width: 740px) and (max-width: 979px)',
     },
     baseImg,


### PR DESCRIPTION
## What does this change?
This updates the packshot images on the Guardian Weekly banner for the duration of the Jan 22 campaign. 

## Images
| Before | After |
| -- | -- |
| <img width="319" alt="Screenshot 2022-01-21 at 10 39 02" src="https://user-images.githubusercontent.com/44685872/150522894-9cddd4c3-cb76-4594-a34d-7321f34e10cc.png"> | <img width="319" alt="Screenshot 2022-01-21 at 10 38 44" src="https://user-images.githubusercontent.com/44685872/150523087-0bf21b6c-fb5a-4b66-8ca6-f377b957c5f5.png"> | 
| <img width="766" alt="Screenshot 2022-01-21 at 11 59 48" src="https://user-images.githubusercontent.com/44685872/150523635-51228e7c-7361-4c5a-8a8a-1f8d8d927b35.png"> | <img width="769" alt="Screenshot 2022-01-21 at 10 38 30" src="https://user-images.githubusercontent.com/44685872/150523139-17e2c05a-d19e-4e3c-a15a-00707426b732.png"> |


 