### PR TITLE
Add temporary 'validation' to /header endpoint.

### DIFF
--- a/packages/server/src/middleware/bodyContainsAllFields.ts
+++ b/packages/server/src/middleware/bodyContainsAllFields.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+
+// This is a temporary 'validation' middleware to provide a minimal level of
+// validation to incoming post requests. This is in response to an ongoing alarm
+// we've been seeing related to invalid POST requests being send to the `/header`
+// endpoint. The proper solution is to use zod to do the validation. However, that
+// will require a bit of a refactor to avoid bundling zod into the dotcom package.
+//
+// TODO: Remove this middleware after adding proper validation.
+export const bodyContainsAllFields = (fields: string[]) => (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+): void => {
+    if (fields.every(f => f in req.body)) {
+        next();
+    } else {
+        res.sendStatus(400);
+    }
+};

--- a/packages/server/src/middleware/index.ts
+++ b/packages/server/src/middleware/index.ts
@@ -1,2 +1,3 @@
 export { errorHandling } from './errorHandling';
 export { logging } from './logging';
+export { bodyContainsAllFields } from './bodyContainsAllFields';

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -23,6 +23,7 @@ import { getQueryParams } from './lib/params';
 import {
     errorHandling as errorHandlingMiddleware,
     logging as loggingMiddleware,
+    bodyContainsAllFields,
 } from './middleware';
 import { buildBannerData, buildEpicData, buildHeaderData, buildPuzzlesData } from './payloads';
 import { ampEpic } from './tests/amp/ampEpic';
@@ -158,6 +159,7 @@ app.post(
 
 app.post(
     '/header',
+    bodyContainsAllFields(['tracking', 'targeting']),
     async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
             const { tracking, targeting } = req.body;


### PR DESCRIPTION
This change adds a `bodyContainsAllFields` middleware that we can use on the /header endpoint. This provides a minimal amount of validation that should be sufficient to address an on going alarm. This alarm has been caused by POST requests to /header without a valid request body. The proper solution is to add zod for validation but that will require a refactor to the packages to avoid the dotcom package pulling in zod as an unrequired dependency. This change is just temporary and can be removed after implementing proper valid.

I originally tried to just check that `req.body` was defined, but express will still provide us with an empty object when making a request without a body.