### PR TITLE
Updating images for GW banner

### DIFF
--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -45,7 +45,7 @@ const mobileImg =
 const baseImg = {
     url: desktopImg,
     media: '(min-width: 980px)',
-    alt: 'The Guardian Weekly magazine',
+    alt: 'The Guardian Weekly magazine - 50% off for 3 months',
 };
 
 const images = [

--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -33,13 +33,13 @@ const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
 const desktopImg =
-    'https://i.guim.co.uk/img/media/a0fd9756e4a75685584f03ded6585320a7642b48/0_0_2652_1360/2652.png?quality=85&s=3dc0d52e5b5b8612699c365fbe80c1e8';
+    'https://i.guim.co.uk/img/media/13bce8e6c19f2b90d063bab1af3f13a09e5aaaab/0_0_2652_1360/2652.png?quality=85&s=c5ec1fc3c5ed3025f68649f16c652eb1';
 
 const tabletImg =
-    'https://i.guim.co.uk/img/media/07785ce96b6dfef227dc60f2c436c0ca7a6b8ba3/0_0_1340_1320/1340.png?quality=85&s=3368803236b24548ad8dd85f3fbe0b71';
+    'https://i.guim.co.uk/img/media/9b8eabb514d074345c39e4a1c95a8a2b6338e177/0_0_1340_1320/1340.png?quality=85&s=ce1a77f1c7cc9bd70d9d7b1f87f7c433';
 
 const mobileImg =
-    'https://i.guim.co.uk/img/media/3293b58ca4abdeda20544ffc5e5a5613a8e7d911/0_0_1220_660/1220.png?quality=85&s=fe83934318cb1660df8764370df49f14';
+    'https://i.guim.co.uk/img/media/630cac972b7152ee385e277ffa161e48b7ec59d9/0_0_1220_660/1220.png?quality=85&s=d776a69e692300fa414c2cba4d6774b2';
 
 // Responsive image props
 const baseImg = {


### PR DESCRIPTION
**Do not merge until ML test is over and Marketing is ready! (expected date 08/06)**

## What does this change?

This updates the images for the Guardian Weekly banner to reflect a 50% off offer.

## Images
(disregard copy mentioning 30% off)

**Mobile**
<img width="578" alt="Screenshot 2022-05-31 at 16 56 49" src="https://user-images.githubusercontent.com/99180049/171217701-8f39da78-1f6f-4caf-b8c1-653cfedf0489.png">

**Tablet**
<img width="921" alt="Screenshot 2022-05-31 at 16 56 34" src="https://user-images.githubusercontent.com/99180049/171217826-df9ca0a0-0f9c-48e6-b0f3-a7167121a133.png">

**Desktop**
<img width="1168" alt="Screenshot 2022-05-31 at 16 56 12" src="https://user-images.githubusercontent.com/99180049/171217504-ec57be7e-6e5d-425f-93fa-cb8b4962f3d5.png">
