### PR TITLE
Refactor placeholder substitution

### DIFF
--- a/packages/shared/src/lib/placeholders.test.ts
+++ b/packages/shared/src/lib/placeholders.test.ts
@@ -1,5 +1,8 @@
-import {containsNonArticleCountPlaceholder, replaceNonArticleCountPlaceholders} from './placeholders';
-import {Prices} from "../types";
+import {
+    containsNonArticleCountPlaceholder,
+    replaceNonArticleCountPlaceholders,
+} from './placeholders';
+import { Prices } from '../types';
 
 describe('containsNonArticleCountPlaceholder', () => {
     it('returns true if string contains placeholder (that is not %%ARTICLE_COUNT%%)', () => {
@@ -66,18 +69,18 @@ describe('replaceNonArticleCountPlaceholders', () => {
         EURCountries: {
             GuardianWeekly: {
                 Monthly: {
-                    price: '0.00',
+                    price: '5.99',
                 },
                 Annual: {
-                    price: '0.00',
+                    price: '99.00',
                 },
             },
             Digisub: {
                 Monthly: {
-                    price: '0.00',
+                    price: '6.00',
                 },
                 Annual: {
-                    price: '0.00',
+                    price: '120.00',
                 },
             },
         },
@@ -155,12 +158,30 @@ describe('replaceNonArticleCountPlaceholders', () => {
         },
     };
 
-    it('replaces %%COUNTRY_NAME%%', () => {
+    it('replaces %%COUNTRY_NAME%% and %%CURRENCY_SYMBOL%%', () => {
         const result = replaceNonArticleCountPlaceholders(
-            'You live in %%COUNTRY_NAME%%.',
+            'You live in %%COUNTRY_NAME%% and your currency is %%CURRENCY_SYMBOL%%.',
             'IT',
             prices,
         );
-        expect(result).toBe('You live in Italy.');
+        expect(result).toBe('You live in Italy and your currency is €.');
+    });
+
+    it('replaces %%PRICE_DIGISUB_MONTHLY%%', () => {
+        const result = replaceNonArticleCountPlaceholders(
+            'Digisub costs %%PRICE_DIGISUB_MONTHLY%% a month.',
+            'IT',
+            prices,
+        );
+        expect(result).toBe('Digisub costs €6.00 a month.');
+    });
+
+    it('replaces %%PRICE_GUARDIANWEEKLY_ANNUAL%%', () => {
+        const result = replaceNonArticleCountPlaceholders(
+            'Guardian Weekly costs %%PRICE_GUARDIANWEEKLY_ANNUAL%% a month.',
+            'IT',
+            prices,
+        );
+        expect(result).toBe('Guardian Weekly costs €99.00 a month.');
     });
 });

--- a/packages/shared/src/lib/placeholders.test.ts
+++ b/packages/shared/src/lib/placeholders.test.ts
@@ -182,6 +182,6 @@ describe('replaceNonArticleCountPlaceholders', () => {
             'IT',
             prices,
         );
-        expect(result).toBe('Guardian Weekly costs €99.00 a month.');
+        expect(result).toBe('Guardian Weekly costs €99.00 a year.');
     });
 });

--- a/packages/shared/src/lib/placeholders.test.ts
+++ b/packages/shared/src/lib/placeholders.test.ts
@@ -178,7 +178,7 @@ describe('replaceNonArticleCountPlaceholders', () => {
 
     it('replaces %%PRICE_GUARDIANWEEKLY_ANNUAL%%', () => {
         const result = replaceNonArticleCountPlaceholders(
-            'Guardian Weekly costs %%PRICE_GUARDIANWEEKLY_ANNUAL%% a month.',
+            'Guardian Weekly costs %%PRICE_GUARDIANWEEKLY_ANNUAL%% a year.',
             'IT',
             prices,
         );

--- a/packages/shared/src/lib/placeholders.test.ts
+++ b/packages/shared/src/lib/placeholders.test.ts
@@ -1,4 +1,5 @@
-import { containsNonArticleCountPlaceholder } from './placeholders';
+import {containsNonArticleCountPlaceholder, replaceNonArticleCountPlaceholders} from './placeholders';
+import {Prices} from "../types";
 
 describe('containsNonArticleCountPlaceholder', () => {
     it('returns true if string contains placeholder (that is not %%ARTICLE_COUNT%%)', () => {
@@ -21,5 +22,145 @@ describe('containsNonArticleCountPlaceholder', () => {
     it('returns false if string does not contain placeholder', () => {
         const got = containsNonArticleCountPlaceholder('apple without placeholder');
         expect(got).toBe(false);
+    });
+});
+
+describe('replaceNonArticleCountPlaceholders', () => {
+    const prices: Prices = {
+        GBPCountries: {
+            GuardianWeekly: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+            Digisub: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+        },
+        UnitedStates: {
+            GuardianWeekly: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+            Digisub: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+        },
+        EURCountries: {
+            GuardianWeekly: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+            Digisub: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+        },
+        AUDCountries: {
+            GuardianWeekly: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+            Digisub: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+        },
+        International: {
+            GuardianWeekly: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+            Digisub: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+        },
+        NZDCountries: {
+            GuardianWeekly: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+            Digisub: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+        },
+        Canada: {
+            GuardianWeekly: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+            Digisub: {
+                Monthly: {
+                    price: '0.00',
+                },
+                Annual: {
+                    price: '0.00',
+                },
+            },
+        },
+    };
+
+    it('replaces %%COUNTRY_NAME%%', () => {
+        const result = replaceNonArticleCountPlaceholders(
+            'You live in %%COUNTRY_NAME%%.',
+            'IT',
+            prices,
+        );
+        expect(result).toBe('You live in Italy.');
     });
 });

--- a/packages/shared/src/lib/placeholders.ts
+++ b/packages/shared/src/lib/placeholders.ts
@@ -1,7 +1,7 @@
 import { getCountryName, getLocalCurrencySymbol, countryCodeToCountryGroupId } from './geolocation';
 import { GuardianProduct, Prices, RatePlan } from '../types/prices';
 
-// Maps each placeholder to a rule for how to substitute it, if possible
+// Maps each placeholder to a rule defining how to substitute it, if possible
 type PlaceholderRules = {
     [placeholder in string]: () => string | undefined;
 };
@@ -53,7 +53,7 @@ export const replaceNonArticleCountPlaceholders = (
                 return result;
             }
         }
-        return placeholder; // leave it unchanged - the calling code must handle this
+        return placeholder; // if unable to substitute then leave it unchanged - the calling code must handle this
     });
 };
 

--- a/packages/shared/src/lib/placeholders.ts
+++ b/packages/shared/src/lib/placeholders.ts
@@ -1,9 +1,9 @@
 import { getCountryName, getLocalCurrencySymbol, countryCodeToCountryGroupId } from './geolocation';
-import { Prices } from '../types/prices';
+import { GuardianProduct, Prices, RatePlan } from '../types/prices';
 
 // we have to treat %%ARTICLE_COUNT%% placeholders specially as they are replaced
 // with react components, not a simple text substitution
-export const replaceNonArticleCountPlaceholders = (
+export const replaceNonArticleCountPlaceholders2 = (
     content: string | undefined,
     countryCode?: string,
     prices?: Prices,
@@ -44,6 +44,59 @@ export const replaceNonArticleCountPlaceholders = (
         );
     }
     return content;
+};
+
+interface PlaceholderRule {
+    placeholder: string;
+    substitute: () => string | undefined;
+}
+const buildRule = (placeholder: string, substitute: () => string | undefined): PlaceholderRule => ({
+    placeholder,
+    substitute,
+});
+
+export const replaceNonArticleCountPlaceholders = (
+    content: string | undefined,
+    countryCode?: string,
+    prices?: Prices,
+): string => {
+    if (!content) {
+        return '';
+    }
+
+    const localCurrencySymbol = getLocalCurrencySymbol(countryCode);
+    const countryGroupId = countryCodeToCountryGroupId(countryCode);
+    const localPrices = prices && prices[countryGroupId] ? prices[countryGroupId] : null;
+
+    const priceSubstitution = (product: GuardianProduct, ratePlan: RatePlan) => {
+        if (localPrices) {
+            return `${localCurrencySymbol}${localPrices[product][ratePlan].price}`;
+        }
+        return undefined;
+    };
+    const rules: PlaceholderRule[] = [
+        buildRule('CURRENCY_SYMBOL', () => localCurrencySymbol),
+        buildRule('COUNTRY_NAME', () => getCountryName(countryCode)),
+        buildRule('PRICE_DIGISUB_MONTHLY', () => priceSubstitution('Digisub', 'Monthly')),
+        buildRule('PRICE_DIGISUB_ANNUAL', () => priceSubstitution('Digisub', 'Annual')),
+        buildRule('PRICE_GUARDIANWEEKLY_MONTHLY', () =>
+            priceSubstitution('GuardianWeekly', 'Monthly'),
+        ),
+        buildRule('PRICE_GUARDIANWEEKLY_ANNUAL', () =>
+            priceSubstitution('GuardianWeekly', 'Annual'),
+        ),
+    ];
+
+    content.replace(PLACEHOLDER_RE, placeholder => {
+        const rule = rules.find(rule => `%%${rule.placeholder}%%` === placeholder);
+        if (rule) {
+            const result = rule.substitute();
+            if (result) {
+                return result;
+            }
+        }
+        return placeholder; // leave it unchanged - the calling code must handle this
+    });
 };
 
 // Nb. don't attempt to use lookbehind (?<!) here, as IE 11 will break alas

--- a/packages/shared/src/lib/placeholders.ts
+++ b/packages/shared/src/lib/placeholders.ts
@@ -12,7 +12,7 @@ const priceSubstitution = (
     ratePlan: RatePlan,
     countryCode?: string,
     prices?: Prices,
-) => {
+): string | undefined => {
     if (prices) {
         const countryGroupId = countryCodeToCountryGroupId(countryCode);
         const localPrices = prices[countryGroupId];

--- a/packages/shared/src/types/prices.ts
+++ b/packages/shared/src/types/prices.ts
@@ -1,17 +1,15 @@
 import { CountryGroupId } from '../lib';
 
-interface ProductPriceData {
-    Monthly: {
+export type RatePlan = 'Monthly' | 'Annual';
+type ProductPriceData = {
+    [ratePlan in RatePlan]: {
         price: string;
     };
-    Annual: {
-        price: string;
-    };
-}
-interface CountryGroupPriceData {
-    GuardianWeekly: ProductPriceData;
-    Digisub: ProductPriceData;
-}
+};
+export type GuardianProduct = 'GuardianWeekly' | 'Digisub';
+type CountryGroupPriceData = {
+    [product in GuardianProduct]: ProductPriceData;
+};
 export type Prices = {
     [country in CountryGroupId]: CountryGroupPriceData;
 };


### PR DESCRIPTION
We now have a number of placeholders (aka templates), e.g. `%%COUNTRY_NAME%%`.
These are substituted on the client when rendering the component.
The existing logic is getting quite inefficient as it scans the same text for each placeholder.

This PR uses the [replace](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) string method to scan the string for placeholders just once.
A set of rules is defined to substitute each placeholder in the string.