### PR TITLE
Update top reader test exclude tags.

### DIFF
--- a/packages/server/src/tests/epics/topReaderArticleCountBadge/build.ts
+++ b/packages/server/src/tests/epics/topReaderArticleCountBadge/build.ts
@@ -9,7 +9,12 @@ interface Options {
     copy: Copy;
 }
 
-const EXCLUDE_TAG_IDS = ['world/ukraine', 'world/russia'];
+const EXCLUDE_TAG_IDS = [
+    'world/ukraine',
+    'world/russia',
+    'australia-news/australian-politics',
+    'australia-news/australian-election-2022',
+];
 
 export function buildTest({ suffix, locations, copy }: Options): EpicTest {
     return {


### PR DESCRIPTION
## What does this change?

This change adds `australia-news/australian-politics` and `australia-news/australian-election-2022` to the exclude tags of the top reader test.
