### PR TITLE
Add browserId to banner targeting

### DIFF
--- a/packages/dotcom/package.json
+++ b/packages/dotcom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/support-dotcom-components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -16,6 +16,7 @@ export type BannerTargeting = {
     sectionId?: string;
     tagIds?: string[];
     contentType?: string;
+    browserId?: string; // Only present if the user has consented to browserId-based targeting
 };
 
 export type BannerPayload = {


### PR DESCRIPTION
We previously added [browserId for epic targeting](https://github.com/guardian/support-dotcom-components/blob/main/packages/shared/src/types/targeting/epic.ts#L29), for the single contributor propensity test.

We will soon be using propensity models for banner targeting, which means the client needs to send a browserId if the user has consented.

TODO - update DCR + frontend to send browserId