### PR TITLE
ML propensity model banner test v2

### DIFF
--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -19,6 +19,10 @@ import {
     ScheduledBannerDeploys,
     defaultDeploySchedule,
 } from './bannerDeploySchedule';
+import {
+    getPropensityModelTestVariantData,
+    PROPENSITY_MODEL_TEST_NAME,
+} from './propensityModelTest/propensityModelTest';
 
 export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
     switch (true) {
@@ -96,6 +100,17 @@ const getForcedVariant = (
     return null;
 };
 
+const getVariant = (test: BannerTest, targeting: BannerTargeting): BannerVariant => {
+    const variant: BannerVariant = selectVariant(test, targeting.mvtId);
+
+    // This test is unusual because we decide what to show *after* assigning the browser to a variant
+    if (test.name === PROPENSITY_MODEL_TEST_NAME) {
+        return getPropensityModelTestVariantData(variant.name, targeting);
+    } else {
+        return variant;
+    }
+};
+
 export const selectBannerTest = async (
     targeting: BannerTargeting,
     pageTracking: PageTracking,
@@ -145,7 +160,8 @@ export const selectBannerTest = async (
                 now,
             ))
         ) {
-            const variant: BannerVariant = selectVariant(test, targeting.mvtId);
+            const variant: BannerVariant = getVariant(test, targeting);
+
             const bannerTestSelection = {
                 test,
                 variant,

--- a/packages/server/src/tests/banners/bannerTests.ts
+++ b/packages/server/src/tests/banners/bannerTests.ts
@@ -5,6 +5,7 @@ import {
     channel2BannersAllTestsGenerator,
 } from './ChannelBannerTests';
 import { DefaultContributionsBanner } from './DefaultContributionsBannerTest';
+import { propensityModelBannerTest } from './propensityModelTest/propensityModelTest';
 
 const defaultBannerTestGenerator: BannerTestGenerator = () =>
     Promise.resolve([DefaultContributionsBanner]);
@@ -13,6 +14,7 @@ const flattenArray = <T>(array: T[][]): T[] => ([] as T[]).concat(...array);
 
 const testGenerators: BannerTestGenerator[] = [
     channel1BannersAllTestsGenerator,
+    propensityModelBannerTest,
     channel2BannersAllTestsGenerator,
     defaultBannerTestGenerator,
 ];

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
@@ -27,7 +27,7 @@ import { GW_CONTENT } from './propensityModelTestGWCopy';
 
 const channelName: OphanComponentType = 'ACQUISITIONS_SUBSCRIPTIONS_BANNER'; // aka channel 2
 
-export const PROPENSITY_MODEL_TEST_NAME = '2022-04-20_BannerTargeting_GW_DS_Propensity_v2';
+export const PROPENSITY_MODEL_TEST_NAME = '2022-05-13_BannerTargeting_GW_DS_Propensity_v2';
 const CONTROL_NAME = 'control';
 const VARIANT_NAME = 'variant';
 

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
@@ -9,7 +9,7 @@ import {
 import { countryCodeToCountryGroupId, inCountryGroups } from '@sdc/shared/dist/lib';
 import { UK_DIGISUB_CONTENT, DIGISUB_CONTENT } from './propensityModelTestDigisubCopy';
 import { fetchHighPropensityIds, isInPropensityTest } from './propensityModelTestData';
-import { EU_GW_CONTENT, GW_CONTENT } from './propensityModelTestGWCopy';
+import { GW_CONTENT } from './propensityModelTestGWCopy';
 
 /**
  * This file defines a banner AB test based on ML propensity model data.
@@ -39,6 +39,8 @@ export const propensityModelBannerTest: BannerTestGenerator = () => {
         {
             name: PROPENSITY_MODEL_TEST_NAME,
             bannerChannel: 'subscriptions',
+            // Exclude AU/NZ, which has an offer
+            locations: ['GBPCountries', 'UnitedStates', 'EURCountries', 'International', 'Canada'],
             isHardcoded: true,
             userCohort: 'AllNonSupporters',
             canRun: () => true,
@@ -55,7 +57,7 @@ export const propensityModelBannerTest: BannerTestGenerator = () => {
                     name: VARIANT_NAME,
                     modulePathBuilder: guardianWeekly.endpointPathBuilder,
                     moduleName: BannerTemplate.GuardianWeeklyBanner,
-                    bannerContent: EU_GW_CONTENT,
+                    bannerContent: GW_CONTENT,
                     componentType: channelName,
                 },
             ],
@@ -63,11 +65,11 @@ export const propensityModelBannerTest: BannerTestGenerator = () => {
     ]);
 };
 
-const getGWBanner = (variantName: string, targeting: BannerTargeting): BannerVariant => ({
+const getGWBanner = (variantName: string): BannerVariant => ({
     name: variantName,
     modulePathBuilder: guardianWeekly.endpointPathBuilder,
     moduleName: BannerTemplate.GuardianWeeklyBanner,
-    bannerContent: GW_CONTENT[countryCodeToCountryGroupId(targeting.countryCode.toUpperCase())],
+    bannerContent: GW_CONTENT,
     componentType: channelName,
 });
 
@@ -83,13 +85,13 @@ const getDSBanner = (variantName: string, targeting: BannerTargeting): BannerVar
 const getControlBanner = (variantName: string, targeting: BannerTargeting): BannerVariant =>
     // are they in Europe?
     inCountryGroups(targeting.countryCode, ['EURCountries'])
-        ? getGWBanner(variantName, targeting)
+        ? getGWBanner(variantName)
         : getDSBanner(variantName, targeting);
 
 const getVariantBanner = (variantName: string, targeting: BannerTargeting): BannerVariant =>
     // are they high-propensity?
     targeting.browserId && isInPropensityTest(targeting.browserId)
-        ? getGWBanner(variantName, targeting)
+        ? getGWBanner(variantName)
         : getDSBanner(variantName, targeting);
 
 // This test is unusual because we decide what to show *after* assigning the browser to a variant

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
@@ -8,7 +8,7 @@ import {
 } from '@sdc/shared/dist/types';
 import { countryCodeToCountryGroupId, inCountryGroups } from '@sdc/shared/dist/lib';
 import { UK_DIGISUB_CONTENT, DIGISUB_CONTENT } from './propensityModelTestDigisubCopy';
-import { isInPropensityTest } from './propensityModelTestData';
+import { fetchHighPropensityIds, isInPropensityTest } from './propensityModelTestData';
 import { EU_GW_CONTENT, GW_CONTENT } from './propensityModelTestGWCopy';
 
 /**
@@ -31,8 +31,11 @@ export const PROPENSITY_MODEL_TEST_NAME = '2022-04-20_BannerTargeting_GW_DS_Prop
 const CONTROL_NAME = 'control';
 const VARIANT_NAME = 'variant';
 
-export const propensityModelBannerTest: BannerTestGenerator = () =>
-    Promise.resolve([
+export const propensityModelBannerTest: BannerTestGenerator = () => {
+    // Kick off streaming of browserIds into memory, but resolve immediately to avoid blocking other tests
+    fetchHighPropensityIds();
+
+    return Promise.resolve([
         {
             name: PROPENSITY_MODEL_TEST_NAME,
             bannerChannel: 'subscriptions',
@@ -58,6 +61,7 @@ export const propensityModelBannerTest: BannerTestGenerator = () =>
             ],
         },
     ]);
+};
 
 const getGWBanner = (variantName: string, targeting: BannerTargeting): BannerVariant => ({
     name: variantName,

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
@@ -1,0 +1,98 @@
+import { contributionsBanner, guardianWeekly } from '@sdc/shared/dist/config';
+import {
+    BannerTestGenerator,
+    BannerTargeting,
+    OphanComponentType,
+    BannerTemplate,
+    BannerVariant,
+} from '@sdc/shared/dist/types';
+import { countryCodeToCountryGroupId, inCountryGroups } from '@sdc/shared/dist/lib';
+import { UK_DIGISUB_CONTENT, DIGISUB_CONTENT } from './propensityModelTestDigisubCopy';
+import { isInPropensityTest } from './propensityModelTestData';
+import { EU_GW_CONTENT, GW_CONTENT } from './propensityModelTestGWCopy';
+
+/**
+ * This file defines a banner AB test based on ML propensity model data.
+ *
+ * All browsers are put into the test.
+ *
+ * In the control:
+ *  - all European browsers see GW
+ *  - all other browsers see DS
+ *
+ * In the variant:
+ *  - all high-GW/low-DS browsers see GW
+ *  - all other browsers see DS
+ */
+
+const channelName: OphanComponentType = 'ACQUISITIONS_SUBSCRIPTIONS_BANNER'; // aka channel 2
+
+export const PROPENSITY_MODEL_TEST_NAME = '2022-04-20_BannerTargeting_GW_DS_Propensity_v2';
+const CONTROL_NAME = 'control';
+const VARIANT_NAME = 'variant';
+
+export const propensityModelBannerTest: BannerTestGenerator = () =>
+    Promise.resolve([
+        {
+            name: PROPENSITY_MODEL_TEST_NAME,
+            bannerChannel: 'subscriptions',
+            isHardcoded: true,
+            userCohort: 'AllNonSupporters',
+            canRun: () => true,
+            minPageViews: 4,
+            variants: [
+                {
+                    name: CONTROL_NAME,
+                    modulePathBuilder: contributionsBanner.endpointPathBuilder,
+                    moduleName: BannerTemplate.ContributionsBanner,
+                    bannerContent: UK_DIGISUB_CONTENT,
+                    componentType: channelName,
+                },
+                {
+                    name: VARIANT_NAME,
+                    modulePathBuilder: guardianWeekly.endpointPathBuilder,
+                    moduleName: BannerTemplate.GuardianWeeklyBanner,
+                    bannerContent: EU_GW_CONTENT,
+                    componentType: channelName,
+                },
+            ],
+        },
+    ]);
+
+const getGWBanner = (variantName: string, targeting: BannerTargeting): BannerVariant => ({
+    name: variantName,
+    modulePathBuilder: guardianWeekly.endpointPathBuilder,
+    moduleName: BannerTemplate.GuardianWeeklyBanner,
+    bannerContent: GW_CONTENT[countryCodeToCountryGroupId(targeting.countryCode.toUpperCase())],
+    componentType: channelName,
+});
+
+const getDSBanner = (variantName: string, targeting: BannerTargeting): BannerVariant => ({
+    name: variantName,
+    modulePathBuilder: contributionsBanner.endpointPathBuilder,
+    moduleName: BannerTemplate.ContributionsBanner,
+    bannerContent:
+        DIGISUB_CONTENT[countryCodeToCountryGroupId(targeting.countryCode.toUpperCase())],
+    componentType: channelName,
+});
+
+const getControlBanner = (variantName: string, targeting: BannerTargeting): BannerVariant =>
+    // are they in Europe?
+    inCountryGroups(targeting.countryCode, ['EURCountries'])
+        ? getGWBanner(variantName, targeting)
+        : getDSBanner(variantName, targeting);
+
+const getVariantBanner = (variantName: string, targeting: BannerTargeting): BannerVariant =>
+    // are they high-propensity?
+    targeting.browserId && isInPropensityTest(targeting.browserId)
+        ? getGWBanner(variantName, targeting)
+        : getDSBanner(variantName, targeting);
+
+// This test is unusual because we decide what to show *after* assigning the browser to a variant
+export const getPropensityModelTestVariantData = (
+    variantName: string,
+    targeting: BannerTargeting,
+): BannerVariant =>
+    variantName === CONTROL_NAME
+        ? getControlBanner(variantName, targeting)
+        : getVariantBanner(variantName, targeting);

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTestData.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTestData.ts
@@ -1,0 +1,21 @@
+import { logInfo } from '../../../utils/logging';
+import { streamS3DataByLine } from '../../../utils/S3';
+import { isProd } from '../../../lib/env';
+
+const guardianWeeklyHighPropensityIds: Set<string> = new Set<string>();
+export const fetchHighPropensityIds = (): void => {
+    logInfo('Loading guardianWeeklyHighPropensityIds...');
+    streamS3DataByLine({
+        bucket: 'support-admin-console',
+        key: `${isProd ? 'PROD' : 'CODE'}/guardian-weekly-propensity-test/ids.txt`,
+        onLine: line => guardianWeeklyHighPropensityIds.add(line),
+        onComplete: () => {
+            logInfo(
+                `Loaded ${guardianWeeklyHighPropensityIds.size} guardianWeeklyHighPropensityIds`,
+            );
+        },
+    });
+};
+
+export const isInPropensityTest = (browserId: string): boolean =>
+    guardianWeeklyHighPropensityIds.has(browserId);

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTestDigisubCopy.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTestDigisubCopy.ts
@@ -1,0 +1,60 @@
+import { BannerContent, SecondaryCtaType } from '@sdc/shared/types';
+import { CountryGroupId } from '@sdc/shared/dist/lib';
+
+const buildDigisubContent = (paragraphs: string[], highlightedText: string): BannerContent => ({
+    heading: 'Power open, independent journalism',
+    paragraphs,
+    highlightedText,
+    cta: {
+        baseUrl:
+            'https://support.theguardian.com/subscribe/digital/checkout?promoCode=DK0NT24WG&period=Monthly',
+        text: 'Subscribe',
+    },
+    secondaryCta: {
+        type: SecondaryCtaType.Custom,
+        cta: {
+            baseUrl: 'https://support.theguardian.com/subscribe/digital',
+            text: 'Find out more',
+        },
+    },
+});
+
+const DEFAULT_HIGHLIGHTED_TEXT =
+    'And to say thank you, we’ll give you ad-free reading, and exclusive access to premium features on our award-winning apps.';
+const AU_HIGHLIGHTED_TEXT =
+    'And to say thank you, we’ll give you ad-free reading, and exclusive access to the Australia Weekend app.';
+
+const buildDigisubBody = (priceCopy: string): string =>
+    `Millions turn to the Guardian every day for fiercely independent journalism that’s open and free for all. We have no shareholders, no billionaire owner and no commercial or political bosses. Just the passion and determination to bring readers quality, truth-seeking reporting on the world, its people and power. This makes us different. <strong>Show your support today by becoming a digital subscriber, ${priceCopy}.</strong> Doing so helps to protect our vital independence, it keeps us free of a paywall, and makes a real difference for our future.`;
+
+export const US_ROW_DIGISUB_CONTENT = buildDigisubContent(
+    [buildDigisubBody('from just $2.50 a week')],
+    DEFAULT_HIGHLIGHTED_TEXT,
+);
+export const UK_DIGISUB_CONTENT = buildDigisubContent(
+    [buildDigisubBody('from just £5.99 a month')],
+    DEFAULT_HIGHLIGHTED_TEXT,
+);
+export const AU_DIGISUB_CONTENT = buildDigisubContent(
+    [buildDigisubBody('from less than $3 a week')],
+    AU_HIGHLIGHTED_TEXT,
+);
+export const EU_DIGISUB_CONTENT = buildDigisubContent(
+    [buildDigisubBody('from just €7.49 a month')],
+    DEFAULT_HIGHLIGHTED_TEXT,
+);
+export const CA_NZ_DIGISUB_CONTENT = buildDigisubContent(
+    [buildDigisubBody('from just $3 a week')],
+    DEFAULT_HIGHLIGHTED_TEXT,
+);
+
+// TODO content
+export const DIGISUB_CONTENT: { [key in CountryGroupId]: BannerContent } = {
+    GBPCountries: UK_DIGISUB_CONTENT,
+    UnitedStates: US_ROW_DIGISUB_CONTENT,
+    International: US_ROW_DIGISUB_CONTENT,
+    EURCountries: EU_DIGISUB_CONTENT,
+    AUDCountries: AU_DIGISUB_CONTENT,
+    Canada: CA_NZ_DIGISUB_CONTENT,
+    NZDCountries: CA_NZ_DIGISUB_CONTENT,
+};

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTestDigisubCopy.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTestDigisubCopy.ts
@@ -48,7 +48,6 @@ export const CA_NZ_DIGISUB_CONTENT = buildDigisubContent(
     DEFAULT_HIGHLIGHTED_TEXT,
 );
 
-// TODO content
 export const DIGISUB_CONTENT: { [key in CountryGroupId]: BannerContent } = {
     GBPCountries: UK_DIGISUB_CONTENT,
     UnitedStates: US_ROW_DIGISUB_CONTENT,

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTestGWCopy.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTestGWCopy.ts
@@ -1,57 +1,12 @@
 import { BannerContent } from '@sdc/shared/dist/types';
-import { CountryGroupId } from '@sdc/shared/dist/lib';
 
-export const AU_GW_CONTENT: BannerContent = {
-    heading: 'Read the Guardian in print, in Australia',
-    paragraphs: [
-        'News moves fast. Find clarity with the Guardian Weekly – an essential roundup of news, analysis and insight, handpicked from the Guardian’s bureaux in Australia and across the globe and delivered to your door. For a limited time, save 25% on an annual subscription.',
-    ],
-    cta: {
-        baseUrl: 'https://support.theguardian.com/subscribe/weekly?promoCode=GW25OZ',
-        text: 'Learn more',
-    },
-};
-
-export const NZ_GW_CONTENT: BannerContent = {
-    heading: 'Read the Guardian in print, delivered to you',
-    paragraphs: [
-        'News moves fast. Find clarity with the Guardian Weekly – an essential roundup of news, analysis and insight, handpicked from the Guardian’s bureaux in Australia and across the globe and delivered to your door. For a limited time, save 25% on an annual subscription.',
-    ],
-    cta: {
-        baseUrl: 'https://support.theguardian.com/subscribe/weekly?promoCode=GW25OZ',
-        text: 'Learn more',
-    },
-};
-
-export const EU_GW_CONTENT: BannerContent = {
+export const GW_CONTENT: BannerContent = {
     heading: 'Read the Guardian in print',
     paragraphs: [
-        'More people across Europe are reading the Guardian. Pause to consider a whole new perspective with the Guardian’s weekly news magazine. Home delivery available wherever you are.',
+        'More people across the world are reading the Guardian. Pause to consider a whole new perspective with the Guardian’s weekly news magazine. Home delivery available wherever you are.',
     ],
     cta: {
         baseUrl: 'https://support.theguardian.com/subscribe/weekly',
         text: 'Support the Guardian',
     },
-};
-
-export const UK_US_ROW_GW_CONTENT: BannerContent = {
-    heading: 'Read the Guardian in print',
-    paragraphs: [
-        'Find clarity with the Guardian Weekly – an essential roundup of news, analysis and insight, handpicked from the Guardian and delivered to your door.',
-    ],
-    cta: {
-        baseUrl: 'https://support.theguardian.com/subscribe/weekly',
-        text: 'Support the Guardian',
-    },
-};
-
-// TODO content
-export const GW_CONTENT: { [key in CountryGroupId]: BannerContent } = {
-    GBPCountries: UK_US_ROW_GW_CONTENT,
-    UnitedStates: UK_US_ROW_GW_CONTENT,
-    International: UK_US_ROW_GW_CONTENT,
-    EURCountries: EU_GW_CONTENT,
-    AUDCountries: AU_GW_CONTENT,
-    Canada: UK_US_ROW_GW_CONTENT,
-    NZDCountries: NZ_GW_CONTENT,
 };

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTestGWCopy.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTestGWCopy.ts
@@ -1,0 +1,57 @@
+import { BannerContent } from '@sdc/shared/dist/types';
+import { CountryGroupId } from '@sdc/shared/dist/lib';
+
+export const AU_GW_CONTENT: BannerContent = {
+    heading: 'Read the Guardian in print, in Australia',
+    paragraphs: [
+        'News moves fast. Find clarity with the Guardian Weekly – an essential roundup of news, analysis and insight, handpicked from the Guardian’s bureaux in Australia and across the globe and delivered to your door. For a limited time, save 25% on an annual subscription.',
+    ],
+    cta: {
+        baseUrl: 'https://support.theguardian.com/subscribe/weekly?promoCode=GW25OZ',
+        text: 'Learn more',
+    },
+};
+
+export const NZ_GW_CONTENT: BannerContent = {
+    heading: 'Read the Guardian in print, delivered to you',
+    paragraphs: [
+        'News moves fast. Find clarity with the Guardian Weekly – an essential roundup of news, analysis and insight, handpicked from the Guardian’s bureaux in Australia and across the globe and delivered to your door. For a limited time, save 25% on an annual subscription.',
+    ],
+    cta: {
+        baseUrl: 'https://support.theguardian.com/subscribe/weekly?promoCode=GW25OZ',
+        text: 'Learn more',
+    },
+};
+
+export const EU_GW_CONTENT: BannerContent = {
+    heading: 'Read the Guardian in print',
+    paragraphs: [
+        'More people across Europe are reading the Guardian. Pause to consider a whole new perspective with the Guardian’s weekly news magazine. Home delivery available wherever you are.',
+    ],
+    cta: {
+        baseUrl: 'https://support.theguardian.com/subscribe/weekly',
+        text: 'Support the Guardian',
+    },
+};
+
+export const UK_US_ROW_GW_CONTENT: BannerContent = {
+    heading: 'Read the Guardian in print',
+    paragraphs: [
+        'Find clarity with the Guardian Weekly – an essential roundup of news, analysis and insight, handpicked from the Guardian and delivered to your door.',
+    ],
+    cta: {
+        baseUrl: 'https://support.theguardian.com/subscribe/weekly',
+        text: 'Support the Guardian',
+    },
+};
+
+// TODO content
+export const GW_CONTENT: { [key in CountryGroupId]: BannerContent } = {
+    GBPCountries: UK_US_ROW_GW_CONTENT,
+    UnitedStates: UK_US_ROW_GW_CONTENT,
+    International: UK_US_ROW_GW_CONTENT,
+    EURCountries: EU_GW_CONTENT,
+    AUDCountries: AU_GW_CONTENT,
+    Canada: UK_US_ROW_GW_CONTENT,
+    NZDCountries: NZ_GW_CONTENT,
+};


### PR DESCRIPTION
This replaces v1 of the test - see https://github.com/guardian/support-dotcom-components/pull/657
We're still using the high-GW / low-DS segment.
But this time the entire banner channel 2 audience is put into the test.

In the control:
- all European browsers see GW
- all other browsers see DS

In the variant:
- all high-GW/low-DS browsers see GW
- all other browsers see DS

It's a slightly hacky implementation. This is because we decide what to show *after* assigning the browser to a variant. This doesn't fit with how our existing logic works, so I've hacked a special case for this test into `bannerSelection.ts`. If this becomes a common way of doing AB tests then we can think about how to support it properly.
