### PR TITLE
Add reminder sign ups to the moment template banner

### DIFF
--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedIn.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedIn.tsx
@@ -3,12 +3,12 @@ import { css, ThemeProvider } from '@emotion/react';
 import { Button, buttonBrandAlt } from '@guardian/src-button';
 import { textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
-import { neutral, error } from '@guardian/src-foundations/palette';
 import { Columns, Column, Hide } from '@guardian/src-layout';
 import { from } from '@guardian/src-foundations/mq';
 import { SvgCheckmark } from '@guardian/src-icons';
 import { BannerEnrichedReminderCta } from '../common/types';
 import { ensureHasPreposition, ReminderStatus } from '../../utils/reminders';
+import { ErrorCopy, InfoCopy, ThankYou } from '../../shared/Reminders';
 
 const bodyContainerStyles = css`
     padding: 10px 0;
@@ -46,35 +46,11 @@ const bodyCopyContainerStyles = css`
 `;
 
 const errorCopyContainerStyles = css`
-    ${textSans.small({ fontWeight: 'bold' })};
-    color: ${error[400]};
-    font-style: italic;
     margin-top: ${space[1]}px;
-    margin-bottom: 0;
 `;
 
 const infoCopyContainerStyles = css`
-    ${textSans.small({})}
-    font-size: 12px;
-
     margin-top: ${space[3]}px;
-`;
-
-const thankyouHeaderStyles = css`
-    ${textSans.small({ fontWeight: 'bold' })}
-`;
-
-const thankyouBodyStyles = css`
-    ${textSans.small({})}
-`;
-
-const privacyLinkSyles = css`
-    font-weight: bold;
-    color: ${neutral[0]};
-`;
-
-const contactLinkStyles = css`
-    color: ${neutral[0]};
 `;
 
 export interface ContributionsBannerReminderSignedInProps {
@@ -100,47 +76,23 @@ export const ContributionsBannerReminderSignedIn: React.FC<ContributionsBannerRe
                 <>
                     <div css={bodyCopyContainerStyles}>
                         Show your support for the Guardian at a later date. To make this easier, set
-                        a reminder and we’ll email you in May.
+                        a reminder and we&apos;ll email you in May.
                     </div>
 
                     {reminderStatus === ReminderStatus.Error && (
                         <div css={errorCopyContainerStyles}>
-                            Sorry we couldn&apos;t set a reminder for you this time. Please try
-                            again later.
+                            <ErrorCopy />
                         </div>
                     )}
 
                     <div css={infoCopyContainerStyles}>
-                        We will send you a maximum of two emails {reminderDateWithPreposition}. To
-                        find out what personal data we collect and how we use it, view our{' '}
-                        <a
-                            css={privacyLinkSyles}
-                            href="https://www.theguardian.com/help/privacy-policy"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            Privacy policy
-                        </a>
+                        <InfoCopy reminderLabelWithPreposition={reminderDateWithPreposition} />
                     </div>
                 </>
             )}
 
             {reminderStatus === ReminderStatus.Completed && (
-                <>
-                    <div css={thankyouHeaderStyles}>Thank you! Your reminder is set</div>
-
-                    <div css={thankyouBodyStyles}>
-                        We will be in touch to invite you to contribute. Look out for a message in
-                        your inbox {reminderDateWithPreposition}. If you have any questions about
-                        contributing, please{' '}
-                        <a
-                            href="mailto:contribution.support@theguardian.com"
-                            css={contactLinkStyles}
-                        >
-                            contact us
-                        </a>
-                    </div>
-                </>
+                <ThankYou reminderLabelWithPreposition={reminderDateWithPreposition} />
             )}
         </div>
     );

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedOut.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedOut.tsx
@@ -3,7 +3,6 @@ import { css, ThemeProvider } from '@emotion/react';
 import { Button, buttonBrandAlt } from '@guardian/src-button';
 import { textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
-import { neutral, error } from '@guardian/src-foundations/palette';
 import { Columns, Column, Hide } from '@guardian/src-layout';
 import { from } from '@guardian/src-foundations/mq';
 import { TextInput } from '@guardian/src-text-input';
@@ -11,6 +10,7 @@ import { SvgCheckmark } from '@guardian/src-icons';
 import { BannerEnrichedReminderCta } from '../common/types';
 import { ensureHasPreposition, ReminderStatus } from '../../utils/reminders';
 import { useContributionsReminderEmailForm } from '../../../hooks/useContributionsReminderEmailForm';
+import { ErrorCopy, InfoCopy, ThankYou } from '../../shared/Reminders';
 
 const bodyContainerStyles = css`
     padding: 10px 0;
@@ -74,35 +74,11 @@ const emailInputStyles = css`
 `;
 
 const errorCopyContainerStyles = css`
-    ${textSans.small({ fontWeight: 'bold' })};
-    color: ${error[400]};
-    font-style: italic;
     margin-top: ${space[1]}px;
-    margin-bottom: 0;
 `;
 
 const infoCopyContainerStyles = css`
-    ${textSans.small({})}
-    font-size: 12px;
-
     margin-top: ${space[3]}px;
-`;
-
-const thankyouHeaderStyles = css`
-    ${textSans.small({ fontWeight: 'bold' })}
-`;
-
-const thankyouBodyStyles = css`
-    ${textSans.small({})}
-`;
-
-const privacyLinkSyles = css`
-    font-weight: bold;
-    color: ${neutral[0]};
-`;
-
-const contactLinkStyles = css`
-    color: ${neutral[0]};
 `;
 
 export interface ContributionsBannerReminderSignedOutProps {
@@ -117,6 +93,10 @@ export const ContributionsBannerReminderSignedOut: React.FC<ContributionsBannerR
     onReminderSetClick,
 }) => {
     const { email, inputError, updateEmail, handleSubmit } = useContributionsReminderEmailForm();
+
+    const reminderLabelWithPreposition = ensureHasPreposition(
+        reminderCta.reminderFields.reminderLabel,
+    );
 
     return (
         <>
@@ -135,7 +115,11 @@ export const ContributionsBannerReminderSignedOut: React.FC<ContributionsBannerR
                         )}
 
                         {reminderStatus === ReminderStatus.Completed && (
-                            <ThankYou reminderLabel={reminderCta.reminderFields.reminderLabel} />
+                            <div css={bodyContainerStyles}>
+                                <ThankYou
+                                    reminderLabelWithPreposition={reminderLabelWithPreposition}
+                                />
+                            </div>
                         )}
                     </Column>
                 </Columns>
@@ -160,9 +144,13 @@ export const ContributionsBannerReminderSignedOut: React.FC<ContributionsBannerR
                         {reminderStatus === ReminderStatus.Completed && (
                             <>
                                 <Column width={9 / 16}>
-                                    <ThankYou
-                                        reminderLabel={reminderCta.reminderFields.reminderLabel}
-                                    />
+                                    <div css={bodyContainerStyles}>
+                                        <ThankYou
+                                            reminderLabelWithPreposition={
+                                                reminderLabelWithPreposition
+                                            }
+                                        />
+                                    </div>
                                 </Column>
 
                                 <Column width={4 / 16}> </Column>
@@ -197,9 +185,13 @@ export const ContributionsBannerReminderSignedOut: React.FC<ContributionsBannerR
                         {reminderStatus === ReminderStatus.Completed && (
                             <>
                                 <Column width={9 / 14}>
-                                    <ThankYou
-                                        reminderLabel={reminderCta.reminderFields.reminderLabel}
-                                    />
+                                    <div css={bodyContainerStyles}>
+                                        <ThankYou
+                                            reminderLabelWithPreposition={
+                                                reminderLabelWithPreposition
+                                            }
+                                        />
+                                    </div>
                                 </Column>
 
                                 <Column width={3 / 14}> </Column>
@@ -229,9 +221,11 @@ export const ContributionsBannerReminderSignedOut: React.FC<ContributionsBannerR
                     {reminderStatus === ReminderStatus.Completed && (
                         <>
                             <Column width={9 / 16}>
-                                <ThankYou
-                                    reminderLabel={reminderCta.reminderFields.reminderLabel}
-                                />
+                                <div css={bodyContainerStyles}>
+                                    <ThankYou
+                                        reminderLabelWithPreposition={reminderLabelWithPreposition}
+                                    />
+                                </div>
                             </Column>
 
                             <Column width={4 / 16}> </Column>
@@ -292,44 +286,12 @@ function Body({
 
             {reminderStatus === ReminderStatus.Error && (
                 <div css={errorCopyContainerStyles}>
-                    Sorry we couldn&apos;t set a reminder for you this time. Please try again later.
+                    <ErrorCopy />
                 </div>
             )}
 
             <div css={infoCopyContainerStyles}>
-                We will send you a maximum of two emails in {reminderLabel}. To find out what
-                personal data we collect and how we use it, view our{' '}
-                <a
-                    css={privacyLinkSyles}
-                    href="https://www.theguardian.com/help/privacy-policy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    Privacy policy
-                </a>
-            </div>
-        </div>
-    );
-}
-
-interface ThankYouProps {
-    reminderLabel: string;
-}
-
-function ThankYou({ reminderLabel }: ThankYouProps) {
-    const reminderLabelWithPreposition = ensureHasPreposition(reminderLabel);
-
-    return (
-        <div css={bodyContainerStyles}>
-            <div css={thankyouHeaderStyles}>Thank you! Your reminder is set</div>
-
-            <div css={thankyouBodyStyles}>
-                We will be in touch to invite you to contribute. Look out for a message in your
-                inbox {reminderLabelWithPreposition}. If you have any questions about contributing,
-                please{' '}
-                <a href="mailto:contribution.support@theguardian.com" css={contactLinkStyles}>
-                    contact us
-                </a>
+                <InfoCopy reminderLabelWithPreposition={reminderDateWithPreposition} />
             </div>
         </div>
     );

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
@@ -145,6 +145,17 @@ const AusElectionBanner = bannerWrapper(
         highlightedTextSettings: {
             textColour: neutral[0],
         },
+        setReminderCtaSettings: {
+            default: {
+                backgroundColour: '#e4e4e3',
+                textColour: neutral[0],
+                border: `1px solid ${neutral[0]}`,
+            },
+            hover: {
+                backgroundColour: 'white',
+                textColour: neutral[0],
+            },
+        },
         imageSettings: {
             mainUrl:
                 'https://i.guim.co.uk/img/media/ad0166d7724eb2dfc6aa16fea50fe41c02324eb8/0_0_281_131/281.png?quality=85&s=7639d39b1492f5e2f4883496fcc5740c',
@@ -170,4 +181,18 @@ const AusElectionTemplate: Story<BannerProps> = (props: BannerProps) => (
 );
 
 export const AusElection = AusElectionTemplate.bind({});
-AusElection.args = GlobalNY.args;
+AusElection.args = {
+    ...GlobalNY.args,
+    content: {
+        ...GlobalNY.args.content,
+        secondaryCta: {
+            type: SecondaryCtaType.ContributionsReminder,
+        },
+    },
+    mobileContent: {
+        ...GlobalNY.args.mobileContent,
+        secondaryCta: {
+            type: SecondaryCtaType.ContributionsReminder,
+        },
+    },
+};

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { space } from '@guardian/src-foundations';
+import { neutral, space } from '@guardian/src-foundations';
 import { Hide } from '@guardian/src-layout';
-import { LinkButton } from '@guardian/src-button';
+import { Button, LinkButton } from '@guardian/src-button';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { BannerEnrichedCta, BannerEnrichedSecondaryCta } from '../../common/types';
 import { buttonStyles } from '../buttonStyles';
@@ -21,6 +21,7 @@ interface MomentTemplateBannerCtasProps {
     desktopCtas: BreakpointCtas;
     onPrimaryCtaClick: () => void;
     onSecondaryCtaClick: () => void;
+    onReminderCtaClick: () => void;
     primaryCtaSettings: CtaSettings;
     secondaryCtaSettings: CtaSettings;
 }
@@ -30,6 +31,7 @@ export function MomentTemplateBannerCtas({
     mobileCtas: maybeMobileCtas,
     onPrimaryCtaClick,
     onSecondaryCtaClick,
+    onReminderCtaClick,
     primaryCtaSettings,
     secondaryCtaSettings,
 }: MomentTemplateBannerCtasProps): JSX.Element {
@@ -38,96 +40,92 @@ export function MomentTemplateBannerCtas({
     return (
         <div css={styles.container}>
             <div>
-                {mobileCtas.primary && (
-                    <Hide above="tablet">
-                        <PrimaryButton
-                            ctaText={mobileCtas.primary.ctaText}
-                            ctaUrl={mobileCtas.primary.ctaUrl}
-                            ctaSettings={primaryCtaSettings}
-                            onClick={onPrimaryCtaClick}
-                        />
-                    </Hide>
-                )}
+                <Hide above="tablet">
+                    <div css={styles.ctasContainer}>
+                        {mobileCtas.primary && (
+                            <LinkButton
+                                href={mobileCtas.primary.ctaUrl}
+                                onClick={onPrimaryCtaClick}
+                                size="small"
+                                priority="primary"
+                                cssOverrides={buttonStyles(primaryCtaSettings)}
+                            >
+                                {mobileCtas.primary.ctaText}
+                            </LinkButton>
+                        )}
 
-                {desktopCtas.primary && (
-                    <Hide below="tablet">
-                        <PrimaryButton
-                            ctaText={desktopCtas.primary.ctaText}
-                            ctaUrl={desktopCtas.primary.ctaUrl}
-                            ctaSettings={primaryCtaSettings}
-                            onClick={onPrimaryCtaClick}
-                        />
-                    </Hide>
-                )}
+                        {mobileCtas.secondary?.type === SecondaryCtaType.Custom && (
+                            <LinkButton
+                                href={mobileCtas.secondary.cta.ctaUrl}
+                                onClick={onSecondaryCtaClick}
+                                size="small"
+                                priority="tertiary"
+                                cssOverrides={buttonStyles(secondaryCtaSettings)}
+                            >
+                                {mobileCtas.secondary.cta.ctaText}
+                            </LinkButton>
+                        )}
+
+                        {mobileCtas.secondary?.type === SecondaryCtaType.ContributionsReminder && (
+                            <Button
+                                priority="subdued"
+                                onClick={onReminderCtaClick}
+                                cssOverrides={styles.reminderCta}
+                            >
+                                Remind me later
+                            </Button>
+                        )}
+                    </div>
+                </Hide>
+
+                <Hide below="tablet">
+                    <div css={styles.ctasContainer}>
+                        {desktopCtas.primary && (
+                            <LinkButton
+                                href={desktopCtas.primary.ctaUrl}
+                                onClick={onPrimaryCtaClick}
+                                size="small"
+                                priority="primary"
+                                cssOverrides={buttonStyles(primaryCtaSettings)}
+                            >
+                                {desktopCtas.primary.ctaText}
+                            </LinkButton>
+                        )}
+
+                        {desktopCtas.secondary?.type === SecondaryCtaType.Custom && (
+                            <LinkButton
+                                href={desktopCtas.secondary.cta.ctaUrl}
+                                onClick={onSecondaryCtaClick}
+                                size="small"
+                                priority="tertiary"
+                                cssOverrides={buttonStyles(secondaryCtaSettings)}
+                            >
+                                {desktopCtas.secondary.cta.ctaText}
+                            </LinkButton>
+                        )}
+
+                        {desktopCtas.secondary?.type === SecondaryCtaType.ContributionsReminder && (
+                            <Button
+                                priority="subdued"
+                                onClick={onReminderCtaClick}
+                                cssOverrides={styles.reminderCta}
+                            >
+                                Remind me later
+                            </Button>
+                        )}
+                    </div>
+                </Hide>
             </div>
 
             <div>
-                {mobileCtas.secondary?.type === SecondaryCtaType.Custom && (
-                    <Hide above="tablet">
-                        <SecondaryButton
-                            ctaText={mobileCtas.secondary.cta.ctaText}
-                            ctaUrl={mobileCtas.secondary.cta.ctaUrl}
-                            ctaSettings={secondaryCtaSettings}
-                            onClick={onSecondaryCtaClick}
-                        />
-                    </Hide>
-                )}
-
-                {desktopCtas.secondary?.type === SecondaryCtaType.Custom && (
-                    <Hide below="tablet">
-                        <SecondaryButton
-                            ctaText={desktopCtas.secondary.cta.ctaText}
-                            ctaUrl={desktopCtas.secondary.cta.ctaUrl}
-                            ctaSettings={secondaryCtaSettings}
-                            onClick={onSecondaryCtaClick}
-                        />
-                    </Hide>
-                )}
+                <Hide above="tablet">{mobileCtas.primary && <PaymentCards />}</Hide>
+                <Hide below="tablet">{desktopCtas.primary && <PaymentCards />}</Hide>
             </div>
         </div>
     );
 }
 
 // ---- Helper Components ---- //
-
-interface ButtonProps {
-    ctaText: string;
-    ctaUrl: string;
-    ctaSettings: CtaSettings;
-    onClick: () => void;
-}
-
-function PrimaryButton({ ctaText, ctaUrl, ctaSettings, onClick }: ButtonProps) {
-    return (
-        <div>
-            <LinkButton
-                href={ctaUrl}
-                onClick={onClick}
-                size="small"
-                priority="primary"
-                cssOverrides={buttonStyles(ctaSettings)}
-            >
-                {ctaText}
-            </LinkButton>
-
-            <PaymentCards />
-        </div>
-    );
-}
-
-function SecondaryButton({ ctaText, ctaUrl, ctaSettings, onClick }: ButtonProps) {
-    return (
-        <LinkButton
-            href={ctaUrl}
-            onClick={onClick}
-            size="small"
-            priority="tertiary"
-            cssOverrides={buttonStyles(ctaSettings)}
-        >
-            {ctaText}
-        </LinkButton>
-    );
-}
 
 function PaymentCards() {
     return (
@@ -207,8 +205,16 @@ function PaymentCards() {
 
 const styles = {
     container: css`
+        padding-bottom: ${space[5]}px;
+
+        ${from.tablet} {
+            padding-bottom: ${space[6]}px;
+        }
+    `,
+    ctasContainer: css`
         display: flex;
         flex-direction: row;
+        align-items: center;
 
         & > * + * {
             margin-left: ${space[3]}px;
@@ -225,5 +231,8 @@ const styles = {
             margin-left: ${space[2]}px;
             height: 1.25rem;
         }
+    `,
+    reminderCta: css`
+        color: ${neutral[0]};
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerReminder.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerReminder.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useContributionsReminderSignup } from '../../../../hooks/useContributionsReminderSignup';
+import { BannerEnrichedReminderCta } from '../../common/types';
+import { CtaSettings } from '../settings';
+import { MomentTemplateBannerReminderSignedOut } from './MomentTemplateBannerReminderSignedOut';
+
+// ---- Component ---- //
+
+export interface MomentTemplateBannerReminderProps {
+    reminderCta: BannerEnrichedReminderCta;
+    trackReminderSetClick: () => void;
+    setReminderCtaSettings?: CtaSettings;
+}
+
+export function MomentTemplateBannerReminder({
+    reminderCta,
+    trackReminderSetClick,
+    setReminderCtaSettings,
+}: MomentTemplateBannerReminderProps): JSX.Element {
+    const { reminderStatus, createReminder } = useContributionsReminderSignup(
+        reminderCta.reminderFields.reminderPeriod,
+        'WEB',
+        'BANNER',
+        'PRE',
+        reminderCta.reminderFields.reminderOption,
+    );
+
+    const onReminderSetClick = (email: string) => {
+        trackReminderSetClick();
+        createReminder(email);
+    };
+
+    return (
+        <MomentTemplateBannerReminderSignedOut
+            reminderCta={reminderCta}
+            reminderStatus={reminderStatus}
+            onReminderSetClick={onReminderSetClick}
+            setReminderCtaSettings={setReminderCtaSettings}
+        />
+    );
+}

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerReminderSignedOut.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerReminderSignedOut.tsx
@@ -1,0 +1,200 @@
+import { css } from '@emotion/react';
+import { Button } from '@guardian/src-button';
+import { textSans } from '@guardian/src-foundations/typography';
+import { error, neutral, space } from '@guardian/src-foundations';
+import { TextInput } from '@guardian/src-text-input';
+import React from 'react';
+import { Container } from '@guardian/src-layout';
+import { BannerEnrichedReminderCta } from '../../common/types';
+import { ensureHasPreposition, ReminderStatus } from '../../../utils/reminders';
+import { useContributionsReminderEmailForm } from '../../../../hooks/useContributionsReminderEmailForm';
+import { SvgCheckmark } from '@guardian/src-icons';
+import { from } from '@guardian/src-foundations/mq';
+import { CtaSettings } from '../settings';
+import { buttonStyles } from '../buttonStyles';
+
+// ---- Component ---- //
+
+export interface MomentTemplateBannerReminderSignedOutProps {
+    reminderCta: BannerEnrichedReminderCta;
+    reminderStatus: ReminderStatus;
+    onReminderSetClick: (email: string) => void;
+    setReminderCtaSettings?: CtaSettings;
+}
+
+export function MomentTemplateBannerReminderSignedOut({
+    reminderCta,
+    reminderStatus,
+    onReminderSetClick,
+    setReminderCtaSettings,
+}: MomentTemplateBannerReminderSignedOutProps): JSX.Element {
+    return (
+        <div css={styles.container}>
+            <Container>
+                {reminderStatus !== ReminderStatus.Completed && (
+                    <Signup
+                        reminderLabel={reminderCta.reminderFields.reminderLabel}
+                        reminderStatus={reminderStatus}
+                        onSubmit={onReminderSetClick}
+                        setReminderCtaSettings={setReminderCtaSettings}
+                    />
+                )}
+
+                {reminderStatus === ReminderStatus.Completed && (
+                    <ThankYou reminderLabel={reminderCta.reminderFields.reminderLabel} />
+                )}
+            </Container>
+        </div>
+    );
+}
+
+// ---- Helper components ---- //
+
+interface SignupProps {
+    reminderLabel: string;
+    reminderStatus: ReminderStatus;
+    onSubmit: (email: string) => void;
+    setReminderCtaSettings?: CtaSettings;
+}
+
+function Signup({ reminderLabel, reminderStatus, onSubmit, setReminderCtaSettings }: SignupProps) {
+    const { email, inputError, updateEmail, handleSubmit } = useContributionsReminderEmailForm();
+
+    const reminderDateWithPreposition = ensureHasPreposition(reminderLabel);
+
+    return (
+        <div>
+            <header>
+                <h3 css={styles.headerCopy}>
+                    Remind me to support {reminderDateWithPreposition} please
+                </h3>
+            </header>
+
+            <form css={styles.form} onSubmit={handleSubmit(() => onSubmit(email))}>
+                <TextInput
+                    label="Email address"
+                    onChange={updateEmail}
+                    error={inputError}
+                    value={email}
+                    width={30}
+                />
+
+                <div css={styles.ctaContainer}>
+                    <Button
+                        type="submit"
+                        icon={<SvgCheckmark />}
+                        iconSide="right"
+                        priority="tertiary"
+                        disabled={reminderStatus === ReminderStatus.Submitting}
+                        cssOverrides={
+                            setReminderCtaSettings && buttonStyles(setReminderCtaSettings)
+                        }
+                    >
+                        Set a reminder
+                    </Button>
+                </div>
+
+                {reminderStatus === ReminderStatus.Error && (
+                    <div css={styles.errorCopy}>
+                        Sorry we couldn&apos;t set a reminder for you this time. Please try again
+                        later.
+                    </div>
+                )}
+            </form>
+
+            <div css={styles.infoCopy}>
+                We will send you a maximum of two emails {reminderDateWithPreposition}. To find out
+                what personal data we collect and how we use it, view our{' '}
+                <a
+                    css={styles.privacyLink}
+                    href="https://www.theguardian.com/help/privacy-policy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Privacy policy
+                </a>
+            </div>
+        </div>
+    );
+}
+
+interface ThankYouProps {
+    reminderLabel: string;
+}
+
+function ThankYou({ reminderLabel }: ThankYouProps) {
+    const reminderLabelWithPreposition = ensureHasPreposition(reminderLabel);
+
+    return (
+        <div>
+            <header>
+                <h3 css={styles.thankYouHeaderCopy}>Thank you! Your reminder is set</h3>
+            </header>
+
+            <div css={styles.thankYouBodyCopy}>
+                We will be in touch to invite you to contribute. Look out for a message in your
+                inbox {reminderLabelWithPreposition}. If you have any questions about contributing,
+                please <a href="mailto:contribution.support@theguardian.com">contact us</a>
+            </div>
+        </div>
+    );
+}
+
+// ---- Styles ---- //
+
+const styles = {
+    container: css`
+        border-top: 2px solid ${neutral[0]};
+
+        padding-top: ${space[2]}px;
+        padding-bottom: ${space[5]}px;
+    `,
+    headerCopy: css`
+        ${textSans.medium()};
+        margin: 0;
+    `,
+    form: css`
+        margin-top: ${space[2]}px;
+
+        display: flex;
+        flex-direction: column;
+
+        ${from.tablet} {
+            flex-direction: row;
+            align-items: flex-end;
+        }
+    `,
+    ctaContainer: css`
+        margin-top: ${space[3]}px;
+
+        ${from.tablet} {
+            margin-top: 0;
+            margin-left: ${space[3]}px;
+        }
+    `,
+    errorCopy: css`
+        ${textSans.small({ fontWeight: 'bold' })};
+        color: ${error[400]};
+        font-style: italic;
+        margin-top: ${space[1]}px;
+        margin-bottom: 0;
+    `,
+
+    infoCopy: css`
+        ${textSans.small({})}
+        font-size: 12px;
+
+        margin-top: ${space[3]}px;
+    `,
+    privacyLink: css`
+        font-weight: bold;
+        color: ${neutral[0]};
+    `,
+    thankYouHeaderCopy: css`
+        ${textSans.small({ fontWeight: 'bold' })}
+        margin: 0;
+    `,
+    thankYouBodyCopy: css`
+        ${textSans.small()}
+    `,
+};

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerReminderSignedOut.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerReminderSignedOut.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { Button } from '@guardian/src-button';
 import { textSans } from '@guardian/src-foundations/typography';
-import { error, neutral, space } from '@guardian/src-foundations';
+import { neutral, space } from '@guardian/src-foundations';
 import { TextInput } from '@guardian/src-text-input';
 import React from 'react';
 import { Container } from '@guardian/src-layout';
@@ -12,6 +12,7 @@ import { SvgCheckmark } from '@guardian/src-icons';
 import { from } from '@guardian/src-foundations/mq';
 import { CtaSettings } from '../settings';
 import { buttonStyles } from '../buttonStyles';
+import { ErrorCopy, InfoCopy, ThankYou } from '../../../shared/Reminders';
 
 // ---- Component ---- //
 
@@ -28,12 +29,16 @@ export function MomentTemplateBannerReminderSignedOut({
     onReminderSetClick,
     setReminderCtaSettings,
 }: MomentTemplateBannerReminderSignedOutProps): JSX.Element {
+    const reminderLabelWithPreposition = ensureHasPreposition(
+        reminderCta.reminderFields.reminderLabel,
+    );
+
     return (
         <div css={styles.container}>
             <Container>
                 {reminderStatus !== ReminderStatus.Completed && (
                     <Signup
-                        reminderLabel={reminderCta.reminderFields.reminderLabel}
+                        reminderLabelWithPreposition={reminderLabelWithPreposition}
                         reminderStatus={reminderStatus}
                         onSubmit={onReminderSetClick}
                         setReminderCtaSettings={setReminderCtaSettings}
@@ -41,7 +46,7 @@ export function MomentTemplateBannerReminderSignedOut({
                 )}
 
                 {reminderStatus === ReminderStatus.Completed && (
-                    <ThankYou reminderLabel={reminderCta.reminderFields.reminderLabel} />
+                    <ThankYou reminderLabelWithPreposition={reminderLabelWithPreposition} />
                 )}
             </Container>
         </div>
@@ -51,22 +56,25 @@ export function MomentTemplateBannerReminderSignedOut({
 // ---- Helper components ---- //
 
 interface SignupProps {
-    reminderLabel: string;
+    reminderLabelWithPreposition: string;
     reminderStatus: ReminderStatus;
     onSubmit: (email: string) => void;
     setReminderCtaSettings?: CtaSettings;
 }
 
-function Signup({ reminderLabel, reminderStatus, onSubmit, setReminderCtaSettings }: SignupProps) {
+function Signup({
+    reminderLabelWithPreposition,
+    reminderStatus,
+    onSubmit,
+    setReminderCtaSettings,
+}: SignupProps) {
     const { email, inputError, updateEmail, handleSubmit } = useContributionsReminderEmailForm();
-
-    const reminderDateWithPreposition = ensureHasPreposition(reminderLabel);
 
     return (
         <div>
             <header>
                 <h3 css={styles.headerCopy}>
-                    Remind me to support {reminderDateWithPreposition} please
+                    Remind me to support {reminderLabelWithPreposition} please
                 </h3>
             </header>
 
@@ -95,46 +103,14 @@ function Signup({ reminderLabel, reminderStatus, onSubmit, setReminderCtaSetting
                 </div>
 
                 {reminderStatus === ReminderStatus.Error && (
-                    <div css={styles.errorCopy}>
-                        Sorry we couldn&apos;t set a reminder for you this time. Please try again
-                        later.
+                    <div css={styles.errorCopyContainer}>
+                        <ErrorCopy />
                     </div>
                 )}
             </form>
 
-            <div css={styles.infoCopy}>
-                We will send you a maximum of two emails {reminderDateWithPreposition}. To find out
-                what personal data we collect and how we use it, view our{' '}
-                <a
-                    css={styles.privacyLink}
-                    href="https://www.theguardian.com/help/privacy-policy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    Privacy policy
-                </a>
-            </div>
-        </div>
-    );
-}
-
-interface ThankYouProps {
-    reminderLabel: string;
-}
-
-function ThankYou({ reminderLabel }: ThankYouProps) {
-    const reminderLabelWithPreposition = ensureHasPreposition(reminderLabel);
-
-    return (
-        <div>
-            <header>
-                <h3 css={styles.thankYouHeaderCopy}>Thank you! Your reminder is set</h3>
-            </header>
-
-            <div css={styles.thankYouBodyCopy}>
-                We will be in touch to invite you to contribute. Look out for a message in your
-                inbox {reminderLabelWithPreposition}. If you have any questions about contributing,
-                please <a href="mailto:contribution.support@theguardian.com">contact us</a>
+            <div css={styles.infoCopyContainer}>
+                <InfoCopy reminderLabelWithPreposition={reminderLabelWithPreposition} />
             </div>
         </div>
     );
@@ -172,29 +148,10 @@ const styles = {
             margin-left: ${space[3]}px;
         }
     `,
-    errorCopy: css`
-        ${textSans.small({ fontWeight: 'bold' })};
-        color: ${error[400]};
-        font-style: italic;
+    errorCopyContainer: css`
         margin-top: ${space[1]}px;
-        margin-bottom: 0;
     `,
-
-    infoCopy: css`
-        ${textSans.small({})}
-        font-size: 12px;
-
+    infoCopyContainer: css`
         margin-top: ${space[3]}px;
-    `,
-    privacyLink: css`
-        font-weight: bold;
-        color: ${neutral[0]};
-    `,
-    thankYouHeaderCopy: css`
-        ${textSans.small({ fontWeight: 'bold' })}
-        margin: 0;
-    `,
-    thankYouBodyCopy: css`
-        ${textSans.small()}
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/react';
 import { from } from '@guardian/src-foundations/mq';
 import { ImageAttrs, ResponsiveImage } from '../../../shared/ResponsiveImage';
-import { Image } from '@sdc/shared/src/types';
+import { Image } from '@sdc/shared/types';
 
 // ---- Component ---- //
 

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -22,5 +22,6 @@ export interface BannerTemplateSettings {
     secondaryCtaSettings: CtaSettings;
     closeButtonSettings: CtaSettings;
     highlightedTextSettings: HighlightedTextSettings;
+    setReminderCtaSettings?: CtaSettings;
     imageSettings: Image;
 }

--- a/packages/modules/src/modules/banners/postElectionAuMoment/settings.ts
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/settings.ts
@@ -38,4 +38,14 @@ export const settings: Omit<BannerTemplateSettings, 'imageSettings'> = {
         textColour: neutral[0],
         highlightColour: neutral[100],
     },
+    setReminderCtaSettings: {
+        default: {
+            backgroundColour: '#ffe500',
+            textColour: neutral[7],
+        },
+        hover: {
+            backgroundColour: '#e4e4e3',
+            textColour: neutral[7],
+        },
+    },
 };

--- a/packages/modules/src/modules/shared/Reminders.tsx
+++ b/packages/modules/src/modules/shared/Reminders.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { error, neutral } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
+
+// ---- Thank you component ---- //
+
+interface ThankYouProps {
+    reminderLabelWithPreposition: string;
+}
+
+export function ThankYou({ reminderLabelWithPreposition }: ThankYouProps): JSX.Element {
+    return (
+        <div>
+            <header>
+                <h3 css={styles.thankYouHeaderCopy}>Thank you! Your reminder is set</h3>
+            </header>
+
+            <div css={styles.thankYouBodyCopy}>
+                We will be in touch to invite you to contribute. Look out for a message in your
+                inbox {reminderLabelWithPreposition}. If you have any questions about contributing,
+                please{' '}
+                <a href="mailto:contribution.support@theguardian.com" css={styles.contactLink}>
+                    contact us
+                </a>
+            </div>
+        </div>
+    );
+}
+
+// ---- Info component ---- //
+
+interface InfoCopyProps {
+    reminderLabelWithPreposition: string;
+}
+
+export function InfoCopy({ reminderLabelWithPreposition }: InfoCopyProps): JSX.Element {
+    return (
+        <div css={styles.infoCopy}>
+            We will send you a maximum of two emails {reminderLabelWithPreposition}. To find out
+            what personal data we collect and how we use it, view our{' '}
+            <a
+                css={styles.privacyLink}
+                href="https://www.theguardian.com/help/privacy-policy"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                Privacy policy
+            </a>
+        </div>
+    );
+}
+
+// ---- Error component ---- //
+
+export function ErrorCopy(): JSX.Element {
+    return (
+        <div css={styles.errorCopy}>
+            Sorry we couldn&apos;t set a reminder for you this time. Please try again later.
+        </div>
+    );
+}
+
+// ---- Styles ---- //
+
+const styles = {
+    errorCopy: css`
+        ${textSans.small({ fontWeight: 'bold' })};
+        color: ${error[400]};
+        font-style: italic;
+    `,
+    infoCopy: css`
+        ${textSans.small({})}
+        font-size: 12px;
+    `,
+    privacyLink: css`
+        font-weight: bold;
+        color: ${neutral[0]};
+    `,
+    thankYouHeaderCopy: css`
+        ${textSans.small({ fontWeight: 'bold' })}
+        margin: 0;
+    `,
+    thankYouBodyCopy: css`
+        ${textSans.small()}
+    `,
+    contactLink: css`
+        color: ${neutral[0]};
+    `,
+};


### PR DESCRIPTION
## What does this change?

This change adds support for `ContributionsReminder` secondary cta type to the moment template banner. It's a slightly simplified version of the one in the main contributions  banner as it doesn't yet support showing a simplified version for signed in users. We can add that as a follow up, here's the [wip branch](https://github.com/guardian/support-dotcom-components/tree/tp-moment-banner-template-with-reminders-signed-in).

## Images

### Mobile

|Closed|Open|
|------|----|
|![Screenshot 2022-05-23 at 09 48 20](https://user-images.githubusercontent.com/17720442/169783002-85e7d1c2-5ee7-4ce8-ac21-12dde7a0821f.png)|![Screenshot 2022-05-23 at 09 48 28](https://user-images.githubusercontent.com/17720442/169782943-205289a5-2a19-4951-8421-343c040e4bf7.png)|

### Mobile scrolling

|Without image|With image|
|-------------|----------|
|![May-23-2022 09-50-09](https://user-images.githubusercontent.com/17720442/169783165-3236d1b7-f6a3-4806-840e-dbff2c3a169f.gif)|![May-23-2022 09-57-09](https://user-images.githubusercontent.com/17720442/169783169-73802a95-25bb-4fcd-a70e-7cef4491bb28.gif)|

### Desktop
|Closed|Open|
|------|----|
|![Screenshot 2022-05-23 at 09 59 22](https://user-images.githubusercontent.com/17720442/169783334-b396cecf-59be-4f15-9c96-3f6315b7faf8.png)|![Screenshot 2022-05-23 at 09 55 49](https://user-images.githubusercontent.com/17720442/169782946-64f779ab-34a9-4452-b6ec-4005df5ce053.png)|




