### PR TITLE
Moment template layout tweaks

### DIFF
--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -45,6 +45,13 @@ export function getMomentTemplateBanner(
                                     heading={content.mainContent.heading}
                                     mobileHeading={content.mobileContent?.heading ?? null}
                                 />
+
+                                <div css={styles.mobileCloseButtonContainer}>
+                                    <MomentTemplateBannerCloseButton
+                                        onCloseClick={onCloseClick}
+                                        settings={templateSettings.closeButtonSettings}
+                                    />
+                                </div>
                             </div>
 
                             {numArticles !== undefined && numArticles > 5 && (
@@ -106,10 +113,14 @@ const styles = {
     outerContainer: (background: string) => css`
         background: ${background};
         border-top: 3px solid ${neutral[0]};
-        padding-bottom: ${space[2]}px;
+        padding-bottom: ${space[5]}px;
 
         * {
             box-sizing: border-box;
+        }
+
+        ${from.tablet} {
+            padding-bottom: ${space[6]}px;
         }
     `,
     containerOverrides: css`
@@ -125,44 +136,53 @@ const styles = {
 
         ${from.tablet} {
             flex-direction: row-reverse;
+            justify-content: flex-end;
         }
     `,
     visualContainer: css`
+        display: none;
+
+        ${from.mobileMedium} {
+            display: block;
+        }
         ${from.tablet} {
-            width: 294px;
+            width: 238px;
             margin-left: ${space[3]}px;
         }
         ${from.desktop} {
-            width: 454px;
+            width: 320px;
+            margin-left: ${space[5]}px;
         }
         ${from.leftCol} {
-            width: 542px;
+            width: 370px;
             margin-left: ${space[9]}px;
-        }
-        ${from.wide} {
-            width: 672px;
-            margin-left: ${space[12]}px;
         }
     `,
     contentContainer: css`
         ${from.tablet} {
-            width: 394px;
+            width: 450px;
         }
         ${from.desktop} {
-            width: 474px;
+            width: 600px;
         }
         ${from.leftCol} {
-            width: 522px;
+            width: 700px;
         }
         ${from.wide} {
-            width: 540px;
+            width: 780px;
         }
     `,
     headerContainer: css`
-        margin-top: ${space[1]}px;
+        margin-top: ${space[2]}px;
+        display: flex;
+        align-items: center;
     `,
     articleCountContainer: css`
-        margin-top: ${space[1]}px;
+        margin-top: ${space[4]}px;
+
+        ${from.tablet} {
+            margin-top: ${space[3]}px;
+        }
     `,
     bodyContainer: css`
         margin-top: ${space[1]}px;
@@ -170,11 +190,27 @@ const styles = {
     ctasContainer: css`
         display: flex;
         flex-direction: row;
-        margin-top: ${space[4]}px;
+        margin-top: ${space[5]}px;
+
+        ${from.tablet} {
+            margin-top: ${space[6]}px;
+        }
+    `,
+    mobileCloseButtonContainer: css`
+        margin-left: ${space[3]}px;
+
+        ${from.mobileMedium} {
+            display: none;
+        }
     `,
     closeButtonContainer: css`
+        display: none;
         position: absolute;
         top: ${space[2]}px;
         right: ${space[4]}px;
+
+        ${from.mobileMedium} {
+            display: block;
+        }
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -4,6 +4,9 @@ import { SvgCross } from '@guardian/src-icons';
 import { Button } from '@guardian/src-button';
 import { buttonStyles } from '../buttonStyles';
 import { CtaSettings } from '../settings';
+import { SvgRoundelDefault } from '@guardian/src-brand';
+import { from } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
 
 // ---- Component ---- //
 
@@ -18,6 +21,10 @@ export function MomentTemplateBannerCloseButton({
 }: MomentTemplateBannerCloseButtonProps): JSX.Element {
     return (
         <div css={styles.container}>
+            <div css={styles.roundelContainer}>
+                <SvgRoundelDefault />
+            </div>
+
             <Button
                 onClick={onCloseClick}
                 cssOverrides={buttonStyles(settings)}
@@ -36,5 +43,18 @@ export function MomentTemplateBannerCloseButton({
 const styles = {
     container: css`
         display: flex;
+    `,
+    roundelContainer: css`
+        display: none;
+        height: 36px;
+
+        svg {
+            height: 100%;
+        }
+
+        ${from.tablet} {
+            display: block;
+            margin-right: ${space[2]}px;
+        }
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
@@ -42,16 +42,12 @@ const styles = {
             font-size: 24px;
             line-height: 115%;
 
-            ${from.mobileLandscape} {
-                font-size: 30px;
-            }
-
-            ${from.tablet} {
+            ${from.desktop} {
                 font-size: 28px;
             }
 
-            ${from.desktop} {
-                font-size: 42px;
+            ${from.leftCol} {
+                font-size: 34px;
             }
         }
     `,

--- a/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentAlbaneseBanner.tsx
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentAlbaneseBanner.tsx
@@ -6,17 +6,11 @@ const PostElectionAuMomentAlbaneseBanner = getMomentTemplateBanner({
     ...settings,
     imageSettings: {
         mainUrl:
-            'https://i.guim.co.uk/img/media/a63c0655afb9403a6e6d74b160ab8947648641bb/0_0_872_296/500.png?quality=85&s=275c125f157ab3686d0e67103c71df38',
+            'https://i.guim.co.uk/img/media/5ffd1915bffebf7edea9055d957dfc56cd9344d7/0_0_1480_1232/500.png?quality=85&s=b1ccbcaeb9ae9ce340d43075e13224d3',
         mobileUrl:
             'https://i.guim.co.uk/img/media/a63c0655afb9403a6e6d74b160ab8947648641bb/0_0_872_296/500.png?quality=85&s=275c125f157ab3686d0e67103c71df38',
-        tabletUrl:
-            'https://i.guim.co.uk/img/media/964062779daabd818444189aea85cc32ae750492/0_0_1504_1260/500.png?quality=85&s=86576cdb9fc8677a71024dc0763e4bc8',
-        desktopUrl:
-            'https://i.guim.co.uk/img/media/182b574c47ea5ae0f21bd1ebac6f21ac90db3962/0_0_2028_1648/500.png?quality=85&s=bc08d2646ea27e0776904706ebc9e198',
-        leftColUrl:
-            'https://i.guim.co.uk/img/media/926d42a6709a14b01e98ca28e1e1dca4d5b5f78f/0_0_2028_1712/500.png?quality=85&s=cbed3e740e40117c972d750609cdbde1',
         wideUrl:
-            'https://i.guim.co.uk/img/media/23aa54b63307e87dd398e85daee090a7afa31fff/0_0_2240_1604/500.png?quality=85&s=027a2278b4ec5450602b60c979e10378',
+            'https://i.guim.co.uk/img/media/5ffd1915bffebf7edea9055d957dfc56cd9344d7/0_0_1480_1232/500.png?quality=85&s=b1ccbcaeb9ae9ce340d43075e13224d3',
         altText: 'Head shot of Anthony Albanese, leader of the Australian Labor Party.',
     },
 });


### PR DESCRIPTION
## What does this change?

This change makes some tweaks to the moment template banner layout given we've now had design feedback from Jade & Alex.

I also updated the Albanese banner to simplify it given that we now need just a single image that works at all breakpoints. We should be able to do the same with the two other post election banners, but we just need some creatives with a slightly different aspect ratio to make them play nicer with the new layout. I'll raise a separate PR to address those changes.

## Images

|mobile|mobile medium|tablet|desktop|leftCol|wide|
|------|-------------|------|-------|-------|----|
|<img width="331" alt="Screenshot 2022-05-18 at 15 40 54" src="https://user-images.githubusercontent.com/17720442/169069316-c8dfdd4c-6129-4e4c-a643-599f859e8317.png">|<img width="384" alt="Screenshot 2022-05-18 at 15 41 06" src="https://user-images.githubusercontent.com/17720442/169069327-67a96cf5-d3cf-469f-ab0e-f21548d7f880.png">|<img width="751" alt="Screenshot 2022-05-18 at 15 41 22" src="https://user-images.githubusercontent.com/17720442/169069343-8e27f1aa-3eb0-405f-b06b-7f75fbf7eba7.png">|<img width="991" alt="Screenshot 2022-05-18 at 15 41 38" src="https://user-images.githubusercontent.com/17720442/169069351-9f974075-87a2-4d13-a2ac-379485d230e1.png">|<img width="1151" alt="Screenshot 2022-05-18 at 15 41 50" src="https://user-images.githubusercontent.com/17720442/169069358-b1107b10-b209-48ee-9340-261a8550d470.png">|<img width="1310" alt="Screenshot 2022-05-18 at 15 42 10" src="https://user-images.githubusercontent.com/17720442/169069363-4f240098-536b-4ddc-87a1-18521f459809.png">|

