### PR TITLE
Set audience size to 0.75 for Single Front Door (SFD) AB tests

### DIFF
--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -54,7 +54,8 @@ export const shouldNotRenderEpic = (meta: EpicTargeting, epicType: EpicType): bo
 
 // https://github.com/guardian/ab-testing/blob/main/packages/ab-core/src/core.ts#L56
 export const userIsInTest = <V extends Variant>(test: Test<V>, mvtId: number): boolean => {
-    const audienceSize = test.name.startsWith('SINGLE_FRONT_DOOR') ? 0.3 : test.audience || 1;
+    // Set audience size to 0.6 for Single Front Door (SFD) AB tests
+    const audienceSize = test.name.startsWith('SFD') ? 0.6 : test.audience || 1;
 
     const maxMVTId = 1000000;
     const lowest = maxMVTId * (test.audienceOffset || 0);

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -55,7 +55,7 @@ export const shouldNotRenderEpic = (meta: EpicTargeting, epicType: EpicType): bo
 // https://github.com/guardian/ab-testing/blob/main/packages/ab-core/src/core.ts#L56
 export const userIsInTest = <V extends Variant>(test: Test<V>, mvtId: number): boolean => {
     // Set audience size to 0.6 for Single Front Door (SFD) AB tests
-    const audienceSize = test.name.startsWith('SFD') ? 0.6 : test.audience || 1;
+    const audienceSize = test.name.startsWith('SFD') ? 0.75 : test.audience || 1;
 
     const maxMVTId = 1000000;
     const lowest = maxMVTId * (test.audienceOffset || 0);

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -54,7 +54,7 @@ export const shouldNotRenderEpic = (meta: EpicTargeting, epicType: EpicType): bo
 
 // https://github.com/guardian/ab-testing/blob/main/packages/ab-core/src/core.ts#L56
 export const userIsInTest = <V extends Variant>(test: Test<V>, mvtId: number): boolean => {
-    // Set audience size to 0.6 for Single Front Door (SFD) AB tests
+    // Set audience size to 0.75 for Single Front Door (SFD) AB tests
     const audienceSize = test.name.startsWith('SFD') ? 0.75 : test.audience || 1;
     const maxMVTId = 1000000;
     const lowest = maxMVTId * (test.audienceOffset || 0);


### PR DESCRIPTION
## What does this change?

Sets audience size to 0.75 for any test whose ID begins with "SFD", this denotes it's a Single Front Door (SFD) AB test.
