### PR TITLE
Update post election aus banner images (hung parliament & morrison win)

### DIFF
--- a/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentHungBanner.tsx
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentHungBanner.tsx
@@ -6,17 +6,11 @@ const PostElectionAuMomentHungBanner = getMomentTemplateBanner({
     ...settings,
     imageSettings: {
         mainUrl:
-            'https://i.guim.co.uk/img/media/5d691128b6956c71539cab0a29e04b2a4eb6539b/0_0_748_296/500.png?quality=85&s=5692724d3c5bfeac365c86503118b1f2',
+            'https://i.guim.co.uk/img/media/96891616b71f3e15d7865d200215249a2174a124/0_0_1480_1240/500.png?quality=85&s=8a6fdf090ef6a8e734eedac798f3519d',
         mobileUrl:
             'https://i.guim.co.uk/img/media/5d691128b6956c71539cab0a29e04b2a4eb6539b/0_0_748_296/500.png?quality=85&s=5692724d3c5bfeac365c86503118b1f2',
-        tabletUrl:
-            'https://i.guim.co.uk/img/media/6b94afbcbeb8d9f848f8bb2099d4721b3fd9144b/0_0_1316_1280/500.png?quality=85&s=fd9a851a7fc985948d5f58e11f70681c',
-        desktopUrl:
-            'https://i.guim.co.uk/img/media/9321f721e90405f4d16b29bdcd3fd336fcc4307e/0_0_1420_1364/500.png?quality=85&s=f05c686e2ee072e97806a38d2a6c38a5',
-        leftColUrl:
-            'https://i.guim.co.uk/img/media/1c7675cd39f7368fff74ef323cb3051fa0ba7650/0_0_1596_1576/500.png?quality=85&s=204024ab5c180241d7dd0644d3d23ad6',
         wideUrl:
-            'https://i.guim.co.uk/img/media/b3c411f0c5d34c643dabcf0538ac62e54d86ef2e/0_0_1792_1708/500.png?quality=85&s=65821026aa503301ae4efc6fd6b1da41',
+            'https://i.guim.co.uk/img/media/96891616b71f3e15d7865d200215249a2174a124/0_0_1480_1240/500.png?quality=85&s=8a6fdf090ef6a8e734eedac798f3519d',
         altText:
             'Head shots of Anthony Albanese, leader of the Australian Labor Party, and Scott Morrison leader of the Liberal Party of Australia.',
     },

--- a/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentMorrisonBanner.tsx
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentMorrisonBanner.tsx
@@ -6,17 +6,11 @@ const PostElectionAuMomentMorrisonBanner = getMomentTemplateBanner({
     ...settings,
     imageSettings: {
         mainUrl:
-            'https://i.guim.co.uk/img/media/76c913749a31ad4847bbcedafc098b003a3963a1/0_0_872_296/500.png?quality=85&s=e0e1d7a7fcf0a656f5a19e68b6800910',
+            'https://i.guim.co.uk/img/media/20b836a4e03e506009d94de14ede430255f7fd4b/0_0_1480_1240/500.png?quality=85&s=ffee1d2cf7c63748a06acd7de11365d1',
         mobileUrl:
             'https://i.guim.co.uk/img/media/76c913749a31ad4847bbcedafc098b003a3963a1/0_0_872_296/500.png?quality=85&s=e0e1d7a7fcf0a656f5a19e68b6800910',
-        tabletUrl:
-            'https://i.guim.co.uk/img/media/cd1bb0b74be9a7eb6a8a7c29101edcaee7b0067b/0_0_1468_1180/500.png?quality=85&s=038b49db59d0b7f9da39aae1b5b2c1e0',
-        desktopUrl:
-            'https://i.guim.co.uk/img/media/f7f9ee7aa5526431fc1c6f2e10206d1032f50e52/0_0_1700_1284/500.png?quality=85&s=99ea8f8dafa34e13433d7925550d6754',
-        leftColUrl:
-            'https://i.guim.co.uk/img/media/392f4a2a6fe26fd3e18a9b2703515937d1bd4602/0_0_2192_1464/500.png?quality=85&s=7ad046500a68605cb285b8327a487b32',
         wideUrl:
-            'https://i.guim.co.uk/img/media/8a737c07c07e1c41bcba95cc15a38b167a82d51f/0_0_2456_1740/500.png?quality=85&s=18ef3405d8065564cf633115e07521ca',
+            'https://i.guim.co.uk/img/media/20b836a4e03e506009d94de14ede430255f7fd4b/0_0_1480_1240/500.png?quality=85&s=ffee1d2cf7c63748a06acd7de11365d1',
         altText: 'Head shot of Scott Morrison, leader of the Liberal Party of Australia.',
     },
 });


### PR DESCRIPTION
## What does this change?

Update post Australian election banner images, specifically the hung Parliament & Morrison win variants (we updated the Albanese win image in #700). We now have an established aspect ratio (370 x 310) for the image from tablet upwards. This means we only need a single image for all the breakpoints and the template should always work provided the image is the correct size.

## Images

![Screenshot 2022-05-20 at 11 44 40](https://user-images.githubusercontent.com/17720442/169512838-15165a81-31dc-4a93-b82f-1a5da13ca86b.png)

![Screenshot 2022-05-20 at 11 44 48](https://user-images.githubusercontent.com/17720442/169512848-31d3cabe-0da8-46a1-bbd5-0544c6218b11.png)

