### PR TITLE
Revert "Header: do not render cta if not defined for mobile"

### DIFF
--- a/packages/modules/src/modules/header/Header.stories.tsx
+++ b/packages/modules/src/modules/header/Header.stories.tsx
@@ -61,13 +61,3 @@ export default {
 const Template: Story<HeaderProps> = (props: HeaderProps) => <Header {...props} />;
 
 export const DefaultHeader = Template.bind({});
-
-export const NoMobileCta = Template.bind({});
-NoMobileCta.args = {
-    ...DefaultHeader.args,
-    mobileContent: {
-        heading: '',
-        subheading: '',
-        primaryCta: undefined,
-    },
-};

--- a/packages/modules/src/modules/header/Header.tsx
+++ b/packages/modules/src/modules/header/Header.tsx
@@ -69,7 +69,7 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
 
             {primaryCta && (
                 <ThemeProvider theme={buttonReaderRevenueBrand}>
-                    <Hide below="tablet">
+                    <Hide below="mobileLandscape">
                         <LinkButton
                             priority="primary"
                             href={primaryCta.ctaUrl}
@@ -82,17 +82,15 @@ const Header: React.FC<HeaderRenderProps> = (props: HeaderRenderProps) => {
                         </LinkButton>
                     </Hide>
 
-                    {props.mobileContent?.primaryCta && (
-                        <Hide above="tablet">
-                            <LinkButton
-                                priority="primary"
-                                href={props.mobileContent.primaryCta.ctaUrl}
-                                css={linkStyles}
-                            >
-                                {props.mobileContent.primaryCta.ctaText}
-                            </LinkButton>
-                        </Hide>
-                    )}
+                    <Hide above="mobileLandscape">
+                        <LinkButton
+                            priority="primary"
+                            href={props.mobileContent?.primaryCta?.ctaUrl || primaryCta.ctaUrl}
+                            css={linkStyles}
+                        >
+                            {props.mobileContent?.primaryCta?.ctaText || primaryCta.ctaText}
+                        </LinkButton>
+                    </Hide>
                 </ThemeProvider>
             )}
 

--- a/packages/modules/src/modules/header/HeaderWrapper.tsx
+++ b/packages/modules/src/modules/header/HeaderWrapper.tsx
@@ -51,21 +51,20 @@ export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<Hea
             secondaryCta,
         };
 
-        const getMobileCta = (): HeaderEnrichedCta | null => {
-            if (mobileContent) {
-                // If mobileContent is defined but its primaryCta is not then we do not render a cta at all
-                return mobileContent.primaryCta ? buildEnrichedCta(mobileContent.primaryCta) : null;
-            }
-            return primaryCta;
-        };
+        const mobilePrimaryCta = mobileContent?.primaryCta
+            ? buildEnrichedCta(mobileContent.primaryCta)
+            : primaryCta;
 
-        const mobilePrimaryCta = getMobileCta();
+        const mobileSecondaryCta = mobileContent?.secondaryCta
+            ? buildEnrichedCta(mobileContent.secondaryCta)
+            : secondaryCta;
 
         const renderedMobileContent = mobileContent
             ? ({
                   heading: mobileContent.heading,
                   subheading: mobileContent.subheading,
                   primaryCta: mobilePrimaryCta,
+                  secondaryCta: mobileSecondaryCta,
               } as HeaderRenderedContent)
             : undefined;
 


### PR DESCRIPTION
Reverts guardian/support-dotcom-components#642
This is removing the cta on mobile when we do want it
Needs a closer look