### PR TITLE
Header: do not render cta if not defined for mobile

### DIFF
--- a/packages/modules/src/modules/header/Header.stories.tsx
+++ b/packages/modules/src/modules/header/Header.stories.tsx
@@ -61,3 +61,13 @@ export default {
 const Template: Story<HeaderProps> = (props: HeaderProps) => <Header {...props} />;
 
 export const DefaultHeader = Template.bind({});
+
+export const NoMobileCta = Template.bind({});
+NoMobileCta.args = {
+    ...DefaultHeader.args,
+    mobileContent: {
+        heading: '',
+        subheading: '',
+        primaryCta: undefined,
+    },
+};

--- a/packages/modules/src/modules/header/Header.tsx
+++ b/packages/modules/src/modules/header/Header.tsx
@@ -69,7 +69,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
 
             {primaryCta && (
                 <ThemeProvider theme={buttonReaderRevenueBrand}>
-                    <Hide below="mobileLandscape">
+                    <Hide below="tablet">
                         <LinkButton
                             priority="primary"
                             href={primaryCta.ctaUrl}
@@ -82,15 +82,17 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                         </LinkButton>
                     </Hide>
 
-                    <Hide above="mobileLandscape">
-                        <LinkButton
-                            priority="primary"
-                            href={props.mobileContent?.primaryCta?.ctaUrl || primaryCta.ctaUrl}
-                            css={linkStyles}
-                        >
-                            {props.mobileContent?.primaryCta?.ctaText || primaryCta.ctaText}
-                        </LinkButton>
-                    </Hide>
+                    {props.mobileContent?.primaryCta && (
+                        <Hide above="tablet">
+                            <LinkButton
+                                priority="primary"
+                                href={props.mobileContent.primaryCta.ctaUrl}
+                                css={linkStyles}
+                            >
+                                {props.mobileContent.primaryCta.ctaText}
+                            </LinkButton>
+                        </Hide>
+                    )}
                 </ThemeProvider>
             )}
 

--- a/packages/modules/src/modules/header/HeaderWrapper.tsx
+++ b/packages/modules/src/modules/header/HeaderWrapper.tsx
@@ -51,20 +51,21 @@ export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<Hea
             secondaryCta,
         };
 
-        const mobilePrimaryCta = mobileContent?.primaryCta
-            ? buildEnrichedCta(mobileContent.primaryCta)
-            : primaryCta;
+        const getMobileCta = (): HeaderEnrichedCta | null => {
+            if (mobileContent) {
+                // If mobileContent is defined but its primaryCta is not then we do not render a cta at all
+                return mobileContent.primaryCta ? buildEnrichedCta(mobileContent.primaryCta) : null;
+            }
+            return primaryCta;
+        };
 
-        const mobileSecondaryCta = mobileContent?.secondaryCta
-            ? buildEnrichedCta(mobileContent.secondaryCta)
-            : secondaryCta;
+        const mobilePrimaryCta = getMobileCta();
 
         const renderedMobileContent = mobileContent
             ? ({
                   heading: mobileContent.heading,
                   subheading: mobileContent.subheading,
                   primaryCta: mobilePrimaryCta,
-                  secondaryCta: mobileSecondaryCta,
               } as HeaderRenderedContent)
             : undefined;
 


### PR DESCRIPTION
The header tool enables us to define a custom primary cta at mobile (for shorter copy than desktop).
However, there's currently no way to show nothing at mobile. This feature has been requested by Marketing - they only want a cta at desktop, because it needs the main copy for context.