### PR TITLE
Restart first GW propensity test

### DIFF
--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
@@ -42,7 +42,7 @@ const buildTest = (
     digisubContent: BannerContent,
     gwContent: BannerContent,
 ): BannerTest => ({
-    name: `2022-03-28_BannerTargeting_GW_DS_Propensity__${name}`,
+    name: `2022-04-05_BannerTargeting_GW_DS_Propensity__${name}`,
     bannerChannel: 'subscriptions',
     isHardcoded: true,
     userCohort: 'AllNonSupporters',


### PR DESCRIPTION
This test briefly went live last month with a different set of browsers.
I'm changing the name before putting it live again, to avoid mixing results together.