### PR TITLE
hardcoded banner tests switch

### DIFF
--- a/packages/server/src/channelSwitches.ts
+++ b/packages/server/src/channelSwitches.ts
@@ -8,6 +8,7 @@ interface ChannelSwitches {
     enableHeaders: boolean;
     enableSuperMode: boolean;
     enableHardcodedEpicTests: boolean;
+    enableHardcodedBannerTests: boolean;
 }
 
 const getSwitches = (): Promise<ChannelSwitches> =>

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -250,7 +250,7 @@ export const buildBannerData = async (
     params: Params,
     req: express.Request,
 ): Promise<BannerDataResponse> => {
-    const { enableBanners } = await cachedChannelSwitches();
+    const { enableBanners, enableHardcodedBannerTests } = await cachedChannelSwitches();
     if (!enableBanners) {
         return {};
     }
@@ -262,6 +262,7 @@ export const buildBannerData = async (
         baseUrl(req),
         getCachedTests,
         bannerDeployCaches,
+        enableHardcodedBannerTests,
         params.force,
     );
 

--- a/packages/server/src/tests/banners/ChannelBannerTests.ts
+++ b/packages/server/src/tests/banners/ChannelBannerTests.ts
@@ -80,6 +80,7 @@ const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTes
                         return {
                             name: testParams.name,
                             bannerChannel,
+                            isHardcoded: false,
                             userCohort: testParams.userCohort,
                             locations: testParams.locations,
                             canRun: (): boolean => testParams.isOn,

--- a/packages/server/src/tests/banners/DefaultContributionsBannerTest.ts
+++ b/packages/server/src/tests/banners/DefaultContributionsBannerTest.ts
@@ -5,6 +5,7 @@ import { DefaultBannerContent } from './DefaultContributionsBannerContent';
 export const DefaultContributionsBanner: BannerTest = {
     name: 'DefaultContributionsBanner',
     bannerChannel: 'contributions',
+    isHardcoded: false,
     userCohort: 'AllNonSupporters',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canRun: (_targeting: BannerTargeting, _pageTracking: PageTracking) => true,

--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -29,6 +29,8 @@ describe('selectBannerTest', () => {
     const firstDate = 'Mon Jun 06 2020 19:20:10 GMT+0100';
     const secondDate = 'Mon Jul 06 2020 19:20:10 GMT+0100';
 
+    const enableHardcodedBannerTests = true;
+
     describe('Contributions banner rules', () => {
         const now = new Date('2020-03-31T12:30:00');
 
@@ -56,6 +58,7 @@ describe('selectBannerTest', () => {
         const test: BannerTest = {
             name: 'test',
             bannerChannel: 'contributions',
+            isHardcoded: false,
             userCohort: 'Everyone',
             canRun: () => true,
             minPageViews: 2,
@@ -91,10 +94,29 @@ describe('selectBannerTest', () => {
                 '',
                 () => Promise.resolve([test]),
                 cache,
+                enableHardcodedBannerTests,
                 undefined,
                 now,
             ).then(result => {
                 expect(result && result.test.name).toBe('test');
+            });
+        });
+
+        it('returns null if hardcoded tests disabled', () => {
+            return selectBannerTest(
+                Object.assign(targeting, {
+                    weeklyArticleHistory: [{ week: 18330, count: 6 }],
+                }),
+                tracking,
+                isMobile,
+                '',
+                () => Promise.resolve([{ ...test, isHardcoded: true }]),
+                cache,
+                false,
+                undefined,
+                now,
+            ).then(result => {
+                expect(result && result.test.name).toBe(null);
             });
         });
 
@@ -108,6 +130,7 @@ describe('selectBannerTest', () => {
                 '',
                 () => Promise.resolve([test]),
                 cache,
+                enableHardcodedBannerTests,
                 undefined,
                 now,
             ).then(result => {
@@ -131,6 +154,7 @@ describe('selectBannerTest', () => {
                         },
                     ]),
                 cache,
+                enableHardcodedBannerTests,
                 undefined,
                 now,
             ).then(result => {
@@ -148,6 +172,7 @@ describe('selectBannerTest', () => {
                 '',
                 () => Promise.resolve([test]),
                 cache,
+                enableHardcodedBannerTests,
                 undefined,
                 now,
             ).then(result => {
@@ -183,6 +208,7 @@ describe('selectBannerTest', () => {
         const test: BannerTest = {
             name: 'test',
             bannerChannel: 'subscriptions',
+            isHardcoded: false,
             userCohort: 'Everyone',
             canRun: (): boolean => true,
             minPageViews: 2,
@@ -217,6 +243,7 @@ describe('selectBannerTest', () => {
                 '',
                 () => Promise.resolve([test]),
                 cache,
+                enableHardcodedBannerTests,
                 undefined,
                 now,
             ).then(result => {
@@ -234,6 +261,7 @@ describe('selectBannerTest', () => {
                 '',
                 () => Promise.resolve([test]),
                 cache,
+                enableHardcodedBannerTests,
                 undefined,
                 now,
             ).then(result => {
@@ -257,6 +285,7 @@ describe('selectBannerTest', () => {
                         },
                     ]),
                 cache,
+                enableHardcodedBannerTests,
                 undefined,
                 now,
             ).then(result => {

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -103,6 +103,7 @@ export const selectBannerTest = async (
     baseUrl: string,
     getTests: () => Promise<BannerTest[]>,
     bannerDeployCaches: BannerDeployCaches,
+    enableHardcodedBannerTests: boolean,
     forcedTestVariant?: TestVariant,
     now: Date = new Date(),
 ): Promise<BannerTestSelection | null> => {
@@ -121,6 +122,7 @@ export const selectBannerTest = async (
         const deploySchedule = targetingTest?.deploySchedule ?? defaultDeploySchedule;
 
         if (
+            (enableHardcodedBannerTests || !test.isHardcoded) &&
             !targeting.shouldHideReaderRevenue &&
             !targeting.isPaidContent &&
             audienceMatches(targeting.showSupportMessaging, test.userCohort) &&

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -41,6 +41,7 @@ export type BannerTestGenerator = () => Promise<BannerTest[]>;
 export interface BannerTest extends Test<BannerVariant> {
     name: string;
     bannerChannel: BannerChannel;
+    isHardcoded: boolean;
     userCohort: UserCohort;
     canRun: CanRun;
     minPageViews: number;


### PR DESCRIPTION
this is to enable us to quickly disable hardcoded tests from the RRCP, in an emergency. We already have this for epics.

I initially tried to do the filtering in [bannerTests.ts](https://github.com/guardian/support-dotcom-components/blob/main/packages/server/src/tests/banners/bannerTests.ts#L14), but it's messy because different hardcoded tests may need different positions in the array. So I've just added an `isHardcoded` field to the `BannerTest` model


admin-console PR: https://github.com/guardian/support-admin-console/pull/302/files