### PR TITLE
Include labels in componentEvents to ophan

### DIFF
--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -83,7 +83,14 @@ export const buildAmpEpicCampaignCode = (testName: string, variantName: string):
 
 const createEventFromTracking = (action: OphanAction) => {
     return (tracking: Tracking, componentId: string): OphanComponentEvent => {
-        const { abTestName, abTestVariant, componentType, products = [], campaignCode } = tracking;
+        const {
+            abTestName,
+            abTestVariant,
+            componentType,
+            products = [],
+            labels = [],
+            campaignCode,
+        } = tracking;
         const abTest =
             abTestName && abTestVariant
                 ? {
@@ -105,6 +112,7 @@ const createEventFromTracking = (action: OphanAction) => {
                 products,
                 campaignCode,
                 id: componentId,
+                labels,
             },
             ...(abTest ? { abTest } : {}),
             ...(targetingAbTest ? { targetingAbTest } : {}),


### PR DESCRIPTION
Back in October we migrated to sending all ophan events from the modules (rather than the client) - https://github.com/guardian/support-dotcom-components/pull/546
The existing logic for sending events to ophan didn't include the `labels` field, which unfortunately means we haven't been tracking `SUPER_MODE` impressions since. We _have_ been tracking `SUPER_MODE` acquisitions however.

This PR adds `labels` to ophan componentEvents:
![Screen Shot 2022-01-26 at 13 20 32](https://user-images.githubusercontent.com/1513454/151170311-c91ef1c9-75a1-4201-89f6-9b94f205ed84.png)

For reference, here's how DCR sends events:
https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/browser/ophan/ophan.ts#L71
