### PR TITLE
Remove deprecated banner fields

### DIFF
--- a/packages/server/src/tests/banners/ChannelBannerTests.ts
+++ b/packages/server/src/tests/banners/ChannelBannerTests.ts
@@ -54,33 +54,16 @@ export const BannerTemplateProducts: {
 };
 
 const BannerVariantFromParams = (forChannel: BannerChannel) => {
-    return (variant: RawVariantParams): BannerVariant => {
-        const bannerContent = () => {
-            if (variant.bannerContent) {
-                return variant.bannerContent;
-            } else {
-                // legacy model
-                return {
-                    messageText: variant.body,
-                    heading: variant.heading,
-                    highlightedText: variant.highlightedText,
-                    cta: variant.cta,
-                    secondaryCta: variant.secondaryCta,
-                };
-            }
-        };
-
-        return {
-            name: variant.name,
-            modulePathBuilder: BannerPaths[variant.template],
-            moduleName: variant.template,
-            bannerContent: bannerContent(),
-            mobileBannerContent: variant.mobileBannerContent,
-            componentType: BannerTemplateComponentTypes[forChannel],
-            products: BannerTemplateProducts[variant.template],
-            separateArticleCount: variant.separateArticleCount,
-        };
-    };
+    return (variant: RawVariantParams): BannerVariant => ({
+        name: variant.name,
+        modulePathBuilder: BannerPaths[variant.template],
+        moduleName: variant.template,
+        bannerContent: variant.bannerContent,
+        mobileBannerContent: variant.mobileBannerContent,
+        componentType: BannerTemplateComponentTypes[forChannel],
+        products: BannerTemplateProducts[variant.template],
+        separateArticleCount: variant.separateArticleCount,
+    });
 };
 
 const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTestGenerator => {

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -1,4 +1,4 @@
-import { BannerChannel, BannerContent, Cta, SecondaryCta, TickerSettings } from '../props';
+import { BannerChannel, BannerContent, TickerSettings } from '../props';
 import {
     ArticlesViewedSettings,
     ControlProportionSettings,
@@ -66,13 +66,6 @@ export interface RawVariantParams {
     bannerContent: BannerContent;
     mobileBannerContent?: BannerContent;
     separateArticleCount?: boolean;
-
-    // deprecated - use bannerContent
-    body: string;
-    heading?: string;
-    highlightedText?: string;
-    cta?: Cta;
-    secondaryCta?: SecondaryCta;
 }
 
 export interface RawTestParams {

--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -18,7 +18,6 @@ export type BannerChannel = z.infer<typeof bannerChannelSchema>;
 export interface BannerContent {
     heading?: string;
     messageText: string;
-    mobileMessageText?: string; // deprecated - use mobileBannerContent instead
     highlightedText?: string;
     cta?: Cta;
     secondaryCta?: SecondaryCta;


### PR DESCRIPTION
The `BannerVariant` model has an optional seperate field for mobile content:
```
bannerContent: BannerContent;
mobileBannerContent?: BannerContent;
```

Historically this was not the case, and in the migration to support both we left some legacy fields in the model.
This PR removes them - they've not been used for a while.

TODO - remove these fields from support-admin-console as well