### PR TITLE
Remove references to @emotion/core

### DIFF
--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedIn.stories.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedIn.stories.tsx
@@ -4,7 +4,7 @@ import {
     ContributionsBannerReminderSignedIn,
     ContributionsBannerReminderSignedInProps,
 } from './ContributionsBannerReminderSignedIn';
-import { css } from '@emotion/core';
+import { css } from '@emotion/react';
 import { brandAlt } from '@guardian/src-foundations/palette';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { ReminderStatus } from '../../utils/reminders';

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedOut.stories.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedOut.stories.tsx
@@ -4,7 +4,7 @@ import {
     ContributionsBannerReminderSignedOut,
     ContributionsBannerReminderSignedOutProps,
 } from './ContributionsBannerReminderSignedOut';
-import { css } from '@emotion/core';
+import { css } from '@emotion/react';
 import { brandAlt } from '@guardian/src-foundations/palette';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { ReminderStatus } from '../../utils/reminders';

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerSecondaryCta.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerSecondaryCta.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ThemeProvider } from '@emotion/react';
-import { css } from '@emotion/core';
+import { css } from '@emotion/react';
 import { buttonReaderRevenueBrandAlt } from '@guardian/src-button';
 import { LinkButton } from '@guardian/src-button';
 import { SvgArrowRightStraight } from '@guardian/src-icons';

--- a/packages/modules/src/modules/banners/environmentMoment/EnvironmentMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/environmentMoment/EnvironmentMomentBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from '@emotion/core';
+import { css } from '@emotion/react';
 import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';

--- a/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
@@ -5,7 +5,7 @@ import { body, textSans } from '@guardian/src-foundations/typography';
 import { palette, space } from '@guardian/src-foundations';
 import { Button } from '@guardian/src-button';
 import { ButtonLink } from '@guardian/src-link';
-import { css } from '@emotion/core';
+import { css } from '@emotion/react';
 import { ArticleCounts, OphanComponentEvent } from '@sdc/shared/types';
 import {
     OPHAN_COMPONENT_ARTICLE_COUNT_OPT_OUT_OPEN,

--- a/packages/modules/src/modules/header/Header.stories.tsx
+++ b/packages/modules/src/modules/header/Header.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { HeaderProps } from '@sdc/shared/types';
 import { HeaderUnvalidated as Header } from './Header';
-import { css } from '@emotion/core';
+import { css } from '@emotion/react';
 import { brand } from '@guardian/src-foundations';
 
 export const props: HeaderProps = {

--- a/packages/modules/src/modules/header/Header.tsx
+++ b/packages/modules/src/modules/header/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from '@emotion/core';
+import { css } from '@emotion/react';
 import { from } from '@guardian/src-foundations/mq';
 import { brandAlt, brandText } from '@guardian/src-foundations';
 import { headline, textSans } from '@guardian/src-foundations/typography';


### PR DESCRIPTION
We've moved on from `@emotion/core` in favour of the newer `@emotion/react`. However, we still had some references in the code to `@emotion/core` which was causing it to get bundled. By removing it, our gzipped epic bundle goes from 43.29kb to 36.72kb. We've actually removed `@emotion/core` from our `package.json` but it was being pulled in by storybook so these old references went unnoticed (i.e it didn't cause a build error).

The biggest contributor to our bundle (outside of our own code) is `zod`. Removing it shaves of 10kb, which is pretty significant. It might be worth looking into any more lightweight validation libraries, but as it stands `zod` has really great DX and I think it adds a lot of value to have the props validated given our architecture.

## Images

**Original**
<img width="508" alt="Screenshot 2022-04-22 at 16 21 59" src="https://user-images.githubusercontent.com/17720442/164748363-ad56ff0c-0456-4f52-a6fc-63f3e73f1050.png">


**After removing references to `@emotion/core`**
<img width="508" alt="Screenshot 2022-04-22 at 16 23 00" src="https://user-images.githubusercontent.com/17720442/164748374-3e3d54a0-7cc2-4aba-b173-f1710a494ca0.png">
