### PR TITLE
Fix top reader config

### DIFF
--- a/packages/server/src/tests/epics/usTopReaderCopy/index.ts
+++ b/packages/server/src/tests/epics/usTopReaderCopy/index.ts
@@ -49,7 +49,7 @@ export const usTopReaderCopyTest: EpicTest = {
     hasCountryName: false,
     highPriority: true,
     isLiveBlog: false,
-    isOn: true,
+    status: 'Live',
     locations: ['UnitedStates'],
     name: 'usTopReaderCopyTest',
     sections: [],

--- a/packages/server/src/tests/epics/usTopReaderCopy/index.ts
+++ b/packages/server/src/tests/epics/usTopReaderCopy/index.ts
@@ -49,7 +49,7 @@ export const usTopReaderCopyTest: EpicTest = {
     hasCountryName: false,
     highPriority: true,
     isLiveBlog: false,
-    status: 'Live',
+    status: 'Draft',
     locations: ['UnitedStates'],
     name: 'usTopReaderCopyTest',
     sections: [],


### PR DESCRIPTION
the auto-merge introduced a type error, causing the build to fail

Edit - I've also set the `usTopReaderCopyTest` test to `Draft` for now while there's some uncertainty about AB tests