### PR TITLE
fix: Include repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Service to serve Reader Revenue components to dotcom",
   "repository": "git@github.com:guardian/support-dotcom-components.git",
   "author": "The Guardian",
+  "repository": "github:guardian/support-dotcom-components",
   "license": "MIT",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What does this change?

As part of an npm audit, I'm adding gh links to package jsons that don't already include them if this repo is being published. This makes it easier to work out which repos are "in production" in one way or another.

