### PR TITLE
Guardian Weekly propensity test

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1034,7 +1034,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
                       Object {
                         "Ref": "Stage",
                       },
-                      "/single-contributor-propensity-test/*",
+                      "/guardian-weekly-propensity-test/*",
                     ],
                   ],
                 },

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -59,7 +59,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
                     `${this.stage}/banner-deploy/*`,
                     `${this.stage}/channel-switches.json`,
                     `${this.stage}/configured-amounts.json`,
-                    `${this.stage}/single-contributor-propensity-test/*`,
+                    `${this.stage}/guardian-weekly-propensity-test/*`,
                 ],
             }),
             new GuGetS3ObjectsPolicy(this, 'S3ReadPolicyGuContributionsPublic', {

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -36,6 +36,7 @@ import { fallbackEpicTest } from './tests/epics/fallback';
 import { selectHeaderTest } from './tests/header/headerSelection';
 import { logWarn } from './utils/logging';
 import { cachedChoiceCardAmounts } from './choiceCardAmounts';
+import { bannerTargetingTests } from './tests/banners/bannerTargetingTests';
 
 interface EpicDataResponse {
     data?: {
@@ -250,6 +251,7 @@ export const buildBannerData = async (
         pageTracking,
         baseUrl(req),
         getCachedTests,
+        bannerTargetingTests,
         bannerDeployCaches,
         params.force,
     );

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -51,6 +51,12 @@ jest.mock('./channelSwitches', () => {
         ),
     };
 });
+jest.mock('./tests/banners/guardianWeeklyPropensityData', () => {
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        fetchHighPropensityIds: jest.fn().mockImplementation(() => {}),
+    };
+});
 jest.mock('./choiceCardAmounts', () => {
     return {
         cachedChoiceCardAmounts: jest.fn().mockImplementation(() =>

--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -2,6 +2,7 @@ import { contributionsBanner, digiSubs } from '@sdc/shared/config';
 import { BannerTargeting, BannerTest } from '@sdc/shared/types';
 import { BannerDeployCaches } from './bannerDeployCache';
 import { selectBannerTest } from './bannerSelection';
+import { TargetingTest } from '../../lib/targetingTesting';
 
 const getBannerDeployCache = (date: string): BannerDeployCaches =>
     ({
@@ -31,6 +32,8 @@ describe('selectBannerTest', () => {
         const now = new Date('2020-03-31T12:30:00');
 
         const cache = getBannerDeployCache(secondDate);
+
+        const targetingTests: TargetingTest<BannerTargeting>[] = [];
 
         const targeting: BannerTargeting = {
             alreadyVisitedCount: 3,
@@ -86,6 +89,7 @@ describe('selectBannerTest', () => {
                 tracking,
                 '',
                 () => Promise.resolve([test]),
+                targetingTests,
                 cache,
                 undefined,
                 now,
@@ -102,6 +106,7 @@ describe('selectBannerTest', () => {
                 tracking,
                 '',
                 () => Promise.resolve([test]),
+                targetingTests,
                 cache,
                 undefined,
                 now,
@@ -124,6 +129,7 @@ describe('selectBannerTest', () => {
                             articlesViewedSettings: undefined,
                         },
                     ]),
+                targetingTests,
                 cache,
                 undefined,
                 now,
@@ -140,6 +146,7 @@ describe('selectBannerTest', () => {
                 tracking,
                 '',
                 () => Promise.resolve([test]),
+                targetingTests,
                 cache,
                 undefined,
                 now,
@@ -153,6 +160,8 @@ describe('selectBannerTest', () => {
         const now = new Date('2020-03-31T12:30:00');
 
         const cache = getBannerDeployCache(secondDate);
+
+        const targetingTests: TargetingTest<BannerTargeting>[] = [];
 
         const targeting: BannerTargeting = {
             alreadyVisitedCount: 3,
@@ -207,6 +216,7 @@ describe('selectBannerTest', () => {
                 tracking,
                 '',
                 () => Promise.resolve([test]),
+                targetingTests,
                 cache,
                 undefined,
                 now,
@@ -223,6 +233,7 @@ describe('selectBannerTest', () => {
                 tracking,
                 '',
                 () => Promise.resolve([test]),
+                targetingTests,
                 cache,
                 undefined,
                 now,
@@ -245,6 +256,7 @@ describe('selectBannerTest', () => {
                             articlesViewedSettings: undefined,
                         },
                     ]),
+                targetingTests,
                 cache,
                 undefined,
                 now,

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -12,8 +12,7 @@ import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { TestVariant } from '../../lib/params';
 import { audienceMatches, userIsInTest } from '../../lib/targeting';
 import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
-import { selectTargetingTest } from '../../lib/targetingTesting';
-import { bannerTargetingTests } from './bannerTargetingTests';
+import { selectTargetingTest, TargetingTest } from '../../lib/targetingTesting';
 import {
     getLastScheduledDeploy,
     ScheduledBannerDeploys,
@@ -101,6 +100,7 @@ export const selectBannerTest = async (
     pageTracking: PageTracking,
     baseUrl: string,
     getTests: () => Promise<BannerTest[]>,
+    targetingTests: TargetingTest<BannerTargeting>[],
     bannerDeployCaches: BannerDeployCaches,
     forcedTestVariant?: TestVariant,
     now: Date = new Date(),
@@ -111,7 +111,7 @@ export const selectBannerTest = async (
         return Promise.resolve(getForcedVariant(forcedTestVariant, tests, baseUrl, targeting));
     }
 
-    const targetingTest = selectTargetingTest(targeting.mvtId, targeting, bannerTargetingTests);
+    const targetingTest = selectTargetingTest(targeting.mvtId, targeting, targetingTests);
     if (targetingTest && !targetingTest.canShow) {
         return Promise.resolve(null);
     }

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -1,7 +1,27 @@
 import { TargetingTest } from '../../lib/targetingTesting';
 import { BannerTargeting } from '@sdc/shared/types';
+import { inCountryGroups } from '@sdc/shared/dist/lib';
+import { isGuardianWeeklyHighPropensity } from './guardianWeeklyPropensityData';
 
 export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
+    {
+        name: '2022-01-21_GuardianWeeklyPropensityTestR1',
+        canInclude: (targeting: BannerTargeting) =>
+            inCountryGroups(targeting.countryCode, ['EURCountries']),
+        variants: [
+            {
+                name: 'control',
+                // All browsers see the banner
+                canShow: () => true,
+            },
+            {
+                name: 'variant',
+                // Only high-propensity browserIds see the banner. This also excludes browsers who have not consented
+                canShow: (targeting: BannerTargeting) =>
+                    !!targeting.browserId && isGuardianWeeklyHighPropensity(targeting.browserId),
+            },
+        ],
+    },
     {
         name: '2021-12-22_BannerTargeting_SubsOncePerWeek',
         canInclude: () => true,

--- a/packages/server/src/tests/banners/guardianWeeklyPropensityData.ts
+++ b/packages/server/src/tests/banners/guardianWeeklyPropensityData.ts
@@ -1,0 +1,24 @@
+import { logInfo } from '../../utils/logging';
+import { streamS3DataByLine } from '../../utils/S3';
+import { isProd } from '../../lib/env';
+
+const guardianWeeklyHighPropensityIds: Set<string> = new Set<string>();
+
+const fetchHighPropensityIds = (): void => {
+    logInfo('Loading guardianWeeklyHighPropensityIds...');
+    streamS3DataByLine(
+        'support-admin-console',
+        `${isProd ? 'PROD' : 'CODE'}/guardian-weekly-propensity-test/ids.txt`,
+        line => guardianWeeklyHighPropensityIds.add(line),
+        () => {
+            logInfo(
+                `Loaded ${guardianWeeklyHighPropensityIds.size} guardianWeeklyHighPropensityIds`,
+            );
+        },
+    );
+};
+
+fetchHighPropensityIds();
+
+export const isGuardianWeeklyHighPropensity = (browserId: string): boolean =>
+    guardianWeeklyHighPropensityIds.has(browserId);

--- a/packages/shared/src/types/banner.ts
+++ b/packages/shared/src/types/banner.ts
@@ -34,7 +34,7 @@ export type BannerTargeting = {
     modulesVersion?: string;
     sectionId?: string;
     tagIds?: string[];
-    browserId?: string;
+    browserId?: string; // Only present if the user has consented to browserId-based targeting
 };
 
 export type BannerDataRequestPayload = {

--- a/packages/shared/src/types/banner.ts
+++ b/packages/shared/src/types/banner.ts
@@ -34,6 +34,7 @@ export type BannerTargeting = {
     modulesVersion?: string;
     sectionId?: string;
     tagIds?: string[];
+    browserId?: string;
 };
 
 export type BannerDataRequestPayload = {


### PR DESCRIPTION
We have an ML model for propensity to buy Guardian Weekly (GW).
This is the first test to use this model for on-site messaging.

Currently only users in Europe ever see the GW banner. So this first test will focus on Europe only for now.

It is a "targeting test", meaning it's an AB test which decides if a browser can see a banner, not which message to display.
The model identifies high-propensity browserIds, and we target by browserId.

Control: all users in Europe see the GW subscriptions banner.
Variant: only users in Europe who are high-propensity can see the banner. The rest see no subscriptions banner.

Note - the client only sends its browserId if the user has consented to this. If a user has not consented _and_ they are put in the variant then they will not see the banner.

We will measure the impact on:
1. £AV/impression
2. Total £AV