### PR TITLE
Sign in after checkout copy changes

### DIFF
--- a/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.stories.tsx
@@ -17,7 +17,7 @@ const Template: ComponentStory<typeof SignInPromptBanner> = props => (
 const content = {
     heading: 'Thank you for subscribing',
     paragraphs: [
-        'Your final step to enjoy the Guardian',
+        'One more step to enjoy the Guardian',
         'Ad free',
         'Fewer interruptions',
         'Newsletters and comments',

--- a/packages/modules/src/modules/headers/SignInPromptHeader.stories.tsx
+++ b/packages/modules/src/modules/headers/SignInPromptHeader.stories.tsx
@@ -17,7 +17,7 @@ const Template: ComponentStory<typeof SignInPromptHeader> = props => (
 const baseArgs = {
     content: {
         heading: 'Thank you for subscribing',
-        subheading: 'Enjoy the Guardian',
+        subheading: 'One more step to enjoy the Guardian',
         primaryCta: {
             baseUrl: 'https://profile.theguardian.com/register',
             text: 'Complete registration',

--- a/packages/modules/src/modules/headers/SignInPromptHeader.tsx
+++ b/packages/modules/src/modules/headers/SignInPromptHeader.tsx
@@ -4,7 +4,7 @@ import { brandAlt, brandText, space } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonBrand } from '@guardian/src-button';
 import { Hide } from '@guardian/src-layout';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { HeaderRenderProps, headerWrapper, validatedHeaderWrapper } from './HeaderWrapper';
 
 const FADE_TIME_MS = 300;
@@ -16,19 +16,31 @@ const headingStyles = () => css`
     color: ${brandText.primary};
     ${headline.xxxsmall({ fontWeight: 'bold' })};
     margin: 0;
+
+    ${from.leftCol} {
+        ${headline.xsmall({ fontWeight: 'bold' })};
+    }
 `;
 
 const subHeadingStyles = css`
     color: ${brandAlt[400]};
     ${headline.xxxsmall({ fontWeight: 'bold' })};
-    font-size: 14px;
     margin: 0;
+
+    ${until.leftCol} {
+        font-size: 14px;
+    }
 `;
 
 const benefitsWrapper = css`
     margin: 2px 0 ${space[2]}px;
     height: 16px;
     position: relative;
+
+    ${from.leftCol} {
+        margin: ${space[1]}px 0 ${space[2]}px;
+        height: 20px;
+    }
 `;
 
 const benefitStyles = css`
@@ -42,17 +54,27 @@ const dotsWrapper = css`
 
 const dotStyles = css`
     background: ${brandAlt[400]};
-    width: 13px;
-    height: 13px;
+    width: 11px;
+    height: 11px;
     border-radius: 50%;
-    margin-top: 2px;
+    margin-top: 3px;
     margin-right: ${space[1]}px;
+
+    ${from.leftCol} {
+        width: 13px;
+        height: 13px;
+        margin-top: ${space[1]}px;
+        margin-right: ${space[2]}px;
+    }
 `;
 
 const benefitTextStyles = css`
     color: ${brandText.primary};
     ${headline.xxxsmall()};
-    font-size: 14px;
+
+    ${until.leftCol} {
+        font-size: 14px;
+    }
 `;
 
 const fadeable = css`

--- a/packages/modules/src/modules/headers/SignInPromptHeader.tsx
+++ b/packages/modules/src/modules/headers/SignInPromptHeader.tsx
@@ -4,6 +4,7 @@ import { brandAlt, brandText, space } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonBrand } from '@guardian/src-button';
 import { Hide } from '@guardian/src-layout';
+import { from } from '@guardian/src-foundations/mq';
 import { HeaderRenderProps, headerWrapper, validatedHeaderWrapper } from './HeaderWrapper';
 
 const FADE_TIME_MS = 300;
@@ -13,19 +14,20 @@ const DOTS_COUNT = 3;
 
 const headingStyles = () => css`
     color: ${brandText.primary};
-    ${headline.xxsmall({ fontWeight: 'bold' })};
+    ${headline.xxxsmall({ fontWeight: 'bold' })};
     margin: 0;
 `;
 
 const subHeadingStyles = css`
     color: ${brandAlt[400]};
     ${headline.xxxsmall({ fontWeight: 'bold' })};
+    font-size: 14px;
     margin: 0;
 `;
 
 const benefitsWrapper = css`
-    margin: ${space[1]}px 0 10px;
-    height: 20px;
+    margin: 2px 0 ${space[2]}px;
+    height: 16px;
     position: relative;
 `;
 
@@ -43,13 +45,14 @@ const dotStyles = css`
     width: 13px;
     height: 13px;
     border-radius: 50%;
-    margin-top: 3px;
-    margin-right: ${space[2]}px;
+    margin-top: 2px;
+    margin-right: ${space[1]}px;
 `;
 
 const benefitTextStyles = css`
     color: ${brandText.primary};
     ${headline.xxxsmall()};
+    font-size: 14px;
 `;
 
 const fadeable = css`

--- a/packages/server/src/tests/headers/headerSelection.ts
+++ b/packages/server/src/tests/headers/headerSelection.ts
@@ -129,7 +129,7 @@ const supporterContent = {
 };
 
 const signInCTA = {
-    baseUrl: 'https://profile.theguardian.com/register',
+    baseUrl: 'https://profile.theguardian.com/signin',
     text: 'Sign in',
 };
 

--- a/packages/server/src/tests/headers/headerSelection.ts
+++ b/packages/server/src/tests/headers/headerSelection.ts
@@ -120,12 +120,12 @@ const baseSignInPromptVariant: Omit<HeaderVariant, 'content'> = {
 
 const subscriberContent = {
     heading: 'Thank you for subscribing',
-    subheading: 'Enjoy the Guardian',
+    subheading: 'One more step to enjoy the Guardian',
 };
 
 const supporterContent = {
     heading: 'Thank you for your support',
-    subheading: 'Enjoy the Guardian',
+    subheading: 'One more step to enjoy the Guardian',
 };
 
 const signInCTA = {


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Follow up to #665 and #710, minor copy and design updates

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Can test in storybook for design changes, I don't feel it's worth manually testing the copy changes.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

### Tablet / small desktop

#### Before

![image](https://user-images.githubusercontent.com/3338808/172437619-45ae3384-4d20-4857-9aa7-3fef7d82cf5b.png)

#### After

![image](https://user-images.githubusercontent.com/3338808/172437298-241265bd-d5e4-4bf3-89dd-b89b334b5a44.png)

### Large desktop

#### Before

(same as above, there wasn't a difference previously)

![image](https://user-images.githubusercontent.com/3338808/172437619-45ae3384-4d20-4857-9aa7-3fef7d82cf5b.png)

#### After

![image](https://user-images.githubusercontent.com/3338808/172437464-a6742211-1622-450f-9004-290d96223e10.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
