### PR TITLE
Add a profile picture to the Epic

### DIFF
--- a/packages/modules/src/modules/epics/BylineWithHeadshot.tsx
+++ b/packages/modules/src/modules/epics/BylineWithHeadshot.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { body } from '@guardian/src-foundations/typography';
+import { BylineWithImage } from '@sdc/shared/types';
+
+interface BylineWithHeadshotProps {
+    bylineWithImage: BylineWithImage;
+}
+
+const bylineWithImageContainer = css`
+    margin: 0;
+    padding: 0;
+    position: relative;
+    width: 100%;
+    height: 130px;
+`;
+
+const bylineCopyContainer = css`
+    width: 70%;
+    position: absolute;
+    bottom: 20px;
+    left: 0;
+`;
+
+const bylineImageContainer = css`
+    width: 30%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    right: 0;
+`;
+
+const bylineName = css`
+    ${body.medium({ fontWeight: 'bold' })};
+    margin: 0;
+`;
+
+const bylineDescription = css`
+    ${body.medium({ fontStyle: 'italic' })};
+    margin: 0;
+`;
+
+const bylineHeadshotImage = css`
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+`;
+
+const bylineBottomDecoration = css`
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-repeat: repeat-x;
+    background-position: top;
+    background-size: 1px calc(0.25rem * 4 + 1px);
+    height: calc(0.25rem * 4 + 1px);
+    background-image: repeating-linear-gradient(
+        to bottom,
+        #dcdcdc,
+        #dcdcdc 1px,
+        transparent 1px,
+        transparent 0.25rem
+    );
+`;
+
+export const BylineWithHeadshot: React.FC<BylineWithHeadshotProps> = ({
+    bylineWithImage,
+}: BylineWithHeadshotProps) => {
+    const { name, description, headshot } = bylineWithImage;
+    const { mainUrl, altText } = headshot;
+    return (
+        <div css={bylineWithImageContainer}>
+            <div css={bylineCopyContainer}>
+                <p css={bylineName}>{name}</p>
+                <p css={bylineDescription}>{description}</p>
+            </div>
+            <div css={bylineBottomDecoration}></div>
+            <div css={bylineImageContainer}>
+                <img src={mainUrl} alt={altText} css={bylineHeadshotImage} />
+            </div>
+        </div>
+    );
+};

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -58,11 +58,12 @@ WithBylineAndHeadshot.args = {
     variant: {
         ...props.variant,
         bylineWithImage: {
-            author: 'Polly Toynbee',
+            name: 'Zoe Williams',
+            description: 'Guardian columnist',
             headshot: {
                 mainUrl:
-                    'https://media.guim.co.uk/a2d31356be7dad09518b09aa5f39a4c7994e08c1/0_511_4262_2539/1000.jpg',
-                altText: 'An image of a cat',
+                    'https://uploads.guim.co.uk/2017/10/09/Zoe-Williams,-L.png',
+                altText: 'Zoe Williams headshot',
             },
         },
     },

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -61,8 +61,7 @@ WithBylineAndHeadshot.args = {
             name: 'Zoe Williams',
             description: 'Guardian columnist',
             headshot: {
-                mainUrl:
-                    'https://uploads.guim.co.uk/2017/10/09/Zoe-Williams,-L.png',
+                mainUrl: 'https://uploads.guim.co.uk/2017/10/09/Zoe-Williams,-L.png',
                 altText: 'Zoe Williams headshot',
             },
         },

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -53,6 +53,21 @@ WithBackgroundImage.args = {
     },
 };
 
+export const WithBylineAndHeadshot = Template.bind({});
+WithBylineAndHeadshot.args = {
+    variant: {
+        ...props.variant,
+        bylineWithImage: {
+            author: 'Polly Toynbee',
+            headshot: {
+                mainUrl:
+                    'https://media.guim.co.uk/a2d31356be7dad09518b09aa5f39a4c7994e08c1/0_511_4262_2539/1000.jpg',
+                altText: 'An image of a cat',
+            },
+        },
+    },
+};
+
 export const WithReminder = Template.bind({});
 WithReminder.args = {
     variant: {

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -311,7 +311,13 @@ const bylineBottomDecoration = css`
     background-position: top;
     background-size: 1px calc(0.25rem * 4 + 1px);
     height: calc(0.25rem * 4 + 1px);
-    background-image: repeating-linear-gradient(to bottom, #DCDCDC, #DCDCDC 1px, transparent 1px, transparent 0.25rem);
+    background-image: repeating-linear-gradient(
+        to bottom,
+        #dcdcdc,
+        #dcdcdc 1px,
+        transparent 1px,
+        transparent 0.25rem
+    );
 `;
 
 const BylineWithHeadshot: React.FC<BylineWithImageProps> = ({

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -124,22 +124,6 @@ const articleCountAboveContainerStyles = css`
     margin-bottom: ${space[4]}px;
 `;
 
-const bylineWithImageContainer = css`
-    border: 1px solid orange;
-`;
-
-const bylineWithImageAuthor = css`
-    border: 1px solid red;
-`;
-
-const bylineWithImageHeadshot = css`
-    border: 1px solid blue;
-`;
-
-const bylineWithImageDecoration = css`
-    border: 1px solid green;
-`;
-
 type HighlightedProps = {
     highlightedText: string;
     countryCode?: string;
@@ -274,37 +258,77 @@ const EpicBody: React.FC<BodyProps> = ({
     );
 };
 
-/*
-const bylineWithImageContainer = css`
-    border: 1px solid orange;
-`;
-
-const bylineWithImageAuthor = css`
-    border: 1px solid red;
-`;
-
-const bylineWithImageHeadshot = css`
-    border: 1px solid blue;
-`;
-
-const bylineWithImageDecoration = css`
-    border: 1px solid green;
-`;
-*/
+// TODO: recode to make this sub-component's image more responsive
 interface BylineWithImageProps {
     bylineWithImage: BylineWithImage;
 }
 
+const bylineWithImageContainer = css`
+    margin: 0;
+    padding: 0;
+    position: relative;
+    width: 100%;
+    height: 130px;
+`;
+
+const bylineCopyContainer = css`
+    width: 70%;
+    position: absolute;
+    bottom: 20px;
+    left: 0;
+`;
+
+const bylineImageContainer = css`
+    width: 30%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    right: 0;
+`;
+
+const bylineName = css`
+    ${body.medium({ fontWeight: 'bold' })};
+    margin: 0;
+`;
+
+const bylineDescription = css`
+    ${body.medium({ fontStyle: 'italic' })};
+    margin: 0;
+`;
+
+const bylineHeadshotImage = css`
+    height: 100%;
+    width: 100%;
+    object-fit: contain;
+`;
+
+const bylineBottomDecoration = css`
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-repeat: repeat-x;
+    background-position: top;
+    background-size: 1px calc(0.25rem * 4 + 1px);
+    height: calc(0.25rem * 4 + 1px);
+    background-image: repeating-linear-gradient(to bottom, #DCDCDC, #DCDCDC 1px, transparent 1px, transparent 0.25rem);
+`;
+
 const BylineWithHeadshot: React.FC<BylineWithImageProps> = ({
     bylineWithImage,
 }: BylineWithImageProps) => {
-    const { author, headshot } = bylineWithImage;
+    const { name, description, headshot } = bylineWithImage;
     const { mainUrl, altText } = headshot;
     return (
         <div css={bylineWithImageContainer}>
-            <p css={bylineWithImageAuthor}>{author}</p>
-            <p css={bylineWithImageHeadshot}>{mainUrl}</p>
-            <p css={bylineWithImageDecoration}>{altText}</p>
+            <div css={bylineCopyContainer}>
+                <p css={bylineName}>{name}</p>
+                <p css={bylineDescription}>{description}</p>
+            </div>
+            <div css={bylineBottomDecoration}></div>
+            <div css={bylineImageContainer}>
+                <img src={mainUrl} alt={altText} css={bylineHeadshotImage} />
+            </div>
         </div>
     );
 };

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -299,7 +299,7 @@ const bylineDescription = css`
 const bylineHeadshotImage = css`
     height: 100%;
     width: 100%;
-    object-fit: contain;
+    object-fit: cover;
 `;
 
 const bylineBottomDecoration = css`

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -9,13 +9,8 @@ import {
     createViewEventFromTracking,
     replaceNonArticleCountPlaceholders,
 } from '@sdc/shared/lib';
-import {
-    BylineWithImage,
-    ContributionFrequency,
-    EpicProps,
-    epicPropsSchema,
-    Stage,
-} from '@sdc/shared/types';
+import { ContributionFrequency, EpicProps, epicPropsSchema, Stage } from '@sdc/shared/types';
+import { BylineWithHeadshot } from './BylineWithHeadshot';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { ContributionsEpicTicker } from './ContributionsEpicTicker';
@@ -255,87 +250,6 @@ const EpicBody: React.FC<BodyProps> = ({
                 return paragraphElement;
             })}
         </>
-    );
-};
-
-// TODO: recode to make this sub-component's image more responsive
-interface BylineWithImageProps {
-    bylineWithImage: BylineWithImage;
-}
-
-const bylineWithImageContainer = css`
-    margin: 0;
-    padding: 0;
-    position: relative;
-    width: 100%;
-    height: 130px;
-`;
-
-const bylineCopyContainer = css`
-    width: 70%;
-    position: absolute;
-    bottom: 20px;
-    left: 0;
-`;
-
-const bylineImageContainer = css`
-    width: 30%;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    right: 0;
-`;
-
-const bylineName = css`
-    ${body.medium({ fontWeight: 'bold' })};
-    margin: 0;
-`;
-
-const bylineDescription = css`
-    ${body.medium({ fontStyle: 'italic' })};
-    margin: 0;
-`;
-
-const bylineHeadshotImage = css`
-    height: 100%;
-    width: 100%;
-    object-fit: cover;
-`;
-
-const bylineBottomDecoration = css`
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    background-repeat: repeat-x;
-    background-position: top;
-    background-size: 1px calc(0.25rem * 4 + 1px);
-    height: calc(0.25rem * 4 + 1px);
-    background-image: repeating-linear-gradient(
-        to bottom,
-        #dcdcdc,
-        #dcdcdc 1px,
-        transparent 1px,
-        transparent 0.25rem
-    );
-`;
-
-const BylineWithHeadshot: React.FC<BylineWithImageProps> = ({
-    bylineWithImage,
-}: BylineWithImageProps) => {
-    const { name, description, headshot } = bylineWithImage;
-    const { mainUrl, altText } = headshot;
-    return (
-        <div css={bylineWithImageContainer}>
-            <div css={bylineCopyContainer}>
-                <p css={bylineName}>{name}</p>
-                <p css={bylineDescription}>{description}</p>
-            </div>
-            <div css={bylineBottomDecoration}></div>
-            <div css={bylineImageContainer}>
-                <img src={mainUrl} alt={altText} css={bylineHeadshotImage} />
-            </div>
-        </div>
     );
 };
 

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -9,7 +9,13 @@ import {
     createViewEventFromTracking,
     replaceNonArticleCountPlaceholders,
 } from '@sdc/shared/lib';
-import { ContributionFrequency, EpicProps, epicPropsSchema, Stage } from '@sdc/shared/types';
+import {
+    BylineWithImage,
+    ContributionFrequency,
+    EpicProps,
+    epicPropsSchema,
+    Stage,
+} from '@sdc/shared/types';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { ContributionsEpicTicker } from './ContributionsEpicTicker';
@@ -116,6 +122,22 @@ const imageStyles = css`
 
 const articleCountAboveContainerStyles = css`
     margin-bottom: ${space[4]}px;
+`;
+
+const bylineWithImageContainer = css`
+    border: 1px solid orange;
+`;
+
+const bylineWithImageAuthor = css`
+    border: 1px solid red;
+`;
+
+const bylineWithImageHeadshot = css`
+    border: 1px solid blue;
+`;
+
+const bylineWithImageDecoration = css`
+    border: 1px solid green;
 `;
 
 type HighlightedProps = {
@@ -249,6 +271,41 @@ const EpicBody: React.FC<BodyProps> = ({
                 return paragraphElement;
             })}
         </>
+    );
+};
+
+/*
+const bylineWithImageContainer = css`
+    border: 1px solid orange;
+`;
+
+const bylineWithImageAuthor = css`
+    border: 1px solid red;
+`;
+
+const bylineWithImageHeadshot = css`
+    border: 1px solid blue;
+`;
+
+const bylineWithImageDecoration = css`
+    border: 1px solid green;
+`;
+*/
+interface BylineWithImageProps {
+    bylineWithImage: BylineWithImage;
+}
+
+const BylineWithHeadshot: React.FC<BylineWithImageProps> = ({
+    bylineWithImage,
+}: BylineWithImageProps) => {
+    const { author, headshot } = bylineWithImage;
+    const { mainUrl, altText } = headshot;
+    return (
+        <div css={bylineWithImageContainer}>
+            <p css={bylineWithImageAuthor}>{author}</p>
+            <p css={bylineWithImageHeadshot}>{mainUrl}</p>
+            <p css={bylineWithImageDecoration}>{altText}</p>
+        </div>
     );
 };
 
@@ -401,6 +458,11 @@ export const getEpic = (
                 tracking={ophanTracking}
                 showAboveArticleCount={showAboveArticleCount}
             />
+
+            {variant.bylineWithImage && (
+                <BylineWithHeadshot bylineWithImage={variant.bylineWithImage} />
+            )}
+
             {variant.showSignInLink && <ContributionsEpicSignInCta />}
 
             {showChoiceCards && choiceCardSelection && choiceCardAmounts && (

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -8,7 +8,7 @@ import {
     Variant,
 } from './shared';
 import { EpicTargeting } from '../targeting';
-import { Cta, Image, SecondaryCta, TickerSettings } from '../props';
+import { BylineWithImage, Cta, Image, SecondaryCta, TickerSettings } from '../props';
 
 export type EpicType = 'ARTICLE' | 'LIVEBLOG';
 
@@ -38,6 +38,7 @@ export interface EpicVariant extends Variant {
     showChoiceCards?: boolean;
     choiceCardAmounts?: ChoiceCardAmounts;
     defaultChoiceCardFrequency?: ContributionFrequency;
+    bylineWithImage?: BylineWithImage;
 
     // Variant level maxViews are for special targeting tests. These
     // are handled differently to our usual copy/design tests. To

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import {
+    bylineWithImageSchema,
     ctaSchema,
     imageSchema,
     secondaryCtaSchema,
@@ -69,6 +70,7 @@ const variantSchema = z.object({
     separateArticleCount: separateArticleCountSchema.optional(),
     maxViews: maxViewsSchema.optional(),
     showSignInLink: z.boolean().optional(),
+    bylineWithImage: bylineWithImageSchema.optional(),
 });
 
 export const epicPropsSchema = z.object({

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -142,11 +142,13 @@ export const imageSchema = z.object({
 });
 
 export interface BylineWithImage {
-    author: string;
+    name: string;
+    description?: string;
     headshot: Image;
 }
 
 export const bylineWithImageSchema = z.object({
-    author: z.string(),
+    name: z.string(),
+    description: z.string().optional(),
     headshot: imageSchema,
 });

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -140,3 +140,13 @@ export const imageSchema = z.object({
     mainUrl: z.string(),
     altText: z.string(),
 });
+
+export interface BylineWithImage {
+    author: string;
+    headshot: Image;
+}
+
+export const bylineWithImageSchema = z.object({
+    author: z.string(),
+    headshot: imageSchema,
+});


### PR DESCRIPTION
## What does this change?
This PR adds the ability to include a message byline with a profile picture to the end of the Epic body copy. The design of the component is very similar to the bylines that get added at the top of main site opinion articles.

**Screenshots:**

Desktop
![Screenshot 2022-04-05 at 16 24 57](https://user-images.githubusercontent.com/5357530/162231417-9fdab2d3-2ed3-4d92-8d6b-9f3e44cf8ee4.png)

Tablet
![Screenshot 2022-04-05 at 16 25 11](https://user-images.githubusercontent.com/5357530/162231525-2fa2f1ec-5275-403a-9e52-5a8e103562a4.png)

Mobile:
![Screenshot 2022-04-05 at 16 24 40](https://user-images.githubusercontent.com/5357530/162231592-e231ce8f-739c-42ad-b848-2ef086ba1bd1.png)

