### PR TITLE
restore old GW banner images

### DIFF
--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -33,10 +33,10 @@ const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
 const mobileAndDesktopImg =
-    'https://i.guim.co.uk/img/media/670c3033e71f48296798480ac22a1123602e8466/0_0_500_240/500.png?quality=85&s=c1456ddb21a061ac1a199670637b5c5a';
+    'https://i.guim.co.uk/img/media/0682b069cf2e32b987ddcfbb2b549a93be61ae36/0_0_500_240/500.png?quality=85&s=1bf9bd8af343813bd6db3f009fccf385';
 
 const tabletImg =
-    'https://i.guim.co.uk/img/media/8d1fea851030b24328e05267fdb9bcd767248aeb/0_0_500_336/500.png?quality=85&s=102abc54f37796d6f668416bdbb993f1';
+    'https://i.guim.co.uk/img/media/6d601169360b35c705412fbfa163c15f140efc2f/0_0_500_336/500.png?quality=85&s=21fb33ade343b7db222823c4d3160b7f';
 
 // Responsive image props
 const baseImg = {


### PR DESCRIPTION
## What does this change?

The Guardian Weekly 50% off campaign is over, we can restore the packshot to the previous version without the roundal. The re-introduced images can be seen below...

### Mobile
<img width="318" alt="Screenshot 2022-02-22 at 14 35 07" src="https://user-images.githubusercontent.com/1590704/155154210-42c52d7e-b158-432e-a524-e3501582318f.png">

### Tablet 
<img width="736" alt="Screenshot 2022-02-22 at 14 35 18" src="https://user-images.githubusercontent.com/1590704/155154249-072b34f9-5c5a-4ebc-a587-5c667ece6f6d.png">

### Desktop
<img width="1299" alt="Screenshot 2022-02-22 at 14 34 47" src="https://user-images.githubusercontent.com/1590704/155154267-d9e88036-d849-4281-adbf-0329870e5225.png">

### Note: 
PR that added the current image with the roundal: https://github.com/guardian/support-dotcom-components/pull/613
