### PR TITLE
Add specific moment template banner article count opt out.

### DIFF
--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -26,7 +26,7 @@ export function getMomentTemplateBanner(
     }: BannerRenderProps): JSX.Element {
         return (
             <div css={styles.outerContainer(templateSettings.backgroundColour)}>
-                <Container>
+                <Container cssOverrides={styles.containerOverrides}>
                     <div css={styles.container}>
                         <div css={styles.closeButtonContainer}>
                             <MomentTemplateBannerCloseButton
@@ -49,7 +49,10 @@ export function getMomentTemplateBanner(
 
                             {numArticles !== undefined && numArticles > 5 && (
                                 <div css={styles.articleCountContainer}>
-                                    <MomentTemplateBannerArticleCount numArticles={numArticles} />
+                                    <MomentTemplateBannerArticleCount
+                                        numArticles={numArticles}
+                                        settings={templateSettings}
+                                    />
                                 </div>
                             )}
 
@@ -106,8 +109,13 @@ const styles = {
             box-sizing: border-box;
         }
     `,
-    container: css`
+    containerOverrides: css`
         position: relative;
+        width: 100%;
+        max-width: 1300px;
+        margin: 0 auto;
+    `,
+    container: css`
         overflow: hidden;
         display: flex;
         flex-direction: column;

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
@@ -3,24 +3,27 @@ import { css } from '@emotion/react';
 import { neutral } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
-import { ArticleCountOptOutPopup } from '../../../shared/ArticleCountOptOutPopup';
+import { MomentTemplateArticleCountOptOut } from './MomentTemplateBannerArticleCountOptOut';
+import { BannerTemplateSettings } from '../settings';
 
 // ---- Component ---- //
 
 interface MomentTemplateBannerArticleCountProps {
     numArticles: number;
+    settings: BannerTemplateSettings;
 }
 
 export function MomentTemplateBannerArticleCount({
     numArticles,
+    settings,
 }: MomentTemplateBannerArticleCountProps): JSX.Element {
     return (
         <p css={styles.container}>
             You&apos;ve read{' '}
-            <ArticleCountOptOutPopup
+            <MomentTemplateArticleCountOptOut
                 numArticles={numArticles}
                 nextWord=" articles"
-                type="global-new-year-banner"
+                settings={settings}
             />{' '}
             in the last year
         </p>

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
@@ -1,0 +1,225 @@
+import React, { useState } from 'react';
+import { css } from '@emotion/react';
+import { textSans } from '@guardian/src-foundations/typography';
+import { Button } from '@guardian/src-button';
+import { SvgCross } from '@guardian/src-icons';
+import { neutral, space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import {
+    addArticleCountOptOutCookie,
+    removeArticleCountFromLocalStorage,
+} from '../../../shared/helpers/articleCountOptOut';
+import { BannerTemplateSettings } from '../settings';
+import { buttonStyles } from '../buttonStyles';
+
+// ---- Component ---- //
+
+export interface MomentTemplateArticleCountOptOutProps {
+    numArticles: number;
+    nextWord: string | null;
+    settings: BannerTemplateSettings;
+}
+
+export const MomentTemplateArticleCountOptOut: React.FC<MomentTemplateArticleCountOptOutProps> = ({
+    numArticles,
+    nextWord,
+    settings,
+}: MomentTemplateArticleCountOptOutProps) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [hasOptedOut, setHasOptedOut] = useState(false);
+
+    const onOptOut = (): void => {
+        addArticleCountOptOutCookie();
+        removeArticleCountFromLocalStorage();
+        setHasOptedOut(true);
+    };
+
+    const onOpen = (): void => {
+        setIsOpen(true);
+    };
+
+    const onClose = (): void => {
+        setIsOpen(false);
+    };
+
+    const onToggle = (): void => (isOpen ? onClose() : onOpen());
+
+    return (
+        <div css={styles.optOutContainer}>
+            <button css={styles.articleCountButton} onClick={onToggle}>
+                {`${numArticles}${nextWord ? nextWord : ''}`}
+            </button>
+
+            {isOpen && (
+                <div css={styles.overlayContainer}>
+                    <Overlay
+                        hasOptedOut={hasOptedOut}
+                        onOptOut={onOptOut}
+                        onClose={onClose}
+                        settings={settings}
+                    />
+                </div>
+            )}
+        </div>
+    );
+};
+
+// ---- Helper Component ---- //
+
+export interface OverlayProps {
+    hasOptedOut: boolean;
+    onOptOut: () => void;
+    onClose: () => void;
+    settings: BannerTemplateSettings;
+}
+
+const Overlay: React.FC<OverlayProps> = ({
+    hasOptedOut,
+    onClose,
+    onOptOut,
+    settings,
+}: OverlayProps) => {
+    return (
+        <div css={overlayStyles.overlayContainer(settings.backgroundColour)}>
+            <div css={overlayStyles.overlayHeader}>
+                <div css={overlayStyles.overlayHeaderText}>
+                    {hasOptedOut ? "You've opted out" : "What's this?"}
+                </div>
+
+                <Button
+                    onClick={onClose}
+                    icon={<SvgCross />}
+                    hideLabel
+                    size="xsmall"
+                    priority="tertiary"
+                    cssOverrides={buttonStyles(settings.closeButtonSettings)}
+                >
+                    Close
+                </Button>
+            </div>
+
+            <div css={overlayStyles.overlayBody}>
+                {hasOptedOut
+                    ? "Starting from your next page view, we won't count the articles you read or show you this message for three months."
+                    : 'We would like to remind you how many Guardian articles you’ve enjoyed on this device. Can we continue showing you this?'}
+            </div>
+
+            {!hasOptedOut && (
+                <div css={overlayStyles.overlayCtaContainer}>
+                    <Button
+                        onClick={onClose}
+                        priority="primary"
+                        size="xsmall"
+                        cssOverrides={buttonStyles(settings.primaryCtaSettings)}
+                    >
+                        Yes, that&apos;s OK
+                    </Button>
+
+                    <Button
+                        onClick={onOptOut}
+                        priority="tertiary"
+                        size="xsmall"
+                        cssOverrides={buttonStyles(settings.secondaryCtaSettings)}
+                    >
+                        No, opt me out
+                    </Button>
+                </div>
+            )}
+
+            <div css={overlayStyles.overlayNote}>
+                {hasOptedOut ? (
+                    <span>
+                        If you have any questions, please{' '}
+                        <a href="https://www.theguardian.com/help/contact-us">contact us.</a>
+                    </span>
+                ) : (
+                    "Please note that opting out is a permanent action and can't be reversed"
+                )}
+            </div>
+        </div>
+    );
+};
+
+// ---- Styles ---- //
+
+const styles = {
+    optOutContainer: css`
+        display: inline-block;
+    `,
+    articleCountButton: css`
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        border-bottom: 1px solid;
+        font-family: inherit;
+        font-size: inherit;
+        font-weight: inherit;
+        font-style: inherit;
+        color: inherit;
+        &:focus {
+            outline: none !important;
+        }
+    `,
+    overlayContainer: css`
+        position: absolute;
+        z-index: 100;
+        top: 0px;
+        left: 0px;
+        display: block;
+
+        ${from.tablet} {
+            top: 10px;
+            left: 10px;
+            width: 450px;
+        }
+    `,
+};
+
+const overlayStyles = {
+    overlayContainer: (backgroundColour: string) => css`
+        ${textSans.medium()}
+        padding: ${space[2]}px;
+        background-color: ${backgroundColour};
+        border: 1px solid ${neutral[0]};
+        box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
+        `,
+    overlayHeader: css`
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    `,
+    overlayHeaderText: css`
+        font-size: 17px;
+        font-weight: bold;
+    `,
+    overlayBody: css`
+        margin-top: ${space[1]}px;
+        font-size: 15px;
+    `,
+    overlayCtaContainer: css`
+        margin-top: ${space[3]}px;
+        display: flex;
+        flex-direction: row;
+
+        > * + * {
+            margin-left: ${space[2]}px;
+        }
+
+        ${from.tablet} {
+            > * + * {
+                margin-left: ${space[3]}px;
+            }
+        }
+    `,
+    overlayNote: css`
+        margin-top: ${space[2]}px;
+        ${textSans.xsmall()}
+        font-style: italic;
+
+        a {
+            color: ${neutral[0]} !important;
+            text-decoration: underline !important;
+        }
+    `,
+};


### PR DESCRIPTION
## What does this change?

This change adds an article count opt out component specific to the moment template banner (MomentTemplateBannerArticleCountOptOut).

This did involve a lot of copy and pasting from the existing opt out (ArticleCountOptOutPopup) which is a shame but I think having some duplication is probably the simplest solution for now. The issue is that the existing component takes a `type` parameter which it then uses to decide on the styles for the component. This doesn't quite fit with moment template banner which we want to be able to fully customise just through the `BannerTemplateSettings` that we provide. The settings already specify everything that we need to style the opt out (background colour, primary cta, secondary cta, and close button) so it was quite simple to create a new component that accepts a `BannerTemplateSettings` instead of an `ArticleCountOptOutType`.

I removed tracking from the component as when I checked the code it was only being used for epics - no banners were passing in the tracking object.

It's worth noting that this new component is only used in the separate, hardcoded article count subheading. If a test is configured in the RRCP that uses the %%ARTICLE_COUNT%% tag in the body copy, the older version is used (it will default to the yellow style of the main contribs banner). This is actually an existing problem with all moment banners so felt out of scope to fix now, especialy given the reason for having the subheading is to remove the need to reference article count in the body text. The reason this is quite tricky to solve is those %% tags are replaced in the shared `bannerWrapper` so it will require a decent refactor to get right.

## Images

Now it matches the styles of the rest of the banner, e.g in the Global EOY remake:

![Screenshot 2022-05-13 at 12 26 46](https://user-images.githubusercontent.com/17720442/168274231-64c5e3dd-6f64-4e7d-a392-5080aca1b195.png)

and the Aus election banner remake: 

![Screenshot 2022-05-13 at 12 26 52](https://user-images.githubusercontent.com/17720442/168274235-f9cb9bc4-99c2-41b0-a9b2-c6bf5dea4659.png)
