### PR TITLE
Sign in after checkout banner (Storybook only)

### DIFF
--- a/packages/modules/src/lib/replaceArticleCount.tsx
+++ b/packages/modules/src/lib/replaceArticleCount.tsx
@@ -16,14 +16,18 @@ export const replaceArticleCountWithLink = (
 
     const parts = subbedText.split(/%%ARTICLE_COUNT_AND_NEXT_WORD%%/);
     const elements = [];
+    let key = 0;
     for (let i = 0; i < parts.length - 1; i += 1) {
-        elements.push(<span dangerouslySetInnerHTML={{ __html: parts[i] as string }} />);
+        elements.push(
+            <span dangerouslySetInnerHTML={{ __html: parts[i] as string }} key={key++} />,
+        );
         elements.push(
             <ArticleCountOptOutPopup
                 numArticles={numArticles}
                 nextWord={nextWords[i] as string}
                 type={articleCountOptOutType}
                 tracking={tracking}
+                key={key++}
             />,
         );
     }
@@ -32,6 +36,7 @@ export const replaceArticleCountWithLink = (
             dangerouslySetInnerHTML={{
                 __html: parts[parts.length - 1] as string,
             }}
+            key={key++}
         />,
     );
 

--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -9,7 +9,8 @@ export type BannerId =
     | 'subscription-banner'
     | 'weekly-banner'
     | 'global-new-year-banner'
-    | 'election-au-moment-banner';
+    | 'election-au-moment-banner'
+    | 'sign-in-prompt-banner';
 
 export interface BannerEnrichedCta {
     ctaUrl: string;

--- a/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.stories.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { SecondaryCtaType } from '@sdc/shared/types';
+
+import { props } from '../utils/storybook';
+import { SignInPromptBannerUnvalidated as SignInPromptBanner } from './SignInPromptBanner';
+
+export default {
+    component: SignInPromptBanner,
+    title: 'Banners/SignInPromptBanner',
+} as ComponentMeta<typeof SignInPromptBanner>;
+
+const Template: ComponentStory<typeof SignInPromptBanner> = props => (
+    <SignInPromptBanner {...props} />
+);
+
+const content = {
+    heading: 'Thank you for subscribing',
+    paragraphs: [
+        'Your final step to enjoy the Guardian',
+        'Ad free',
+        'Fewer interruptions',
+        'Newsletters and comments',
+    ],
+    cta: {
+        baseUrl: 'https://profile.theguardian.com/register',
+        text: 'Complete registration',
+    },
+    secondaryCta: {
+        type: SecondaryCtaType.Custom,
+        cta: {
+            baseUrl: '',
+            text: 'Not now',
+        },
+    },
+};
+
+const baseArgs = {
+    ...props,
+    content,
+};
+
+export const DefaultBanner = Template.bind({});
+DefaultBanner.args = baseArgs;

--- a/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
+++ b/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { ThemeProvider, css } from '@emotion/react';
+import { brand, brandAlt, brandText, space, neutral } from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/typography';
+import { Button, LinkButton, buttonBrand } from '@guardian/src-button';
+import { SvgRoundelBrandInverse } from '@guardian/src-brand';
+import { SecondaryCtaType } from '@sdc/shared/types';
+
+import { BannerRenderProps } from '../common/types';
+import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
+
+const background = css`
+    background-color: ${brand[400]};
+`;
+
+const headingStyles = css`
+    ${headline.medium({ fontWeight: 'bold' })}
+    font-size: 32px;
+    color: ${neutral[100]};
+    margin: 0;
+`;
+
+const subHeadingStyles = css`
+    ${headline.xxsmall({ fontWeight: 'bold' })};
+    color: ${brandAlt[400]};
+    margin: 0;
+`;
+
+const bulletStyles = css`
+    ${headline.xxsmall({ fontWeight: 'medium' })};
+    color: ${neutral[100]};
+    display: flex;
+    flex-direction: column;
+
+    span::before {
+        content: '';
+        display: inline-block;
+        width: 15px;
+        height: 15px;
+        margin-right: ${space[2]}px;
+        background: ${brandAlt[400]};
+        border-radius: 50%;
+    }
+`;
+
+const closeButton = css`
+    margin-left: ${space[5]}px;
+`;
+
+const logo = css`
+    width: 42px;
+    height: 42px;
+`;
+
+const SignInPromptBanner: React.FC<BannerRenderProps> = props => {
+    const { heading, paragraphs, primaryCta, secondaryCta } = props.content.mainContent;
+    const [subheading, ...bullets] = paragraphs;
+
+    return (
+        <div css={background}>
+            <h1 css={headingStyles}>{heading}</h1>
+            <h2 css={subHeadingStyles}>{subheading}</h2>
+            <div css={bulletStyles}>{bullets}</div>
+            <ThemeProvider theme={buttonBrand}>
+                {primaryCta && (
+                    <LinkButton priority="primary" href={primaryCta.ctaUrl} size="small">
+                        {primaryCta.ctaText}
+                    </LinkButton>
+                )}
+                {secondaryCta && secondaryCta.type === SecondaryCtaType.Custom && (
+                    <Button
+                        priority="subdued"
+                        size="small"
+                        onClick={props.onCloseClick}
+                        cssOverrides={closeButton}
+                    >
+                        {secondaryCta.cta.ctaText}
+                    </Button>
+                )}
+            </ThemeProvider>
+            <div css={logo}>
+                <SvgRoundelBrandInverse />
+            </div>
+        </div>
+    );
+};
+
+const unvalidated = bannerWrapper(SignInPromptBanner, 'sign-in-prompt-banner');
+const validated = validatedBannerWrapper(SignInPromptBanner, 'sign-in-prompt-banner');
+
+export { validated as SignInPromptBanner, unvalidated as SignInPromptBannerUnvalidated };

--- a/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
+++ b/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { ThemeProvider, css } from '@emotion/react';
-import { brand, brandAlt, brandText, space, neutral } from '@guardian/src-foundations';
+import { brand, brandAlt, space, neutral } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 import { Button, LinkButton, buttonBrand } from '@guardian/src-button';
 import { SvgRoundelBrandInverse } from '@guardian/src-brand';
 import { SecondaryCtaType } from '@sdc/shared/types';
+import { Container, Column, Columns } from '@guardian/src-layout';
 
 import { BannerRenderProps } from '../common/types';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
@@ -13,17 +14,21 @@ const background = css`
     background-color: ${brand[400]};
 `;
 
+const mainColumn = css`
+    position: relative;
+`;
+
 const headingStyles = css`
     ${headline.medium({ fontWeight: 'bold' })}
     font-size: 32px;
     color: ${neutral[100]};
-    margin: 0;
+    margin: ${space[1]}px 0 0;
 `;
 
 const subHeadingStyles = css`
     ${headline.xxsmall({ fontWeight: 'bold' })};
     color: ${brandAlt[400]};
-    margin: 0;
+    margin: ${space[2]}px 0;
 `;
 
 const bulletStyles = css`
@@ -31,6 +36,10 @@ const bulletStyles = css`
     color: ${neutral[100]};
     display: flex;
     flex-direction: column;
+
+    span:not(:first-of-type) {
+        margin-top: 10px;
+    }
 
     span::before {
         content: '';
@@ -43,11 +52,18 @@ const bulletStyles = css`
     }
 `;
 
+const actions = css`
+    margin: ${space[5]}px 0;
+`;
+
 const closeButton = css`
     margin-left: ${space[5]}px;
 `;
 
 const logo = css`
+    position: absolute;
+    top: ${space[2]}px;
+    right: 0px;
     width: 42px;
     height: 42px;
 `;
@@ -57,31 +73,44 @@ const SignInPromptBanner: React.FC<BannerRenderProps> = props => {
     const [subheading, ...bullets] = paragraphs;
 
     return (
-        <div css={background}>
-            <h1 css={headingStyles}>{heading}</h1>
-            <h2 css={subHeadingStyles}>{subheading}</h2>
-            <div css={bulletStyles}>{bullets}</div>
-            <ThemeProvider theme={buttonBrand}>
-                {primaryCta && (
-                    <LinkButton priority="primary" href={primaryCta.ctaUrl} size="small">
-                        {primaryCta.ctaText}
-                    </LinkButton>
-                )}
-                {secondaryCta && secondaryCta.type === SecondaryCtaType.Custom && (
-                    <Button
-                        priority="subdued"
-                        size="small"
-                        onClick={props.onCloseClick}
-                        cssOverrides={closeButton}
-                    >
-                        {secondaryCta.cta.ctaText}
-                    </Button>
-                )}
-            </ThemeProvider>
-            <div css={logo}>
-                <SvgRoundelBrandInverse />
-            </div>
-        </div>
+        <Container cssOverrides={background}>
+            <Columns>
+                <Column width={[0, 0, 0, 2, 3]}> </Column>
+                <Column width={[4, 12, 12, 12, 13]} cssOverrides={mainColumn}>
+                    <h1 css={headingStyles}>{heading}</h1>
+                    <h2 css={subHeadingStyles}>{subheading}</h2>
+                    <div css={bulletStyles}>{bullets}</div>
+
+                    <div css={actions}>
+                        <ThemeProvider theme={buttonBrand}>
+                            {primaryCta && (
+                                <LinkButton
+                                    priority="primary"
+                                    href={primaryCta.ctaUrl}
+                                    size="small"
+                                >
+                                    {primaryCta.ctaText}
+                                </LinkButton>
+                            )}
+                            {secondaryCta && secondaryCta.type === SecondaryCtaType.Custom && (
+                                <Button
+                                    priority="subdued"
+                                    size="small"
+                                    onClick={props.onCloseClick}
+                                    cssOverrides={closeButton}
+                                >
+                                    {secondaryCta.cta.ctaText}
+                                </Button>
+                            )}
+                        </ThemeProvider>
+                    </div>
+
+                    <div css={logo}>
+                        <SvgRoundelBrandInverse />
+                    </div>
+                </Column>
+            </Columns>
+        </Container>
     );
 };
 


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Added a new type of banner which is intended to prompt users to sign in / register so they can benefit from a contribution they have made.

In draft until /pull/665 is merged

I couldn't link this PR to the trello card correctly, so here's a link instead: https://trello.com/c/u0L4ZDqF/3956-sign-in-after-checkout-visual-aspect-of-the-banner-s

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Using Storybook

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

### Mobile

![image](https://user-images.githubusercontent.com/3338808/170465921-9409444f-f5ad-4b2a-9b98-c3049b47fd5d.png)

### Tablet

![image](https://user-images.githubusercontent.com/3338808/170465980-821b7849-b392-4923-adb3-dc286e9a50f3.png)

### Desktop

![image](https://user-images.githubusercontent.com/3338808/170466038-c72b1440-5a6c-49a7-8226-168cb813632d.png)

### Left col

![image](https://user-images.githubusercontent.com/3338808/170466270-e0acb0ff-8b0f-4949-8a04-16f7e0dcaf0e.png)

### Wide

![image](https://user-images.githubusercontent.com/3338808/170466413-cd0d03ba-3dd9-416a-a6e6-bce23726ae0e.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [x] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
