### PR TITLE
Allow highlighted text to be customised in the moment template banner

### DIFF
--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
@@ -45,6 +45,9 @@ const GlobalNYBanner = bannerWrapper(
                 textColour: neutral[0],
             },
         },
+        highlightedTextSettings: {
+            textColour: neutral[0],
+        },
         imageSettings: {
             mainUrl:
                 'https://media.guim.co.uk/a1087c3f7e6da4f1e97947acccdd7f0d15f327d4/0_0_142_124/140.png',
@@ -138,6 +141,9 @@ const AusElectionBanner = bannerWrapper(
                 backgroundColour: 'white',
                 textColour: neutral[0],
             },
+        },
+        highlightedTextSettings: {
+            textColour: neutral[0],
         },
         imageSettings: {
             mainUrl:

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -64,6 +64,9 @@ export function getMomentTemplateBanner(
                                     mobileHighlightedText={
                                         content.mobileContent?.highlightedText ?? null
                                     }
+                                    highlightedTextSettings={
+                                        templateSettings.highlightedTextSettings
+                                    }
                                 />
                             </div>
 

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -5,7 +5,8 @@ import { from } from '@guardian/src-foundations/mq';
 import { Hide } from '@guardian/src-layout';
 import { body } from '@guardian/src-foundations/typography';
 
-import { BannerTextStyles, createBannerBodyCopy } from '../../common/BannerText';
+import { createBannerBodyCopy } from '../../common/BannerText';
+import { HighlightedTextSettings } from '../settings';
 
 // ---- Component ---- //
 
@@ -14,6 +15,7 @@ interface MomentTemplateBannerBodyProps {
     mobileParagraphs: (JSX.Element | JSX.Element[])[] | null;
     highlightedText: JSX.Element | JSX.Element[] | null;
     mobileHighlightedText: JSX.Element | JSX.Element[] | null;
+    highlightedTextSettings: HighlightedTextSettings;
 }
 
 export function MomentTemplateBannerBody({
@@ -21,7 +23,10 @@ export function MomentTemplateBannerBody({
     mobileParagraphs,
     highlightedText,
     mobileHighlightedText,
+    highlightedTextSettings,
 }: MomentTemplateBannerBodyProps): JSX.Element {
+    const styles = getStyles(highlightedTextSettings);
+
     return (
         <div css={styles.container}>
             <Hide above="tablet">
@@ -39,7 +44,7 @@ export function MomentTemplateBannerBody({
 
 // ---- Styles ---- //
 
-const styles: BannerTextStyles = {
+const getStyles = (settings: HighlightedTextSettings) => ({
     container: css`
         ${body.small()}
         color: ${neutral[0]};
@@ -63,6 +68,23 @@ const styles: BannerTextStyles = {
         }
     `,
     highlightedText: css`
-        font-weight: bold;
+        display: inline;
+        color: ${settings.textColour};
+
+        ${settings.highlightColour
+            ? `
+            background: ${settings.highlightColour};
+            box-shadow: 2px 0 0 ${settings.highlightColour}, -2px 0 0 ${settings.highlightColour};
+            box-decoration-break: clone;
+        `
+            : ''}
+
+        padding: 0.15rem 0.15rem;
+        ${body.small({ fontWeight: 'bold', lineHeight: 'loose' })};
+        font-size: 15px;
+
+        ${from.desktop} {
+            font-size: 17px;
+        }
     `,
-};
+});

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -11,10 +11,16 @@ export interface CtaSettings {
     hover: CtaStateSettings;
 }
 
+export interface HighlightedTextSettings {
+    textColour: string;
+    highlightColour?: string;
+}
+
 export interface BannerTemplateSettings {
     backgroundColour: string;
     primaryCtaSettings: CtaSettings;
     secondaryCtaSettings: CtaSettings;
     closeButtonSettings: CtaSettings;
+    highlightedTextSettings: HighlightedTextSettings;
     imageSettings: Image;
 }

--- a/packages/modules/src/modules/banners/postElectionAuMoment/settings.ts
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/settings.ts
@@ -34,4 +34,8 @@ export const settings: Omit<BannerTemplateSettings, 'imageSettings'> = {
             textColour: neutral[0],
         },
     },
+    highlightedTextSettings: {
+        textColour: neutral[0],
+        highlightColour: neutral[100],
+    },
 };


### PR DESCRIPTION
This change adds `HighlightedTextSettings` to the `BannerTemplateSettings` type. This allows specifying the text colour & highlight colour. I've implemented the highlight using a box-shadow and `box-decoration-break` which is slightly different to how we've done it previously. This allows for the begining and end of wrapped lines to still have some padding. In older browsers that don't support `box-decoration-break` it falls back to having the start and end of lines tight with the end of the highlight. This looks less good visually, but it's in line with how our highlighted text currently looks in the main contribs banner. I found this method [here](https://css-tricks.com/multi-line-padded-text/#aa-fabien-doirons-box-shadow-method).

## Images

**`box-decoration-break` is supported (96.83% of browsers)**

<img width="528" alt="Screenshot 2022-05-16 at 16 44 42" src="https://user-images.githubusercontent.com/17720442/168632193-4983314a-5426-47cf-98e5-4aea0dbc0ce8.png">

**fallback when it isn't**

<img width="528" alt="Screenshot 2022-05-16 at 16 44 52" src="https://user-images.githubusercontent.com/17720442/168632200-0b67e3d1-f6a1-4ea0-baa9-effd02ecdc50.png">

**what we currently have in the main contribs banner**

<img width="478" alt="Screenshot 2022-05-16 at 16 48 08" src="https://user-images.githubusercontent.com/17720442/168632826-755bd654-9078-49c9-9fa6-8215aa6f8040.png">




