### PR TITLE
Remove variant2 from banner deploy test

### DIFF
--- a/packages/server/src/tests/banners/bannerTargetingTests.test.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.test.ts
@@ -29,31 +29,4 @@ describe('Banner pageview targeting test', () => {
         });
         expect(canShow).toBe(true);
     });
-
-    it('variant 2 returns false if AC = 1 and contentType = article', () => {
-        const canShow = test.variants[2].canShow({
-            ...targeting,
-            articleCountToday: 1,
-            contentType: 'Article',
-        });
-        expect(canShow).toBe(false);
-    });
-
-    it('variant 2 returns true if AC = 1 and contentType = Network Front', () => {
-        const canShow = test.variants[2].canShow({
-            ...targeting,
-            articleCountToday: 1,
-            contentType: 'Network Front',
-        });
-        expect(canShow).toBe(true);
-    });
-
-    it('variant 2 returns true if AC = 2 and contentType = Article', () => {
-        const canShow = test.variants[2].canShow({
-            ...targeting,
-            articleCountToday: 2,
-            contentType: 'Article',
-        });
-        expect(canShow).toBe(true);
-    });
 });

--- a/packages/server/src/tests/banners/bannerTargetingTests.ts
+++ b/packages/server/src/tests/banners/bannerTargetingTests.ts
@@ -1,10 +1,6 @@
 import { TargetingTest } from '../../lib/targetingTesting';
 import { BannerTargeting } from '@sdc/shared/types';
 
-const isNetworkFront = (targeting: BannerTargeting): boolean =>
-    // https://github.com/guardian/frontend/blob/5b970cd7308175cfc1bcae2d4fb8c06ee13c5fa0/common/app/model/DotcomContentType.scala#L33
-    targeting.contentType?.toLowerCase() === 'network front';
-
 export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
     {
         name: '2022-03-18_BannerTargeting_PageView',
@@ -20,14 +16,6 @@ export const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
                 name: 'variant1',
                 // show on/after 1st article view of the day
                 canShow: (targeting: BannerTargeting) => (targeting.articleCountToday || 0) >= 1,
-            },
-            {
-                name: 'variant2',
-                // show after 1st article view of the day
-                canShow: (targeting: BannerTargeting): boolean => {
-                    const count = targeting.articleCountToday || 0;
-                    return count >= 2 || (count >= 1 && isNetworkFront(targeting));
-                },
             },
         ],
     },


### PR DESCRIPTION
variant1 is doing very well, but variant2 is doing poorly and losing money.
This PR removes variant2, so we can focus on gathering data for control vs variant1