### PR TITLE
Use status field instead of isOn

### DIFF
--- a/packages/server/src/factories/test.ts
+++ b/packages/server/src/factories/test.ts
@@ -3,7 +3,7 @@ import { Factory } from 'fishery';
 
 export default Factory.define<EpicTest>(({ factories }) => ({
     name: '2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count',
-    isOn: true,
+    status: 'Live',
     locations: [],
     tagIds: ['environment/series/the-polluters', 'environment/environment'],
     sections: ['environment'],

--- a/packages/server/src/lib/ab.test.ts
+++ b/packages/server/src/lib/ab.test.ts
@@ -3,7 +3,7 @@ import { selectVariant, withinRange, selectWithSeed } from './ab';
 
 const test: EpicTest = {
     name: 'example-1', // note - changing this name will change the results of the tests, as it's used for the seed
-    isOn: true,
+    status: 'Live',
     locations: [],
     tagIds: [],
     sections: [],

--- a/packages/server/src/lib/targetingTesting.test.ts
+++ b/packages/server/src/lib/targetingTesting.test.ts
@@ -4,6 +4,7 @@ import { BannerTargeting } from '@sdc/shared/types';
 const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
     {
         name: 'BannerTargetingTest',
+        status: 'Live',
         canInclude: (targeting: BannerTargeting) => targeting.countryCode === 'GB',
         variants: [
             {

--- a/packages/server/src/tests/amp/ampEpicModels.ts
+++ b/packages/server/src/tests/amp/ampEpicModels.ts
@@ -1,5 +1,5 @@
 import { CountryGroupId } from '@sdc/shared/lib';
-import { Cta, TickerSettings, ContributionFrequency } from '@sdc/shared/types';
+import { Cta, TickerSettings, ContributionFrequency, TestStatus } from '@sdc/shared/types';
 import { AMPTicker } from './ampTicker';
 
 /**
@@ -41,7 +41,7 @@ export interface AmpEpicTestVariant {
 export interface AmpEpicTest {
     name: string;
     nickname?: string;
-    isOn: boolean;
+    status: TestStatus;
     locations: CountryGroupId[];
     variants: AmpEpicTestVariant[];
 }

--- a/packages/server/src/tests/amp/ampEpicSelection.test.ts
+++ b/packages/server/src/tests/amp/ampEpicSelection.test.ts
@@ -18,7 +18,7 @@ jest.mock('../../lib/fetchTickerData', () => {
 const epicTest: AmpEpicTest = {
     name: 'TEST1',
     nickname: 'TEST1',
-    isOn: true,
+    status: 'Live',
     locations: [],
     variants: [
         {
@@ -101,7 +101,7 @@ describe('ampEpicTests', () => {
     });
 
     it('should not select test if disabled', async () => {
-        const tests = [{ ...epicTest, isOn: false }];
+        const tests: AmpEpicTest[] = [{ ...epicTest, status: 'Draft' }];
         const result = await selectAmpEpic(tests, ampVariantAssignments, 'GB');
         expect(result).toEqual(null);
     });

--- a/packages/server/src/tests/amp/ampEpicSelection.ts
+++ b/packages/server/src/tests/amp/ampEpicSelection.ts
@@ -59,7 +59,9 @@ const selectAmpEpicTestAndVariant = async (
     ampVariantAssignments: AmpVariantAssignments,
     countryCode?: string,
 ): Promise<AMPEpic | null> => {
-    const test = tests.find(test => test.isOn && inCountryGroups(countryCode, test.locations));
+    const test = tests.find(
+        test => test.status === 'Live' && inCountryGroups(countryCode, test.locations),
+    );
 
     if (test && test.variants) {
         const assignedVariantName = ampVariantAssignments[test.name];

--- a/packages/server/src/tests/banners/DefaultContributionsBannerTest.ts
+++ b/packages/server/src/tests/banners/DefaultContributionsBannerTest.ts
@@ -1,14 +1,13 @@
 import { contributionsBanner } from '@sdc/shared/config';
-import { BannerTargeting, BannerTest, PageTracking } from '@sdc/shared/types';
+import { BannerTest } from '@sdc/shared/types';
 import { DefaultBannerContent } from './DefaultContributionsBannerContent';
 
 export const DefaultContributionsBanner: BannerTest = {
     name: 'DefaultContributionsBanner',
+    status: 'Live',
     bannerChannel: 'contributions',
     isHardcoded: false,
     userCohort: 'AllNonSupporters',
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    canRun: (_targeting: BannerTargeting, _pageTracking: PageTracking) => true,
     minPageViews: 2,
     variants: [
         {

--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -57,10 +57,10 @@ describe('selectBannerTest', () => {
 
         const test: BannerTest = {
             name: 'test',
+            status: 'Live',
             bannerChannel: 'contributions',
             isHardcoded: false,
             userCohort: 'Everyone',
-            canRun: () => true,
             minPageViews: 2,
             variants: [
                 {
@@ -207,10 +207,10 @@ describe('selectBannerTest', () => {
 
         const test: BannerTest = {
             name: 'test',
+            status: 'Live',
             bannerChannel: 'subscriptions',
             isHardcoded: false,
             userCohort: 'Everyone',
-            canRun: (): boolean => true,
             minPageViews: 2,
             variants: [
                 {

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -137,13 +137,13 @@ export const selectBannerTest = async (
         const deploySchedule = targetingTest?.deploySchedule ?? defaultDeploySchedule;
 
         if (
+            test.status === 'Live' &&
             (enableHardcodedBannerTests || !test.isHardcoded) &&
             !targeting.shouldHideReaderRevenue &&
             !targeting.isPaidContent &&
             audienceMatches(targeting.showSupportMessaging, test.userCohort) &&
             inCountryGroups(targeting.countryCode, test.locations) &&
             targeting.alreadyVisitedCount >= test.minPageViews &&
-            test.canRun(targeting, pageTracking) &&
             !(test.articlesViewedSettings && targeting.hasOptedOutOfArticleCount) &&
             historyWithinArticlesViewedSettings(
                 test.articlesViewedSettings,

--- a/packages/server/src/tests/banners/bannerTests.ts
+++ b/packages/server/src/tests/banners/bannerTests.ts
@@ -3,7 +3,7 @@ import { cacheAsync } from '../../lib/cache';
 import {
     channel1BannersAllTestsGenerator,
     channel2BannersAllTestsGenerator,
-} from './ChannelBannerTests';
+} from './channelBannerTests';
 import { DefaultContributionsBanner } from './DefaultContributionsBannerTest';
 import { propensityModelBannerTest } from './propensityModelTest/propensityModelTest';
 

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -80,11 +80,11 @@ const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTes
                 (testParams: RawTestParams): BannerTest => {
                     return {
                         name: testParams.name,
+                        status: testParams.status,
                         bannerChannel,
                         isHardcoded: false,
                         userCohort: testParams.userCohort,
                         locations: testParams.locations,
-                        canRun: (): boolean => testParams.isOn,
                         minPageViews: testParams.minArticlesBeforeShowingBanner,
                         articlesViewedSettings: testParams.articlesViewedSettings,
                         variants: testParams.variants.map(BannerVariantFromParams(bannerChannel)),

--- a/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
+++ b/packages/server/src/tests/banners/propensityModelTest/propensityModelTest.ts
@@ -43,7 +43,7 @@ export const propensityModelBannerTest: BannerTestGenerator = () => {
             locations: ['GBPCountries', 'UnitedStates', 'EURCountries', 'International', 'Canada'],
             isHardcoded: true,
             userCohort: 'AllNonSupporters',
-            canRun: () => true,
+            status: 'Live',
             minPageViews: 4,
             variants: [
                 {

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -21,7 +21,7 @@ import {
 
 const testDefault: EpicTest = {
     name: 'example-1',
-    isOn: true,
+    status: 'Live',
     locations: [],
     audience: 1,
     tagIds: [],

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -104,9 +104,9 @@ export const excludeTags: Filter = {
     },
 };
 
-export const isOn: Filter = {
-    id: 'isOn',
-    test: (test): boolean => test.isOn,
+export const isLive: Filter = {
+    id: 'isLive',
+    test: (test): boolean => test.status === 'Live',
 };
 
 export const canShow = (targeting: EpicTargeting): Filter => ({
@@ -240,7 +240,7 @@ export const findTestAndVariant = (
     const getFilters = (isSuperModePass: boolean): Filter[] => {
         return [
             shouldNotRender(epicType),
-            isOn,
+            isLive,
             canShow(targeting),
             isNotExpired(),
             hasSectionOrTags,

--- a/packages/server/src/tests/epics/fallback.ts
+++ b/packages/server/src/tests/epics/fallback.ts
@@ -3,7 +3,7 @@ import { EpicTest } from '@sdc/shared/types';
 
 export const fallbackEpicTest: EpicTest = {
     name: 'FallbackEpicTest',
-    isOn: true,
+    status: 'Live',
     locations: [],
     audience: 1,
     tagIds: [],

--- a/packages/server/src/tests/epics/inEpicPayments/build.ts
+++ b/packages/server/src/tests/epics/inEpicPayments/build.ts
@@ -61,7 +61,7 @@ function _build({
         name: `InEpicPaymentTest__${suffix}`,
         campaignId: `InEpicPaymentTest__${suffix}`,
         hasArticleCountInCopy: copy.hasArticleCount,
-        isOn: false,
+        status: 'Draft',
         locations: locations,
         audience: 1,
         tagIds: [],

--- a/packages/server/src/tests/headers/headerSelection.test.ts
+++ b/packages/server/src/tests/headers/headerSelection.test.ts
@@ -7,7 +7,7 @@ const modulePathBuilder = header.endpointPathBuilder;
 const remote_nonUK: HeaderTest = {
     name: 'RemoteRrHeaderLinksTest__NonUK',
     userCohort: 'AllNonSupporters',
-    isOn: true,
+    status: 'Live',
     locations: [
         'AUDCountries',
         'Canada',
@@ -38,7 +38,7 @@ const remote_nonUK: HeaderTest = {
 const remote_UK: HeaderTest = {
     name: 'RemoteRrHeaderLinksTest__UK',
     userCohort: 'AllNonSupporters',
-    isOn: true,
+    status: 'Live',
     locations: ['GBPCountries'],
     variants: [
         {
@@ -62,7 +62,7 @@ const remote_UK: HeaderTest = {
 const locationsNotSet: HeaderTest = {
     name: 'LocationsArrayEmpty',
     userCohort: 'AllNonSupporters',
-    isOn: true,
+    status: 'Live',
     locations: [],
     variants: [
         {
@@ -86,7 +86,7 @@ const locationsNotSet: HeaderTest = {
 const header_supporter: HeaderTest = {
     name: 'header-supporter',
     userCohort: 'AllExistingSupporters',
-    isOn: true,
+    status: 'Live',
     locations: [
         'AUDCountries',
         'Canada',
@@ -111,7 +111,7 @@ const header_supporter: HeaderTest = {
 const header_new_supporter: HeaderTest = {
     name: 'header-new-supporter',
     userCohort: 'Everyone',
-    isOn: true,
+    status: 'Live',
     locations: [
         'AUDCountries',
         'Canada',
@@ -140,7 +140,7 @@ const header_new_supporter: HeaderTest = {
 const header_existing_subscriber: HeaderTest = {
     name: 'header-existing-subscriber',
     userCohort: 'Everyone',
-    isOn: true,
+    status: 'Live',
     locations: [
         'AUDCountries',
         'Canada',

--- a/packages/server/src/tests/headers/headerSelection.ts
+++ b/packages/server/src/tests/headers/headerSelection.ts
@@ -15,7 +15,7 @@ const moduleName = 'Header';
 const nonSupportersTestNonUK: HeaderTest = {
     name: 'RemoteRrHeaderLinksTest__NonUK',
     userCohort: 'AllNonSupporters',
-    isOn: true,
+    status: 'Live',
     locations: [
         'AUDCountries',
         'Canada',
@@ -48,7 +48,7 @@ const nonSupportersTestNonUK: HeaderTest = {
 const nonSupportersTestUK: HeaderTest = {
     name: 'RemoteRrHeaderLinksTest__UK',
     userCohort: 'AllNonSupporters',
-    isOn: true,
+    status: 'Live',
     locations: ['GBPCountries'],
     variants: [
         {
@@ -74,7 +74,7 @@ const nonSupportersTestUK: HeaderTest = {
 const supportersTest: HeaderTest = {
     name: 'header-supporter',
     userCohort: 'AllExistingSupporters',
-    isOn: true,
+    status: 'Live',
     locations: [
         'AUDCountries',
         'Canada',
@@ -99,7 +99,7 @@ const supportersTest: HeaderTest = {
 
 const baseSignInPromptTest: Omit<HeaderTest, 'name' | 'variants'> = {
     userCohort: 'Everyone',
-    isOn: true,
+    status: 'Live',
     locations: [
         'AUDCountries',
         'Canada',
@@ -294,10 +294,10 @@ export const selectBestTest = (
     const { showSupportMessaging, countryCode, purchaseInfo, isSignedIn } = targeting;
 
     const selectedTest = allTests.find(test => {
-        const { isOn, userCohort, locations } = test;
+        const { status, userCohort, locations } = test;
 
         return (
-            isOn &&
+            status === 'Live' &&
             audienceMatches(showSupportMessaging, userCohort) &&
             inCountryGroups(countryCode, locations) &&
             userIsInTest(test, targeting.mvtId) &&

--- a/packages/server/src/tests/testsStore.ts
+++ b/packages/server/src/tests/testsStore.ts
@@ -32,7 +32,12 @@ function queryChannel(channel: ChannelTypes, stage: string) {
             KeyConditionExpression: 'channel = :channel',
             ExpressionAttributeValues: {
                 ':channel': channel,
+                ':archived': 'Archived',
             },
+            ExpressionAttributeNames: {
+                '#status': 'status', // Necessary because status is a reserved word in dynamodb
+            },
+            FilterExpression: '#status <> :archived',
         })
         .promise();
 }

--- a/packages/shared/src/factories/test.ts
+++ b/packages/shared/src/factories/test.ts
@@ -3,7 +3,7 @@ import { Factory } from 'fishery';
 
 export default Factory.define<EpicTest>(({ factories }) => ({
     name: '2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count',
-    isOn: true,
+    status: 'Live',
     locations: [],
     tagIds: ['environment/series/the-polluters', 'environment/environment'],
     sections: ['environment'],

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -5,11 +5,11 @@ import {
     DeviceType,
     TargetingAbTest,
     Test,
+    TestStatus,
     UserCohort,
     Variant,
 } from './shared';
 import { OphanComponentType, OphanProduct } from '../ophan';
-import { BannerTargeting, PageTracking } from '../targeting';
 import { CountryGroupId } from '../../lib';
 
 export enum BannerTemplate {
@@ -38,16 +38,14 @@ export interface BannerVariant extends Variant {
     separateArticleCount?: boolean;
 }
 
-export type CanRun = (targeting: BannerTargeting, pageTracking: PageTracking) => boolean;
-
 export type BannerTestGenerator = () => Promise<BannerTest[]>;
 
 export interface BannerTest extends Test<BannerVariant> {
     name: string;
+    status: TestStatus;
     bannerChannel: BannerChannel;
     isHardcoded: boolean;
     userCohort: UserCohort;
-    canRun: CanRun;
     minPageViews: number;
     variants: BannerVariant[];
     locations?: CountryGroupId[];
@@ -77,7 +75,7 @@ export interface RawVariantParams {
 export interface RawTestParams {
     name: string;
     nickname: string;
-    isOn: boolean;
+    status: TestStatus;
     minArticlesBeforeShowingBanner: number;
     userCohort: UserCohort;
     locations: CountryGroupId[];

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -4,6 +4,7 @@ import {
     ArticlesViewedSettings,
     ControlProportionSettings,
     Test,
+    TestStatus,
     UserCohort,
     Variant,
 } from './shared';
@@ -85,7 +86,7 @@ export type ChoiceCardAmounts = {
 
 export interface EpicTest extends Test<EpicVariant> {
     name: string;
-    isOn: boolean;
+    status: TestStatus;
     locations: CountryGroupId[];
     tagIds: string[];
     sections: string[]; // section IDs

--- a/packages/shared/src/types/abTests/header.ts
+++ b/packages/shared/src/types/abTests/header.ts
@@ -1,4 +1,4 @@
-import { UserCohort, Test, Variant } from './shared';
+import { UserCohort, Test, Variant, TestStatus } from './shared';
 import { HeaderContent } from '../props';
 import { CountryGroupId } from '../../lib';
 import { PurchaseInfo } from '../targeting';
@@ -13,7 +13,7 @@ export interface HeaderVariant extends Variant {
 
 export interface HeaderTest extends Test<HeaderVariant> {
     name: string;
-    isOn: boolean;
+    status: TestStatus;
     locations: CountryGroupId[];
     userCohort: UserCohort;
     purchaseInfo?: {

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -1,10 +1,13 @@
 import { OphanComponentType, OphanProduct } from '../ophan';
 
+export type TestStatus = 'Live' | 'Draft' | 'Archived';
+
 export interface Variant {
     name: string;
 }
 export interface Test<V extends Variant> {
     name: string;
+    status: TestStatus;
     variants: V[];
     controlProportionSettings?: ControlProportionSettings;
     audienceOffset?: number;


### PR DESCRIPTION
The `isOn` field has been deprecated in favour of `status` - https://github.com/guardian/support-admin-console/pull/345
This PR migrates SDC to use `status`.
It also excludes tests with a status of `Archived`, as we will soon be using this field for archiving of tests.