### PR TITLE
Fix banner paragraph margins

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerText.tsx
+++ b/packages/modules/src/modules/banners/common/BannerText.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { SerializedStyles } from '@emotion/utils';
 import { BannerTextContent } from './types';
 import { BannerContentRenderer } from './BannerContentRenderer';
+import { css } from '@emotion/react';
 
 type BannerTextStyleableAreas =
     | 'container'
@@ -24,6 +25,17 @@ type BannerTextProps = {
     children?: React.ReactNode;
 };
 
+const styles = {
+    paragraphs: css`
+        > :first-child {
+            margin-top: 0;
+        }
+        > :last-child {
+            margin-bottom: 0;
+        }
+    `,
+};
+
 export const createBannerBodyCopy = (
     paragraphs: (Array<JSX.Element> | JSX.Element)[],
     highlightedText: Array<JSX.Element> | JSX.Element | null | undefined,
@@ -35,22 +47,28 @@ export const createBannerBodyCopy = (
     // To cover situations where there are no paragraphs to process
     if (numberOfNonFinalParagraphs < 0) {
         return (
-            <p>
-                <span css={renderStyles.highlightedText}>{highlightedText}</span>
-            </p>
+            <div css={styles.paragraphs}>
+                <p>
+                    <span css={renderStyles.highlightedText}>{highlightedText}</span>
+                </p>
+            </div>
         );
     }
 
-    return paragraphsToProcess.map((p, index) => {
-        if (index < numberOfNonFinalParagraphs) {
-            return <p key={index}>{p}</p>;
-        }
-        return (
-            <p key={index}>
-                {p} <span css={renderStyles.highlightedText}>{highlightedText}</span>
-            </p>
-        );
-    });
+    return (
+        <div css={styles.paragraphs}>
+            {paragraphsToProcess.map((p, index) => {
+                if (index < numberOfNonFinalParagraphs) {
+                    return <p key={index}>{p}</p>;
+                }
+                return (
+                    <p key={index}>
+                        {p} <span css={renderStyles.highlightedText}>{highlightedText}</span>
+                    </p>
+                );
+            })}
+        </div>
+    );
 };
 
 export const BannerText: React.FC<BannerTextProps> = ({ styles, content, children }) => {


### PR DESCRIPTION
A [recent PR](https://github.com/guardian/support-dotcom-components/pull/632) introduced paragraphs for banners.
But this has added margin above and below the body.
This PR removes it.

### Before
<img width="660" alt="Screen Shot 2022-03-04 at 13 39 53" src="https://user-images.githubusercontent.com/1513454/156773903-d7a24d81-56d6-4c10-bb27-58ee4f94f42c.png">

### After
<img width="660" alt="Screen Shot 2022-03-04 at 13 39 39" src="https://user-images.githubusercontent.com/1513454/156773962-455dd872-233c-4975-9a5f-19127ec95d9f.png">
