### PR TITLE
Banner AC subheading

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerText.tsx
+++ b/packages/modules/src/modules/banners/common/BannerText.tsx
@@ -38,7 +38,9 @@ export const BannerText: React.FC<BannerTextProps> = ({ styles, content, childre
                 return (
                     <div css={renderStyles.container}>
                         <h2 css={renderStyles.heading}>{heading}</h2>
-                        {subheading && <h3 css={renderStyles.subheading}>{subheading}</h3>}
+                        {subheading && renderStyles.subheading && (
+                            <h3 css={renderStyles.subheading}>{subheading}</h3>
+                        )}
 
                         <div css={renderStyles.body}>
                             <div css={renderStyles.copy}>

--- a/packages/modules/src/modules/banners/common/BannerText.tsx
+++ b/packages/modules/src/modules/banners/common/BannerText.tsx
@@ -3,7 +3,13 @@ import { SerializedStyles } from '@emotion/utils';
 import { BannerTextContent } from './types';
 import { BannerContentRenderer } from './BannerContentRenderer';
 
-type BannerTextStyleableAreas = 'container' | 'heading' | 'body' | 'copy' | 'highlightedText';
+type BannerTextStyleableAreas =
+    | 'container'
+    | 'heading'
+    | 'subheading'
+    | 'body'
+    | 'copy'
+    | 'highlightedText';
 
 type BannerTextStyles = {
     [key in BannerTextStyleableAreas]?: SerializedStyles | SerializedStyles[];
@@ -27,11 +33,13 @@ export const BannerText: React.FC<BannerTextProps> = ({ styles, content, childre
             content={content}
             render={({ renderContent, isMobile }) => {
                 const renderStyles = isMobile ? mobileStyles : desktopStyles;
-                const { heading, messageText, highlightedText } = renderContent;
+                const { heading, subheading, messageText, highlightedText } = renderContent;
 
                 return (
                     <div css={renderStyles.container}>
                         <h2 css={renderStyles.heading}>{heading}</h2>
+                        {subheading && <h3 css={renderStyles.subheading}>{subheading}</h3>}
+
                         <div css={renderStyles.body}>
                             <div css={renderStyles.copy}>
                                 {messageText}

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -31,6 +31,21 @@ import { withParsedProps } from '../../shared/ModuleWrapper';
 import { buildReminderFields } from '@sdc/shared/lib';
 import { HasBeenSeen, useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 
+// A separate article count is rendered as a subheading
+const buildSubheading = (
+    numArticles: number,
+    separateArticleCount: boolean,
+): JSX.Element | JSX.Element[] | null => {
+    if (separateArticleCount && numArticles >= 5) {
+        return replaceArticleCount(
+            `You’ve read %%ARTICLE_COUNT%% articles in the last year`,
+            numArticles,
+            'banner',
+        );
+    }
+    return null;
+};
+
 const withBannerData = (
     Banner: React.FC<BannerRenderProps>,
     bannerId: BannerId,
@@ -47,6 +62,7 @@ const withBannerData = (
         numArticles = 0,
         tickerSettings,
         isSupporter,
+        separateArticleCount,
     } = bannerProps;
 
     const [hasBeenSeen, setNode] = useHasBeenSeen(
@@ -134,6 +150,8 @@ const withBannerData = (
             ? replaceArticleCount(cleanHighlightedText, numArticles, 'banner')
             : null;
 
+        const subheading = buildSubheading(numArticles, !!separateArticleCount);
+
         if (copyHasPlaceholder) {
             throw Error('Banner copy contains placeholders, abandoning.');
         }
@@ -142,6 +160,7 @@ const withBannerData = (
             highlightedText: highlightedTextWithArticleCount,
             messageText: messageTextWithArticleCount,
             heading: headingWithArticleCount,
+            subheading,
             primaryCta,
             secondaryCta,
         };

--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -38,6 +38,7 @@ export interface ContributionsReminderTracking {
 
 export interface BannerRenderedContent {
     heading: JSX.Element | JSX.Element[] | null;
+    subheading: JSX.Element | JSX.Element[] | null;
     messageText: JSX.Element | JSX.Element[];
     highlightedText?: JSX.Element | JSX.Element[] | null;
     primaryCta: BannerEnrichedCta | null;

--- a/packages/modules/src/modules/banners/contributions/ContributionsBanner.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBanner.tsx
@@ -35,6 +35,15 @@ const styles = {
             padding-left: 12px;
         }
     `,
+    subheading: css`
+        margin: 0;
+        ${headline.xxsmall({ fontWeight: 'bold' })}
+        padding-top: 10px;
+        padding-bottom: 8px;
+        ${from.leftCol} {
+            padding-left: 12px;
+        }
+    `,
     body: css`
         padding-bottom: 16px;
     `,
@@ -212,6 +221,7 @@ const ContributionsBanner: React.FC<BannerRenderProps> = ({
                 desktop: {
                     container: styles.bodyAndHeading,
                     heading: styles.heading,
+                    subheading: styles.subheading,
                     body: styles.body,
                     copy: [commonStyles.copy, styles.copy],
                     highlightedText: commonStyles.highlightedText,

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerMobile.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerMobile.tsx
@@ -28,6 +28,11 @@ const styles = {
         ${headline.xxsmall({ fontWeight: 'bold' })};
         max-width: 90%; /* to avoid pushing the close button off screen on mobile devices with extra large font */
     `,
+    subheading: css`
+        ${headline.xxxsmall({ fontWeight: 'bold' })};
+        padding-top: 6px;
+        padding-bottom: 10px;
+    `,
     copy: css`
         margin-top: 2px;
         padding: 0 ${space[3]}px;
@@ -140,6 +145,7 @@ export const ContributionsBannerMobile: React.FC<ContributionsBannerMobileProps>
                 <ContributionsBannerCloseButton onCloseClick={onCloseClick} />
             </div>
             <div css={[commonStyles.copy, styles.copy]}>
+                {content.subheading && <div css={styles.subheading}>{content.subheading}</div>}
                 {content.messageText}
                 {content.highlightedText && (
                     <>

--- a/packages/modules/src/modules/banners/utils/storybook.ts
+++ b/packages/modules/src/modules/banners/utils/storybook.ts
@@ -59,4 +59,6 @@ export const props: BannerProps = {
     tracking,
     content,
     tickerSettings,
+    separateArticleCount: true,
+    numArticles: 6,
 };

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -284,6 +284,7 @@ export const buildBannerData = async (
             ),
             hasOptedOutOfArticleCount: targeting.hasOptedOutOfArticleCount,
             tickerSettings,
+            separateArticleCount: variant.separateArticleCount,
         };
 
         return {

--- a/packages/server/src/tests/banners/ChannelBannerTests.ts
+++ b/packages/server/src/tests/banners/ChannelBannerTests.ts
@@ -101,6 +101,7 @@ const BannerVariantFromParams = (forChannel: BannerChannel) => {
             componentType: BannerTemplateComponentTypes[forChannel],
             products: BannerTemplateProducts[variant.template],
             tickerSettings,
+            separateArticleCount: variant.separateArticleCount,
         };
     };
 };

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -67,6 +67,7 @@ export interface RawVariantParams {
     template: BannerTemplate;
     bannerContent: BannerContent;
     mobileBannerContent?: BannerContent;
+    separateArticleCount?: boolean;
 
     // deprecated - use bannerContent
     body: string;

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -32,6 +32,7 @@ export interface BannerVariant extends Variant {
     mobileBannerContent?: BannerContent;
     componentType: OphanComponentType;
     products?: OphanProduct[];
+    separateArticleCount?: boolean;
 }
 
 export type CanRun = (targeting: BannerTargeting, pageTracking: PageTracking) => boolean;

--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -46,6 +46,7 @@ export interface BannerProps {
     hasOptedOutOfArticleCount?: boolean;
     email?: string;
     fetchEmail?: () => Promise<string | null>;
+    separateArticleCount?: boolean;
 }
 
 export const bannerSchema = z.object({
@@ -61,6 +62,7 @@ export const bannerSchema = z.object({
     hasOptedOutOfArticleCount: z.boolean().optional(),
     email: z.string().optional(),
     fetchEmail: z.any().optional(),
+    separateArticleCount: z.boolean().optional(),
 });
 
 export interface PuzzlesBannerProps extends Partial<BannerProps> {


### PR DESCRIPTION
Based on design here: https://www.figma.com/file/MHJFoREcjTbQuaNakm8VIV/Generic-Banner?node-id=1756%3A28624

The PR enables us to A/B test putting article count (AC) in a subheading of the banner. Currently the AC goes in the heading or body. The subheading would only be displayed if AC >= 5, which means we'd no longer have to create AC and non-AC versions of each banner test.

- Rather than doing a hardcoded test I'm going to add a new "Separate article count" checkbox to the tool, so the test can be configured from the banner tool. I suspect this toggle will be useful even if we decide a subheading isn't the right place for AC.
- This new feature behaves like the epic AC "badge" in that it's automatically hidden if the user's AC is below 5. But - for this AB test only users with AC of 5 or above will be in the test because the control needs to display AC in the heading/body.
- The `BannerVariant` and `BannerProps` models have a new `separateArticleCount` bool field. This means we can later change how/where the AC is rendered without having to change the backend/tool.
- The `BannerWrapper` builds a subheading with AC if `separateArticleCount` is true and article count >= 5.

### Desktop
<img width="1366" alt="Screen Shot 2022-02-02 at 09 30 42" src="https://user-images.githubusercontent.com/1513454/152143388-c9273521-8d8f-4279-a0c5-8e48cdcacf8c.png">

### Tablet
<img width="738" alt="Screen Shot 2022-02-02 at 09 31 20" src="https://user-images.githubusercontent.com/1513454/152143407-f79d1412-9673-4370-9244-95c0660971ef.png">

### Mobile
<img width="321" alt="Screen Shot 2022-02-02 at 09 31 44" src="https://user-images.githubusercontent.com/1513454/152143415-66680eb0-60f3-4d9b-be7a-448362ff87dd.png">
