### PR TITLE
Hide credit card icons if no support link

### DIFF
--- a/packages/modules/src/modules/banners/contributions/ContributionsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBanner.stories.tsx
@@ -36,3 +36,15 @@ WithPrefilledReminder.args = {
         });
     },
 };
+
+export const WithoutSupportUrl = Template.bind({});
+WithoutSupportUrl.args = {
+    ...WithReminder.args,
+    content: {
+        ...content,
+        cta: {
+            baseUrl: 'https://theguardian.com',
+            text: 'The Guardian',
+        },
+    },
+};

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerCta.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerCta.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { css, SerializedStyles } from '@emotion/react';
 import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
+import { isSupportUrl } from '@sdc/shared/dist/lib';
 
 const styles = {
     ctaButton: (stacked: boolean): SerializedStyles => css`
@@ -35,6 +36,7 @@ export const ContributionsBannerCta: React.FC<ContributionsBannerCtaProps> = ({
     ctaUrl,
     stacked,
 }: ContributionsBannerCtaProps) => {
+    const hasSupportCta = isSupportUrl(ctaUrl);
     return (
         <div>
             <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
@@ -54,13 +56,16 @@ export const ContributionsBannerCta: React.FC<ContributionsBannerCtaProps> = ({
                     {ctaText}
                 </LinkButton>
             </ThemeProvider>
-            <img
-                width={422}
-                height={60}
-                src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
-                alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-                css={styles.paymentMethods}
-            />
+
+            {hasSupportCta && (
+                <img
+                    width={422}
+                    height={60}
+                    src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+                    alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                    css={styles.paymentMethods}
+                />
+            )}
         </div>
     );
 };

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -613,3 +613,14 @@ WithReminderAndSignInLink.args = {
         },
     },
 };
+
+export const WithoutSupportUrl = Template.bind({});
+WithoutSupportUrl.args = {
+    variant: {
+        ...props.variant,
+        cta: {
+            baseUrl: 'https://theguardian.com',
+            text: 'The Guardian',
+        },
+    },
+};

--- a/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
@@ -13,6 +13,7 @@ import {
 import { useHasBeenSeen } from '../../hooks/useHasBeenSeen';
 import { hasSetReminder } from '../utils/reminders';
 import { ChoiceCardSelection } from './ContributionsEpicChoiceCards';
+import { isSupportUrl } from '@sdc/shared/dist/lib';
 
 const buttonWrapperStyles = css`
     margin: ${space[6]}px ${space[2]}px ${space[1]}px 0;
@@ -153,6 +154,10 @@ export const ContributionsEpicButtons = ({
         onOpenReminderClick();
     };
 
+    const hasSupportCta =
+        isSupportUrl(cta.baseUrl) ||
+        (secondaryCta?.type === SecondaryCtaType.Custom && isSupportUrl(secondaryCta.cta.baseUrl));
+
     return (
         <div ref={setNode} css={buttonWrapperStyles} data-testid="epic=buttons">
             {!isReminderActive && (
@@ -185,13 +190,15 @@ export const ContributionsEpicButtons = ({
                         )
                     )}
 
-                    <img
-                        width={422}
-                        height={60}
-                        src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
-                        alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-                        css={paymentImageStyles}
-                    />
+                    {hasSupportCta && (
+                        <img
+                            width={422}
+                            height={60}
+                            src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+                            alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                            css={paymentImageStyles}
+                        />
+                    )}
                 </>
             )}
         </div>

--- a/packages/modules/src/modules/epics/ContributionsLiveblogEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsLiveblogEpic.stories.tsx
@@ -1,64 +1,28 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
 import { ContributionsLiveblogEpic } from './ContributionsLiveblogEpic';
-import { withKnobs, text, object } from '@storybook/addon-knobs';
-import { StorybookWrapper } from '../../utils/StorybookWrapper';
-import testData from './ContributionsLiveblogEpic.testData';
-import { EpicVariant, Tracking } from '@sdc/shared/types';
+import { Story, Meta } from '@storybook/react';
+import { EpicProps } from '@sdc/shared/types';
+import { props } from './utils/storybook';
+import { WithReminder } from '../banners/contributions/ContributionsBanner.stories';
 
 export default {
     component: ContributionsLiveblogEpic,
-    title: 'Components/ContributionsLiveblogEpic',
-    decorators: [withKnobs],
-};
+    title: 'Epics/ContributionsLiveblogEpic',
+    args: props,
+} as Meta;
 
-// Number of articles viewed
-// Used to replace the template placeholder
-const articleCounts = {
-    for52Weeks: 99,
-    forTargetedWeeks: 99,
-};
+const Template: Story<EpicProps> = (props: EpicProps) => <ContributionsLiveblogEpic {...props} />;
 
-export const defaultStory = (): ReactElement => {
-    // Epic content props
-    const variant: EpicVariant = {
-        name: 'Test Epic',
-        paragraphs: object('paragraphs', testData.content.paragraphs),
+export const Default = Template.bind({});
+
+export const WithoutSupportUrl = Template.bind({});
+WithoutSupportUrl.args = {
+    ...WithReminder.args,
+    variant: {
+        ...props.variant,
         cta: {
-            text: text('primaryCta.text', testData.content.cta.text),
-            baseUrl: text('primaryCta.baseUrl', testData.content.cta.baseUrl),
+            baseUrl: 'https://theguardian.com',
+            text: 'The Guardian',
         },
-    };
-
-    // Epic metadata props
-    const epicTracking: Tracking = {
-        ophanPageId: text('ophanPageId', testData.tracking.ophanPageId),
-        componentType: testData.tracking.componentType,
-        products: testData.tracking.products,
-        platformId: text('platformId', testData.tracking.platformId),
-        clientName: testData.tracking.clientName,
-        campaignCode: text('campaignCode', testData.tracking.campaignCode),
-        campaignId: text(
-            'campaignId',
-            testData.tracking.campaignId || testData.tracking.abTestName,
-        ),
-        abTestName: text('abTestName', testData.tracking.abTestName),
-        abTestVariant: text('abTestVariant', testData.tracking.abTestVariant),
-        referrerUrl: text('referrerUrl', testData.tracking.referrerUrl),
-    };
-
-    // Epic countryCode prop
-    const countryCode = text('countryCode', testData.targeting.countryCode || 'GB');
-
-    return (
-        <StorybookWrapper>
-            <ContributionsLiveblogEpic
-                variant={variant}
-                tracking={epicTracking}
-                countryCode={countryCode}
-                articleCounts={articleCounts}
-            />
-        </StorybookWrapper>
-    );
+    },
 };
-
-defaultStory.story = { name: 'Default Epic' };

--- a/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
@@ -11,6 +11,7 @@ import {
     containsNonArticleCountPlaceholder,
     createViewEventFromTracking,
     createInsertEventFromTracking,
+    isSupportUrl,
 } from '@sdc/shared/lib';
 import { EpicVariant, Tracking } from '@sdc/shared/types';
 import { replaceArticleCount } from '../../lib/replaceArticleCount';
@@ -169,16 +170,20 @@ const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
         numArticles,
         countryCode,
     );
+    const hasSupportCta = !!baseUrl && isSupportUrl(baseUrl);
+
     return (
         <div css={ctaContainer}>
             <LinkButton css={cta} priority="primary" href={url}>
                 {text || DEFAULT_CTA_TEXT}
             </LinkButton>
-            <img
-                src="https://uploads.guim.co.uk/2021/02/04/liveblog-epic-cards.png"
-                alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-                css={paymentMethods}
-            />
+            {hasSupportCta && (
+                <img
+                    src="https://uploads.guim.co.uk/2021/02/04/liveblog-epic-cards.png"
+                    alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+                    css={paymentMethods}
+                />
+            )}
         </div>
     );
 };

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -57,15 +57,15 @@ export const addTrackingParams = (
     return `${baseUrl}${alreadyHasQueryString ? '&' : '?'}${queryString.join('&')}`;
 };
 
+export const isSupportUrl = (baseUrl: string): boolean => /\bsupport\./.test(baseUrl);
+
 export const addRegionIdAndTrackingParamsToSupportUrl = (
     baseUrl: string,
     tracking: Tracking,
     numArticles?: number,
     countryCode?: string,
 ): string => {
-    const isSupportUrl = /\bsupport\./.test(baseUrl);
-
-    return isSupportUrl
+    return isSupportUrl(baseUrl)
         ? addTrackingParams(addRegionIdToSupportUrl(baseUrl, countryCode), tracking, numArticles)
         : baseUrl;
 };


### PR DESCRIPTION
Sometimes we don't link to the support site, and so it doesn't make sense to display the credit card icons.
E.g. an upcoming test to link to mobile apps instead.

This PR affects:
- contributions banner
<img width="948" alt="Screen Shot 2022-03-01 at 09 40 37" src="https://user-images.githubusercontent.com/1513454/156144522-0db15ca6-d50c-4215-8e0a-d33a41d3b022.png">

- epic
<img width="624" alt="Screen Shot 2022-03-01 at 09 40 55" src="https://user-images.githubusercontent.com/1513454/156144537-c86c4b7a-b760-4d0c-a176-462183cfee92.png">

- liveblog epic
<img width="624" alt="Screen Shot 2022-03-01 at 09 41 17" src="https://user-images.githubusercontent.com/1513454/156144549-f7effe99-0f53-4846-a88b-799b5e6f2cac.png">
