### PR TITLE
Load propensity test data once

### DIFF
--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
@@ -8,7 +8,7 @@ import {
 } from '@sdc/shared/dist/types';
 import { countryCodeToCountryGroupId, inCountryGroups } from '@sdc/shared/dist/lib';
 import { UK_DIGISUB_CONTENT, DIGISUB_CONTENT } from './propensityModelTestDigisubCopy';
-import { fetchHighPropensityIds, isInPropensityTest } from './propensityModelTestData';
+import { isInPropensityTest } from './propensityModelTestData';
 import { GW_CONTENT } from './propensityModelTestGWCopy';
 
 /**
@@ -32,9 +32,6 @@ const CONTROL_NAME = 'control';
 const VARIANT_NAME = 'variant';
 
 export const propensityModelBannerTest: BannerTestGenerator = () => {
-    // Kick off streaming of browserIds into memory, but resolve immediately to avoid blocking other tests
-    fetchHighPropensityIds();
-
     return Promise.resolve([
         {
             name: PROPENSITY_MODEL_TEST_NAME,

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
@@ -8,7 +8,7 @@ import {
 } from '@sdc/shared/dist/types';
 import { countryCodeToCountryGroupId, inCountryGroups } from '@sdc/shared/dist/lib';
 import { UK_DIGISUB_CONTENT, DIGISUB_CONTENT } from './propensityModelTestDigisubCopy';
-import { isInPropensityTest } from './propensityModelTestData';
+import { fetchHighPropensityIds, isInPropensityTest } from './propensityModelTestData';
 import { GW_CONTENT } from './propensityModelTestGWCopy';
 
 /**
@@ -32,6 +32,9 @@ const CONTROL_NAME = 'control';
 const VARIANT_NAME = 'variant';
 
 export const propensityModelBannerTest: BannerTestGenerator = () => {
+    // Kick off streaming of browserIds into memory, but resolve immediately to avoid blocking other tests
+    fetchHighPropensityIds();
+
     return Promise.resolve([
         {
             name: PROPENSITY_MODEL_TEST_NAME,

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTestData.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTestData.ts
@@ -3,7 +3,7 @@ import { streamS3DataByLine } from '../../../utils/S3';
 import { isProd } from '../../../lib/env';
 
 const guardianWeeklyHighPropensityIds: Set<string> = new Set<string>();
-export const fetchHighPropensityIds = (): void => {
+const fetchHighPropensityIds = (): void => {
     logInfo('Loading guardianWeeklyHighPropensityIds...');
     streamS3DataByLine({
         bucket: 'support-admin-console',
@@ -19,3 +19,5 @@ export const fetchHighPropensityIds = (): void => {
 
 export const isInPropensityTest = (browserId: string): boolean =>
     guardianWeeklyHighPropensityIds.has(browserId);
+
+fetchHighPropensityIds();

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTestData.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTestData.ts
@@ -3,21 +3,21 @@ import { streamS3DataByLine } from '../../../utils/S3';
 import { isProd } from '../../../lib/env';
 
 const guardianWeeklyHighPropensityIds: Set<string> = new Set<string>();
-const fetchHighPropensityIds = (): void => {
-    logInfo('Loading guardianWeeklyHighPropensityIds...');
-    streamS3DataByLine({
-        bucket: 'support-admin-console',
-        key: `${isProd ? 'PROD' : 'CODE'}/guardian-weekly-propensity-test/ids.txt`,
-        onLine: line => guardianWeeklyHighPropensityIds.add(line),
-        onComplete: () => {
-            logInfo(
-                `Loaded ${guardianWeeklyHighPropensityIds.size} guardianWeeklyHighPropensityIds`,
-            );
-        },
-    });
+export const fetchHighPropensityIds = (): void => {
+    if (guardianWeeklyHighPropensityIds.size === 0) {
+        logInfo('Loading guardianWeeklyHighPropensityIds...');
+        streamS3DataByLine({
+            bucket: 'support-admin-console',
+            key: `${isProd ? 'PROD' : 'CODE'}/guardian-weekly-propensity-test/ids.txt`,
+            onLine: line => guardianWeeklyHighPropensityIds.add(line),
+            onComplete: () => {
+                logInfo(
+                    `Loaded ${guardianWeeklyHighPropensityIds.size} guardianWeeklyHighPropensityIds`,
+                );
+            },
+        });
+    }
 };
 
 export const isInPropensityTest = (browserId: string): boolean =>
     guardianWeeklyHighPropensityIds.has(browserId);
-
-fetchHighPropensityIds();


### PR DESCRIPTION
Currently it's streaming the data every time it polls for the banner test data, which is very wasteful.
With this PR it streams once on startup