### PR TITLE
Fix banner bug when no highlightedText

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerText.tsx
+++ b/packages/modules/src/modules/banners/common/BannerText.tsx
@@ -48,9 +48,11 @@ export const createBannerBodyCopy = (
     if (numberOfNonFinalParagraphs < 0) {
         return (
             <div css={styles.paragraphs}>
-                <p>
-                    <span css={renderStyles.highlightedText}>{highlightedText}</span>
-                </p>
+                {highlightedText && (
+                    <p>
+                        <span css={renderStyles.highlightedText}>{highlightedText}</span>
+                    </p>
+                )}
             </div>
         );
     }
@@ -63,7 +65,10 @@ export const createBannerBodyCopy = (
                 }
                 return (
                     <p key={index}>
-                        {p} <span css={renderStyles.highlightedText}>{highlightedText}</span>
+                        {p}{' '}
+                        {highlightedText && (
+                            <span css={renderStyles.highlightedText}>{highlightedText}</span>
+                        )}
                     </p>
                 );
             })}


### PR DESCRIPTION
Currently if `highlightedText` is not set, an element with a background colour is still rendered at the end of the body:
<img width="667" alt="Screen Shot 2022-04-27 at 12 07 21" src="https://user-images.githubusercontent.com/1513454/165505255-caacb90f-713a-446b-8491-5b05c9c49399.png">


This PR ensures it is not rendered if `highlightedText` is either undefined or an empty string.
After the fix -

### With paragraphs + highlightedText
<img width="667" alt="Screen Shot 2022-04-27 at 12 02 08" src="https://user-images.githubusercontent.com/1513454/165504776-d4465939-7daf-46e5-932c-1a6c96cf3e2d.png">

### With paragraphs +  no highlightedText
<img width="667" alt="Screen Shot 2022-04-27 at 12 02 17" src="https://user-images.githubusercontent.com/1513454/165504850-3010feba-a956-457e-ac6f-c67084fe7b58.png">

### Without paragraphs + highlightedText
<img width="667" alt="Screen Shot 2022-04-27 at 12 03 00" src="https://user-images.githubusercontent.com/1513454/165504911-91e7915f-0cd0-467c-b49a-1b9a51cb0998.png">

### Without paragraphs + no highlightedText
<img width="667" alt="Screen Shot 2022-04-27 at 12 02 47" src="https://user-images.githubusercontent.com/1513454/165504939-091bc799-bf20-453e-a8c8-75ddd0866de2.png">
