### PR TITLE
Top reader article count badge test

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -252,7 +252,15 @@ const EpicBody: React.FC<BodyProps> = ({
     );
 };
 
-const ContributionsEpic: React.FC<EpicProps> = ({
+export enum TopReaderArticleCountBadgeVariant {
+    CONTROL,
+    V1_AC_LEAD,
+    V2_CONGRATS_LEAD,
+}
+
+export const getEpic = (
+    topReaderVariant: TopReaderArticleCountBadgeVariant,
+): React.FC<EpicProps> => ({
     variant,
     tracking,
     countryCode,
@@ -357,6 +365,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                         openCmp={openCmp}
                         submitComponentEvent={submitComponentEvent}
                         aboveArticleCountByTag={false}
+                        topReaderVariant={topReaderVariant}
                     />
                 </div>
             )}
@@ -451,6 +460,8 @@ const ContributionsEpic: React.FC<EpicProps> = ({
         </section>
     );
 };
+
+const ContributionsEpic = getEpic(TopReaderArticleCountBadgeVariant.CONTROL);
 
 export const validate = (props: unknown): props is EpicProps => {
     const result = epicPropsSchema.safeParse(props);

--- a/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
@@ -18,6 +18,267 @@ import {
 import { from, until } from '@guardian/src-foundations/mq';
 import { TopReaderArticleCountBadgeVariant } from './ContributionsEpic';
 
+// --- Component --- //
+
+export interface ContributionsEpicArticleCountAboveWithOptOutProps {
+    articleCounts: ArticleCounts;
+    isArticleCountOn: boolean;
+    onArticleCountOptOut: () => void;
+    onArticleCountOptIn: () => void;
+    openCmp?: () => void;
+    submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
+    aboveArticleCountByTag: boolean;
+    topReaderVariant: TopReaderArticleCountBadgeVariant;
+}
+
+export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<ContributionsEpicArticleCountAboveWithOptOutProps> = ({
+    articleCounts,
+    isArticleCountOn,
+    onArticleCountOptOut,
+    onArticleCountOptIn,
+    openCmp,
+    submitComponentEvent,
+    aboveArticleCountByTag,
+    topReaderVariant,
+}: ContributionsEpicArticleCountAboveWithOptOutProps) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const onToggleClick = () => {
+        setIsOpen(!isOpen);
+        submitComponentEvent &&
+            submitComponentEvent(
+                isOpen
+                    ? OPHAN_COMPONENT_ARTICLE_COUNT_OPT_OUT_CLOSE
+                    : OPHAN_COMPONENT_ARTICLE_COUNT_OPT_OUT_OPEN,
+            );
+    };
+
+    const onStayInClick = () => {
+        setIsOpen(false);
+        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_ARTICLE_COUNT_STAY_IN);
+    };
+
+    const onOptOutClick = () => {
+        setIsOpen(false);
+        onArticleCountOptOut();
+        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_ARTICLE_COUNT_OPT_OUT);
+    };
+
+    const onOptInClick = () => {
+        setIsOpen(false);
+        onArticleCountOptIn();
+        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_ARTICLE_COUNT_OPT_IN);
+    };
+
+    const onStayOutClick = () => {
+        setIsOpen(false);
+        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_ARTICLE_COUNT_STAY_OUT);
+    };
+
+    return (
+        <div css={topContainer}>
+            <ArticleCountWithToggle
+                isArticleCountOn={isArticleCountOn}
+                articleCounts={articleCounts}
+                onToggleClick={onToggleClick}
+                aboveArticleCountByTag={aboveArticleCountByTag}
+                topReaderVariant={topReaderVariant}
+            />
+
+            {isOpen && (
+                <div css={articleCountDescriptionTopContainerStyles}>
+                    <div css={caretStyles}></div>
+                    <div css={articleCountDescriptionContainer}>
+                        {isArticleCountOn ? (
+                            <>
+                                <div css={articleCountBodyTextStyles}>
+                                    Many readers tell us they enjoy seeing how many pieces of
+                                    Guardian journalism they’ve read, watched or listened to. So
+                                    here’s your count. Can we continue showing you this on support
+                                    appeals like this?
+                                </div>
+                                <div css={articleCountCtasContainerStyles}>
+                                    <Button
+                                        priority="primary"
+                                        size="xsmall"
+                                        cssOverrides={articleCountDefaultCtaStyles}
+                                        onClick={onStayInClick}
+                                    >
+                                        Yes, that&apos;s OK
+                                    </Button>
+                                    <Button
+                                        priority="tertiary"
+                                        size="xsmall"
+                                        cssOverrides={articleCountOptOutCtaStyles}
+                                        onClick={onOptOutClick}
+                                    >
+                                        No, opt me out
+                                    </Button>
+                                </div>
+                            </>
+                        ) : (
+                            <>
+                                <div css={articleCountBodyTextStyles}>
+                                    Many readers tell us they enjoy seeing how many pieces of
+                                    Guardian journalism they’ve read, watched or listened to. Can we
+                                    start showing you your article count on support appeals like
+                                    this?
+                                </div>
+                                <div css={articleCountCtasContainerStyles}>
+                                    <Button
+                                        priority="primary"
+                                        size="xsmall"
+                                        cssOverrides={articleCountOptInCtaStyles}
+                                        onClick={onOptInClick}
+                                    >
+                                        Yes, opt me in
+                                    </Button>
+                                    <Button
+                                        priority="tertiary"
+                                        size="xsmall"
+                                        cssOverrides={articleCountOptOutCtaStyles}
+                                        onClick={onStayOutClick}
+                                    >
+                                        No, thank you
+                                    </Button>
+                                </div>
+                            </>
+                        )}
+                    </div>
+                    <div css={trackingSettingsContainerStyles}>
+                        To opt out of other tracking activity, manage your{' '}
+                        <ButtonLink
+                            priority="secondary"
+                            cssOverrides={privacySettingsLinkStyles}
+                            onClick={openCmp}
+                        >
+                            Privacy Settings
+                        </ButtonLink>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+// --- Helper components --- //
+
+interface ArticleCountWithToggleProps {
+    articleCounts: ArticleCounts;
+    isArticleCountOn: boolean;
+    onToggleClick: () => void;
+    aboveArticleCountByTag: boolean;
+    topReaderVariant: TopReaderArticleCountBadgeVariant;
+}
+
+const ArticleCountWithToggle: React.FC<ArticleCountWithToggleProps> = ({
+    isArticleCountOn,
+    articleCounts,
+    onToggleClick,
+    aboveArticleCountByTag,
+    topReaderVariant,
+}: ArticleCountWithToggleProps) => {
+    // By default we display the 52-week count
+    const articleCount = aboveArticleCountByTag
+        ? articleCounts.forTargetedWeeks
+        : articleCounts.for52Weeks;
+
+    if (isArticleCountOn && articleCount >= 5) {
+        return (
+            <div css={articleCountOnHeaderContainerStyles}>
+                {topReaderVariant === TopReaderArticleCountBadgeVariant.CONTROL && (
+                    <ArticleCount
+                        articleCount={articleCount}
+                        aboveArticleCountByTag={aboveArticleCountByTag}
+                    />
+                )}
+
+                {topReaderVariant === TopReaderArticleCountBadgeVariant.V1_AC_LEAD && (
+                    <TopReaderArticleCountV1 articleCount={articleCount} />
+                )}
+
+                {topReaderVariant === TopReaderArticleCountBadgeVariant.V2_CONGRATS_LEAD && (
+                    <TopReaderArticleCountV2 articleCount={articleCount} />
+                )}
+
+                <div css={articleCountWrapperStyles}>
+                    <div css={articleCountTextStyles}>Article count</div>
+                    <ButtonLink
+                        priority="secondary"
+                        onClick={onToggleClick}
+                        cssOverrides={articleCountCtaStyles}
+                    >
+                        on
+                    </ButtonLink>
+                </div>
+            </div>
+        );
+    }
+
+    if (!isArticleCountOn) {
+        return (
+            <div css={articleCountWrapperStyles}>
+                <div css={articleCountTextStyles}>Article count</div>
+                <ButtonLink
+                    priority="secondary"
+                    onClick={onToggleClick}
+                    cssOverrides={articleCountCtaStyles}
+                >
+                    off
+                </ButtonLink>
+            </div>
+        );
+    }
+
+    return null;
+};
+
+interface ArticleCountProps {
+    articleCount: number;
+    aboveArticleCountByTag: boolean;
+}
+
+const ArticleCount: React.FC<ArticleCountProps> = ({ articleCount, aboveArticleCountByTag }) => {
+    const timeWindowCopy = aboveArticleCountByTag ? (
+        <span>
+            about the
+            <br />
+            climate crisis in the last six weeks
+        </span>
+    ) : (
+        'in the last year'
+    );
+
+    return (
+        <div css={articleCountAboveContainerStyles}>
+            You&apos;ve read <span css={optOutContainer}>{articleCount} articles</span>{' '}
+            {timeWindowCopy}
+        </div>
+    );
+};
+
+interface TopReaderArticleCountProps {
+    articleCount: number;
+}
+
+const TopReaderArticleCountV1: React.FC<TopReaderArticleCountProps> = ({ articleCount }) => {
+    return (
+        <div css={articleCountAboveContainerStyles}>
+            You&apos;ve read <span css={optOutContainer}>{articleCount} articles</span> in the last
+            year – congratulations on being one of our top readers globally
+        </div>
+    );
+};
+
+const TopReaderArticleCountV2: React.FC<TopReaderArticleCountProps> = ({ articleCount }) => {
+    return (
+        <div css={articleCountAboveContainerStyles}>
+            Congratulations on being one of our top readers globally – you&apos;ve read{' '}
+            <span css={optOutContainer}>{articleCount} articles</span> in the last year
+        </div>
+    );
+};
+
 // --- Styles --- //
 
 const topContainer = css`
@@ -223,262 +484,3 @@ const caretStyles = css`
         }
     }
 `;
-
-interface ArticleCountWithToggleProps {
-    articleCounts: ArticleCounts;
-    isArticleCountOn: boolean;
-    onToggleClick: () => void;
-    aboveArticleCountByTag: boolean;
-    topReaderVariant: TopReaderArticleCountBadgeVariant;
-}
-
-export interface ContributionsEpicArticleCountAboveWithOptOutProps {
-    articleCounts: ArticleCounts;
-    isArticleCountOn: boolean;
-    onArticleCountOptOut: () => void;
-    onArticleCountOptIn: () => void;
-    openCmp?: () => void;
-    submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
-    aboveArticleCountByTag: boolean;
-    topReaderVariant: TopReaderArticleCountBadgeVariant;
-}
-
-// -- Components -- //
-
-interface ArticleCountProps {
-    articleCount: number;
-    aboveArticleCountByTag: boolean;
-}
-
-const ArticleCount: React.FC<ArticleCountProps> = ({ articleCount, aboveArticleCountByTag }) => {
-    const timeWindowCopy = aboveArticleCountByTag ? (
-        <span>
-            about the
-            <br />
-            climate crisis in the last six weeks
-        </span>
-    ) : (
-        'in the last year'
-    );
-
-    return (
-        <div css={articleCountAboveContainerStyles}>
-            You&apos;ve read <span css={optOutContainer}>{articleCount} articles</span>{' '}
-            {timeWindowCopy}
-        </div>
-    );
-};
-
-interface TopReaderArticleCountProps {
-    articleCount: number;
-}
-
-const TopReaderArticleCountV1: React.FC<TopReaderArticleCountProps> = ({ articleCount }) => {
-    return (
-        <div css={articleCountAboveContainerStyles}>
-            You&apos;ve read <span css={optOutContainer}>{articleCount} articles</span> in the last
-            year – congratulations on being one of our top readers globally
-        </div>
-    );
-};
-
-const TopReaderArticleCountV2: React.FC<TopReaderArticleCountProps> = ({ articleCount }) => {
-    return (
-        <div css={articleCountAboveContainerStyles}>
-            Congratulations on being one of our top readers globally – you&apos;ve read{' '}
-            <span css={optOutContainer}>{articleCount} articles</span> in the last year
-        </div>
-    );
-};
-
-const ArticleCountWithToggle: React.FC<ArticleCountWithToggleProps> = ({
-    isArticleCountOn,
-    articleCounts,
-    onToggleClick,
-    aboveArticleCountByTag,
-    topReaderVariant,
-}: ArticleCountWithToggleProps) => {
-    // By default we display the 52-week count
-    const articleCount = aboveArticleCountByTag
-        ? articleCounts.forTargetedWeeks
-        : articleCounts.for52Weeks;
-
-    if (isArticleCountOn && articleCount >= 5) {
-        return (
-            <div css={articleCountOnHeaderContainerStyles}>
-                {topReaderVariant === TopReaderArticleCountBadgeVariant.CONTROL && (
-                    <ArticleCount
-                        articleCount={articleCount}
-                        aboveArticleCountByTag={aboveArticleCountByTag}
-                    />
-                )}
-
-                {topReaderVariant === TopReaderArticleCountBadgeVariant.V1_AC_LEAD && (
-                    <TopReaderArticleCountV1 articleCount={articleCount} />
-                )}
-
-                {topReaderVariant === TopReaderArticleCountBadgeVariant.V2_CONGRATS_LEAD && (
-                    <TopReaderArticleCountV2 articleCount={articleCount} />
-                )}
-
-                <div css={articleCountWrapperStyles}>
-                    <div css={articleCountTextStyles}>Article count</div>
-                    <ButtonLink
-                        priority="secondary"
-                        onClick={onToggleClick}
-                        cssOverrides={articleCountCtaStyles}
-                    >
-                        on
-                    </ButtonLink>
-                </div>
-            </div>
-        );
-    }
-
-    if (!isArticleCountOn) {
-        return (
-            <div css={articleCountWrapperStyles}>
-                <div css={articleCountTextStyles}>Article count</div>
-                <ButtonLink
-                    priority="secondary"
-                    onClick={onToggleClick}
-                    cssOverrides={articleCountCtaStyles}
-                >
-                    off
-                </ButtonLink>
-            </div>
-        );
-    }
-
-    return null;
-};
-
-export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<ContributionsEpicArticleCountAboveWithOptOutProps> = ({
-    articleCounts,
-    isArticleCountOn,
-    onArticleCountOptOut,
-    onArticleCountOptIn,
-    openCmp,
-    submitComponentEvent,
-    aboveArticleCountByTag,
-    topReaderVariant,
-}: ContributionsEpicArticleCountAboveWithOptOutProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    const onToggleClick = () => {
-        setIsOpen(!isOpen);
-        submitComponentEvent &&
-            submitComponentEvent(
-                isOpen
-                    ? OPHAN_COMPONENT_ARTICLE_COUNT_OPT_OUT_CLOSE
-                    : OPHAN_COMPONENT_ARTICLE_COUNT_OPT_OUT_OPEN,
-            );
-    };
-
-    const onStayInClick = () => {
-        setIsOpen(false);
-        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_ARTICLE_COUNT_STAY_IN);
-    };
-
-    const onOptOutClick = () => {
-        setIsOpen(false);
-        onArticleCountOptOut();
-        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_ARTICLE_COUNT_OPT_OUT);
-    };
-
-    const onOptInClick = () => {
-        setIsOpen(false);
-        onArticleCountOptIn();
-        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_ARTICLE_COUNT_OPT_IN);
-    };
-
-    const onStayOutClick = () => {
-        setIsOpen(false);
-        submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_ARTICLE_COUNT_STAY_OUT);
-    };
-
-    return (
-        <div css={topContainer}>
-            <ArticleCountWithToggle
-                isArticleCountOn={isArticleCountOn}
-                articleCounts={articleCounts}
-                onToggleClick={onToggleClick}
-                aboveArticleCountByTag={aboveArticleCountByTag}
-                topReaderVariant={topReaderVariant}
-            />
-
-            {isOpen && (
-                <div css={articleCountDescriptionTopContainerStyles}>
-                    <div css={caretStyles}></div>
-                    <div css={articleCountDescriptionContainer}>
-                        {isArticleCountOn ? (
-                            <>
-                                <div css={articleCountBodyTextStyles}>
-                                    Many readers tell us they enjoy seeing how many pieces of
-                                    Guardian journalism they’ve read, watched or listened to. So
-                                    here’s your count. Can we continue showing you this on support
-                                    appeals like this?
-                                </div>
-                                <div css={articleCountCtasContainerStyles}>
-                                    <Button
-                                        priority="primary"
-                                        size="xsmall"
-                                        cssOverrides={articleCountDefaultCtaStyles}
-                                        onClick={onStayInClick}
-                                    >
-                                        Yes, that&apos;s OK
-                                    </Button>
-                                    <Button
-                                        priority="tertiary"
-                                        size="xsmall"
-                                        cssOverrides={articleCountOptOutCtaStyles}
-                                        onClick={onOptOutClick}
-                                    >
-                                        No, opt me out
-                                    </Button>
-                                </div>
-                            </>
-                        ) : (
-                            <>
-                                <div css={articleCountBodyTextStyles}>
-                                    Many readers tell us they enjoy seeing how many pieces of
-                                    Guardian journalism they’ve read, watched or listened to. Can we
-                                    start showing you your article count on support appeals like
-                                    this?
-                                </div>
-                                <div css={articleCountCtasContainerStyles}>
-                                    <Button
-                                        priority="primary"
-                                        size="xsmall"
-                                        cssOverrides={articleCountOptInCtaStyles}
-                                        onClick={onOptInClick}
-                                    >
-                                        Yes, opt me in
-                                    </Button>
-                                    <Button
-                                        priority="tertiary"
-                                        size="xsmall"
-                                        cssOverrides={articleCountOptOutCtaStyles}
-                                        onClick={onStayOutClick}
-                                    >
-                                        No, thank you
-                                    </Button>
-                                </div>
-                            </>
-                        )}
-                    </div>
-                    <div css={trackingSettingsContainerStyles}>
-                        To opt out of other tracking activity, manage your{' '}
-                        <ButtonLink
-                            priority="secondary"
-                            cssOverrides={privacySettingsLinkStyles}
-                            onClick={openCmp}
-                        >
-                            Privacy Settings
-                        </ButtonLink>
-                    </div>
-                </div>
-            )}
-        </div>
-    );
-};

--- a/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
@@ -16,6 +16,7 @@ import {
     OPHAN_COMPONENT_ARTICLE_COUNT_OPT_IN,
 } from './utils/ophan';
 import { from, until } from '@guardian/src-foundations/mq';
+import { TopReaderArticleCountBadgeVariant } from './ContributionsEpic';
 
 // --- Styles --- //
 
@@ -55,6 +56,7 @@ const articleCountOnHeaderContainerStyles = css`
 `;
 
 const articleCountWrapperStyles = css`
+    flex-shrink: 0;
     display: flex;
     flex-direction: row;
     align-items: flex-start;
@@ -63,6 +65,7 @@ const articleCountWrapperStyles = css`
     justify-content: start;
 
     ${from.tablet} {
+        margin-left: ${space[5]}px;
         margin-bottom: 0;
         justify-content: flex-end;
     }
@@ -226,6 +229,7 @@ interface ArticleCountWithToggleProps {
     isArticleCountOn: boolean;
     onToggleClick: () => void;
     aboveArticleCountByTag: boolean;
+    topReaderVariant: TopReaderArticleCountBadgeVariant;
 }
 
 export interface ContributionsEpicArticleCountAboveWithOptOutProps {
@@ -236,15 +240,63 @@ export interface ContributionsEpicArticleCountAboveWithOptOutProps {
     openCmp?: () => void;
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
     aboveArticleCountByTag: boolean;
+    topReaderVariant: TopReaderArticleCountBadgeVariant;
 }
 
 // -- Components -- //
+
+interface ArticleCountProps {
+    articleCount: number;
+    aboveArticleCountByTag: boolean;
+}
+
+const ArticleCount: React.FC<ArticleCountProps> = ({ articleCount, aboveArticleCountByTag }) => {
+    const timeWindowCopy = aboveArticleCountByTag ? (
+        <span>
+            about the
+            <br />
+            climate crisis in the last six weeks
+        </span>
+    ) : (
+        'in the last year'
+    );
+
+    return (
+        <div css={articleCountAboveContainerStyles}>
+            You&apos;ve read <span css={optOutContainer}>{articleCount} articles</span>{' '}
+            {timeWindowCopy}
+        </div>
+    );
+};
+
+interface TopReaderArticleCountProps {
+    articleCount: number;
+}
+
+const TopReaderArticleCountV1: React.FC<TopReaderArticleCountProps> = ({ articleCount }) => {
+    return (
+        <div css={articleCountAboveContainerStyles}>
+            You&apos;ve read <span css={optOutContainer}>{articleCount} articles</span> in the last
+            year – congratulations on being one of our top readers globally
+        </div>
+    );
+};
+
+const TopReaderArticleCountV2: React.FC<TopReaderArticleCountProps> = ({ articleCount }) => {
+    return (
+        <div css={articleCountAboveContainerStyles}>
+            Congratulations on being one of our top readers globally – you&apos;ve read{' '}
+            <span css={optOutContainer}>{articleCount} articles</span> in the last year
+        </div>
+    );
+};
 
 const ArticleCountWithToggle: React.FC<ArticleCountWithToggleProps> = ({
     isArticleCountOn,
     articleCounts,
     onToggleClick,
     aboveArticleCountByTag,
+    topReaderVariant,
 }: ArticleCountWithToggleProps) => {
     // By default we display the 52-week count
     const articleCount = aboveArticleCountByTag
@@ -252,26 +304,23 @@ const ArticleCountWithToggle: React.FC<ArticleCountWithToggleProps> = ({
         : articleCounts.for52Weeks;
 
     if (isArticleCountOn && articleCount >= 5) {
-        const timeWindowCopy = aboveArticleCountByTag ? (
-            <span>
-                about the
-                <br />
-                climate crisis in the last six weeks
-            </span>
-        ) : (
-            'in the last year'
-        );
         return (
             <div css={articleCountOnHeaderContainerStyles}>
-                <div css={articleCountAboveContainerStyles}>
-                    {articleCount >= 5 && (
-                        <>
-                            You&apos;ve read{' '}
-                            <span css={optOutContainer}>{articleCount} articles</span>{' '}
-                            {timeWindowCopy}
-                        </>
-                    )}
-                </div>
+                {topReaderVariant === TopReaderArticleCountBadgeVariant.CONTROL && (
+                    <ArticleCount
+                        articleCount={articleCount}
+                        aboveArticleCountByTag={aboveArticleCountByTag}
+                    />
+                )}
+
+                {topReaderVariant === TopReaderArticleCountBadgeVariant.V1_AC_LEAD && (
+                    <TopReaderArticleCountV1 articleCount={articleCount} />
+                )}
+
+                {topReaderVariant === TopReaderArticleCountBadgeVariant.V2_CONGRATS_LEAD && (
+                    <TopReaderArticleCountV2 articleCount={articleCount} />
+                )}
+
                 <div css={articleCountWrapperStyles}>
                     <div css={articleCountTextStyles}>Article count</div>
                     <ButtonLink
@@ -312,6 +361,7 @@ export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<Contribution
     openCmp,
     submitComponentEvent,
     aboveArticleCountByTag,
+    topReaderVariant,
 }: ContributionsEpicArticleCountAboveWithOptOutProps) => {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -354,6 +404,7 @@ export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<Contribution
                 articleCounts={articleCounts}
                 onToggleClick={onToggleClick}
                 aboveArticleCountByTag={aboveArticleCountByTag}
+                topReaderVariant={topReaderVariant}
             />
 
             {isOpen && (

--- a/packages/modules/src/modules/epics/ContributionsEpicTopReaderArticleCountBadgeV1.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicTopReaderArticleCountBadgeV1.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { ContributionsEpicUnvalidated as ContributionsEpic } from './ContributionsEpicTopReaderArticleCountBadgeV1';
+import { props } from './utils/storybook';
+import { EpicProps } from '@sdc/shared/types';
+import { EpicDecorator, WithAboveArticleCount } from './ContributionsEpic.stories';
+
+export default {
+    component: ContributionsEpic,
+    title: 'Epics/ContributionsTopReaderV1',
+    args: props,
+    decorators: [EpicDecorator],
+    excludeStories: /.*Decorator$/,
+} as Meta;
+
+const Template: Story<EpicProps> = (props: EpicProps) => <ContributionsEpic {...props} />;
+
+export const Default = Template.bind({});
+Default.args = WithAboveArticleCount.args;

--- a/packages/modules/src/modules/epics/ContributionsEpicTopReaderArticleCountBadgeV1.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicTopReaderArticleCountBadgeV1.tsx
@@ -1,0 +1,8 @@
+import { withParsedProps } from '../shared/ModuleWrapper';
+import { getEpic, TopReaderArticleCountBadgeVariant, validate } from './ContributionsEpic';
+
+const ContributionsEpic = getEpic(TopReaderArticleCountBadgeVariant.V1_AC_LEAD);
+
+const validatedEpic = withParsedProps(ContributionsEpic, validate);
+const unValidatedEpic = ContributionsEpic;
+export { validatedEpic as ContributionsEpic, unValidatedEpic as ContributionsEpicUnvalidated };

--- a/packages/modules/src/modules/epics/ContributionsEpicTopReaderArticleCountBadgeV2.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicTopReaderArticleCountBadgeV2.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { ContributionsEpicUnvalidated as ContributionsEpic } from './ContributionsEpicTopReaderArticleCountBadgeV2';
+import { props } from './utils/storybook';
+import { EpicProps } from '@sdc/shared/types';
+import { EpicDecorator, WithAboveArticleCount } from './ContributionsEpic.stories';
+
+export default {
+    component: ContributionsEpic,
+    title: 'Epics/ContributionsTopReaderV2',
+    args: props,
+    decorators: [EpicDecorator],
+    excludeStories: /.*Decorator$/,
+} as Meta;
+
+const Template: Story<EpicProps> = (props: EpicProps) => <ContributionsEpic {...props} />;
+
+export const Default = Template.bind({});
+Default.args = WithAboveArticleCount.args;

--- a/packages/modules/src/modules/epics/ContributionsEpicTopReaderArticleCountBadgeV2.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicTopReaderArticleCountBadgeV2.tsx
@@ -1,0 +1,8 @@
+import { withParsedProps } from '../shared/ModuleWrapper';
+import { getEpic, TopReaderArticleCountBadgeVariant, validate } from './ContributionsEpic';
+
+const ContributionsEpic = getEpic(TopReaderArticleCountBadgeVariant.V2_CONGRATS_LEAD);
+
+const validatedEpic = withParsedProps(ContributionsEpic, validate);
+const unValidatedEpic = ContributionsEpic;
+export { validatedEpic as ContributionsEpic, unValidatedEpic as ContributionsEpicUnvalidated };

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -36,6 +36,7 @@ import { fallbackEpicTest } from './tests/epics/fallback';
 import { selectHeaderTest } from './tests/header/headerSelection';
 import { logWarn } from './utils/logging';
 import { cachedChoiceCardAmounts } from './choiceCardAmounts';
+import { tests as topReaderAcBadgeTests } from './tests/epics/topReaderArticleCountBadge';
 
 interface EpicDataResponse {
     data?: {
@@ -110,7 +111,7 @@ const fetchConfiguredLiveblogEpicTestsCached = cacheAsync(
 const fetchSuperModeArticlesCached = cacheAsync(fetchSuperModeArticles, { ttlSec: 60 });
 
 // Any hardcoded epic tests should go here. They will take priority over any tests from the epic tool.
-const hardcodedEpicTests: EpicTest[] = [];
+const hardcodedEpicTests: EpicTest[] = [...topReaderAcBadgeTests];
 
 const getArticleEpicTests = async (
     mvtId: number,

--- a/packages/server/src/tests/epics/topReaderArticleCountBadge/build.ts
+++ b/packages/server/src/tests/epics/topReaderArticleCountBadge/build.ts
@@ -1,0 +1,71 @@
+import { epic, epicTopReaderAcBadgeV1, epicTopReaderAcBadgeV2 } from '@sdc/shared/dist/config';
+import { CountryGroupId } from '@sdc/shared/dist/lib';
+import { EpicTest, SecondaryCtaType } from '@sdc/shared/dist/types';
+import { Copy, CTA } from './copy';
+
+interface Options {
+    suffix: string;
+    locations: CountryGroupId[];
+    copy: Copy;
+}
+
+export function buildTest({ suffix, locations, copy }: Options): EpicTest {
+    return {
+        name: `TopReaderArticleCountBadge__${suffix}`,
+        campaignId: `TopReaderArticleCountBadge__${suffix}`,
+        hasArticleCountInCopy: true,
+        isOn: false,
+        locations,
+        audience: 1,
+        tagIds: [],
+        sections: [],
+        excludedTagIds: [],
+        excludedSections: [],
+        alwaysAsk: false,
+        maxViews: {
+            maxViewsCount: 4,
+            maxViewsDays: 30,
+            minDaysBetweenViews: 0,
+        },
+        userCohort: 'AllNonSupporters',
+        isLiveBlog: false,
+        hasCountryName: true,
+        variants: [
+            {
+                name: 'CONTROL',
+                modulePathBuilder: epic.endpointPathBuilder,
+                paragraphs: copy.control.paragraphs,
+                highlightedText: copy.control.highlightedText,
+                cta: CTA,
+                secondaryCta: { type: SecondaryCtaType.ContributionsReminder },
+                showChoiceCards: true,
+            },
+            {
+                name: 'V1_AC_LEAD',
+                modulePathBuilder: epicTopReaderAcBadgeV1.endpointPathBuilder,
+                paragraphs: copy.variants.paragraphs,
+                highlightedText: copy.variants.highlightedText,
+                cta: CTA,
+                secondaryCta: { type: SecondaryCtaType.ContributionsReminder },
+                separateArticleCount: { type: 'above' },
+                showChoiceCards: true,
+            },
+            {
+                name: 'V2_CONGRATS_LEAD',
+                modulePathBuilder: epicTopReaderAcBadgeV2.endpointPathBuilder,
+                paragraphs: copy.variants.paragraphs,
+                highlightedText: copy.variants.highlightedText,
+                cta: CTA,
+                secondaryCta: { type: SecondaryCtaType.ContributionsReminder },
+                separateArticleCount: { type: 'above' },
+                showChoiceCards: true,
+            },
+        ],
+        highPriority: true,
+        useLocalViewLog: true,
+        articlesViewedSettings: {
+            minViews: 50,
+            periodInWeeks: 52,
+        },
+    };
+}

--- a/packages/server/src/tests/epics/topReaderArticleCountBadge/copy.ts
+++ b/packages/server/src/tests/epics/topReaderArticleCountBadge/copy.ts
@@ -1,0 +1,86 @@
+export const CTA = {
+    text: 'Support the Guardian',
+    baseUrl: 'https://support.theguardian.com/contribute',
+};
+
+export interface Copy {
+    control: VariantCopy;
+    variants: VariantCopy;
+}
+
+interface VariantCopy {
+    paragraphs: string[];
+    highlightedText: string;
+}
+
+export const UK_AUS_COPY: Copy = {
+    control: {
+        paragraphs: [
+            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions.',
+            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s fearless journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million supporters, from 180 countries, now power us financially – keeping us open to all, and fiercely independent.',
+            'Unlike many others, the Guardian has no shareholders and no billionaire owner. Just the determination and passion to deliver high-impact global reporting, always free from commercial or political influence. Reporting like this is vital for democracy, for fairness and to demand better from the powerful.',
+            'And we provide all this for free, for everyone to read. We do this because we believe in information equality. Greater numbers of people can keep track of the global events shaping our world, understand their impact on people and communities, and become inspired to take meaningful action. Millions can benefit from open access to quality, truthful news, regardless of their ability to pay for it.',
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        highlightedText:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    variants: {
+        paragraphs: [
+            '… we have a small favour to ask. Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s fearless journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million supporters, from 180 countries, now power us financially – keeping us open to all, and fiercely independent.',
+            'Unlike many others, the Guardian has no shareholders and no billionaire owner. Just the determination and passion to deliver high-impact global reporting, always free from commercial or political influence. Reporting like this is vital for democracy, for fairness and to demand better from the powerful.',
+            'And we provide all this for free, for everyone to read. We do this because we believe in information equality. Greater numbers of people can keep track of the global events shaping our world, understand their impact on people and communities, and become inspired to take meaningful action. Millions can benefit from open access to quality, truthful news, regardless of their ability to pay for it.',
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        highlightedText:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+};
+
+export const EU_ROW_COPY: Copy = {
+    control: {
+        paragraphs: [
+            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions, and joining us today from %%COUNTRY_NAME%%.',
+            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s fearless journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million supporters, from 180 countries, now power us financially – keeping us open to all, and fiercely independent.',
+            'Unlike many others, the Guardian has no shareholders and no billionaire owner. Just the determination and passion to deliver high-impact global reporting, always free from commercial or political influence. Reporting like this is vital for democracy, for fairness and to demand better from the powerful.',
+            'And we provide all this for free, for everyone to read. We do this because we believe in information equality. Greater numbers of people can keep track of the global events shaping our world, understand their impact on people and communities, and become inspired to take meaningful action. Millions can benefit from open access to quality, truthful news, regardless of their ability to pay for it.',
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        highlightedText:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+    variants: {
+        paragraphs: [
+            '… as you’re joining us today from %%COUNTRY_NAME%%, we have a small favour to ask. Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s fearless journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million supporters, from 180 countries, now power us financially – keeping us open to all, and fiercely independent.',
+            'Unlike many others, the Guardian has no shareholders and no billionaire owner. Just the determination and passion to deliver high-impact global reporting, always free from commercial or political influence. Reporting like this is vital for democracy, for fairness and to demand better from the powerful.',
+            'And we provide all this for free, for everyone to read. We do this because we believe in information equality. Greater numbers of people can keep track of the global events shaping our world, understand their impact on people and communities, and become inspired to take meaningful action. Millions can benefit from open access to quality, truthful news, regardless of their ability to pay for it.',
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        highlightedText:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.',
+    },
+};
+
+export const US_COPY: Copy = {
+    control: {
+        paragraphs: [
+            '… congratulations on being one of our top readers globally. Did you know you’ve read %%ARTICLE_COUNT%% articles in the last year? Thank you for choosing the Guardian on so many occasions.',
+            'Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s fearless journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million supporters, from 180 countries, now power us financially – keeping us open to all, and fiercely independent.',
+            'Unlike many others, the Guardian has no shareholders and no billionaire owner. Just the determination and passion to deliver high-impact global reporting, always free from commercial or political influence. Reporting like this is vital for democracy, for fairness and to demand better from the powerful.',
+            'And we provide all this for free, for everyone to read. We do this because we believe in information equality. Greater numbers of people can keep track of the global events shaping our world, understand their impact on people and communities, and become inspired to take meaningful action. Millions can benefit from open access to quality, truthful news, regardless of their ability to pay for it.',
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        highlightedText:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.',
+    },
+    variants: {
+        paragraphs: [
+            '… we have a small favour to ask. Since we started publishing 200 years ago, tens of millions have placed their trust in the Guardian’s fearless journalism, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million supporters, from 180 countries, now power us financially – keeping us open to all, and fiercely independent.',
+            'Unlike many others, the Guardian has no shareholders and no billionaire owner. Just the determination and passion to deliver high-impact global reporting, always free from commercial or political influence. Reporting like this is vital for democracy, for fairness and to demand better from the powerful.',
+            'And we provide all this for free, for everyone to read. We do this because we believe in information equality. Greater numbers of people can keep track of the global events shaping our world, understand their impact on people and communities, and become inspired to take meaningful action. Millions can benefit from open access to quality, truthful news, regardless of their ability to pay for it.',
+            'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
+        ],
+        highlightedText:
+            'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.',
+    },
+};

--- a/packages/server/src/tests/epics/topReaderArticleCountBadge/index.ts
+++ b/packages/server/src/tests/epics/topReaderArticleCountBadge/index.ts
@@ -1,0 +1,12 @@
+import { buildTest } from './build';
+import { EU_ROW_COPY, UK_AUS_COPY, US_COPY } from './copy';
+
+export const tests = [
+    buildTest({ suffix: 'UK_AUS', locations: ['GBPCountries', 'AUDCountries'], copy: UK_AUS_COPY }),
+    buildTest({
+        suffix: 'EU_ROW',
+        locations: ['EURCountries', 'Canada', 'NZDCountries', 'International'],
+        copy: EU_ROW_COPY,
+    }),
+    buildTest({ suffix: 'US', locations: ['UnitedStates'], copy: US_COPY }),
+];

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -17,6 +17,14 @@ export const getDefaultModuleInfo = (name: string, path: string): ModuleInfo => 
 });
 
 export const epic: ModuleInfo = getDefaultModuleInfo('epic', 'epics/ContributionsEpic');
+export const epicTopReaderAcBadgeV1: ModuleInfo = getDefaultModuleInfo(
+    'epic',
+    'epics/ContributionsEpicTopReaderArticleCountBadgeV1',
+);
+export const epicTopReaderAcBadgeV2: ModuleInfo = getDefaultModuleInfo(
+    'epic',
+    'epics/ContributionsEpicTopReaderArticleCountBadgeV2',
+);
 
 export const liveblogEpic: ModuleInfo = getDefaultModuleInfo(
     'liveblog-epic',
@@ -67,6 +75,8 @@ export const header: ModuleInfo = getDefaultModuleInfo('header', 'header/Header'
 
 export const moduleInfos: ModuleInfo[] = [
     epic,
+    epicTopReaderAcBadgeV1,
+    epicTopReaderAcBadgeV2,
     liveblogEpic,
     contributionsBanner,
     contributionsBannerWithSignIn,


### PR DESCRIPTION
## What does this change?

Add the top reader article count badge test. Releasing this test is blocked until the single front door test has finished running. I've set `isOn` to `false` so that we can merge this ahead of time and then switch the tests on in a follow up PR.

[**Trello card**](https://trello.com/c/pNrmeCcR/119-test-top-reader-article-count-badge)

## Images

### UK + AUS

**Control**

![Screenshot 2022-03-17 at 15 31 09](https://user-images.githubusercontent.com/17720442/158837441-1a86f9e8-6de3-43f4-8fee-aadc195c1f13.png)

**V1_AC_LEAD**

![Screenshot 2022-03-17 at 15 32 43](https://user-images.githubusercontent.com/17720442/158837460-b1c76f9c-f6dd-4e14-8bb0-371d70445875.png)

**V2_CONGRATS_LEAD**

![Screenshot 2022-03-17 at 15 33 15](https://user-images.githubusercontent.com/17720442/158837461-e00fc917-697f-41c5-8295-d871cc91ddcf.png)

