### PR TITLE
Cloudwatch metrics/alarms

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1143,7 +1143,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
           "Fn::Join": Array [
             "",
             Array [
-              "support-dotcom-components: Epic Super Mode error - ",
+              "support-dotcom-components: Super Mode error - ",
               Object {
                 "Ref": "Stage",
               },

--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1143,7 +1143,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
           "Fn::Join": Array [
             "",
             Array [
-              "dotcom-components: Epic Super Mode error - ",
+              "support-dotcom-components: Epic Super Mode error - ",
               Object {
                 "Ref": "Stage",
               },
@@ -1157,7 +1157,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
           "Fn::Join": Array [
             "",
             Array [
-              "dotcom-components-",
+              "support-dotcom-components-",
               Object {
                 "Ref": "Stage",
               },

--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -571,6 +571,27 @@ chown -R dotcom-components:support /var/log/dotcom-components
       },
       "Type": "AWS::IAM::Policy",
     },
+    "GuPutCloudwatchMetricsPolicyC5BCE402": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuPutCloudwatchMetricsPolicyC5BCE402",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleDotcomcomponents2E8FDE7D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "High5xxPercentageAlarmDotcomcomponents70DE8F71": Object {
       "Properties": Object {
         "ActionsEnabled": Object {

--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1165,7 +1165,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
           ],
         },
         "Period": 3600,
-        "Statistic": "Average",
+        "Statistic": "Sum",
         "Threshold": 1,
       },
       "Type": "AWS::CloudWatch::Alarm",

--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1088,6 +1088,67 @@ chown -R dotcom-components:support /var/log/dotcom-components
       },
       "Type": "AWS::IAM::Policy",
     },
+    "SuperModeAlarmDBFE793D": Object {
+      "Properties": Object {
+        "ActionsEnabled": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "alarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":reader-revenue-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Error fetching Epic Super Mode data from Dynamodb",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "dotcom-components: Epic Super Mode error - ",
+              Object {
+                "Ref": "Stage",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "super-mode-error",
+        "Namespace": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "dotcom-components-",
+              Object {
+                "Ref": "Stage",
+              },
+            ],
+          ],
+        },
+        "Period": 3600,
+        "Statistic": "Average",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "TargetGroupDotcomcomponents54FF73AB": Object {
       "Properties": Object {
         "HealthCheckIntervalSeconds": 10,

--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1167,6 +1167,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
         "Period": 3600,
         "Statistic": "Sum",
         "Threshold": 1,
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -34,7 +34,7 @@ export class DotcomComponents extends GuStack {
         const namespace = `support-${appName}-${this.stage}`;
 
         new GuAlarm(this, 'SuperModeAlarm', {
-            alarmName: `support-${appName}: Epic Super Mode error - ${this.stage}`,
+            alarmName: `support-${appName}: Super Mode error - ${this.stage}`,
             alarmDescription: 'Error fetching Epic Super Mode data from Dynamodb',
             snsTopicName,
             metric: new Metric({

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -132,6 +132,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
             threshold: 1,
             evaluationPeriods: 1,
             comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            statistic: 'sum',
         });
     }
 }

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -118,10 +118,10 @@ chown -R dotcom-components:support /var/log/dotcom-components
 
         // Cloudwatch alarms
         const snsTopicName = 'reader-revenue-dev';
-        const namespace = `${appName}-${this.stage}`;
+        const namespace = `support-${appName}-${this.stage}`;
 
         new GuAlarm(this, 'SuperModeAlarm', {
-            alarmName: `${appName}: Epic Super Mode error - ${this.stage}`,
+            alarmName: `support-${appName}: Epic Super Mode error - ${this.stage}`,
             alarmDescription: 'Error fetching Epic Super Mode data from Dynamodb',
             snsTopicName,
             metric: new Metric({

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -11,7 +11,11 @@ import {
     GuStack,
     GuStringParameter,
 } from '@guardian/cdk/lib/constructs/core';
-import { GuDynamoDBReadPolicy, GuGetS3ObjectsPolicy } from '@guardian/cdk/lib/constructs/iam';
+import {
+    GuDynamoDBReadPolicy,
+    GuGetS3ObjectsPolicy,
+    GuPutCloudwatchMetricsPolicy,
+} from '@guardian/cdk/lib/constructs/iam';
 
 export class DotcomComponents extends GuStack {
     constructor(scope: App, id: string, props: GuStackProps) {
@@ -76,6 +80,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
             new GuDynamoDBReadPolicy(this, 'DynamoReadPolicySecondaryIndex', {
                 tableName: `super-mode-${this.stage}/index/*`,
             }),
+            new GuPutCloudwatchMetricsPolicy(this),
         ];
 
         const ec2App = new GuEc2App(this, {

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -1,4 +1,4 @@
-import { ComparisonOperator, Metric } from '@aws-cdk/aws-cloudwatch';
+import { ComparisonOperator, Metric, TreatMissingData } from '@aws-cdk/aws-cloudwatch';
 import type { Policy } from '@aws-cdk/aws-iam';
 import type { App } from '@aws-cdk/core';
 import { Duration } from '@aws-cdk/core';
@@ -46,6 +46,7 @@ export class DotcomComponents extends GuStack {
             evaluationPeriods: 1,
             comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
             statistic: 'sum',
+            treatMissingData: TreatMissingData.NOT_BREACHING,
         });
 
         const userData = `#!/bin/bash

--- a/packages/server/src/utils/cloudwatch.ts
+++ b/packages/server/src/utils/cloudwatch.ts
@@ -1,0 +1,30 @@
+import * as AWS from 'aws-sdk';
+import { isProd } from '../lib/env';
+import { logError } from './logging';
+
+const cloudwatch = new AWS.CloudWatch({ region: 'eu-west-1' });
+
+const stage = isProd ? 'PROD' : 'CODE';
+const namespace = `support-dotcom-components-${stage}`;
+
+type Metric = 'super-mode-error' | 'channel-tests-error';
+
+// Sends a metric to cloudwatch.
+// Avoid doing this per-request, to avoid high costs. This should instead be called from within a cacheAsync
+export const putMetric = (
+    metricName: Metric,
+    dimensions: AWS.CloudWatch.Dimension[] = [],
+): void => {
+    cloudwatch
+        .putMetricData({
+            Namespace: namespace,
+            MetricData: [
+                {
+                    MetricName: metricName,
+                    Dimensions: dimensions,
+                },
+            ],
+        })
+        .promise()
+        .catch(error => logError(`Error putting cloudwatch metric: ${error}`));
+};

--- a/packages/server/src/utils/cloudwatch.ts
+++ b/packages/server/src/utils/cloudwatch.ts
@@ -9,7 +9,7 @@ const namespace = `support-dotcom-components-${stage}`;
 
 type Metric = 'super-mode-error' | 'channel-tests-error';
 
-// Sends a metric to cloudwatch.
+// Sends a single metric to cloudwatch.
 // Avoid doing this per-request, to avoid high costs. This should instead be called from within a cacheAsync
 export const putMetric = (
     metricName: Metric,
@@ -21,6 +21,8 @@ export const putMetric = (
             MetricData: [
                 {
                     MetricName: metricName,
+                    Value: 1,
+                    Unit: 'Count',
                     Dimensions: dimensions,
                 },
             ],


### PR DESCRIPTION
This PR introduces the use of cloudwatch metrics for alarms.
This is to alert us to internal errors, e.g. if it fails to fetch super mode data but can still serve requests.

For now it's just writing a metric for super mode failures (and alerting when an error happens), but in follow up PRs we can add more.
In particular, we're about to start fetching channel tests data from dynamodb - this can be a new metric/alarm.