### PR TITLE
Add image field to epic model

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -46,7 +46,7 @@ WithBackgroundImage.args = {
     variant: {
         ...props.variant,
         image: {
-            url:
+            mainUrl:
                 'https://images.unsplash.com/photo-1494256997604-768d1f608cac?ixlib=rb-1.2.1&auto=format&fit=crop&w=1701&q=80',
             altText: 'An image of a cat',
         },

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -47,7 +47,7 @@ WithBackgroundImage.args = {
         ...props.variant,
         image: {
             mainUrl:
-                'https://images.unsplash.com/photo-1494256997604-768d1f608cac?ixlib=rb-1.2.1&auto=format&fit=crop&w=1701&q=80',
+                'https://media.guim.co.uk/a2d31356be7dad09518b09aa5f39a4c7994e08c1/0_511_4262_2539/1000.jpg',
             altText: 'An image of a cat',
         },
     },

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -45,8 +45,11 @@ export const WithBackgroundImage = Template.bind({});
 WithBackgroundImage.args = {
     variant: {
         ...props.variant,
-        backgroundImageUrl:
-            'https://images.unsplash.com/photo-1494256997604-768d1f608cac?ixlib=rb-1.2.1&auto=format&fit=crop&w=1701&q=80',
+        image: {
+            url:
+                'https://images.unsplash.com/photo-1494256997604-768d1f608cac?ixlib=rb-1.2.1&auto=format&fit=crop&w=1701&q=80',
+            altText: 'An image of a cat',
+        },
     },
 };
 

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -380,7 +380,7 @@ export const getEpic = (
 
             {image && (
                 <div css={imageWrapperStyles}>
-                    <img src={image.url} css={imageStyles} alt={image.altText} />
+                    <img src={image.mainUrl} css={imageStyles} alt={image.altText} />
                 </div>
             )}
 

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -292,7 +292,7 @@ export const getEpic = (
     const fetchEmailDefined = defineFetchEmail(email, fetchEmail);
 
     const {
-        backgroundImageUrl,
+        image,
         showReminderFields,
         tickerSettings,
         showChoiceCards,
@@ -378,13 +378,9 @@ export const getEpic = (
                 />
             )}
 
-            {backgroundImageUrl && (
+            {image && (
                 <div css={imageWrapperStyles}>
-                    <img
-                        src={backgroundImageUrl}
-                        css={imageStyles}
-                        alt="Guardian contributions message"
-                    />
+                    <img src={image.url} css={imageStyles} alt={image.altText} />
                 </div>
             )}
 

--- a/packages/server/src/factories/variant.ts
+++ b/packages/server/src/factories/variant.ts
@@ -13,7 +13,7 @@ export default Factory.define<EpicVariant>(() => ({
     highlightedText:
         'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 - and it only takes a minute. Thank you.',
     image: {
-        url:
+        mainUrl:
             'https://images.unsplash.com/photo-1494256997604-768d1f608cac?ixlib=rb-1.2.1&auto=format&fit=crop&w=1701&q=80',
         altText: 'An image of a cat',
     },

--- a/packages/server/src/factories/variant.ts
+++ b/packages/server/src/factories/variant.ts
@@ -12,8 +12,11 @@ export default Factory.define<EpicVariant>(() => ({
     ],
     highlightedText:
         'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 - and it only takes a minute. Thank you.',
-    backgroundImageUrl:
-        'https://images.unsplash.com/photo-1494256997604-768d1f608cac?ixlib=rb-1.2.1&auto=format&fit=crop&w=1701&q=80',
+    image: {
+        url:
+            'https://images.unsplash.com/photo-1494256997604-768d1f608cac?ixlib=rb-1.2.1&auto=format&fit=crop&w=1701&q=80',
+        altText: 'An image of a cat',
+    },
     cta: {
         text: 'Contribute to The Guardian!',
         baseUrl: 'https://support.theguardian.com/support',

--- a/packages/server/src/factories/variant.ts
+++ b/packages/server/src/factories/variant.ts
@@ -14,7 +14,7 @@ export default Factory.define<EpicVariant>(() => ({
         'Support The Guardian from as little as %%CURRENCY_SYMBOL%%1 - and it only takes a minute. Thank you.',
     image: {
         mainUrl:
-            'https://images.unsplash.com/photo-1494256997604-768d1f608cac?ixlib=rb-1.2.1&auto=format&fit=crop&w=1701&q=80',
+            'https://media.guim.co.uk/a2d31356be7dad09518b09aa5f39a4c7994e08c1/0_511_4262_2539/1000.jpg',
         altText: 'An image of a cat',
     },
     cta: {

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -8,7 +8,7 @@ import {
     Variant,
 } from './shared';
 import { EpicTargeting } from '../targeting';
-import { Cta, SecondaryCta, TickerSettings } from '../props';
+import { Cta, Image, SecondaryCta, TickerSettings } from '../props';
 
 export type EpicType = 'ARTICLE' | 'LIVEBLOG';
 
@@ -31,7 +31,7 @@ export interface EpicVariant extends Variant {
     cta?: Cta;
     secondaryCta?: SecondaryCta;
     footer?: string;
-    backgroundImageUrl?: string;
+    image?: Image;
     showReminderFields?: ReminderFields;
     modulePathBuilder?: (version?: string) => string;
     separateArticleCount?: SeparateArticleCount;

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
     ctaSchema,
+    imageSchema,
     secondaryCtaSchema,
     Stage,
     tickerSettingsSchema,
@@ -63,7 +64,7 @@ const variantSchema = z.object({
     cta: ctaSchema.optional(),
     secondaryCta: secondaryCtaSchema.optional(),
     footer: z.string().optional(),
-    backgroundImageUrl: z.string().optional(),
+    image: imageSchema.optional(),
     showReminderFields: reminderFieldsSchema.optional(),
     separateArticleCount: separateArticleCountSchema.optional(),
     maxViews: maxViewsSchema.optional(),

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -132,11 +132,11 @@ export const trackingSchema = z.object({
 });
 
 export interface Image {
-    url: string;
+    mainUrl: string;
     altText: string;
 }
 
 export const imageSchema = z.object({
-    url: z.string(),
+    mainUrl: z.string(),
     altText: z.string(),
 });

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -130,3 +130,13 @@ export const trackingSchema = z.object({
     referrerUrl: z.string(),
     clientName: z.string(),
 });
+
+export interface Image {
+    url: string;
+    altText: string;
+}
+
+export const imageSchema = z.object({
+    url: z.string(),
+    altText: z.string(),
+});


### PR DESCRIPTION
The existing `backgroundImageUrl` field hasn't been used for a long time. The name is a bit misleading because it appears at the top.

This PR proposes replacing it with an `image` field - we leave it to the component to decide how/where an image should be rendered.
And it defines an `Image` type which requires an alt-text (credit to @KaliedaRik for pointing out that this is missing).
The `Image` type can be reused elsewhere (e.g. for the upcoming author profile test in the epic, or in the banner)

TODO - add the new field to the epic tool

<img width="639" alt="Screen Shot 2022-03-25 at 11 22 36" src="https://user-images.githubusercontent.com/1513454/160112078-841210c4-21f7-4674-b0d2-56a391329768.png">
