### PR TITLE
Test impact of showing banner on different pageviews

### DIFF
--- a/packages/dotcom/package.json
+++ b/packages/dotcom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/support-dotcom-components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/server/src/lib/targetingTesting.test.ts
+++ b/packages/server/src/lib/targetingTesting.test.ts
@@ -27,6 +27,7 @@ const targeting: BannerTargeting = {
     countryCode: 'GB',
     weeklyArticleHistory: [],
     hasOptedOutOfArticleCount: false,
+    contentType: 'Article',
 };
 
 describe('selectTargetingTest', () => {

--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -41,6 +41,7 @@ describe('selectBannerTest', () => {
             countryCode: 'AU',
             engagementBannerLastClosedAt: firstDate,
             hasOptedOutOfArticleCount: false,
+            contentType: 'Article',
         };
 
         const tracking = {
@@ -163,6 +164,7 @@ describe('selectBannerTest', () => {
             countryCode: 'GB',
             engagementBannerLastClosedAt: firstDate,
             hasOptedOutOfArticleCount: false,
+            contentType: 'Article',
         };
 
         const tracking = {

--- a/packages/server/src/tests/banners/bannerTargetingTests.test.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.test.ts
@@ -30,14 +30,6 @@ describe('Banner pageview targeting test', () => {
         expect(canShow).toBe(true);
     });
 
-    it('variant 2 returns false if AC = 1', () => {
-        const canShow = test.variants[2].canShow({
-            ...targeting,
-            articleCountToday: 1,
-        });
-        expect(canShow).toBe(false);
-    });
-
     it('variant 2 returns false if AC = 1 and contentType = article', () => {
         const canShow = test.variants[2].canShow({
             ...targeting,

--- a/packages/server/src/tests/banners/bannerTargetingTests.test.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.test.ts
@@ -1,0 +1,67 @@
+import { bannerTargetingTests } from './bannerTargetingTests';
+import { BannerTargeting } from '@sdc/shared/types';
+
+const targeting: BannerTargeting = {
+    alreadyVisitedCount: 3,
+    shouldHideReaderRevenue: false,
+    isPaidContent: false,
+    showSupportMessaging: true,
+    mvtId: 3,
+    countryCode: 'GB',
+    hasOptedOutOfArticleCount: false,
+};
+
+const test = bannerTargetingTests[0];
+
+describe('Banner pageview targeting test', () => {
+    it('variant 1 returns false if AC = 0', () => {
+        const canShow = test.variants[1].canShow({
+            ...targeting,
+            articleCountToday: 0,
+        });
+        expect(canShow).toBe(false);
+    });
+
+    it('variant 1 returns true if AC = 1', () => {
+        const canShow = test.variants[1].canShow({
+            ...targeting,
+            articleCountToday: 1,
+        });
+        expect(canShow).toBe(true);
+    });
+
+    it('variant 2 returns false if AC = 1', () => {
+        const canShow = test.variants[2].canShow({
+            ...targeting,
+            articleCountToday: 1,
+        });
+        expect(canShow).toBe(false);
+    });
+
+    it('variant 2 returns false if AC = 1 and contentType = article', () => {
+        const canShow = test.variants[2].canShow({
+            ...targeting,
+            articleCountToday: 1,
+            contentType: 'Article',
+        });
+        expect(canShow).toBe(false);
+    });
+
+    it('variant 2 returns true if AC = 1 and contentType = Network Front', () => {
+        const canShow = test.variants[2].canShow({
+            ...targeting,
+            articleCountToday: 1,
+            contentType: 'Network Front',
+        });
+        expect(canShow).toBe(true);
+    });
+
+    it('variant 2 returns true if AC = 2 and contentType = Article', () => {
+        const canShow = test.variants[2].canShow({
+            ...targeting,
+            articleCountToday: 2,
+            contentType: 'Article',
+        });
+        expect(canShow).toBe(true);
+    });
+});

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -10,7 +10,7 @@ const getCountForToday = (dailyArticleHistory?: DailyArticleHistory): number => 
 
 const isNetworkFront = (targeting: BannerTargeting): boolean =>
     // https://github.com/guardian/frontend/blob/5b970cd7308175cfc1bcae2d4fb8c06ee13c5fa0/common/app/model/DotcomContentType.scala#L33
-    targeting.contentType.toLowerCase() === 'network front';
+    targeting.contentType?.toLowerCase() === 'network front';
 
 export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
     {

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -8,6 +8,10 @@ const getCountForToday = (dailyArticleHistory?: DailyArticleHistory): number => 
     return 0;
 };
 
+const isNetworkFront = (targeting: BannerTargeting): boolean =>
+    // https://github.com/guardian/frontend/blob/5b970cd7308175cfc1bcae2d4fb8c06ee13c5fa0/common/app/model/DotcomContentType.scala#L33
+    targeting.contentType.toLowerCase() === 'network front';
+
 export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
     {
         name: '2022-02-10_BannerTargeting_PageView',
@@ -27,7 +31,7 @@ export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
                 name: 'variant2',
                 canShow: (targeting: BannerTargeting): boolean => {
                     const count = getCountForToday(targeting.dailyArticleHistory);
-                    return count >= 2 || (count >= 1 && targeting.contentType === 'Network Front');
+                    return count >= 2 || (count >= 1 && isNetworkFront(targeting));
                 },
             },
         ],

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -1,4 +1,35 @@
 import { TargetingTest } from '../../lib/targetingTesting';
-import { BannerTargeting } from '@sdc/shared/types';
+import { BannerTargeting, DailyArticleHistory } from '@sdc/shared/types';
 
-export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [];
+const getCountForToday = (dailyArticleHistory?: DailyArticleHistory): number => {
+    if (dailyArticleHistory && dailyArticleHistory[0]) {
+        return dailyArticleHistory[0].count;
+    }
+    return 0;
+};
+
+export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
+    {
+        name: '2022-02-10_BannerTargeting_PageView',
+        // Exclude browsers that have not consented to article counting
+        canInclude: (targeting: BannerTargeting) => !!targeting.dailyArticleHistory,
+        variants: [
+            {
+                name: 'control',
+                canShow: () => true,
+            },
+            {
+                name: 'variant1',
+                canShow: (targeting: BannerTargeting) =>
+                    getCountForToday(targeting.dailyArticleHistory) >= 1,
+            },
+            {
+                name: 'variant2',
+                canShow: (targeting: BannerTargeting): boolean => {
+                    const count = getCountForToday(targeting.dailyArticleHistory);
+                    return count >= 2 || (count >= 1 && targeting.contentType === 'Network Front');
+                },
+            },
+        ],
+    },
+];

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -1,12 +1,5 @@
 import { TargetingTest } from '../../lib/targetingTesting';
-import { BannerTargeting, DailyArticleHistory } from '@sdc/shared/types';
-
-const getCountForToday = (dailyArticleHistory?: DailyArticleHistory): number => {
-    if (dailyArticleHistory && dailyArticleHistory[0]) {
-        return dailyArticleHistory[0].count;
-    }
-    return 0;
-};
+import { BannerTargeting } from '@sdc/shared/types';
 
 const isNetworkFront = (targeting: BannerTargeting): boolean =>
     // https://github.com/guardian/frontend/blob/5b970cd7308175cfc1bcae2d4fb8c06ee13c5fa0/common/app/model/DotcomContentType.scala#L33
@@ -16,7 +9,7 @@ export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
     {
         name: '2022-02-10_BannerTargeting_PageView',
         // Exclude browsers that have not consented to article counting
-        canInclude: (targeting: BannerTargeting) => !!targeting.dailyArticleHistory,
+        canInclude: (targeting: BannerTargeting) => targeting.articleCountToday !== undefined,
         variants: [
             {
                 name: 'control',
@@ -24,13 +17,12 @@ export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
             },
             {
                 name: 'variant1',
-                canShow: (targeting: BannerTargeting) =>
-                    getCountForToday(targeting.dailyArticleHistory) >= 1,
+                canShow: (targeting: BannerTargeting) => (targeting.articleCountToday || 0) >= 1,
             },
             {
                 name: 'variant2',
                 canShow: (targeting: BannerTargeting): boolean => {
-                    const count = getCountForToday(targeting.dailyArticleHistory);
+                    const count = targeting.articleCountToday || 0;
                     return count >= 2 || (count >= 1 && isNetworkFront(targeting));
                 },
             },

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -13,14 +13,17 @@ export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
         variants: [
             {
                 name: 'control',
+                // show banner on first page view after redeploy
                 canShow: () => true,
             },
             {
                 name: 'variant1',
+                // show on/after 1st article view of the day
                 canShow: (targeting: BannerTargeting) => (targeting.articleCountToday || 0) >= 1,
             },
             {
                 name: 'variant2',
+                // show after 1st article view of the day
                 canShow: (targeting: BannerTargeting): boolean => {
                     const count = targeting.articleCountToday || 0;
                     return count >= 2 || (count >= 1 && isNetworkFront(targeting));

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -1,4 +1,4 @@
-import { DailyArticleHistory, PageTracking, WeeklyArticleHistory } from './shared';
+import { PageTracking, WeeklyArticleHistory } from './shared';
 
 export type BannerTargeting = {
     alreadyVisitedCount: number;
@@ -10,7 +10,7 @@ export type BannerTargeting = {
     mvtId: number;
     countryCode: string;
     weeklyArticleHistory?: WeeklyArticleHistory;
-    dailyArticleHistory?: DailyArticleHistory;
+    articleCountToday?: number;
     hasOptedOutOfArticleCount: boolean;
     modulesVersion?: string;
     sectionId?: string;

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -15,7 +15,7 @@ export type BannerTargeting = {
     modulesVersion?: string;
     sectionId?: string;
     tagIds?: string[];
-    contentType: string;
+    contentType?: string;
 };
 
 export type BannerPayload = {

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -1,4 +1,4 @@
-import { PageTracking, WeeklyArticleHistory } from './shared';
+import { DailyArticleHistory, PageTracking, WeeklyArticleHistory } from './shared';
 
 export type BannerTargeting = {
     alreadyVisitedCount: number;
@@ -10,10 +10,12 @@ export type BannerTargeting = {
     mvtId: number;
     countryCode: string;
     weeklyArticleHistory?: WeeklyArticleHistory;
+    dailyArticleHistory?: DailyArticleHistory;
     hasOptedOutOfArticleCount: boolean;
     modulesVersion?: string;
     sectionId?: string;
     tagIds?: string[];
+    contentType: string;
 };
 
 export type BannerPayload = {

--- a/packages/shared/src/types/targeting/shared.ts
+++ b/packages/shared/src/types/targeting/shared.ts
@@ -1,28 +1,21 @@
-export interface PageTracking {
+export type PageTracking = {
     ophanPageId: string;
     platformId: string;
     referrerUrl: string;
     clientName: string;
-}
+};
 
-export interface TagCounts {
+export type TagCounts = {
     [tag: string]: number;
-}
+};
 
-export interface WeeklyArticleLog {
+export type WeeklyArticleLog = {
     week: number;
     count: number;
     tags?: TagCounts;
-}
+};
 
 export type WeeklyArticleHistory = WeeklyArticleLog[];
-
-export interface DailyArticleLog {
-    day: number;
-    count: number;
-}
-
-export type DailyArticleHistory = DailyArticleLog[];
 
 /**
  * This interface is duplicated from the @guardian/libs definition of StorageFactory. This is to avoid adding the

--- a/packages/shared/src/types/targeting/shared.ts
+++ b/packages/shared/src/types/targeting/shared.ts
@@ -1,21 +1,28 @@
-export type PageTracking = {
+export interface PageTracking {
     ophanPageId: string;
     platformId: string;
     referrerUrl: string;
     clientName: string;
-};
+}
 
-export type TagCounts = {
+export interface TagCounts {
     [tag: string]: number;
-};
+}
 
-export type WeeklyArticleLog = {
+export interface WeeklyArticleLog {
     week: number;
     count: number;
     tags?: TagCounts;
-};
+}
 
 export type WeeklyArticleHistory = WeeklyArticleLog[];
+
+export interface DailyArticleLog {
+    day: number;
+    count: number;
+}
+
+export type DailyArticleHistory = DailyArticleLog[];
 
 /**
  * This interface is duplicated from the @guardian/libs definition of StorageFactory. This is to avoid adding the


### PR DESCRIPTION
Currently for existing browsers we show the banner on the first page view after a redeploy.
For most users that means their first page view of the day.
This means we don't currently have the data to explore whether it's best to wait for the `nth` page view of the day before showing a banner. E.g. it's possible the 1st page view has a terrible conversion rate because most users just want the headlines.

We don't currently have a daily page view count in the browser. But we do have an _article_ view count for the day.

### Test:
- control - show banner on first page view after redeploy (existing behaviour)
- variant 1 - show if today's AC >= 1.
- variant 2 - if network front, show if AC >= 1. If article, show if AC >= 2.

In the example of a user visiting the network front on a monday morning:
- in the control the user sees the banner on the first page view (the front).
- with variant 1 the user sees the banner on their first article view.
- with variant 2 the user sees the banner on the page view after their first article view.


### TODO -
Update DCR/frontend to send `articleCountToday` and `contentType` in banner requests

- [ ] https://github.com/guardian/dotcom-rendering/pull/3954
- [ ] https://github.com/guardian/frontend/pull/24632