### PR TITLE
Research survey banner

### DIFF
--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -3,6 +3,7 @@ import { SecondaryCtaType, TickerSettings } from '@sdc/shared/types';
 
 export type BannerId =
     | 'contributions-banner'
+    | 'research-survey-banner'
     | 'aus-moment-banner'
     | 'investigations-moment-banner'
     | 'environment-moment-banner'

--- a/packages/modules/src/modules/banners/contributions/ContributionsBanner.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBanner.tsx
@@ -17,10 +17,10 @@ import { SecondaryCtaType } from '@sdc/shared/types';
 import { defineFetchEmail } from '../../shared/helpers/definedFetchEmail';
 
 const styles = {
-    bannerContainer: css`
+    bannerContainer: (backgroundColor: string) => css`
         overflow: hidden;
         width: 100%;
-        background-color: ${brandAlt[400]};
+        background-color: ${backgroundColor};
         color: ${neutral[7]};
         ${from.tablet} {
             border-top: 1px solid ${neutral[7]};
@@ -186,7 +186,7 @@ const columnCounts = {
     wide: 16,
 };
 
-const ContributionsBanner: React.FC<BannerRenderProps> = ({
+export const getContributionsBanner = (backgroundColor: string): React.FC<BannerRenderProps> => ({
     onCtaClick,
     onSecondaryCtaClick,
     reminderTracking,
@@ -257,7 +257,7 @@ const ContributionsBanner: React.FC<BannerRenderProps> = ({
     );
 
     return (
-        <div css={styles.bannerContainer}>
+        <div css={styles.bannerContainer(backgroundColor)}>
             <ContributionsBannerMobile
                 onCloseClick={onCloseClick}
                 onContributeClick={onCtaClick}
@@ -327,6 +327,8 @@ const ContributionsBanner: React.FC<BannerRenderProps> = ({
         </div>
     );
 };
+
+const ContributionsBanner = getContributionsBanner(brandAlt[400]);
 
 const unvalidated = bannerWrapper(ContributionsBanner, 'contributions-banner');
 const validated = validatedBannerWrapper(ContributionsBanner, 'contributions-banner');

--- a/packages/modules/src/modules/banners/researchSurveyBanner/ResearchSurveyBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/researchSurveyBanner/ResearchSurveyBanner.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { ResearchSurveyBannerUnvalidated as ResearchSurveyBanner } from './ResearchSurveyBanner';
+import { props } from '../utils/storybook';
+import { BannerProps } from '@sdc/shared/types';
+
+export default {
+    component: ResearchSurveyBanner,
+    title: 'Banners/ResearchSurveyBanner',
+    args: props,
+} as Meta;
+
+const Template: Story<BannerProps> = (props: BannerProps) => <ResearchSurveyBanner {...props} />;
+
+export const Default = Template.bind({});
+Default.args = {
+    ...props,
+    separateArticleCount: false,
+    content: {
+        heading: 'Take part in this short survey from the Guardian',
+        paragraphs: [
+            "We are always looking to improve what we do and we'd love to have your input. The feedback we receive will enable us to improve our website and products to better meet your needs, and should take less than 5 minutes to complete.",
+        ],
+        cta: {
+            text: 'Take the survey',
+            baseUrl: 'https://surveys.theguardian.com/c/a/6NlT5qcs0w6E6NVjsTpVO8',
+        },
+    },
+};

--- a/packages/modules/src/modules/banners/researchSurveyBanner/ResearchSurveyBanner.tsx
+++ b/packages/modules/src/modules/banners/researchSurveyBanner/ResearchSurveyBanner.tsx
@@ -1,0 +1,9 @@
+import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
+import { getContributionsBanner } from '../contributions/ContributionsBanner';
+
+const ResearchSurveyBanner = getContributionsBanner('#feeef7');
+
+const unvalidated = bannerWrapper(ResearchSurveyBanner, 'research-survey-banner');
+const validated = validatedBannerWrapper(ResearchSurveyBanner, 'research-survey-banner');
+
+export { validated as ResearchSurveyBanner, unvalidated as ResearchSurveyBannerUnvalidated };

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -123,6 +123,7 @@ export const selectBannerTest = async (
 
         if (
             test.status === 'Live' &&
+            (!test.canRun || test.canRun(targeting, pageTracking)) &&
             (enableHardcodedBannerTests || !test.isHardcoded) &&
             !targeting.shouldHideReaderRevenue &&
             !targeting.isPaidContent &&

--- a/packages/server/src/tests/banners/bannerTests.ts
+++ b/packages/server/src/tests/banners/bannerTests.ts
@@ -5,6 +5,7 @@ import {
     channel2BannersAllTestsGenerator,
 } from './channelBannerTests';
 import { DefaultContributionsBanner } from './DefaultContributionsBannerTest';
+import { researchSurveyBannerTest } from './researchSurveyBannerTest';
 
 const defaultBannerTestGenerator: BannerTestGenerator = () =>
     Promise.resolve([DefaultContributionsBanner]);
@@ -13,6 +14,7 @@ const flattenArray = <T>(array: T[][]): T[] => ([] as T[]).concat(...array);
 
 const testGenerators: BannerTestGenerator[] = [
     channel1BannersAllTestsGenerator,
+    researchSurveyBannerTest,
     channel2BannersAllTestsGenerator,
     defaultBannerTestGenerator,
 ];

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -10,6 +10,7 @@ import {
     postElectionAuMomentAlbaneseBanner,
     postElectionAuMomentHungBanner,
     postElectionAuMomentMorrisonBanner,
+    researchSurveyBanner,
 } from '@sdc/shared/config';
 import {
     BannerChannel,
@@ -42,6 +43,7 @@ export const BannerPaths: {
         postElectionAuMomentMorrisonBanner.endpointPathBuilder,
     [BannerTemplate.DigitalSubscriptionsBanner]: digiSubs.endpointPathBuilder,
     [BannerTemplate.GuardianWeeklyBanner]: guardianWeekly.endpointPathBuilder,
+    [BannerTemplate.ResearchSurveyBanner]: researchSurveyBanner.endpointPathBuilder,
 };
 
 export const BannerTemplateComponentTypes: {

--- a/packages/server/src/tests/banners/researchSurveyBannerTest.ts
+++ b/packages/server/src/tests/banners/researchSurveyBannerTest.ts
@@ -16,6 +16,7 @@ export const researchSurveyBannerTest: BannerTestGenerator = () => {
                 bannerChannel: 'subscriptions',
                 isHardcoded: true,
                 userCohort: 'Everyone',
+                status: 'Live',
                 canRun: targeting => targeting.contentType !== 'Network Front',
                 minPageViews: 4,
                 audience: 0.05, // 5%

--- a/packages/server/src/tests/banners/researchSurveyBannerTest.ts
+++ b/packages/server/src/tests/banners/researchSurveyBannerTest.ts
@@ -1,9 +1,8 @@
-import { BannerTemplate, BannerTestGenerator, SecondaryCtaType } from '@sdc/shared/dist/types';
-import { contributionsBanner, researchSurveyBanner } from '@sdc/shared/dist/config';
+import { BannerTemplate, BannerTestGenerator } from '@sdc/shared/dist/types';
+import { researchSurveyBanner } from '@sdc/shared/dist/config';
 
 /**
  * TODO:
- * - copy
  * - audience size
  * - targeting
  */
@@ -16,33 +15,11 @@ export const researchSurveyBannerTest: BannerTestGenerator = () =>
             userCohort: 'AllNonSupporters',
             canRun: () => true,
             minPageViews: 4,
+            audience: 0.01, // TODO
+            audienceOffset: 0,
             variants: [
                 {
                     name: 'control',
-                    modulePathBuilder: contributionsBanner.endpointPathBuilder,
-                    moduleName: BannerTemplate.ContributionsBanner,
-                    bannerContent: {
-                        heading: 'Power open, independent journalism',
-                        paragraphs: [],
-                        highlightedText: '',
-                        cta: {
-                            baseUrl:
-                                'https://support.theguardian.com/subscribe/digital/checkout?promoCode=DK0NT24WG&period=Monthly',
-                            text: 'Subscribe',
-                        },
-                        secondaryCta: {
-                            type: SecondaryCtaType.Custom,
-                            cta: {
-                                baseUrl: 'https://support.theguardian.com/subscribe/digital',
-                                text: 'Find out more',
-                            },
-                        },
-                    },
-                    componentType: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
-                    separateArticleCount: false,
-                },
-                {
-                    name: 'variant',
                     modulePathBuilder: researchSurveyBanner.endpointPathBuilder,
                     moduleName: BannerTemplate.ResearchSurveyBanner,
                     bannerContent: {

--- a/packages/server/src/tests/banners/researchSurveyBannerTest.ts
+++ b/packages/server/src/tests/banners/researchSurveyBannerTest.ts
@@ -1,0 +1,63 @@
+import { BannerTemplate, BannerTestGenerator, SecondaryCtaType } from '@sdc/shared/dist/types';
+import { contributionsBanner, researchSurveyBanner } from '@sdc/shared/dist/config';
+
+/**
+ * TODO:
+ * - copy
+ * - audience size
+ * - targeting
+ */
+export const researchSurveyBannerTest: BannerTestGenerator = () =>
+    Promise.resolve([
+        {
+            name: '2022-05-26_research-survey-banner-test',
+            bannerChannel: 'subscriptions',
+            isHardcoded: true,
+            userCohort: 'AllNonSupporters',
+            canRun: () => true,
+            minPageViews: 4,
+            variants: [
+                {
+                    name: 'control',
+                    modulePathBuilder: contributionsBanner.endpointPathBuilder,
+                    moduleName: BannerTemplate.ContributionsBanner,
+                    bannerContent: {
+                        heading: 'Power open, independent journalism',
+                        paragraphs: [],
+                        highlightedText: '',
+                        cta: {
+                            baseUrl:
+                                'https://support.theguardian.com/subscribe/digital/checkout?promoCode=DK0NT24WG&period=Monthly',
+                            text: 'Subscribe',
+                        },
+                        secondaryCta: {
+                            type: SecondaryCtaType.Custom,
+                            cta: {
+                                baseUrl: 'https://support.theguardian.com/subscribe/digital',
+                                text: 'Find out more',
+                            },
+                        },
+                    },
+                    componentType: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
+                    separateArticleCount: false,
+                },
+                {
+                    name: 'variant',
+                    modulePathBuilder: researchSurveyBanner.endpointPathBuilder,
+                    moduleName: BannerTemplate.ResearchSurveyBanner,
+                    bannerContent: {
+                        heading: 'Take part in this short survey from the Guardian',
+                        paragraphs: [
+                            "We are always looking to improve what we do and we'd love to have your input. The feedback we receive will enable us to improve our website and products to better meet your needs, and should take less than 5 minutes to complete.",
+                        ],
+                        cta: {
+                            text: 'Take the survey',
+                            baseUrl: 'https://surveys.theguardian.com/c/a/6NlT5qcs0w6E6NVjsTpVO8',
+                        },
+                    },
+                    componentType: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
+                    separateArticleCount: false,
+                },
+            ],
+        },
+    ]);

--- a/packages/server/src/tests/banners/researchSurveyBannerTest.ts
+++ b/packages/server/src/tests/banners/researchSurveyBannerTest.ts
@@ -13,7 +13,7 @@ export const researchSurveyBannerTest: BannerTestGenerator = () =>
             bannerChannel: 'subscriptions',
             isHardcoded: true,
             userCohort: 'AllNonSupporters',
-            canRun: () => true,
+            canRun: targeting => targeting.contentType !== 'Network Front',
             minPageViews: 4,
             audience: 0.01, // TODO
             audienceOffset: 0,

--- a/packages/server/src/tests/banners/researchSurveyBannerTest.ts
+++ b/packages/server/src/tests/banners/researchSurveyBannerTest.ts
@@ -1,8 +1,8 @@
 import { BannerTemplate, BannerTestGenerator } from '@sdc/shared/dist/types';
 import { researchSurveyBanner } from '@sdc/shared/dist/config';
 
-const startDate = new Date('2022-06-07');
-const endDate = new Date('2022-06-10');
+const startDate = new Date('2022-06-14');
+const endDate = new Date('2022-06-17');
 const isLive = () => {
     const now = new Date();
     return now > startDate && now < endDate;

--- a/packages/server/src/tests/banners/researchSurveyBannerTest.ts
+++ b/packages/server/src/tests/banners/researchSurveyBannerTest.ts
@@ -1,40 +1,47 @@
 import { BannerTemplate, BannerTestGenerator } from '@sdc/shared/dist/types';
 import { researchSurveyBanner } from '@sdc/shared/dist/config';
 
-/**
- * TODO:
- * - audience size
- * - targeting
- */
-export const researchSurveyBannerTest: BannerTestGenerator = () =>
-    Promise.resolve([
-        {
-            name: '2022-05-26_research-survey-banner-test',
-            bannerChannel: 'subscriptions',
-            isHardcoded: true,
-            userCohort: 'AllNonSupporters',
-            canRun: targeting => targeting.contentType !== 'Network Front',
-            minPageViews: 4,
-            audience: 0.01, // TODO
-            audienceOffset: 0,
-            variants: [
-                {
-                    name: 'control',
-                    modulePathBuilder: researchSurveyBanner.endpointPathBuilder,
-                    moduleName: BannerTemplate.ResearchSurveyBanner,
-                    bannerContent: {
-                        heading: 'Take part in this short survey from the Guardian',
-                        paragraphs: [
-                            "We are always looking to improve what we do and we'd love to have your input. The feedback we receive will enable us to improve our website and products to better meet your needs, and should take less than 5 minutes to complete.",
-                        ],
-                        cta: {
-                            text: 'Take the survey',
-                            baseUrl: 'https://surveys.theguardian.com/c/a/6NlT5qcs0w6E6NVjsTpVO8',
+const startDate = new Date('2022-06-07');
+const endDate = new Date('2022-06-10');
+const isLive = () => {
+    const now = new Date();
+    return now > startDate && now < endDate;
+};
+
+export const researchSurveyBannerTest: BannerTestGenerator = () => {
+    if (isLive()) {
+        return Promise.resolve([
+            {
+                name: '2022-05-26_research-survey-banner-test',
+                bannerChannel: 'subscriptions',
+                isHardcoded: true,
+                userCohort: 'AllNonSupporters',
+                canRun: targeting => targeting.contentType !== 'Network Front',
+                minPageViews: 4,
+                audience: 0.05, // 5%
+                audienceOffset: 0,
+                variants: [
+                    {
+                        name: 'control',
+                        modulePathBuilder: researchSurveyBanner.endpointPathBuilder,
+                        moduleName: BannerTemplate.ResearchSurveyBanner,
+                        bannerContent: {
+                            heading: 'Take part in this short survey from the Guardian',
+                            paragraphs: [
+                                "We are always looking to improve what we do and we'd love to have your input. The feedback we receive will enable us to improve our website and products to better meet your needs, and should take less than 5 minutes to complete.",
+                            ],
+                            cta: {
+                                text: 'Take the survey',
+                                baseUrl:
+                                    'https://surveys.theguardian.com/c/a/6NlT5qcs0w6E6NVjsTpVO8',
+                            },
                         },
+                        componentType: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
+                        separateArticleCount: false,
                     },
-                    componentType: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
-                    separateArticleCount: false,
-                },
-            ],
-        },
-    ]);
+                ],
+            },
+        ]);
+    }
+    return Promise.resolve([]);
+};

--- a/packages/server/src/tests/banners/researchSurveyBannerTest.ts
+++ b/packages/server/src/tests/banners/researchSurveyBannerTest.ts
@@ -15,7 +15,7 @@ export const researchSurveyBannerTest: BannerTestGenerator = () => {
                 name: '2022-05-26_research-survey-banner-test',
                 bannerChannel: 'subscriptions',
                 isHardcoded: true,
-                userCohort: 'AllNonSupporters',
+                userCohort: 'Everyone',
                 canRun: targeting => targeting.contentType !== 'Network Front',
                 minPageViews: 4,
                 audience: 0.05, // 5%

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -30,7 +30,7 @@ export const contributionsBanner: ModuleInfo = getDefaultModuleInfo(
 
 export const researchSurveyBanner: ModuleInfo = getDefaultModuleInfo(
     'research-survey-banner',
-    'banners/researchSurveyBanner',
+    'banners/researchSurveyBanner/ResearchSurveyBanner',
 );
 
 export const contributionsBannerWithSignIn: ModuleInfo = getDefaultModuleInfo(

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -28,6 +28,11 @@ export const contributionsBanner: ModuleInfo = getDefaultModuleInfo(
     'banners/contributions/ContributionsBanner',
 );
 
+export const researchSurveyBanner: ModuleInfo = getDefaultModuleInfo(
+    'research-survey-banner',
+    'banners/researchSurveyBanner',
+);
+
 export const contributionsBannerWithSignIn: ModuleInfo = getDefaultModuleInfo(
     'contributions-banner-with-sign-in',
     'banners/contributions/ContributionsBannerWithSignIn',
@@ -94,6 +99,7 @@ export const moduleInfos: ModuleInfo[] = [
     epic,
     liveblogEpic,
     contributionsBanner,
+    researchSurveyBanner,
     contributionsBannerWithSignIn,
     investigationsMomentBanner,
     environmentMomentBanner,

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -24,6 +24,7 @@ export enum BannerTemplate {
     PostElectionAuMomentAlbaneseBanner = 'PostElectionAuMomentAlbaneseBanner',
     PostElectionAuMomentHungBanner = 'PostElectionAuMomentHungBanner',
     PostElectionAuMomentMorrisonBanner = 'PostElectionAuMomentMorrisonBanner',
+    ResearchSurveyBanner = 'ResearchSurveyBanner',
 }
 
 export interface BannerVariant extends Variant {

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -11,6 +11,7 @@ import {
 } from './shared';
 import { OphanComponentType, OphanProduct } from '../ophan';
 import { CountryGroupId } from '../../lib';
+import { BannerTargeting, PageTracking } from '../targeting';
 
 export enum BannerTemplate {
     ContributionsBanner = 'ContributionsBanner',
@@ -39,6 +40,8 @@ export interface BannerVariant extends Variant {
     separateArticleCount?: boolean;
 }
 
+export type CanRun = (targeting: BannerTargeting, pageTracking: PageTracking) => boolean;
+
 export type BannerTestGenerator = () => Promise<BannerTest[]>;
 
 export interface BannerTest extends Test<BannerVariant> {
@@ -47,6 +50,7 @@ export interface BannerTest extends Test<BannerVariant> {
     bannerChannel: BannerChannel;
     isHardcoded: boolean;
     userCohort: UserCohort;
+    canRun?: CanRun;
     minPageViews: number;
     variants: BannerVariant[];
     locations?: CountryGroupId[];


### PR DESCRIPTION
A 'test' with just a control variant, linking to a research survey. We want to find out if we can use banners for this purpose.
The test is in banner channel 2. It targets 5% of the audience. It is only enabled from tues-thurs, to avoid the banner redeploy times, as we don't want users to see it more than once.

<img width="1157" alt="Screen Shot 2022-05-26 at 14 50 29" src="https://user-images.githubusercontent.com/1513454/170501492-4bdeb7f6-4280-46c4-8e34-f9c170657c9f.png">
