### PR TITLE
Revert "Disable scheduled banner deploys in AU"

### DIFF
--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -63,11 +63,9 @@ export const redeployedSinceLastClosed = (
             deployTimes => deployTimes[region],
         );
         const lastClosed = new Date(lastClosedRaw);
-        const scheduledDeploysEnabled = targeting.countryCode !== 'AU';
         return (
             lastManualDeploy > lastClosed ||
-            (scheduledDeploysEnabled &&
-                getLastScheduledDeploy(now, scheduledBannerDeploys[bannerChannel]) > lastClosed)
+            getLastScheduledDeploy(now, scheduledBannerDeploys[bannerChannel]) > lastClosed
         );
     };
 


### PR DESCRIPTION
We want automatic redeploys again

Reverts guardian/support-dotcom-components#703