### PR TITLE
Small tweaks to the MomentTemplateBanner

### DIFF
--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
@@ -45,7 +45,7 @@ const GlobalNYBanner = bannerWrapper(
                 textColour: neutral[0],
             },
         },
-        imageSetings: {
+        imageSettings: {
             mainUrl:
                 'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
             altText: 'Guardian logo being held up by supporters of the Guardian',
@@ -139,7 +139,7 @@ const AusElectionBanner = bannerWrapper(
                 textColour: neutral[0],
             },
         },
-        imageSetings: {
+        imageSettings: {
             mainUrl:
                 'https://i.guim.co.uk/img/media/ad0166d7724eb2dfc6aa16fea50fe41c02324eb8/0_0_281_131/281.png?quality=85&s=7639d39b1492f5e2f4883496fcc5740c',
             mobileUrl:

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -36,7 +36,7 @@ export function getMomentTemplateBanner(
                         </div>
 
                         <div css={styles.visualContainer}>
-                            <MomentTemplateBannerVisual settings={templateSettings.imageSetings} />
+                            <MomentTemplateBannerVisual settings={templateSettings.imageSettings} />
                         </div>
 
                         <div css={styles.contentContainer}>

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
@@ -45,7 +45,6 @@ export function MomentTemplateBannerCtas({
                             ctaUrl={mobileCtas.primary.ctaUrl}
                             ctaSettings={primaryCtaSettings}
                             onClick={onPrimaryCtaClick}
-                            size="small"
                         />
                     </Hide>
                 )}
@@ -57,7 +56,6 @@ export function MomentTemplateBannerCtas({
                             ctaUrl={desktopCtas.primary.ctaUrl}
                             ctaSettings={primaryCtaSettings}
                             onClick={onPrimaryCtaClick}
-                            size="default"
                         />
                     </Hide>
                 )}
@@ -71,7 +69,6 @@ export function MomentTemplateBannerCtas({
                             ctaUrl={mobileCtas.secondary.cta.ctaUrl}
                             ctaSettings={secondaryCtaSettings}
                             onClick={onSecondaryCtaClick}
-                            size="small"
                         />
                     </Hide>
                 )}
@@ -83,7 +80,6 @@ export function MomentTemplateBannerCtas({
                             ctaUrl={desktopCtas.secondary.cta.ctaUrl}
                             ctaSettings={secondaryCtaSettings}
                             onClick={onSecondaryCtaClick}
-                            size="small"
                         />
                     </Hide>
                 )}
@@ -99,16 +95,15 @@ interface ButtonProps {
     ctaUrl: string;
     ctaSettings: CtaSettings;
     onClick: () => void;
-    size: 'small' | 'default';
 }
 
-function PrimaryButton({ ctaText, ctaUrl, ctaSettings, onClick, size }: ButtonProps) {
+function PrimaryButton({ ctaText, ctaUrl, ctaSettings, onClick }: ButtonProps) {
     return (
         <div>
             <LinkButton
                 href={ctaUrl}
                 onClick={onClick}
-                size={size}
+                size="small"
                 priority="primary"
                 cssOverrides={buttonStyles(ctaSettings)}
             >
@@ -120,12 +115,12 @@ function PrimaryButton({ ctaText, ctaUrl, ctaSettings, onClick, size }: ButtonPr
     );
 }
 
-function SecondaryButton({ ctaText, ctaUrl, ctaSettings, onClick, size }: ButtonProps) {
+function SecondaryButton({ ctaText, ctaUrl, ctaSettings, onClick }: ButtonProps) {
     return (
         <LinkButton
             href={ctaUrl}
             onClick={onClick}
-            size={size}
+            size="small"
             priority="tertiary"
             cssOverrides={buttonStyles(ctaSettings)}
         >

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -16,5 +16,5 @@ export interface BannerTemplateSettings {
     primaryCtaSettings: CtaSettings;
     secondaryCtaSettings: CtaSettings;
     closeButtonSettings: CtaSettings;
-    imageSetings: Image;
+    imageSettings: Image;
 }


### PR DESCRIPTION
This change just makes a couple of small tweaks to the MomentTemplateBanner:

- sets the CTA size always to small (as per designs)
- fixes a typ0 with `imageSetings` (should be `imageSettings`)