### PR TITLE
Add server dev build command

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "build": "webpack --config webpack.prod.js",
+    "build-dev": "webpack --config webpack.dev.js",
     "prestart": "webpack --config webpack.dev.js",
     "start-watch": "webpack --config webpack.dev.js --watch",
     "start-server": "stage=DEV PORT=8082 nodemon dist/server.js",


### PR DESCRIPTION
## What does this change?

Just a tiny tweak to add a dev build command to the server `package.json`. It's quite useful for debugging in vscode to have a specific command to build the project to run before launching the debugger.
