### PR TITLE
Remove suffix from test name for variant allocation

### DIFF
--- a/packages/server/src/lib/ab.ts
+++ b/packages/server/src/lib/ab.ts
@@ -34,7 +34,7 @@ export const selectWithSeed = <V extends Variant>(
  */
 export const selectVariant = <V extends Variant, T extends Test<V>>(test: T, mvtId: number): V => {
     const control = test.variants.find(v => v.name.toLowerCase() === 'control');
-    const seed = test.name.startsWith('SINGLE_FRONT_DOOR') ? 'SINGLE_FRONT_DOOR' : test.name;
+    const seed = test.name.split('__')[0];
 
     if (test.controlProportionSettings && control) {
         if (


### PR DESCRIPTION
For the SFD test we wanted consistent variant allocation across channels. We're going to be doing this again, so this PR adds a more general solution.
We already use `__` in the test name to group together different tests in the AB test dashboard.
With this change, we'll also coordinate variant allocation across channels for tests with the same prefix (before the `__`).

Note - any existing tests with `__` in the name will be affected by this change. It effectively shuffles the variant allocation for existing browsers.