### PR TITLE
Log user-agent string.

### DIFF
--- a/packages/server/src/middleware/logging.ts
+++ b/packages/server/src/middleware/logging.ts
@@ -18,7 +18,10 @@ export const logging = (
             clientName: res.locals.clientName || 'unknown',
             bannerTargeting: res.locals.bannerTargeting,
             epicTargeting: res.locals.epicTargeting,
+            userAgent: isServerError(res.statusCode) ? req.headers['user-agent'] : undefined,
         }),
     );
     next();
 };
+
+const isServerError = (statusCode: number) => statusCode >= 500;


### PR DESCRIPTION
We've been investigating a spike in 500 responses from dotcom components. It's tricky to tell where these requests are coming from so we've decided to start logging the user agent string to see if that can provide any clarity. The step change in 5xxs and the regularity of them is leading us to think it might be coming from something internal.
