### PR TITLE
Track product in GW ML test

### DIFF
--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
@@ -71,6 +71,7 @@ const getGWBanner = (variantName: string): BannerVariant => ({
     moduleName: BannerTemplate.GuardianWeeklyBanner,
     bannerContent: GW_CONTENT,
     componentType: channelName,
+    products: ['PRINT_SUBSCRIPTION'],
 });
 
 const getDSBanner = (variantName: string, targeting: BannerTargeting): BannerVariant => ({
@@ -80,6 +81,7 @@ const getDSBanner = (variantName: string, targeting: BannerTargeting): BannerVar
     bannerContent:
         DIGISUB_CONTENT[countryCodeToCountryGroupId(targeting.countryCode.toUpperCase())],
     componentType: channelName,
+    products: ['DIGITAL_SUBSCRIPTION'],
 });
 
 const getControlBanner = (variantName: string, targeting: BannerTargeting): BannerVariant =>


### PR DESCRIPTION
Currently impressions + conversions within a variant are indistinguishable, e.g. in the variant a user who sees DS and a user who sees GW are tracked the same.

But we can set the `products` field in the tracking data, which [ophan will accept](https://github.com/guardian/support-dotcom-components/blob/main/packages/shared/src/types/ophan.ts#L5).