### PR TITLE
Enable custom mobile cta in header

### DIFF
--- a/packages/modules/src/modules/header/Header.stories.tsx
+++ b/packages/modules/src/modules/header/Header.stories.tsx
@@ -18,6 +18,14 @@ export const props: HeaderProps = {
             text: 'Subscribe',
         },
     },
+    mobileContent: {
+        heading: 'Support the Guardian',
+        subheading: '',
+        primaryCta: {
+            baseUrl: 'https://support.theguardian.com/contribute',
+            text: 'Support us',
+        },
+    },
     tracking: {
         ophanPageId: 'pvid',
         platformId: 'GUARDIAN_WEB',

--- a/packages/modules/src/modules/header/Header.tsx
+++ b/packages/modules/src/modules/header/Header.tsx
@@ -69,7 +69,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
 
             {primaryCta && (
                 <ThemeProvider theme={buttonReaderRevenueBrand}>
-                    <Hide below="mobileMedium">
+                    <Hide below="mobileLandscape">
                         <LinkButton
                             priority="primary"
                             href={primaryCta.ctaUrl}
@@ -82,9 +82,13 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                         </LinkButton>
                     </Hide>
 
-                    <Hide above="mobileMedium">
-                        <LinkButton priority="primary" href={primaryCta.ctaUrl} css={linkStyles}>
-                            {primaryCta.ctaText}
+                    <Hide above="mobileLandscape">
+                        <LinkButton
+                            priority="primary"
+                            href={props.mobileContent?.primaryCta?.ctaUrl || primaryCta.ctaUrl}
+                            css={linkStyles}
+                        >
+                            {props.mobileContent?.primaryCta?.ctaText || primaryCta.ctaText}
                         </LinkButton>
                     </Hide>
                 </ThemeProvider>


### PR DESCRIPTION
There is an optional `mobileContent` field on the header model, but currently the component doesn't use it.

On mobile only the primary cta is displayed in the header (no heading/subheading/2nd cta).
Also, currently we hide the arrow svg in the cta below `mobileMedium` (375px).

With this change:
1. Below `mobileLandscape` (480px) we use the primary cta from the `mobileContent`.
2. Below `mobileLandscape` we hide the arrow svg. This means we now hide it up to 480px, not 375px. I think it's preferable to have this and the cta text change at the same breakpoint, otherwise you might get weird widths between 375-480 where the cta is too long


### mobileLandscape
![Screen Shot 2022-02-01 at 14 20 49](https://user-images.githubusercontent.com/1513454/151985562-34f45a39-b0a7-4b69-8412-0f55a66115e9.png)

### mobileMedium
![Screen Shot 2022-02-01 at 14 21 00](https://user-images.githubusercontent.com/1513454/151985581-b83d174e-8c20-4b99-9bd9-39ff9773a9ea.png)
