### PR TITLE
Vary `ContributionsLiveblogEpic` padding for DCR

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsLiveblogEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsLiveblogEpic.stories.tsx
@@ -26,3 +26,11 @@ WithoutSupportUrl.args = {
         },
     },
 };
+
+export const WhenOnDCR = Template.bind({});
+WhenOnDCR.args = {
+    tracking: {
+        ...props.tracking,
+        platformId: 'dcr',
+    },
+};

--- a/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
@@ -21,7 +21,7 @@ import { HasBeenSeen, useHasBeenSeen } from '../../hooks/useHasBeenSeen';
 import { OphanComponentEvent } from '@sdc/shared/dist/types';
 import { logEpicView } from '@sdc/shared/lib';
 
-const container: SerializedStyles = css`
+const container = (platformId: string) => css`
     padding: 6px 10px 28px 10px;
     border-top: 1px solid ${brandAlt[400]};
     border-bottom: 1px solid ${neutral[86]};
@@ -40,7 +40,7 @@ const container: SerializedStyles = css`
     }
 
     ${from.tablet} {
-        padding-left: 80px;
+        padding-left: ${platformId === 'dcr' ? '60px' : '80px'};
         padding-right: 20px;
 
         & > * + * {
@@ -95,7 +95,7 @@ const ctaContainer: SerializedStyles = css`
     }
 `;
 
-const yellowHeading = css`
+const yellowHeading = (platformId: string) => css`
     ${headline.medium({ fontWeight: 'bold' })};
     font-size: 28px;
     background-color: ${brandAlt[400]};
@@ -105,7 +105,7 @@ const yellowHeading = css`
 
     padding: 8px 10px 12px 10px;
     ${from.tablet} {
-        padding-left: 80px;
+        padding-left: ${platformId === 'dcr' ? '60px' : '80px'};
         padding-right: 20px;
     }
 `;
@@ -238,8 +238,8 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
 
     return (
         <div ref={setNode}>
-            {cleanHeading && <div css={yellowHeading}>{cleanHeading}</div>}
-            <section css={container}>
+            {cleanHeading && <div css={yellowHeading(tracking.platformId)}>{cleanHeading}</div>}
+            <section css={container(tracking.platformId)}>
                 <LiveblogEpicBody
                     paragraphs={cleanParagraphs}
                     numArticles={articleCounts.forTargetedWeeks}


### PR DESCRIPTION
## What does this change?
On DCR, we only have 60 pixels of padding to the left of liveblog content, not 80. This PR introduces the ability to vary this padding value based on `platformId` to allow for this

### Before
<img width="1008" alt="Screenshot 2022-03-10 at 08 52 24" src="https://user-images.githubusercontent.com/1336821/157625869-d96838fa-3371-412c-84bd-0ca8fbe512dc.png">


### After
<img width="1008" alt="Screenshot 2022-03-10 at 08 52 32" src="https://user-images.githubusercontent.com/1336821/157625851-54c9c365-640a-4eb8-969d-fcbddf59548c.png">
