### PR TITLE
Fix GW banner close on mobile

### DIFF
--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -7,6 +7,7 @@ import { SvgRoundelDefault } from '@guardian/src-brand';
 import { SvgCross } from '@guardian/src-icons';
 import {
     banner,
+    closeButtonStyles,
     copyColumn,
     heading,
     iconAndClosePosition,
@@ -68,6 +69,7 @@ type ButtonPropTypes = {
 
 const CloseButton = (props: ButtonPropTypes): ReactElement => (
     <Button
+        css={closeButtonStyles}
         data-link-name={closeComponentId}
         onClick={props.onClick}
         icon={<SvgCross />}

--- a/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -106,6 +106,10 @@ export const iconAndClosePosition = css`
     min-width: ${height.ctaMedium * 2}px;
 `;
 
+export const closeButtonStyles = css`
+    z-index: 999;
+`;
+
 export const logoContainer = css`
     display: none;
     ${from.mobileMedium} {


### PR DESCRIPTION
The close button isn't clickable on mobile. This only affects the GW banner