### PR TITLE
Post Australian Election banners

### DIFF
--- a/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentAlbaneseBanner.tsx
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentAlbaneseBanner.tsx
@@ -1,0 +1,33 @@
+import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
+import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
+import { settings } from './settings';
+
+const PostElectionAuMomentAlbaneseBanner = getMomentTemplateBanner({
+    ...settings,
+    imageSettings: {
+        mainUrl:
+            'https://i.guim.co.uk/img/media/a63c0655afb9403a6e6d74b160ab8947648641bb/0_0_872_296/500.png?quality=85&s=275c125f157ab3686d0e67103c71df38',
+        mobileUrl:
+            'https://i.guim.co.uk/img/media/a63c0655afb9403a6e6d74b160ab8947648641bb/0_0_872_296/500.png?quality=85&s=275c125f157ab3686d0e67103c71df38',
+        tabletUrl:
+            'https://i.guim.co.uk/img/media/964062779daabd818444189aea85cc32ae750492/0_0_1504_1260/500.png?quality=85&s=86576cdb9fc8677a71024dc0763e4bc8',
+        desktopUrl:
+            'https://i.guim.co.uk/img/media/182b574c47ea5ae0f21bd1ebac6f21ac90db3962/0_0_2028_1648/500.png?quality=85&s=bc08d2646ea27e0776904706ebc9e198',
+        leftColUrl:
+            'https://i.guim.co.uk/img/media/926d42a6709a14b01e98ca28e1e1dca4d5b5f78f/0_0_2028_1712/500.png?quality=85&s=cbed3e740e40117c972d750609cdbde1',
+        wideUrl:
+            'https://i.guim.co.uk/img/media/23aa54b63307e87dd398e85daee090a7afa31fff/0_0_2240_1604/500.png?quality=85&s=027a2278b4ec5450602b60c979e10378',
+        altText: 'Head shot of Anthony Albanese, leader of the Australian Labor Party.',
+    },
+});
+
+const unvalidated = bannerWrapper(PostElectionAuMomentAlbaneseBanner, 'election-au-moment-banner');
+const validated = validatedBannerWrapper(
+    PostElectionAuMomentAlbaneseBanner,
+    'election-au-moment-banner',
+);
+
+export {
+    validated as PostElectionAuMomentAlbaneseBanner,
+    unvalidated as PostElectionAuMomentAlbaneseBannerUnvalidated,
+};

--- a/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentBanners.stories.tsx
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentBanners.stories.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { PostElectionAuMomentAlbaneseBannerUnvalidated as PostElectionAuMomentAlbaneseBanner } from './PostElectionAuMomentAlbaneseBanner';
+import { PostElectionAuMomentHungBannerUnvalidated as PostElectionAuMomentHungBanner } from './PostElectionAuMomentHungBanner';
+import { PostElectionAuMomentMorrisonBannerUnvalidated as PostElectionAuMomentMorrisonBanner } from './PostElectionAuMomentMorrisonBanner';
+import { props } from '../utils/storybook';
+import { BannerProps, SecondaryCtaType } from '@sdc/shared/types';
+
+export default {
+    title: 'Banners/PostElectionAuMoment',
+    args: props,
+} as Meta;
+
+const AlbaneseTemplate: Story<BannerProps> = (props: BannerProps) => (
+    <PostElectionAuMomentAlbaneseBanner {...props} />
+);
+
+export const Albanese = AlbaneseTemplate.bind({});
+Albanese.args = {
+    ...props,
+    content: {
+        heading: 'As Australia prepares to head to the polls...',
+        messageText:
+            'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo.',
+        highlightedText:
+            'Show your support today from just %%CURRENCY_SYMBOL%%1, or sustain us long term with a little more. Thank you.',
+        cta: {
+            text: 'Support independent journalism',
+            baseUrl: 'https://support.theguardian.com/contribute',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Hear from our editor',
+                baseUrl: 'https://theguardian.com',
+            },
+        },
+    },
+    mobileContent: {
+        messageText:
+            'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.',
+        highlightedText:
+            'Show your support today from just %%CURRENCY_SYMBOL%%1, or sustain us long term with a little more. Thank you.',
+        cta: {
+            text: 'Support us',
+            baseUrl: 'https://support.theguardian.com/contribute',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Learn more',
+                baseUrl: 'https://theguardian.com',
+            },
+        },
+    },
+    numArticles: 50,
+};
+
+const HungTemplate: Story<BannerProps> = (props: BannerProps) => (
+    <PostElectionAuMomentHungBanner {...props} />
+);
+
+export const Hung = HungTemplate.bind({});
+Hung.args = { ...Albanese.args };
+
+const MorrisonTemplate: Story<BannerProps> = (props: BannerProps) => (
+    <PostElectionAuMomentMorrisonBanner {...props} />
+);
+
+export const Morrison = MorrisonTemplate.bind({});
+Morrison.args = { ...Albanese.args };

--- a/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentHungBanner.tsx
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentHungBanner.tsx
@@ -1,0 +1,34 @@
+import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
+import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
+import { settings } from './settings';
+
+const PostElectionAuMomentHungBanner = getMomentTemplateBanner({
+    ...settings,
+    imageSettings: {
+        mainUrl:
+            'https://i.guim.co.uk/img/media/5d691128b6956c71539cab0a29e04b2a4eb6539b/0_0_748_296/500.png?quality=85&s=5692724d3c5bfeac365c86503118b1f2',
+        mobileUrl:
+            'https://i.guim.co.uk/img/media/5d691128b6956c71539cab0a29e04b2a4eb6539b/0_0_748_296/500.png?quality=85&s=5692724d3c5bfeac365c86503118b1f2',
+        tabletUrl:
+            'https://i.guim.co.uk/img/media/6b94afbcbeb8d9f848f8bb2099d4721b3fd9144b/0_0_1316_1280/500.png?quality=85&s=fd9a851a7fc985948d5f58e11f70681c',
+        desktopUrl:
+            'https://i.guim.co.uk/img/media/9321f721e90405f4d16b29bdcd3fd336fcc4307e/0_0_1420_1364/500.png?quality=85&s=f05c686e2ee072e97806a38d2a6c38a5',
+        leftColUrl:
+            'https://i.guim.co.uk/img/media/1c7675cd39f7368fff74ef323cb3051fa0ba7650/0_0_1596_1576/500.png?quality=85&s=204024ab5c180241d7dd0644d3d23ad6',
+        wideUrl:
+            'https://i.guim.co.uk/img/media/b3c411f0c5d34c643dabcf0538ac62e54d86ef2e/0_0_1792_1708/500.png?quality=85&s=65821026aa503301ae4efc6fd6b1da41',
+        altText:
+            'Head shots of Anthony Albanese, leader of the Australian Labor Party, and Scott Morrison leader of the Liberal Party of Australia.',
+    },
+});
+
+const unvalidated = bannerWrapper(PostElectionAuMomentHungBanner, 'election-au-moment-banner');
+const validated = validatedBannerWrapper(
+    PostElectionAuMomentHungBanner,
+    'election-au-moment-banner',
+);
+
+export {
+    validated as PostElectionAuMomentHungBanner,
+    unvalidated as PostElectionAuMomentHungBannerUnvalidated,
+};

--- a/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentMorrisonBanner.tsx
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentMorrisonBanner.tsx
@@ -1,0 +1,33 @@
+import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
+import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
+import { settings } from './settings';
+
+const PostElectionAuMomentMorrisonBanner = getMomentTemplateBanner({
+    ...settings,
+    imageSettings: {
+        mainUrl:
+            'https://i.guim.co.uk/img/media/76c913749a31ad4847bbcedafc098b003a3963a1/0_0_872_296/500.png?quality=85&s=e0e1d7a7fcf0a656f5a19e68b6800910',
+        mobileUrl:
+            'https://i.guim.co.uk/img/media/76c913749a31ad4847bbcedafc098b003a3963a1/0_0_872_296/500.png?quality=85&s=e0e1d7a7fcf0a656f5a19e68b6800910',
+        tabletUrl:
+            'https://i.guim.co.uk/img/media/cd1bb0b74be9a7eb6a8a7c29101edcaee7b0067b/0_0_1468_1180/500.png?quality=85&s=038b49db59d0b7f9da39aae1b5b2c1e0',
+        desktopUrl:
+            'https://i.guim.co.uk/img/media/f7f9ee7aa5526431fc1c6f2e10206d1032f50e52/0_0_1700_1284/500.png?quality=85&s=99ea8f8dafa34e13433d7925550d6754',
+        leftColUrl:
+            'https://i.guim.co.uk/img/media/392f4a2a6fe26fd3e18a9b2703515937d1bd4602/0_0_2192_1464/500.png?quality=85&s=7ad046500a68605cb285b8327a487b32',
+        wideUrl:
+            'https://i.guim.co.uk/img/media/8a737c07c07e1c41bcba95cc15a38b167a82d51f/0_0_2456_1740/500.png?quality=85&s=18ef3405d8065564cf633115e07521ca',
+        altText: 'Head shot of Scott Morrison, leader of the Liberal Party of Australia.',
+    },
+});
+
+const unvalidated = bannerWrapper(PostElectionAuMomentMorrisonBanner, 'election-au-moment-banner');
+const validated = validatedBannerWrapper(
+    PostElectionAuMomentMorrisonBanner,
+    'election-au-moment-banner',
+);
+
+export {
+    validated as PostElectionAuMomentMorrisonBanner,
+    unvalidated as PostElectionAuMomentMorrisonBannerUnvalidated,
+};

--- a/packages/modules/src/modules/banners/postElectionAuMoment/settings.ts
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/settings.ts
@@ -1,0 +1,37 @@
+import { neutral } from '@guardian/src-foundations';
+import { BannerTemplateSettings } from '../momentTemplate/settings';
+
+export const settings: Omit<BannerTemplateSettings, 'imageSettings'> = {
+    backgroundColour: '#ffe500',
+    primaryCtaSettings: {
+        default: {
+            backgroundColour: '#121212',
+            textColour: 'white',
+        },
+        hover: {
+            backgroundColour: '#454545',
+            textColour: 'white',
+        },
+    },
+    secondaryCtaSettings: {
+        default: {
+            backgroundColour: '#ffe500',
+            textColour: neutral[7],
+        },
+        hover: {
+            backgroundColour: '#e4e4e3',
+            textColour: neutral[7],
+        },
+    },
+    closeButtonSettings: {
+        default: {
+            backgroundColour: '#ffe500',
+            textColour: neutral[0],
+            border: `1px solid ${neutral[0]}`,
+        },
+        hover: {
+            backgroundColour: 'white',
+            textColour: neutral[0],
+        },
+    },
+};

--- a/packages/server/src/tests/banners/ChannelBannerTests.ts
+++ b/packages/server/src/tests/banners/ChannelBannerTests.ts
@@ -7,6 +7,9 @@ import {
     investigationsMomentBanner,
     globalNewYearBanner,
     electionAuMomentBanner,
+    postElectionAuMomentAlbaneseBanner,
+    postElectionAuMomentHungBanner,
+    postElectionAuMomentMorrisonBanner,
 } from '@sdc/shared/config';
 import {
     BannerChannel,
@@ -37,6 +40,12 @@ export const BannerPaths: {
     [BannerTemplate.EnvironmentMomentBanner]: environmentMomentBanner.endpointPathBuilder,
     [BannerTemplate.GlobalNewYearBanner]: globalNewYearBanner.endpointPathBuilder,
     [BannerTemplate.ElectionAuMomentBanner]: electionAuMomentBanner.endpointPathBuilder,
+    [BannerTemplate.PostElectionAuMomentAlbaneseBanner]:
+        postElectionAuMomentAlbaneseBanner.endpointPathBuilder,
+    [BannerTemplate.PostElectionAuMomentHungBanner]:
+        postElectionAuMomentHungBanner.endpointPathBuilder,
+    [BannerTemplate.PostElectionAuMomentMorrisonBanner]:
+        postElectionAuMomentMorrisonBanner.endpointPathBuilder,
     [BannerTemplate.DigitalSubscriptionsBanner]: digiSubs.endpointPathBuilder,
     [BannerTemplate.GuardianWeeklyBanner]: guardianWeekly.endpointPathBuilder,
 };

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -53,6 +53,21 @@ export const electionAuMomentBanner: ModuleInfo = getDefaultModuleInfo(
     'banners/electionAuMoment/ElectionAuMomentBanner',
 );
 
+export const postElectionAuMomentAlbaneseBanner: ModuleInfo = getDefaultModuleInfo(
+    'post-election-au-moment-albanese-banner',
+    'banners/postElectionAuMoment/PostElectionAuMomentAlbaneseBanner',
+);
+
+export const postElectionAuMomentHungBanner: ModuleInfo = getDefaultModuleInfo(
+    'post-election-au-moment-hung-banner',
+    'banners/postElectionAuMoment/PostElectionAuMomentHungBanner',
+);
+
+export const postElectionAuMomentMorrisonBanner: ModuleInfo = getDefaultModuleInfo(
+    'post-election-au-moment-morrison-banner',
+    'banners/postElectionAuMoment/PostElectionAuMomentMorrisonBanner',
+);
+
 export const digiSubs: ModuleInfo = getDefaultModuleInfo(
     'digital-subscriptions-banner',
     'banners/digitalSubscriptions/DigitalSubscriptionsBanner',
@@ -79,6 +94,9 @@ export const moduleInfos: ModuleInfo[] = [
     environmentMomentBanner,
     globalNewYearBanner,
     electionAuMomentBanner,
+    postElectionAuMomentAlbaneseBanner,
+    postElectionAuMomentHungBanner,
+    postElectionAuMomentMorrisonBanner,
     digiSubs,
     guardianWeekly,
     puzzlesBanner,

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -21,6 +21,9 @@ export enum BannerTemplate {
     GuardianWeeklyBanner = 'GuardianWeeklyBanner',
     GlobalNewYearBanner = 'GlobalNewYearBanner',
     ElectionAuMomentBanner = 'ElectionAuMomentBanner',
+    PostElectionAuMomentAlbaneseBanner = 'PostElectionAuMomentAlbaneseBanner',
+    PostElectionAuMomentHungBanner = 'PostElectionAuMomentHungBanner',
+    PostElectionAuMomentMorrisonBanner = 'PostElectionAuMomentMorrisonBanner',
 }
 
 export interface BannerVariant extends Variant {


### PR DESCRIPTION
## What does this change?

This PR adds the 3 possible post Australian election banners. We will make all three of these [available in the RRCP](https://github.com/guardian/support-admin-console/pull/334), which will allow us to quickly update the messaging on the site after the election is called.

## TODO

- [x] update images with `i.guim` links after design sign off

## Images

**Albanese win**
![Screenshot 2022-05-13 at 16 05 37](https://user-images.githubusercontent.com/17720442/168312740-00556887-571b-4c3e-8b5f-4e1e40342734.png)

**Hung parliament**
![Screenshot 2022-05-13 at 16 05 42](https://user-images.githubusercontent.com/17720442/168312750-1126d771-348f-494d-864c-33050ed4f258.png)

**Morrison win**
![Screenshot 2022-05-13 at 16 05 46](https://user-images.githubusercontent.com/17720442/168312752-95c61eee-38b9-4f05-82e4-2f5fd9f1f129.png)

