### PR TITLE
Moment banner template

### DIFF
--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { getMomentTemplateBanner } from './MomentTemplateBanner';
+import { props } from '../utils/storybook';
+import { BannerProps, SecondaryCtaType } from '@sdc/shared/types';
+import { bannerWrapper } from '../common/BannerWrapper';
+import { neutral } from '@guardian/src-foundations';
+
+export default {
+    title: 'Banners/MomentTemplate',
+    args: props,
+} as Meta;
+
+const GlobalNYBanner = bannerWrapper(
+    getMomentTemplateBanner({
+        backgroundColour: '#f79e1b',
+        primaryCtaSettings: {
+            default: {
+                backgroundColour: '#007abc',
+                textColour: 'white',
+            },
+            hover: {
+                backgroundColour: 'white',
+                textColour: '#007abc',
+            },
+        },
+        secondaryCtaSettings: {
+            default: {
+                backgroundColour: '#f79e1b',
+                textColour: neutral[0],
+            },
+            hover: {
+                backgroundColour: 'white',
+                textColour: neutral[0],
+            },
+        },
+        closeButtonSettings: {
+            default: {
+                backgroundColour: '#f79e1b',
+                textColour: neutral[0],
+                border: `1px solid ${neutral[0]}`,
+            },
+            hover: {
+                backgroundColour: 'white',
+                textColour: neutral[0],
+            },
+        },
+        imageSetings: {
+            mobileUrl:
+                'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
+            tabletUrl:
+                'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
+            desktopUrl:
+                'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
+            leftColUrl:
+                'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
+            wideUrl:
+                'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
+            alt: 'Guardian logo being held up by supporters of the Guardian',
+        },
+    }),
+    'global-new-year-banner',
+);
+
+const GlobalNYTemplate: Story<BannerProps> = (props: BannerProps) => <GlobalNYBanner {...props} />;
+
+export const GlobalNY = GlobalNYTemplate.bind({});
+GlobalNY.args = {
+    ...props,
+    content: {
+        heading: 'As 2022 begins, will you support us?',
+        messageText:
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations. We do not shy away. And we provide all this for free, for everyone.',
+        paragraphs: [
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations.',
+            'We do not shy away. And we provide all this for free, for everyone.',
+        ],
+        highlightedText:
+            'Show your support today from just %%CURRENCY_SYMBOL%%1, or sustain us long term with a little more. Thank you.',
+        cta: {
+            text: 'Support the Guardian',
+            baseUrl: 'https://support.theguardian.com/contribute',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Hear from our editor',
+                baseUrl: 'https://theguardian.com',
+            },
+        },
+    },
+    mobileContent: {
+        heading: 'As 2022 begins, will you support us?',
+        messageText:
+            'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus',
+        paragraphs: [
+            'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus',
+        ],
+        highlightedText:
+            'Show your support today from just %%CURRENCY_SYMBOL%%1, or sustain us long term with a little more. Thank you.',
+        cta: {
+            text: 'Support us',
+            baseUrl: 'https://support.theguardian.com/contribute',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Learn more',
+                baseUrl: 'https://theguardian.com',
+            },
+        },
+    },
+    numArticles: 50,
+};
+
+const AusElectionBanner = bannerWrapper(
+    getMomentTemplateBanner({
+        backgroundColour: '#e4e4e3',
+        primaryCtaSettings: {
+            default: {
+                backgroundColour: '#121212',
+                textColour: 'white',
+            },
+            hover: {
+                backgroundColour: '#454545',
+                textColour: 'white',
+            },
+        },
+        secondaryCtaSettings: {
+            default: {
+                backgroundColour: '#e4e4e3',
+                textColour: neutral[7],
+            },
+            hover: {
+                backgroundColour: '#e4e4e3',
+                textColour: neutral[7],
+            },
+        },
+        closeButtonSettings: {
+            default: {
+                backgroundColour: '#e4e4e3',
+                textColour: neutral[0],
+                border: `1px solid ${neutral[0]}`,
+            },
+            hover: {
+                backgroundColour: 'white',
+                textColour: neutral[0],
+            },
+        },
+        imageSetings: {
+            mobileUrl:
+                'https://i.guim.co.uk/img/media/ad0166d7724eb2dfc6aa16fea50fe41c02324eb8/0_0_281_131/281.png?quality=85&s=7639d39b1492f5e2f4883496fcc5740c',
+            tabletUrl:
+                'https://i.guim.co.uk/img/media/8da1d854dee753e006afc5677a09a13bc84b4eb9/0_0_1524_1652/923.png?quality=85&s=7df1807f0583e942744bdda49b0503b7',
+            desktopUrl:
+                'https://i.guim.co.uk/img/media/6daf1817afa379d842b10eb91d7bcda3c4c5fdad/0_0_2028_1648/1000.png?quality=85&s=86cc64b3196566587cf0b9bffc30828e',
+            leftColUrl:
+                'https://i.guim.co.uk/img/media/4fa98ca4b70ee9b21b74d16f2586b5d6c513297f/0_195_2836_1961/2000.png?quality=85&s=0ce3473523516664ed9a7f9cde095073',
+            wideUrl:
+                'https://i.guim.co.uk/img/media/4fa98ca4b70ee9b21b74d16f2586b5d6c513297f/0_319_2836_1837/2000.png?quality=85&s=3ef36bd5ab569f310b0f975372f54d29',
+            alt:
+                'Head shots of Anthony Albanese, leader of the Australian Labor Party, and Scott Morrison, current Prime Minister and leader of the Liberal Party of Australia, who are running for the office of Prime Minister in the Australian federal election, to be held on 21 May 2022.',
+        },
+    }),
+    'aus-moment-banner',
+);
+
+const AusElectionTemplate: Story<BannerProps> = (props: BannerProps) => (
+    <AusElectionBanner {...props} />
+);
+
+export const AusElection = AusElectionTemplate.bind({});
+AusElection.args = GlobalNY.args;

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
@@ -46,17 +46,9 @@ const GlobalNYBanner = bannerWrapper(
             },
         },
         imageSetings: {
-            mobileUrl:
+            mainUrl:
                 'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
-            tabletUrl:
-                'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
-            desktopUrl:
-                'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
-            leftColUrl:
-                'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
-            wideUrl:
-                'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
-            alt: 'Guardian logo being held up by supporters of the Guardian',
+            altText: 'Guardian logo being held up by supporters of the Guardian',
         },
     }),
     'global-new-year-banner',
@@ -148,6 +140,8 @@ const AusElectionBanner = bannerWrapper(
             },
         },
         imageSetings: {
+            mainUrl:
+                'https://i.guim.co.uk/img/media/ad0166d7724eb2dfc6aa16fea50fe41c02324eb8/0_0_281_131/281.png?quality=85&s=7639d39b1492f5e2f4883496fcc5740c',
             mobileUrl:
                 'https://i.guim.co.uk/img/media/ad0166d7724eb2dfc6aa16fea50fe41c02324eb8/0_0_281_131/281.png?quality=85&s=7639d39b1492f5e2f4883496fcc5740c',
             tabletUrl:
@@ -158,7 +152,7 @@ const AusElectionBanner = bannerWrapper(
                 'https://i.guim.co.uk/img/media/4fa98ca4b70ee9b21b74d16f2586b5d6c513297f/0_195_2836_1961/2000.png?quality=85&s=0ce3473523516664ed9a7f9cde095073',
             wideUrl:
                 'https://i.guim.co.uk/img/media/4fa98ca4b70ee9b21b74d16f2586b5d6c513297f/0_319_2836_1837/2000.png?quality=85&s=3ef36bd5ab569f310b0f975372f54d29',
-            alt:
+            altText:
                 'Head shots of Anthony Albanese, leader of the Australian Labor Party, and Scott Morrison, current Prime Minister and leader of the Liberal Party of Australia, who are running for the office of Prime Minister in the Australian federal election, to be held on 21 May 2022.',
         },
     }),

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { neutral, space } from '@guardian/src-foundations';
+import { Container } from '@guardian/src-layout';
+import { BannerRenderProps } from '../common/types';
+import { MomentTemplateBannerHeader } from './components/MomentTemplateBannerHeader';
+import { MomentTemplateBannerArticleCount } from './components/MomentTemplateBannerArticleCount';
+import { MomentTemplateBannerBody } from './components/MomentTemplateBannerBody';
+import { MomentTemplateBannerCtas } from './components/MomentTemplateBannerCtas';
+import { MomentTemplateBannerCloseButton } from './components/MomentTemplateBannerCloseButton';
+import { MomentTemplateBannerVisual } from './components/MomentTemplateBannerVisual';
+import { BannerTemplateSettings } from './settings';
+import { from } from '@guardian/src-foundations/mq';
+
+// ---- Banner ---- //
+
+export function getMomentTemplateBanner(
+    templateSettings: BannerTemplateSettings,
+): React.FC<BannerRenderProps> {
+    function MomentTemplateBanner({
+        content,
+        onCloseClick,
+        numArticles,
+        onCtaClick,
+        onSecondaryCtaClick,
+    }: BannerRenderProps): JSX.Element {
+        return (
+            <div css={styles.outerContainer(templateSettings.backgroundColour)}>
+                <Container>
+                    <div css={styles.container}>
+                        <div css={styles.closeButtonContainer}>
+                            <MomentTemplateBannerCloseButton
+                                onCloseClick={onCloseClick}
+                                settings={templateSettings.closeButtonSettings}
+                            />
+                        </div>
+
+                        <div css={styles.visualContainer}>
+                            <MomentTemplateBannerVisual settings={templateSettings.imageSetings} />
+                        </div>
+
+                        <div css={styles.contentContainer}>
+                            <div css={styles.headerContainer}>
+                                <MomentTemplateBannerHeader
+                                    heading={content.mainContent.heading}
+                                    mobileHeading={content.mobileContent?.heading ?? null}
+                                />
+                            </div>
+
+                            {numArticles !== undefined && numArticles > 5 && (
+                                <div css={styles.articleCountContainer}>
+                                    <MomentTemplateBannerArticleCount numArticles={numArticles} />
+                                </div>
+                            )}
+
+                            <div css={styles.bodyContainer}>
+                                <MomentTemplateBannerBody
+                                    paragraphs={content.mainContent.paragraphs}
+                                    mobileParagraphs={content.mobileContent?.paragraphs ?? null}
+                                    highlightedText={content.mainContent.highlightedText ?? null}
+                                    mobileHighlightedText={
+                                        content.mobileContent?.highlightedText ?? null
+                                    }
+                                />
+                            </div>
+
+                            <section css={styles.ctasContainer}>
+                                <MomentTemplateBannerCtas
+                                    desktopCtas={{
+                                        primary: content.mainContent.primaryCta,
+                                        secondary: content.mainContent.secondaryCta,
+                                    }}
+                                    mobileCtas={
+                                        content.mobileContent
+                                            ? {
+                                                  primary: content.mobileContent.primaryCta,
+                                                  secondary: content.mobileContent.secondaryCta,
+                                              }
+                                            : null
+                                    }
+                                    onPrimaryCtaClick={onCtaClick}
+                                    onSecondaryCtaClick={onSecondaryCtaClick}
+                                    primaryCtaSettings={templateSettings.primaryCtaSettings}
+                                    secondaryCtaSettings={templateSettings.secondaryCtaSettings}
+                                />
+                            </section>
+                        </div>
+                    </div>
+                </Container>
+            </div>
+        );
+    }
+
+    return MomentTemplateBanner;
+}
+
+// ---- Styles ---- //
+
+const styles = {
+    outerContainer: (background: string) => css`
+        background: ${background};
+        border-top: 3px solid ${neutral[0]};
+        padding-bottom: ${space[2]}px;
+
+        * {
+            box-sizing: border-box;
+        }
+    `,
+    container: css`
+        position: relative;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+
+        ${from.tablet} {
+            flex-direction: row-reverse;
+        }
+    `,
+    visualContainer: css`
+        ${from.tablet} {
+            width: 294px;
+            margin-left: ${space[3]}px;
+        }
+        ${from.desktop} {
+            width: 454px;
+        }
+        ${from.leftCol} {
+            width: 542px;
+            margin-left: ${space[9]}px;
+        }
+        ${from.wide} {
+            width: 672px;
+            margin-left: ${space[12]}px;
+        }
+    `,
+    contentContainer: css`
+        ${from.tablet} {
+            width: 394px;
+        }
+        ${from.desktop} {
+            width: 474px;
+        }
+        ${from.leftCol} {
+            width: 522px;
+        }
+        ${from.wide} {
+            width: 540px;
+        }
+    `,
+    headerContainer: css`
+        margin-top: ${space[1]}px;
+    `,
+    articleCountContainer: css`
+        margin-top: ${space[1]}px;
+    `,
+    bodyContainer: css`
+        margin-top: ${space[1]}px;
+    `,
+    ctasContainer: css`
+        display: flex;
+        flex-direction: row;
+        margin-top: ${space[4]}px;
+    `,
+    closeButtonContainer: css`
+        position: absolute;
+        top: ${space[2]}px;
+        right: ${space[4]}px;
+    `,
+};

--- a/packages/modules/src/modules/banners/momentTemplate/buttonStyles.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/buttonStyles.ts
@@ -1,0 +1,27 @@
+import { css, SerializedStyles } from '@emotion/react';
+import { CtaSettings } from './settings';
+
+export function buttonStyles(settings: CtaSettings): SerializedStyles {
+    return css`
+        ${toCssString(settings.default)}
+
+        &:hover {
+            ${toCssString(settings.hover)}
+        }
+    `;
+}
+
+// ---- Helpers ---- //
+
+function toCssString(cssProps: Record<string, string>) {
+    return Object.entries(cssProps).map(([prop, val]) => `${toCssProp(prop)}: ${val};`);
+}
+
+function toCssProp(prop: string) {
+    return CSS_PROPERTY_NAME_SUBSTITUTIONS.get(prop) ?? prop;
+}
+
+const CSS_PROPERTY_NAME_SUBSTITUTIONS = new Map<string, string>([
+    ['textColour', 'color'],
+    ['backgroundColour', 'background-color'],
+]);

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { neutral } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { headline } from '@guardian/src-foundations/typography';
+import { ArticleCountOptOutPopup } from '../../../shared/ArticleCountOptOutPopup';
+
+// ---- Component ---- //
+
+interface MomentTemplateBannerArticleCountProps {
+    numArticles: number;
+}
+
+export function MomentTemplateBannerArticleCount({
+    numArticles,
+}: MomentTemplateBannerArticleCountProps): JSX.Element {
+    return (
+        <p css={styles.container}>
+            You&apos;ve read{' '}
+            <ArticleCountOptOutPopup
+                numArticles={numArticles}
+                nextWord=" articles"
+                type="global-new-year-banner"
+            />{' '}
+            in the last year
+        </p>
+    );
+}
+
+// ---- Styles ---- //
+
+const styles = {
+    container: css`
+        ${headline.xxxsmall({ fontWeight: 'bold' })}
+        font-size: 15px;
+        color: ${neutral[0]};
+        margin: 0;
+
+        ${from.tablet} {
+            font-size: 17px;
+        }
+
+        ${from.desktop} {
+            font-size: 20px;
+        }
+    `,
+};

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { neutral } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { Hide } from '@guardian/src-layout';
+import { body } from '@guardian/src-foundations/typography';
+
+import { BannerTextStyles, createBannerBodyCopy } from '../../common/BannerText';
+
+// ---- Component ---- //
+
+interface MomentTemplateBannerBodyProps {
+    paragraphs: (JSX.Element | JSX.Element[])[];
+    mobileParagraphs: (JSX.Element | JSX.Element[])[] | null;
+    highlightedText: JSX.Element | JSX.Element[] | null;
+    mobileHighlightedText: JSX.Element | JSX.Element[] | null;
+}
+
+export function MomentTemplateBannerBody({
+    paragraphs,
+    mobileParagraphs,
+    highlightedText,
+    mobileHighlightedText,
+}: MomentTemplateBannerBodyProps): JSX.Element {
+    return (
+        <div css={styles.container}>
+            <Hide above="tablet">
+                {createBannerBodyCopy(
+                    mobileParagraphs ?? paragraphs,
+                    mobileHighlightedText ?? highlightedText,
+                    styles,
+                )}
+            </Hide>
+
+            <Hide below="tablet">{createBannerBodyCopy(paragraphs, highlightedText, styles)}</Hide>
+        </div>
+    );
+}
+
+// ---- Styles ---- //
+
+const styles: BannerTextStyles = {
+    container: css`
+        ${body.small()}
+        color: ${neutral[0]};
+        font-size: 15px;
+        line-height: 135%;
+
+        ${from.desktop} {
+            font-size: 17px;
+        }
+
+        ${from.wide} {
+            line-height: 150%;
+        }
+
+        p {
+            margin: 0 0 0.5em 0;
+        }
+
+        strong {
+            font-weight: bold;
+        }
+    `,
+    highlightedText: css`
+        font-weight: bold;
+    `,
+};

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { SvgCross } from '@guardian/src-icons';
+import { Button } from '@guardian/src-button';
+import { buttonStyles } from '../buttonStyles';
+import { CtaSettings } from '../settings';
+
+// ---- Component ---- //
+
+interface MomentTemplateBannerCloseButtonProps {
+    onCloseClick: () => void;
+    settings: CtaSettings;
+}
+
+export function MomentTemplateBannerCloseButton({
+    onCloseClick,
+    settings,
+}: MomentTemplateBannerCloseButtonProps): JSX.Element {
+    return (
+        <div css={styles.container}>
+            <Button
+                onClick={onCloseClick}
+                cssOverrides={buttonStyles(settings)}
+                icon={<SvgCross />}
+                size="small"
+                hideLabel
+            >
+                Close
+            </Button>
+        </div>
+    );
+}
+
+// ---- Styles ---- //
+
+const styles = {
+    container: css`
+        display: flex;
+    `,
+};

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { space } from '@guardian/src-foundations';
+import { Hide } from '@guardian/src-layout';
+import { LinkButton } from '@guardian/src-button';
+import { SecondaryCtaType } from '@sdc/shared/types';
+import { BannerEnrichedCta, BannerEnrichedSecondaryCta } from '../../common/types';
+import { buttonStyles } from '../buttonStyles';
+import { CtaSettings } from '../settings';
+import { from } from '@guardian/src-foundations/mq';
+
+// ---- Component ---- //
+
+interface BreakpointCtas {
+    primary: BannerEnrichedCta | null;
+    secondary: BannerEnrichedSecondaryCta | null;
+}
+
+interface MomentTemplateBannerCtasProps {
+    mobileCtas: BreakpointCtas | null;
+    desktopCtas: BreakpointCtas;
+    onPrimaryCtaClick: () => void;
+    onSecondaryCtaClick: () => void;
+    primaryCtaSettings: CtaSettings;
+    secondaryCtaSettings: CtaSettings;
+}
+
+export function MomentTemplateBannerCtas({
+    desktopCtas,
+    mobileCtas: maybeMobileCtas,
+    onPrimaryCtaClick,
+    onSecondaryCtaClick,
+    primaryCtaSettings,
+    secondaryCtaSettings,
+}: MomentTemplateBannerCtasProps): JSX.Element {
+    const mobileCtas = maybeMobileCtas ?? desktopCtas;
+
+    return (
+        <div css={styles.container}>
+            <div>
+                {mobileCtas.primary && (
+                    <Hide above="tablet">
+                        <PrimaryButton
+                            ctaText={mobileCtas.primary.ctaText}
+                            ctaUrl={mobileCtas.primary.ctaUrl}
+                            ctaSettings={primaryCtaSettings}
+                            onClick={onPrimaryCtaClick}
+                            size="small"
+                        />
+                    </Hide>
+                )}
+
+                {desktopCtas.primary && (
+                    <Hide below="tablet">
+                        <PrimaryButton
+                            ctaText={desktopCtas.primary.ctaText}
+                            ctaUrl={desktopCtas.primary.ctaUrl}
+                            ctaSettings={primaryCtaSettings}
+                            onClick={onPrimaryCtaClick}
+                            size="default"
+                        />
+                    </Hide>
+                )}
+            </div>
+
+            <div>
+                {mobileCtas.secondary?.type === SecondaryCtaType.Custom && (
+                    <Hide above="tablet">
+                        <SecondaryButton
+                            ctaText={mobileCtas.secondary.cta.ctaText}
+                            ctaUrl={mobileCtas.secondary.cta.ctaUrl}
+                            ctaSettings={secondaryCtaSettings}
+                            onClick={onSecondaryCtaClick}
+                            size="small"
+                        />
+                    </Hide>
+                )}
+
+                {desktopCtas.secondary?.type === SecondaryCtaType.Custom && (
+                    <Hide below="tablet">
+                        <SecondaryButton
+                            ctaText={desktopCtas.secondary.cta.ctaText}
+                            ctaUrl={desktopCtas.secondary.cta.ctaUrl}
+                            ctaSettings={secondaryCtaSettings}
+                            onClick={onSecondaryCtaClick}
+                            size="small"
+                        />
+                    </Hide>
+                )}
+            </div>
+        </div>
+    );
+}
+
+// ---- Helper Components ---- //
+
+interface ButtonProps {
+    ctaText: string;
+    ctaUrl: string;
+    ctaSettings: CtaSettings;
+    onClick: () => void;
+    size: 'small' | 'default';
+}
+
+function PrimaryButton({ ctaText, ctaUrl, ctaSettings, onClick, size }: ButtonProps) {
+    return (
+        <div>
+            <LinkButton
+                href={ctaUrl}
+                onClick={onClick}
+                size={size}
+                priority="primary"
+                cssOverrides={buttonStyles(ctaSettings)}
+            >
+                {ctaText}
+            </LinkButton>
+
+            <PaymentCards />
+        </div>
+    );
+}
+
+function SecondaryButton({ ctaText, ctaUrl, ctaSettings, onClick, size }: ButtonProps) {
+    return (
+        <LinkButton
+            href={ctaUrl}
+            onClick={onClick}
+            size={size}
+            priority="tertiary"
+            cssOverrides={buttonStyles(ctaSettings)}
+        >
+            {ctaText}
+        </LinkButton>
+    );
+}
+
+function PaymentCards() {
+    return (
+        <img
+            width={138}
+            height={20}
+            src="https://media.guim.co.uk/b6772cef0acaa243c379527b54f4375801b4cdec/0_0_138_20/138.png"
+            alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+            css={styles.paymentMethods}
+        />
+    );
+}
+
+// ---- Styles ---- //
+
+const styles = {
+    container: css`
+        display: flex;
+        flex-direction: row;
+
+        & > * + * {
+            margin-left: ${space[3]}px;
+        }
+    `,
+    paymentMethods: css`
+        display: block;
+        height: 1.1rem;
+        width: auto;
+        margin-top: ${space[2]}px;
+        margin-left: ${space[1]}px;
+
+        ${from.tablet} {
+            margin-left: ${space[2]}px;
+            height: 1.25rem;
+        }
+    `,
+};

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { from } from '@guardian/src-foundations/mq';
+import { headline } from '@guardian/src-foundations/typography';
+import { neutral } from '@guardian/src-foundations/palette';
+import { Hide } from '@guardian/src-layout';
+
+// ---- Component ---- //
+
+interface MomentTemplateBannerHeaderProps {
+    heading: JSX.Element | JSX.Element[] | null;
+    mobileHeading: JSX.Element | JSX.Element[] | null;
+}
+
+export function MomentTemplateBannerHeader({
+    heading,
+    mobileHeading,
+}: MomentTemplateBannerHeaderProps): JSX.Element {
+    return (
+        <div css={styles.container}>
+            <header css={styles.header}>
+                <h2>
+                    <Hide below="tablet">{mobileHeading ?? heading}</Hide>
+                    <Hide above="tablet">{heading}</Hide>
+                </h2>
+            </header>
+        </div>
+    );
+}
+
+// ---- Styles ---- //
+
+const styles = {
+    container: css`
+        position: relative;
+    `,
+    header: css`
+        h2 {
+            ${headline.xsmall({ fontWeight: 'bold' })}
+            margin: 0;
+            color: ${neutral[0]};
+            font-size: 24px;
+            line-height: 115%;
+
+            ${from.mobileLandscape} {
+                font-size: 30px;
+            }
+
+            ${from.tablet} {
+                font-size: 28px;
+            }
+
+            ${from.desktop} {
+                font-size: 42px;
+            }
+        }
+    `,
+};

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { ImageSettings } from '../settings';
+import { from } from '@guardian/src-foundations/mq';
+import { Image, ResponsiveImage } from '../../../shared/ResponsiveImage';
+
+// ---- Component ---- //
+
+interface MomentTemplateBannerVisualProps {
+    settings: ImageSettings;
+}
+
+export function MomentTemplateBannerVisual({
+    settings,
+}: MomentTemplateBannerVisualProps): JSX.Element {
+    const baseImage: Image = {
+        url: settings.mobileUrl,
+        media: '(max-width: 739px)',
+        alt: settings.alt,
+    };
+
+    const images: Image[] = [baseImage];
+    if (settings.tabletUrl) {
+        images.push({ url: settings.tabletUrl, media: '(max-width: 979px)' });
+    }
+    if (settings.desktopUrl) {
+        images.push({ url: settings.desktopUrl, media: '(max-width: 1139px)' });
+    }
+    if (settings.leftColUrl) {
+        images.push({ url: settings.leftColUrl, media: '(max-width: 1299px)' });
+    }
+    if (settings.wideUrl) {
+        images.push({ url: settings.wideUrl, media: '' });
+    }
+
+    return (
+        <div css={container}>
+            <ResponsiveImage baseImage={baseImage} images={images} />
+        </div>
+    );
+}
+
+// ---- Styles ---- //
+
+const container = css`
+    height: 140px;
+    display: flex;
+    justify-content: center;
+
+    img {
+        height: 100%;
+        width: 100%;
+        object-fit: contain;
+    }
+
+    ${from.tablet} {
+        height: 100%;
+        width: 100%;
+        align-items: center;
+    }
+`;

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
@@ -1,25 +1,28 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { ImageSettings } from '../settings';
 import { from } from '@guardian/src-foundations/mq';
-import { Image, ResponsiveImage } from '../../../shared/ResponsiveImage';
+import { ImageAttrs, ResponsiveImage } from '../../../shared/ResponsiveImage';
+import { Image } from '@sdc/shared/src/types';
 
 // ---- Component ---- //
 
 interface MomentTemplateBannerVisualProps {
-    settings: ImageSettings;
+    settings: Image;
 }
 
 export function MomentTemplateBannerVisual({
     settings,
 }: MomentTemplateBannerVisualProps): JSX.Element {
-    const baseImage: Image = {
-        url: settings.mobileUrl,
-        media: '(max-width: 739px)',
-        alt: settings.alt,
+    const baseImage: ImageAttrs = {
+        url: settings.mainUrl,
+        media: '',
+        alt: settings.altText,
     };
 
-    const images: Image[] = [baseImage];
+    const images: ImageAttrs[] = [];
+    if (settings.mobileUrl) {
+        images.push({ url: settings.mobileUrl, media: '(max-width: 739px)' });
+    }
     if (settings.tabletUrl) {
         images.push({ url: settings.tabletUrl, media: '(max-width: 979px)' });
     }

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -1,0 +1,27 @@
+export type CtaStateSettings = {
+    textColour: string;
+    backgroundColour: string;
+    border?: string;
+};
+
+export interface CtaSettings {
+    default: CtaStateSettings;
+    hover: CtaStateSettings;
+}
+
+export interface ImageSettings {
+    mobileUrl: string;
+    tabletUrl?: string;
+    desktopUrl?: string;
+    leftColUrl?: string;
+    wideUrl?: string;
+    alt: string;
+}
+
+export interface BannerTemplateSettings {
+    backgroundColour: string;
+    primaryCtaSettings: CtaSettings;
+    secondaryCtaSettings: CtaSettings;
+    closeButtonSettings: CtaSettings;
+    imageSetings: ImageSettings;
+}

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -1,3 +1,5 @@
+import { Image } from '@sdc/shared/src/types';
+
 export type CtaStateSettings = {
     textColour: string;
     backgroundColour: string;
@@ -9,19 +11,10 @@ export interface CtaSettings {
     hover: CtaStateSettings;
 }
 
-export interface ImageSettings {
-    mobileUrl: string;
-    tabletUrl?: string;
-    desktopUrl?: string;
-    leftColUrl?: string;
-    wideUrl?: string;
-    alt: string;
-}
-
 export interface BannerTemplateSettings {
     backgroundColour: string;
     primaryCtaSettings: CtaSettings;
     secondaryCtaSettings: CtaSettings;
     closeButtonSettings: CtaSettings;
-    imageSetings: ImageSettings;
+    imageSetings: Image;
 }

--- a/packages/modules/src/modules/shared/ResponsiveImage.tsx
+++ b/packages/modules/src/modules/shared/ResponsiveImage.tsx
@@ -1,17 +1,17 @@
 import React, { ReactElement } from 'react';
 
-type Image = {
+export type ImageAttrs = {
     url: string;
     media: string;
     alt?: string;
 };
 
 type ResponsiveImageProps = {
-    images: Array<Image>;
-    baseImage: Image;
+    images: Array<ImageAttrs>;
+    baseImage: ImageAttrs;
 };
 
-function createSource(image: Image): ReactElement {
+function createSource(image: ImageAttrs): ReactElement {
     return <source media={image.media} srcSet={image.url} key={image.url} />;
 }
 

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -133,11 +133,21 @@ export const trackingSchema = z.object({
 
 export interface Image {
     mainUrl: string;
+    mobileUrl?: string;
+    tabletUrl?: string;
+    desktopUrl?: string;
+    leftColUrl?: string;
+    wideUrl?: string;
     altText: string;
 }
 
 export const imageSchema = z.object({
     mainUrl: z.string(),
+    mobileUrl: z.string().optional(),
+    tabletUrl: z.string().optional(),
+    desktopUrl: z.string().optional(),
+    leftColUrl: z.string().optional(),
+    wideUrl: z.string().optional(),
     altText: z.string(),
 });
 


### PR DESCRIPTION
## What does this change?
This change adds the `MomentTemplateBanner` component. The idea with this component is to allow for quickly putting together moment banners in the future. 

The ultimate goal here is to hook this up to the RRCP to allow configuring moment banners without any dev involvment. That probably means adding the new `BannerTemplateSettings` type to the `BannerProps` and then adding the corresponding fields to the RRCP.

For now, a dev will have to create moment banners using this template. We can see an example of that [here](https://github.com/guardian/support-dotcom-components/pull/691/files#diff-fab4c18cd160490fbf12df2f444e6da0bb0e66b4377b7c52b6d60e65a20bfb7aR14). It involves importing the `getMomentTemplateBanner` function and passing in some hardcoded `BannerTemplateSettings` to set the right colours and images.

In a follow up PR I will add the remiders signup component.

## Images

| mobile | tablet | desktop | leftCol | wide |
|--------|--------|---------|---------|------|
|![Screenshot 2022-05-04 at 11 52 54](https://user-images.githubusercontent.com/17720442/166668983-3f4fcc9a-e42e-40b6-a2d3-d75cebafa501.png)|![Screenshot 2022-05-04 at 11 53 10](https://user-images.githubusercontent.com/17720442/166668986-9d64c785-3ea8-44ef-8931-36c4eff86d53.png)|![Screenshot 2022-05-04 at 11 53 31](https://user-images.githubusercontent.com/17720442/166668988-5450cfc4-c1b0-422e-b671-7854146b7272.png)|![Screenshot 2022-05-04 at 11 53 45](https://user-images.githubusercontent.com/17720442/166668994-6f087da0-b220-4fd7-b91a-977b005ac31b.png)|![Screenshot 2022-05-04 at 11 54 02](https://user-images.githubusercontent.com/17720442/166668995-c314d470-8da2-48af-9eb8-8a585974aabc.png)|


I built the banner to reflow continuously at mobile, but from tablet onwards only change at breakpoints. We don't always do this, but I think it's a good standard to follow as it's inline with dotcom.

![banner-response](https://user-images.githubusercontent.com/17720442/166669780-c2816b26-194b-4faa-8b98-567deeb930c3.gif)

