### PR TITLE
Run banner page view targeting test

### DIFF
--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -7,10 +7,9 @@ const isNetworkFront = (targeting: BannerTargeting): boolean =>
 
 export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
     {
-        name: '2022-02-10_BannerTargeting_PageView',
+        name: '2022-03-18_BannerTargeting_PageView',
         // Exclude browsers that have not consented to article counting
-        // canInclude: (targeting: BannerTargeting) => targeting.articleCountToday !== undefined,
-        canInclude: () => false,
+        canInclude: (targeting: BannerTargeting) => targeting.articleCountToday !== undefined,
         variants: [
             {
                 name: 'control',


### PR DESCRIPTION
this was blocked by an issue with daily article count which has now been fixed by:
https://github.com/guardian/dotcom-rendering/pull/4312
https://github.com/guardian/frontend/pull/24784