### PR TITLE
Do not check epicType in epic selection

### DIFF
--- a/packages/server/src/lib/targeting.test.ts
+++ b/packages/server/src/lib/targeting.test.ts
@@ -2,18 +2,6 @@ import { factories } from '../factories';
 import { shouldNotRenderEpic, shouldThrottle } from './targeting';
 
 describe('shouldNotRenderEpic', () => {
-    it('returns true for non-articles when epic type is ARTICLE', () => {
-        const data = factories.targeting.build({ contentType: 'Liveblog' });
-        const got = shouldNotRenderEpic(data, 'ARTICLE');
-        expect(got).toBe(true);
-    });
-
-    it('returns true for non-liveblogs when epic type is LIVEBLOG', () => {
-        const data = factories.targeting.build({ contentType: 'Article' });
-        const got = shouldNotRenderEpic(data, 'LIVEBLOG');
-        expect(got).toBe(true);
-    });
-
     it('returns true for blacklisted section', () => {
         const data = factories.targeting.build({ sectionId: 'careers' });
         const got = shouldNotRenderEpic(data, 'ARTICLE');

--- a/packages/server/src/lib/targeting.test.ts
+++ b/packages/server/src/lib/targeting.test.ts
@@ -4,13 +4,13 @@ import { shouldNotRenderEpic, shouldThrottle } from './targeting';
 describe('shouldNotRenderEpic', () => {
     it('returns true for blacklisted section', () => {
         const data = factories.targeting.build({ sectionId: 'careers' });
-        const got = shouldNotRenderEpic(data, 'ARTICLE');
+        const got = shouldNotRenderEpic(data);
         expect(got).toBe(true);
     });
 
     it('returns false for valid data', () => {
         const data = factories.targeting.build();
-        const got = shouldNotRenderEpic(data, 'ARTICLE');
+        const got = shouldNotRenderEpic(data);
         expect(got).toBe(false);
     });
 });

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -47,7 +47,6 @@ export const shouldNotRenderEpic = (meta: EpicTargeting, epicType: EpicType): bo
         meta.shouldHideReaderRevenue ||
         isLowValueSection ||
         isLowValueTag ||
-        meta.contentType.toUpperCase() !== epicType ||
         meta.isPaidContent
     );
 };

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -1,4 +1,4 @@
-import { EpicTargeting, EpicType, UserCohort, EpicViewLog, Test, Variant } from '@sdc/shared/types';
+import { EpicTargeting, UserCohort, EpicViewLog, Test, Variant } from '@sdc/shared/types';
 import { daysSince } from './dates';
 
 const lowValueSections = ['money', 'education', 'games', 'teacher-network', 'careers'];
@@ -38,17 +38,12 @@ export const shouldThrottle = (
     return hasReachedViewsLimitInWindow || withinMinDaysSinceLastView;
 };
 
-export const shouldNotRenderEpic = (meta: EpicTargeting, epicType: EpicType): boolean => {
+export const shouldNotRenderEpic = (meta: EpicTargeting): boolean => {
     const section = meta.sectionId || meta.sectionName;
     const isLowValueSection = !!section && lowValueSections.includes(section);
     const isLowValueTag = lowValueTags.some(id => meta.tags.some(pageTag => pageTag.id === id));
 
-    return (
-        meta.shouldHideReaderRevenue ||
-        isLowValueSection ||
-        isLowValueTag ||
-        meta.isPaidContent
-    );
+    return meta.shouldHideReaderRevenue || isLowValueSection || isLowValueTag || meta.isPaidContent;
 };
 
 // https://github.com/guardian/ab-testing/blob/main/packages/ab-core/src/core.ts#L56

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -180,14 +180,7 @@ export const buildEpicData = async (
 
     const result = params.force
         ? findForcedTestAndVariant(tests, params.force)
-        : findTestAndVariant(
-              tests,
-              targeting,
-              isMobile(req),
-              superModeArticles,
-              type,
-              params.debug,
-          );
+        : findTestAndVariant(tests, targeting, isMobile(req), superModeArticles, params.debug);
 
     if (process.env.log_targeting === 'true') {
         console.log(

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -99,9 +99,8 @@ describe('findTestAndVariant', () => {
             ...targetingDefault,
             weeklyArticleHistory: [{ week: 18330, count: 45 }],
         };
-        const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles, epicType);
+        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles);
 
         expect(got.result?.test.name).toBe('example-1');
         expect(got.result?.variant.name).toBe('control-example-1');
@@ -114,9 +113,8 @@ describe('findTestAndVariant', () => {
             weeklyArticleHistory: [{ week: 18330, count: 45 }],
             hasOptedOutOfArticleCount: true,
         };
-        const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles, epicType);
+        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles);
 
         expect(got.result).toBe(undefined);
     });
@@ -125,9 +123,8 @@ describe('findTestAndVariant', () => {
         const test = { ...testDefault, excludedSections: ['news'] };
         const tests = [test];
         const targeting = { ...targetingDefault, sectionId: 'news' };
-        const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles, epicType);
+        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles);
 
         expect(got.result).toBe(undefined);
     });
@@ -143,9 +140,8 @@ describe('findTestAndVariant', () => {
             ...targetingDefault,
             showSupportMessaging: false,
         };
-        const epicType = 'ARTICLE';
 
-        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles, epicType);
+        const got = findTestAndVariant(tests, targeting, isMobile, superModeArticles);
 
         expect(got.result?.variant.showReminderFields).toBe(undefined);
     });

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -2,7 +2,6 @@ import { countryCodeToCountryGroupId, getCountryName, inCountryGroups } from '@s
 import {
     EpicTargeting,
     EpicTest,
-    EpicType,
     EpicVariant,
     UserCohort,
     EpicViewLog,
@@ -230,7 +229,6 @@ export const findTestAndVariant = (
     targeting: EpicTargeting,
     isMobile: boolean,
     superModeArticles: SuperModeArticle[],
-    epicType: EpicType,
     includeDebug = false,
 ): Result => {
     const debug: Debug = {};

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -178,10 +178,10 @@ export const inCorrectCohort = (userCohorts: UserCohort[], isSuperModePass: bool
     },
 });
 
-export const shouldNotRender = (epicType: EpicType): Filter => ({
+export const shouldNotRender: Filter = {
     id: 'shouldNotRender',
-    test: (_, targeting): boolean => !shouldNotRenderEpic(targeting, epicType),
-});
+    test: (_, targeting): boolean => !shouldNotRenderEpic(targeting),
+};
 
 export const isNotExpired = (now: Date = new Date()): Filter => ({
     id: 'isNotExpired',
@@ -239,7 +239,7 @@ export const findTestAndVariant = (
 
     const getFilters = (isSuperModePass: boolean): Filter[] => {
         return [
-            shouldNotRender(epicType),
+            shouldNotRender,
             isLive,
             canShow(targeting),
             isNotExpired(),


### PR DESCRIPTION
This condition isn't necessary. It was originally intended to target specific epic tests to LIVEBLOG and ARTICLE types.
But for liveblogs, the client hits a different endpoint which uses a separate tests list.