### PR TITLE
Mobile targeting

### DIFF
--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -76,3 +76,14 @@ export const audienceMatches = (
             return true;
     }
 };
+
+export const deviceTypeMatches = <V extends Variant>(test: Test<V>, isMobile: boolean): boolean => {
+    switch (test.deviceType) {
+        case 'Mobile':
+            return isMobile;
+        case 'Desktop':
+            return !isMobile;
+        default:
+            return true;
+    }
+};

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -353,12 +353,13 @@ export const buildHeaderData = async (
     targeting: HeaderTargeting,
     baseUrl: string,
     params: Params,
+    req: express.Request,
 ): Promise<HeaderDataResponse> => {
     const { enableHeaders } = await cachedChannelSwitches();
     if (!enableHeaders) {
         return {};
     }
-    const testSelection = await selectHeaderTest(targeting, params.force);
+    const testSelection = await selectHeaderTest(targeting, isMobile(req), params.force);
     if (testSelection) {
         const { test, variant, modulePathBuilder } = testSelection;
         const testTracking: TestTracking = {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -162,7 +162,7 @@ app.post(
         try {
             const { tracking, targeting } = req.body;
             const params = getQueryParams(req.query);
-            const response = await buildHeaderData(tracking, targeting, baseUrl(req), params);
+            const response = await buildHeaderData(tracking, targeting, baseUrl(req), params, req);
             res.send(response);
         } catch (error) {
             next(error);

--- a/packages/server/src/tests/banners/ChannelBannerTests.ts
+++ b/packages/server/src/tests/banners/ChannelBannerTests.ts
@@ -89,6 +89,7 @@ const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTes
                                 BannerVariantFromParams(bannerChannel),
                             ),
                             controlProportionSettings: testParams.controlProportionSettings,
+                            deviceType: testParams.deviceType,
                         };
                     },
                 );

--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -23,6 +23,8 @@ const getBannerDeployCache = (date: string): BannerDeployCaches =>
             }),
     } as BannerDeployCaches);
 
+const isMobile = false;
+
 describe('selectBannerTest', () => {
     const firstDate = 'Mon Jun 06 2020 19:20:10 GMT+0100';
     const secondDate = 'Mon Jul 06 2020 19:20:10 GMT+0100';
@@ -85,6 +87,7 @@ describe('selectBannerTest', () => {
                     weeklyArticleHistory: [{ week: 18330, count: 6 }],
                 }),
                 tracking,
+                isMobile,
                 '',
                 () => Promise.resolve([test]),
                 cache,
@@ -101,6 +104,7 @@ describe('selectBannerTest', () => {
                     weeklyArticleHistory: [{ week: 18330, count: 1 }],
                 }),
                 tracking,
+                isMobile,
                 '',
                 () => Promise.resolve([test]),
                 cache,
@@ -117,6 +121,7 @@ describe('selectBannerTest', () => {
                     weeklyArticleHistory: [{ week: 18330, count: 1 }],
                 }),
                 tracking,
+                isMobile,
                 '',
                 () =>
                     Promise.resolve([
@@ -139,6 +144,7 @@ describe('selectBannerTest', () => {
                     hasOptedOutOfArticleCount: true,
                 }),
                 tracking,
+                isMobile,
                 '',
                 () => Promise.resolve([test]),
                 cache,
@@ -207,6 +213,7 @@ describe('selectBannerTest', () => {
                     weeklyArticleHistory: [{ week: 18330, count: 6 }],
                 }),
                 tracking,
+                isMobile,
                 '',
                 () => Promise.resolve([test]),
                 cache,
@@ -223,6 +230,7 @@ describe('selectBannerTest', () => {
                     weeklyArticleHistory: [{ week: 18330, count: 1 }],
                 }),
                 tracking,
+                isMobile,
                 '',
                 () => Promise.resolve([test]),
                 cache,
@@ -239,6 +247,7 @@ describe('selectBannerTest', () => {
                     weeklyArticleHistory: [{ week: 18330, count: 1 }],
                 }),
                 tracking,
+                isMobile,
                 '',
                 () =>
                     Promise.resolve([

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -10,7 +10,7 @@ import {
 import { selectVariant } from '../../lib/ab';
 import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { TestVariant } from '../../lib/params';
-import { audienceMatches, userIsInTest } from '../../lib/targeting';
+import { audienceMatches, deviceTypeMatches, userIsInTest } from '../../lib/targeting';
 import { BannerDeployCaches, ReaderRevenueRegion } from './bannerDeployCache';
 import { selectTargetingTest } from '../../lib/targetingTesting';
 import { bannerTargetingTests } from './bannerTargetingTests';
@@ -99,6 +99,7 @@ const getForcedVariant = (
 export const selectBannerTest = async (
     targeting: BannerTargeting,
     pageTracking: PageTracking,
+    isMobile: boolean,
     baseUrl: string,
     getTests: () => Promise<BannerTest[]>,
     bannerDeployCaches: BannerDeployCaches,
@@ -133,6 +134,7 @@ export const selectBannerTest = async (
                 now,
             ) &&
             userIsInTest(test, targeting.mvtId) &&
+            deviceTypeMatches(test, isMobile) &&
             (await redeployedSinceLastClosed(
                 targeting,
                 test.bannerChannel,

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -16,6 +16,7 @@ import {
     withinArticleViewedSettings,
     withinArticleViewedByTagSettings,
     withinMaxViews,
+    deviceTypeMatchesFilter,
 } from './epicSelection';
 
 const testDefault: EpicTest = {
@@ -85,6 +86,8 @@ const targetingDefault: EpicTargeting = {
 
 const superModeArticles: SuperModeArticle[] = [];
 
+const isMobile = false;
+
 describe('findTestAndVariant', () => {
     it('should find the correct variant for test and targeting data', () => {
         const testWithoutArticlesViewedSettings = {
@@ -98,7 +101,7 @@ describe('findTestAndVariant', () => {
         };
         const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, superModeArticles, epicType);
+        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles, epicType);
 
         expect(got.result?.test.name).toBe('example-1');
         expect(got.result?.variant.name).toBe('control-example-1');
@@ -113,7 +116,7 @@ describe('findTestAndVariant', () => {
         };
         const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, superModeArticles, epicType);
+        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles, epicType);
 
         expect(got.result).toBe(undefined);
     });
@@ -124,7 +127,7 @@ describe('findTestAndVariant', () => {
         const targeting = { ...targetingDefault, sectionId: 'news' };
         const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, superModeArticles, epicType);
+        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles, epicType);
 
         expect(got.result).toBe(undefined);
     });
@@ -142,7 +145,7 @@ describe('findTestAndVariant', () => {
         };
         const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, superModeArticles, epicType);
+        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles, epicType);
 
         expect(got.result?.variant.showReminderFields).toBe(undefined);
     });
@@ -813,5 +816,48 @@ describe('isNotExpired filter', () => {
         const got = filter.test(test, targetingDefault);
 
         expect(got).toBe(false);
+    });
+});
+
+describe('deviceTypeMatchesFilter', () => {
+    it('should return true if test.deviceType == undefined', () => {
+        const result = deviceTypeMatchesFilter(false).test(testDefault, targetingDefault);
+        expect(result).toBe(true);
+    });
+
+    it('should return true if test.deviceType == All', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            deviceType: 'All',
+        };
+        const result = deviceTypeMatchesFilter(false).test(test, targetingDefault);
+        expect(result).toBe(true);
+    });
+
+    it('should return true if test.deviceType == Desktop and not mobile', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            deviceType: 'Desktop',
+        };
+        const result = deviceTypeMatchesFilter(false).test(test, targetingDefault);
+        expect(result).toBe(true);
+    });
+
+    it('should return true if test.deviceType == Mobile and is mobile', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            deviceType: 'Mobile',
+        };
+        const result = deviceTypeMatchesFilter(true).test(test, targetingDefault);
+        expect(result).toBe(true);
+    });
+
+    it('should return false if test.deviceType == Mobile and is not mobile', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            deviceType: 'Mobile',
+        };
+        const result = deviceTypeMatchesFilter(false).test(test, targetingDefault);
+        expect(result).toBe(false);
     });
 });

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -17,7 +17,12 @@ import {
 import { TestVariant } from '../../lib/params';
 import { SuperModeArticle } from '../../lib/superMode';
 import { isInSuperMode, superModeify } from '../../lib/superMode';
-import { shouldNotRenderEpic, shouldThrottle, userIsInTest } from '../../lib/targeting';
+import {
+    deviceTypeMatches,
+    shouldNotRenderEpic,
+    shouldThrottle,
+    userIsInTest,
+} from '../../lib/targeting';
 
 interface Filter {
     id: string;
@@ -203,6 +208,11 @@ export const respectArticleCountOptOut: Filter = {
     },
 };
 
+export const deviceTypeMatchesFilter = (isMobile: boolean): Filter => ({
+    id: 'deviceTypeMatches',
+    test: (test): boolean => deviceTypeMatches(test, isMobile),
+});
+
 type FilterResults = Record<string, boolean>;
 
 export type Debug = Record<string, FilterResults>;
@@ -218,6 +228,7 @@ export interface Result {
 export const findTestAndVariant = (
     tests: EpicTest[],
     targeting: EpicTargeting,
+    isMobile: boolean,
     superModeArticles: SuperModeArticle[],
     epicType: EpicType,
     includeDebug = false,
@@ -244,6 +255,7 @@ export const findTestAndVariant = (
             respectArticleCountOptOut,
             withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
             withinArticleViewedByTagSettings(targeting.weeklyArticleHistory || []),
+            deviceTypeMatchesFilter(isMobile),
         ];
     };
 

--- a/packages/server/src/tests/header/headerSelection.test.ts
+++ b/packages/server/src/tests/header/headerSelection.test.ts
@@ -142,6 +142,7 @@ describe('selectBestTest', () => {
 
         const result_1: HeaderTestSelection | null = selectBestTest(
             mockTargetingObject_1,
+            false,
             mockTests,
         );
         const result_1_test: HeaderTest | NullReturn = result_1
@@ -171,6 +172,7 @@ describe('selectBestTest', () => {
 
         const result_2: HeaderTestSelection | null = selectBestTest(
             mockTargetingObject_2,
+            false,
             mockTests,
         );
         const result_2_test: HeaderTest | NullReturn = result_2
@@ -200,6 +202,7 @@ describe('selectBestTest', () => {
 
         const result_3: HeaderTestSelection | null = selectBestTest(
             mockTargetingObject_3,
+            false,
             mockTests,
         );
         const result_3_test: HeaderTest | NullReturn = result_3
@@ -229,6 +232,7 @@ describe('selectBestTest', () => {
 
         const result_4: HeaderTestSelection | null = selectBestTest(
             mockTargetingObject_4,
+            false,
             mockTests,
         );
         const result_4_test: HeaderTest | NullReturn = result_4
@@ -259,6 +263,7 @@ describe('selectBestTest', () => {
 
         const result_5: HeaderTestSelection | null = selectBestTest(
             mockTargetingObject_5,
+            false,
             mockTestEmptyLocations,
         );
         const result_5_test: HeaderTest | NullReturn = result_5

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -2,6 +2,7 @@ import { BannerChannel, BannerContent, TickerSettings } from '../props';
 import {
     ArticlesViewedSettings,
     ControlProportionSettings,
+    DeviceType,
     TargetingAbTest,
     Test,
     UserCohort,
@@ -78,4 +79,5 @@ export interface RawTestParams {
     variants: RawVariantParams[];
     articlesViewedSettings?: ArticlesViewedSettings;
     controlProportionSettings?: ControlProportionSettings;
+    deviceType?: DeviceType;
 }

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -9,6 +9,7 @@ export interface Test<V extends Variant> {
     controlProportionSettings?: ControlProportionSettings;
     audienceOffset?: number;
     audience?: number;
+    deviceType?: DeviceType;
 }
 
 export interface ControlProportionSettings {
@@ -54,3 +55,5 @@ export type TestTracking = {
     labels?: string[];
     targetingAbTest?: TargetingAbTest;
 };
+
+export type DeviceType = 'Mobile' | 'Desktop' | 'All';


### PR DESCRIPTION
Introduces a `deviceType` field to the `Test` type:
`type DeviceType = 'Mobile' | 'Desktop' | 'All';`

I've implemented support for deviceType targeting on the epic/banner/header.
This will be used for targeting mobile-only banners which advertise the mobile apps. We plan to A/B test this against normal reader revenue messages.

It uses the user-agent string, and I've copied the [regexes from frontend](https://github.com/guardian/frontend/blob/main/static/src/javascripts/lib/detect.js#L187).

PR to add this to the tools: https://github.com/guardian/support-admin-console/pull/289

### Testing
I've added unit tests to `epicSelection.test.ts`, which effectively covers the same logic used by the banner/header.
I've tested in CODE by making POST requests with different user-agents.