### PR TITLE
Enable forcing the header test/variant

### DIFF
--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -349,7 +349,7 @@ export const buildHeaderData = async (
     }
     const testSelection = await selectHeaderTest(targeting, params.force);
     if (testSelection) {
-        const { test, variant } = testSelection;
+        const { test, variant, modulePathBuilder } = testSelection;
         const testTracking: TestTracking = {
             abTestName: test.name,
             abTestVariant: variant.name,
@@ -359,7 +359,7 @@ export const buildHeaderData = async (
         return {
             data: {
                 module: {
-                    url: `${baseUrl}/${variant.modulePathBuilder(targeting.modulesVersion)}`,
+                    url: `${baseUrl}/${modulePathBuilder(targeting.modulesVersion)}`,
                     name: 'Header',
                     props: {
                         content: variant.content,

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -341,12 +341,13 @@ export const buildHeaderData = async (
     pageTracking: PageTracking,
     targeting: HeaderTargeting,
     baseUrl: string,
+    params: Params,
 ): Promise<HeaderDataResponse> => {
     const { enableHeaders } = await cachedChannelSwitches();
     if (!enableHeaders) {
         return {};
     }
-    const testSelection = await selectHeaderTest(targeting);
+    const testSelection = await selectHeaderTest(targeting, params.force);
     if (testSelection) {
         const { test, variant } = testSelection;
         const testTracking: TestTracking = {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -159,7 +159,8 @@ app.post(
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
             const { tracking, targeting } = req.body;
-            const response = await buildHeaderData(tracking, targeting, baseUrl(req));
+            const params = getQueryParams(req.query);
+            const response = await buildHeaderData(tracking, targeting, baseUrl(req), params);
             res.send(response);
         } catch (error) {
             next(error);

--- a/packages/server/src/tests/header/headerSelection.test.ts
+++ b/packages/server/src/tests/header/headerSelection.test.ts
@@ -153,7 +153,6 @@ describe('selectBestTest', () => {
         expect(result_1).toBeDefined();
         expect(result_1).toHaveProperty('test');
         expect(result_1).toHaveProperty('variant');
-        expect(result_1).toHaveProperty('moduleName');
         expect(result_1).toHaveProperty('modulePathBuilder');
         expect(result_1_test).toHaveProperty('name');
         expect(result_1_test.name).toBe('RemoteRrHeaderLinksTest__NonUK');
@@ -183,7 +182,6 @@ describe('selectBestTest', () => {
         expect(result_2).toBeDefined();
         expect(result_2).toHaveProperty('test');
         expect(result_2).toHaveProperty('variant');
-        expect(result_2).toHaveProperty('moduleName');
         expect(result_2).toHaveProperty('modulePathBuilder');
         expect(result_2_test).toHaveProperty('name');
         expect(result_2_test.name).toBe('header-supporter');
@@ -213,7 +211,6 @@ describe('selectBestTest', () => {
         expect(result_3).toBeDefined();
         expect(result_3).toHaveProperty('test');
         expect(result_3).toHaveProperty('variant');
-        expect(result_3).toHaveProperty('moduleName');
         expect(result_3).toHaveProperty('modulePathBuilder');
         expect(result_3_test).toHaveProperty('name');
         expect(result_3_test.name).toBe('RemoteRrHeaderLinksTest__UK');
@@ -243,7 +240,6 @@ describe('selectBestTest', () => {
         expect(result_4).toBeDefined();
         expect(result_4).toHaveProperty('test');
         expect(result_4).toHaveProperty('variant');
-        expect(result_4).toHaveProperty('moduleName');
         expect(result_4).toHaveProperty('modulePathBuilder');
         expect(result_4_test).toHaveProperty('name');
         expect(result_4_test.name).toBe('header-supporter');
@@ -274,7 +270,6 @@ describe('selectBestTest', () => {
         expect(result_5).toBeDefined();
         expect(result_5).toHaveProperty('test');
         expect(result_5).toHaveProperty('variant');
-        expect(result_5).toHaveProperty('moduleName');
         expect(result_5).toHaveProperty('modulePathBuilder');
         expect(result_5_test).toHaveProperty('name');
         expect(result_5_test.name).toBe('LocationsArrayEmpty');

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -169,7 +169,7 @@ export const selectHeaderTest = async (
     const allTests = [...configuredTests, ...hardcodedTests];
 
     if (forcedTestVariant) {
-        return Promise.resolve(getForcedVariant(forcedTestVariant, allTests));
+        return getForcedVariant(forcedTestVariant, allTests);
     }
     return selectBestTest(targeting, allTests);
 };

--- a/packages/server/src/tests/header/headerSelection.ts
+++ b/packages/server/src/tests/header/headerSelection.ts
@@ -131,12 +131,10 @@ export const selectBestTest = (
 
     const selectedVariant: HeaderVariant = selectVariant(selectedTest, targeting.mvtId);
 
-    selectedVariant.modulePathBuilder = modulePathBuilder;
-
     return {
         test: selectedTest,
         variant: selectedVariant,
-        modulePathBuilder,
+        modulePathBuilder: selectedVariant.modulePathBuilder || modulePathBuilder,
     };
 };
 
@@ -155,7 +153,7 @@ const getForcedVariant = (
         return {
             test,
             variant,
-            modulePathBuilder: variant.modulePathBuilder,
+            modulePathBuilder: variant.modulePathBuilder || modulePathBuilder,
         };
     }
     return null;

--- a/packages/shared/src/types/abTests/header.ts
+++ b/packages/shared/src/types/abTests/header.ts
@@ -6,7 +6,7 @@ export interface HeaderVariant extends Variant {
     name: string;
     content: HeaderContent;
     mobileContent?: HeaderContent;
-    modulePathBuilder: (version?: string) => string;
+    modulePathBuilder?: (version?: string) => string;
 }
 
 export interface HeaderTest extends Test<HeaderVariant> {

--- a/packages/shared/src/types/abTests/header.ts
+++ b/packages/shared/src/types/abTests/header.ts
@@ -21,5 +21,4 @@ export interface HeaderTestSelection {
     test: HeaderTest;
     variant: HeaderVariant;
     modulePathBuilder: (version?: string) => string;
-    moduleName: string;
 }


### PR DESCRIPTION
The epic + banner already support this, as does the client.
e.g. `?force-header=TEST_NAME:VARIANT_NAME`