### PR TITLE
Implement selection logic for sign in prompt banner

### DIFF
--- a/packages/dotcom/package.json
+++ b/packages/dotcom/package.json
@@ -1,38 +1,39 @@
 {
-  "name": "@guardian/support-dotcom-components",
-  "version": "1.0.3",
-  "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.esm.js",
-  "types": "dist/dotcom/src/index.d.ts",
-  "files": ["dist/**/*"],
-  "scripts": {
-    "lint": "eslint 'src/**/*.{ts,tsx}'",
-    "build": "rollup -c",
-    "types": "tsc --project tsconfig.types.json",
-    "test": "jest --passWithNoTests",
-    "publishDryRun": "yarn build && yarn types && npm publish --dry-run",
-    "publish": "yarn build && yarn types && npm publish"
-  },
-  "devDependencies": {
-    "jest": "^26.6.3",
-    "ts-jest": "^26.5.4",
-    "ts-loader": "^9.2.5",
-    "typescript": "^4.2.4",
-    "@babel/core": "7.16.0",
-    "@babel/preset-env": "7.16.4",
-    "babel-loader": "^8.2.3",
-    "rollup": "^2.23.0",
-    "rollup-plugin-external-globals": "^0.5.0",
-    "rollup-plugin-filesize": "^9.0.2",
-    "rollup-plugin-peer-deps-external": "^2.2.3",
-    "rollup-plugin-terser": "^6.1.0",
-    "@rollup/plugin-alias": "^3.1.1",
-    "@rollup/plugin-babel": "^5.1.0",
-    "@rollup/plugin-commonjs": "^14.0.0",
-    "@rollup/plugin-node-resolve": "^8.4.0",
-    "@rollup/plugin-replace": "^2.3.3"
-  },
-  "dependencies": {
-  }
+    "name": "@guardian/support-dotcom-components",
+    "version": "1.0.4",
+    "license": "MIT",
+    "main": "dist/index.js",
+    "module": "dist/index.esm.js",
+    "types": "dist/dotcom/src/index.d.ts",
+    "files": [
+        "dist/**/*"
+    ],
+    "scripts": {
+        "lint": "eslint 'src/**/*.{ts,tsx}'",
+        "build": "rollup -c",
+        "types": "tsc --project tsconfig.types.json",
+        "test": "jest --passWithNoTests",
+        "publishDryRun": "yarn build && yarn types && npm publish --dry-run",
+        "publish": "yarn build && yarn types && npm publish"
+    },
+    "devDependencies": {
+        "jest": "^26.6.3",
+        "ts-jest": "^26.5.4",
+        "ts-loader": "^9.2.5",
+        "typescript": "^4.2.4",
+        "@babel/core": "7.16.0",
+        "@babel/preset-env": "7.16.4",
+        "babel-loader": "^8.2.3",
+        "rollup": "^2.23.0",
+        "rollup-plugin-external-globals": "^0.5.0",
+        "rollup-plugin-filesize": "^9.0.2",
+        "rollup-plugin-peer-deps-external": "^2.2.3",
+        "rollup-plugin-terser": "^6.1.0",
+        "@rollup/plugin-alias": "^3.1.1",
+        "@rollup/plugin-babel": "^5.1.0",
+        "@rollup/plugin-commonjs": "^14.0.0",
+        "@rollup/plugin-node-resolve": "^8.4.0",
+        "@rollup/plugin-replace": "^2.3.3"
+    },
+    "dependencies": {}
 }

--- a/packages/modules/src/modules/banners/localStorage.ts
+++ b/packages/modules/src/modules/banners/localStorage.ts
@@ -8,16 +8,21 @@ const setBannerClosedTimestamp = (name: string): void =>
         }),
     );
 
-export const setContributionsBannerClosedTimestamp = (): void =>
+const setContributionsBannerClosedTimestamp = (): void =>
     setBannerClosedTimestamp('engagementBannerLastClosedAt');
 
-export const setSubscriptionsBannerClosedTimestamp = (): void =>
+const setSubscriptionsBannerClosedTimestamp = (): void =>
     setBannerClosedTimestamp('subscriptionBannerLastClosedAt');
+
+const setSignInBannerClosedTimestamp = (): void =>
+    setBannerClosedTimestamp('signInBannerLastClosedAt');
 
 export const setChannelClosedTimestamp = (channel: BannerChannel): void => {
     if (channel === 'contributions') {
         setContributionsBannerClosedTimestamp();
     } else if (channel === 'subscriptions') {
         setSubscriptionsBannerClosedTimestamp();
+    } else if (channel === 'signIn') {
+        setSignInBannerClosedTimestamp();
     }
 };

--- a/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
+++ b/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
@@ -10,8 +10,20 @@ import { Container, Column, Columns } from '@guardian/src-layout';
 import { BannerRenderProps } from '../common/types';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 
-const background = css`
+const bannerStyles = css`
     background-color: ${brand[400]};
+
+    ::before {
+        content: '';
+        display: block;
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        background: rgb(0, 0, 0, 0.3);
+        z-index: -1;
+    }
 `;
 
 const mainColumn = css`
@@ -73,7 +85,7 @@ const SignInPromptBanner: React.FC<BannerRenderProps> = props => {
     const [subheading, ...bullets] = paragraphs;
 
     return (
-        <Container cssOverrides={background}>
+        <Container cssOverrides={bannerStyles}>
             <Columns>
                 <Column width={[0, 0, 0, 2, 3]}> </Column>
                 <Column width={[4, 12, 12, 12, 13]} cssOverrides={mainColumn}>

--- a/packages/server/src/lib/targetingTesting.test.ts
+++ b/packages/server/src/lib/targetingTesting.test.ts
@@ -29,6 +29,7 @@ const targeting: BannerTargeting = {
     weeklyArticleHistory: [],
     hasOptedOutOfArticleCount: false,
     contentType: 'Article',
+    isSignedIn: false,
 };
 
 describe('selectTargetingTest', () => {

--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -321,7 +321,7 @@ describe('selectBannerTest', () => {
         };
 
         const baseTest: Omit<BannerTest, 'name'> = {
-            bannerChannel: 'contributions',
+            bannerChannel: 'signIn',
             isHardcoded: true,
             userCohort: 'Everyone',
             status: 'Live',
@@ -388,6 +388,16 @@ describe('selectBannerTest', () => {
                 ...baseTargeting,
                 purchaseInfo: { product: 'Contribution', userType: 'new' },
                 isSignedIn: true,
+            });
+
+            expect(result).toBeNull();
+        });
+
+        it('It should ignore purchase information if sign in banner has previously been closed', async () => {
+            const result = await runSelection({
+                ...baseTargeting,
+                purchaseInfo: { product: 'Contribution', userType: 'new' },
+                signInBannerLastClosedAt: new Date().toISOString(),
             });
 
             expect(result).toBeNull();

--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -1,5 +1,5 @@
-import { contributionsBanner, digiSubs } from '@sdc/shared/config';
-import { BannerTargeting, BannerTest } from '@sdc/shared/types';
+import { contributionsBanner, digiSubs, signInPromptBanner } from '@sdc/shared/config';
+import { BannerTargeting, BannerTest, BannerTemplate } from '@sdc/shared/types';
 import { BannerDeployCaches } from './bannerDeployCache';
 import { selectBannerTest } from './bannerSelection';
 
@@ -46,6 +46,7 @@ describe('selectBannerTest', () => {
             engagementBannerLastClosedAt: firstDate,
             hasOptedOutOfArticleCount: false,
             contentType: 'Article',
+            isSignedIn: false,
         };
 
         const tracking = {
@@ -196,6 +197,7 @@ describe('selectBannerTest', () => {
             engagementBannerLastClosedAt: firstDate,
             hasOptedOutOfArticleCount: false,
             contentType: 'Article',
+            isSignedIn: false,
         };
 
         const tracking = {
@@ -291,6 +293,104 @@ describe('selectBannerTest', () => {
             ).then(result => {
                 expect(result && result.test.name).toBe('test');
             });
+        });
+    });
+
+    describe('Sign in prompt banner rules', () => {
+        const now = new Date('2020-03-31T12:30:00');
+
+        const cache = getBannerDeployCache(secondDate);
+
+        const baseTargeting: BannerTargeting = {
+            alreadyVisitedCount: 0,
+            shouldHideReaderRevenue: false,
+            isPaidContent: false,
+            showSupportMessaging: true,
+            mvtId: 1,
+            countryCode: 'AU',
+            hasOptedOutOfArticleCount: false,
+            contentType: 'Article',
+            isSignedIn: false,
+        };
+
+        const tracking = {
+            ophanPageId: '',
+            platformId: '',
+            referrerUrl: '',
+            clientName: '',
+        };
+
+        const baseTest: Omit<BannerTest, 'name'> = {
+            bannerChannel: 'contributions',
+            isHardcoded: true,
+            userCohort: 'Everyone',
+            status: 'Live',
+            minPageViews: 0,
+            variants: [
+                {
+                    name: 'control',
+                    modulePathBuilder: signInPromptBanner.endpointPathBuilder,
+                    moduleName: BannerTemplate.SignInPromptBanner,
+                    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+                },
+            ],
+        };
+
+        const tests: BannerTest[] = [
+            {
+                ...baseTest,
+                name: 'banner-new-contribution',
+                purchaseInfo: { product: ['Contribution'], userType: ['new', 'guest'] },
+            },
+            {
+                ...baseTest,
+                name: 'banner-existing-subscriber',
+                purchaseInfo: { product: ['DigitalPack'], userType: ['current'] },
+            },
+        ];
+
+        const runSelection = (targeting: BannerTargeting) => {
+            return selectBannerTest(
+                Object.assign(targeting, {
+                    weeklyArticleHistory: [{ week: 18330, count: 6 }],
+                }),
+                tracking,
+                isMobile,
+                '',
+                () => Promise.resolve(tests),
+                cache,
+                enableHardcodedBannerTests,
+                undefined,
+                now,
+            );
+        };
+
+        it('It should return a test matching a contribution from a new user', async () => {
+            const result = await runSelection({
+                ...baseTargeting,
+                purchaseInfo: { product: 'Contribution', userType: 'new' },
+            });
+
+            expect(result?.test.name).toEqual('banner-new-contribution');
+        });
+
+        it('It should return a test matching a subscription from an existing user', async () => {
+            const result = await runSelection({
+                ...baseTargeting,
+                purchaseInfo: { product: 'DigitalPack', userType: 'current' },
+            });
+
+            expect(result?.test.name).toEqual('banner-existing-subscriber');
+        });
+
+        it('It should ignore purchase information if user is signed in', async () => {
+            const result = await runSelection({
+                ...baseTargeting,
+                purchaseInfo: { product: 'Contribution', userType: 'new' },
+                isSignedIn: true,
+            });
+
+            expect(result).toBeNull();
         });
     });
 });

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -96,6 +96,25 @@ const getForcedVariant = (
     return null;
 };
 
+const purchaseMatches = (
+    test: BannerTest,
+    purchaseInfo: BannerTargeting['purchaseInfo'],
+    isSignedIn: boolean,
+) => {
+    const { purchaseInfo: testPurchaseInfo } = test;
+
+    // Ignore tests specifying purchase info if user is signed in / if no purchase info in targeting
+    if (isSignedIn || !purchaseInfo) {
+        return !testPurchaseInfo;
+    }
+
+    const { product, userType } = purchaseInfo;
+    const productValid = product && testPurchaseInfo?.product.includes(product);
+    const userValid = userType && testPurchaseInfo?.userType.includes(userType);
+
+    return productValid && userValid;
+};
+
 export const selectBannerTest = async (
     targeting: BannerTargeting,
     pageTracking: PageTracking,
@@ -138,6 +157,7 @@ export const selectBannerTest = async (
             ) &&
             userIsInTest(test, targeting.mvtId) &&
             deviceTypeMatches(test, isMobile) &&
+            purchaseMatches(test, targeting.purchaseInfo, targeting.isSignedIn) &&
             (await redeployedSinceLastClosed(
                 targeting,
                 test.bannerChannel,

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -36,10 +36,11 @@ export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderR
 };
 
 /**
- * Has the banner been redeployed since the user last closed it?
+ * If the banner has been closed previously, can we show it again?
+ * e.g. if changes have been deployed
  * Takes into account both the manual deploys (from RRCP) and the scheduled deploys.
  */
-export const redeployedSinceLastClosed = (
+export const canShowBannerAgain = (
     targeting: BannerTargeting,
     bannerChannel: BannerChannel,
     bannerDeployCaches: BannerDeployCaches,
@@ -167,7 +168,7 @@ export const selectBannerTest = async (
             userIsInTest(test, targeting.mvtId) &&
             deviceTypeMatches(test, isMobile) &&
             purchaseMatches(test, targeting.purchaseInfo, targeting.isSignedIn) &&
-            (await redeployedSinceLastClosed(
+            (await canShowBannerAgain(
                 targeting,
                 test.bannerChannel,
                 bannerDeployCaches,

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -46,9 +46,18 @@ export const redeployedSinceLastClosed = (
     scheduledBannerDeploys: ScheduledBannerDeploys,
     now: Date,
 ): Promise<boolean> => {
-    const { subscriptionBannerLastClosedAt, engagementBannerLastClosedAt } = targeting;
+    const {
+        subscriptionBannerLastClosedAt,
+        engagementBannerLastClosedAt,
+        signInBannerLastClosedAt,
+    } = targeting;
 
     const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
+
+    // Never show a sign in prompt banner if it has been closed previously
+    if (bannerChannel === 'signIn') {
+        return Promise.resolve(!signInBannerLastClosedAt);
+    }
 
     const canShow = async (lastClosedRaw: string | undefined): Promise<boolean> => {
         if (!lastClosedRaw) {

--- a/packages/server/src/tests/banners/bannerTests.ts
+++ b/packages/server/src/tests/banners/bannerTests.ts
@@ -5,6 +5,7 @@ import {
     channel2BannersAllTestsGenerator,
 } from './channelBannerTests';
 import { DefaultContributionsBanner } from './DefaultContributionsBannerTest';
+import { signInPromptTests } from './signInPromptTests';
 
 const defaultBannerTestGenerator: BannerTestGenerator = () =>
     Promise.resolve([DefaultContributionsBanner]);
@@ -15,6 +16,7 @@ const testGenerators: BannerTestGenerator[] = [
     channel1BannersAllTestsGenerator,
     channel2BannersAllTestsGenerator,
     defaultBannerTestGenerator,
+    signInPromptTests,
 ];
 
 const getTests = (): Promise<BannerTest[]> =>

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -53,6 +53,7 @@ export const BannerTemplateComponentTypes: {
 } = {
     contributions: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     subscriptions: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
+    signIn: 'ACQUISITIONS_ENGAGEMENT_BANNER',
 };
 
 export const BannerTemplateProducts: {

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -11,6 +11,7 @@ import {
     postElectionAuMomentHungBanner,
     postElectionAuMomentMorrisonBanner,
     researchSurveyBanner,
+    signInPromptBanner,
 } from '@sdc/shared/config';
 import {
     BannerChannel,
@@ -44,6 +45,7 @@ export const BannerPaths: {
     [BannerTemplate.DigitalSubscriptionsBanner]: digiSubs.endpointPathBuilder,
     [BannerTemplate.GuardianWeeklyBanner]: guardianWeekly.endpointPathBuilder,
     [BannerTemplate.ResearchSurveyBanner]: researchSurveyBanner.endpointPathBuilder,
+    [BannerTemplate.SignInPromptBanner]: signInPromptBanner.endpointPathBuilder,
 };
 
 export const BannerTemplateComponentTypes: {

--- a/packages/server/src/tests/banners/signInPromptTests.ts
+++ b/packages/server/src/tests/banners/signInPromptTests.ts
@@ -3,7 +3,7 @@ import { signInPromptBanner } from '@sdc/shared/dist/config';
 import { SecondaryCtaType } from '@sdc/shared/types';
 
 const baseSignInPromptTest: Omit<BannerTest, 'name' | 'variants'> = {
-    bannerChannel: 'contributions', // TODO: check with Tom if this is right
+    bannerChannel: 'signIn',
     isHardcoded: true,
     userCohort: 'Everyone',
     status: 'Live',
@@ -14,7 +14,7 @@ const baseSignInPromptVariant: Omit<BannerVariant, 'bannerContent'> = {
     name: 'control',
     modulePathBuilder: signInPromptBanner.endpointPathBuilder,
     moduleName: BannerTemplate.SignInPromptBanner,
-    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER', // TODO: check with Tom if this is right
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
 };
 
 const subscriberHeading = 'Thank you for subscribing';

--- a/packages/server/src/tests/banners/signInPromptTests.ts
+++ b/packages/server/src/tests/banners/signInPromptTests.ts
@@ -1,0 +1,177 @@
+import { BannerTemplate, BannerTest, BannerTestGenerator, BannerVariant } from '@sdc/shared/types';
+import { signInPromptBanner } from '@sdc/shared/dist/config';
+import { SecondaryCtaType } from '@sdc/shared/types';
+
+const baseSignInPromptTest: Omit<BannerTest, 'name' | 'variants'> = {
+    bannerChannel: 'contributions', // TODO: check with Tom if this is right
+    isHardcoded: true,
+    userCohort: 'Everyone',
+    status: 'Live',
+    minPageViews: 0,
+};
+
+const baseSignInPromptVariant: Omit<BannerVariant, 'bannerContent'> = {
+    name: 'control',
+    modulePathBuilder: signInPromptBanner.endpointPathBuilder,
+    moduleName: BannerTemplate.SignInPromptBanner,
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER', // TODO: check with Tom if this is right
+};
+
+const subscriberHeading = 'Thank you for subscribing';
+const supporterHeading = 'Thank you for your support';
+const subheading = 'One more step to enjoy the Guardian';
+
+const signInCTA = {
+    baseUrl: 'https://profile.theguardian.com/signin',
+    text: 'Sign in',
+};
+
+const registerCTA = {
+    baseUrl: 'https://profile.theguardian.com/register',
+    text: 'Complete registration',
+};
+
+const dismissAction = {
+    type: SecondaryCtaType.Custom,
+    cta: {
+        baseUrl: '',
+        text: 'Not now',
+    },
+};
+
+const baseBenefits = ['Fewer interruptions', 'Newsletters and comments'];
+const normalBenefits = [...baseBenefits, 'Manage your account'];
+const digiSubBenefits = ['Ad free', ...baseBenefits];
+const paragraphs = [subheading, ...normalBenefits];
+const digiSubParagraphs = [subheading, ...digiSubBenefits];
+
+const signInPromptNewUserDigitalSubscriberTest: BannerTest = {
+    ...baseSignInPromptTest,
+    name: 'banner-sign-in-prompt-new-user-digital-subscriber',
+    purchaseInfo: {
+        product: ['DigitalPack'],
+        userType: ['new', 'guest'],
+    },
+    variants: [
+        {
+            ...baseSignInPromptVariant,
+            bannerContent: {
+                heading: subscriberHeading,
+                paragraphs: digiSubParagraphs,
+                cta: registerCTA,
+                secondaryCta: dismissAction,
+            },
+        },
+    ],
+};
+
+const signInPromptNewUserPrintSubscriberTest: BannerTest = {
+    ...baseSignInPromptTest,
+    name: 'banner-sign-in-prompt-new-user-print-subscriber',
+    purchaseInfo: {
+        product: ['GuardianWeekly', 'Paper'],
+        userType: ['new', 'guest'],
+    },
+    variants: [
+        {
+            ...baseSignInPromptVariant,
+            bannerContent: {
+                heading: subscriberHeading,
+                paragraphs,
+                cta: registerCTA,
+                secondaryCta: dismissAction,
+            },
+        },
+    ],
+};
+
+const signInPromptNewUserSupporterTest: BannerTest = {
+    ...baseSignInPromptTest,
+    name: 'banner-sign-in-prompt-new-user-supporter',
+    purchaseInfo: {
+        product: ['Contribution'],
+        userType: ['new', 'guest'],
+    },
+    variants: [
+        {
+            ...baseSignInPromptVariant,
+            bannerContent: {
+                heading: supporterHeading,
+                paragraphs,
+                cta: registerCTA,
+                secondaryCta: dismissAction,
+            },
+        },
+    ],
+};
+
+const signInPromptExistingUserDigitalSubscriberTest: BannerTest = {
+    ...baseSignInPromptTest,
+    name: 'banner-sign-in-prompt-existing-user-digital-subscriber',
+    purchaseInfo: {
+        product: ['DigitalPack'],
+        userType: ['current'],
+    },
+    variants: [
+        {
+            ...baseSignInPromptVariant,
+            bannerContent: {
+                heading: subscriberHeading,
+                paragraphs: digiSubParagraphs,
+                cta: signInCTA,
+                secondaryCta: dismissAction,
+            },
+        },
+    ],
+};
+
+const signInPromptExistingUserPrintSubscriberTest: BannerTest = {
+    ...baseSignInPromptTest,
+    name: 'banner-sign-in-prompt-existing-user-print-subscriber',
+    purchaseInfo: {
+        product: ['GuardianWeekly', 'Paper'],
+        userType: ['current'],
+    },
+    variants: [
+        {
+            ...baseSignInPromptVariant,
+            bannerContent: {
+                heading: subscriberHeading,
+                paragraphs,
+                cta: signInCTA,
+                secondaryCta: dismissAction,
+            },
+        },
+    ],
+};
+
+const signInPromptExistingUserSupporterTest: BannerTest = {
+    ...baseSignInPromptTest,
+    name: 'banner-sign-in-prompt-existing-user-supporter',
+    purchaseInfo: {
+        product: ['Contribution'],
+        userType: ['current'],
+    },
+    variants: [
+        {
+            ...baseSignInPromptVariant,
+            bannerContent: {
+                heading: supporterHeading,
+                paragraphs,
+                cta: signInCTA,
+                secondaryCta: dismissAction,
+            },
+        },
+    ],
+};
+
+const tests = [
+    signInPromptNewUserDigitalSubscriberTest,
+    signInPromptNewUserPrintSubscriberTest,
+    signInPromptNewUserSupporterTest,
+    signInPromptExistingUserDigitalSubscriberTest,
+    signInPromptExistingUserPrintSubscriberTest,
+    signInPromptExistingUserSupporterTest,
+];
+
+export const signInPromptTests: BannerTestGenerator = () => Promise.resolve(tests);

--- a/packages/server/src/tests/headers/headerSelection.ts
+++ b/packages/server/src/tests/headers/headerSelection.ts
@@ -109,7 +109,6 @@ const baseSignInPromptTest: Omit<HeaderTest, 'name' | 'variants'> = {
         'UnitedStates',
         'International',
     ],
-    isSignedIn: false,
 };
 
 const baseSignInPromptVariant: Omit<HeaderVariant, 'content'> = {
@@ -139,6 +138,7 @@ const registerCTA = {
 };
 
 const baseBenefits = ['Fewer interruptions', 'Newsletters and comments'];
+const normalBenefits = [...baseBenefits, 'Manage your account'];
 const digiSubBenefits = ['Ad free', ...baseBenefits];
 
 const signInPromptNewUserDigitalSubscriberTest: HeaderTest = {
@@ -173,7 +173,7 @@ const signInPromptNewUserPrintSubscriberTest: HeaderTest = {
             content: {
                 ...subscriberContent,
                 primaryCta: registerCTA,
-                benefits: baseBenefits,
+                benefits: normalBenefits,
             },
         },
     ],
@@ -192,7 +192,7 @@ const signInPromptNewUserSupporterTest: HeaderTest = {
             content: {
                 ...supporterContent,
                 primaryCta: registerCTA,
-                benefits: baseBenefits,
+                benefits: normalBenefits,
             },
         },
     ],
@@ -230,7 +230,7 @@ const signInPromptExistingUserPrintSubscriberTest: HeaderTest = {
             content: {
                 ...subscriberContent,
                 primaryCta: signInCTA,
-                benefits: baseBenefits,
+                benefits: normalBenefits,
             },
         },
     ],
@@ -249,7 +249,7 @@ const signInPromptExistingUserSupporterTest: HeaderTest = {
             content: {
                 ...supporterContent,
                 primaryCta: signInCTA,
-                benefits: baseBenefits,
+                benefits: normalBenefits,
             },
         },
     ],
@@ -274,8 +274,9 @@ const purchaseMatches = (
 ) => {
     const { purchaseInfo: testPurchaseInfo } = test;
 
+    // Ignore tests specifying purchase info if user is signed in / if no purchase info in targeting
     if (isSignedIn || !purchaseInfo) {
-        return true;
+        return !testPurchaseInfo;
     }
 
     const { product, userType } = purchaseInfo;

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -88,10 +88,15 @@ export const puzzlesBanner: ModuleInfo = getDefaultModuleInfo(
     'puzzles/puzzlesBanner/PuzzlesBanner',
 );
 
+export const signInPromptBanner: ModuleInfo = getDefaultModuleInfo(
+    'sign-in-prompt-banner',
+    'banners/signInPrompt/SignInPromptBanner',
+);
+
 export const header: ModuleInfo = getDefaultModuleInfo('header', 'headers/Header');
 
 export const signInPromptHeader: ModuleInfo = getDefaultModuleInfo(
-    'signInPromptHeader',
+    'sign-in-prompt-header',
     'headers/SignInPromptHeader',
 );
 
@@ -111,6 +116,7 @@ export const moduleInfos: ModuleInfo[] = [
     digiSubs,
     guardianWeekly,
     puzzlesBanner,
+    signInPromptBanner,
     header,
     signInPromptHeader,
 ];

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -12,6 +12,7 @@ import {
 import { OphanComponentType, OphanProduct } from '../ophan';
 import { CountryGroupId } from '../../lib';
 import { BannerTargeting, PageTracking } from '../targeting';
+import { PurchaseInfoTest } from './shared';
 
 export enum BannerTemplate {
     ContributionsBanner = 'ContributionsBanner',
@@ -26,6 +27,7 @@ export enum BannerTemplate {
     PostElectionAuMomentHungBanner = 'PostElectionAuMomentHungBanner',
     PostElectionAuMomentMorrisonBanner = 'PostElectionAuMomentMorrisonBanner',
     ResearchSurveyBanner = 'ResearchSurveyBanner',
+    SignInPromptBanner = 'SignInPromptBanner',
 }
 
 export interface BannerVariant extends Variant {
@@ -58,6 +60,7 @@ export interface BannerTest extends Test<BannerVariant> {
     audienceOffset?: number;
     audience?: number;
     controlProportionSettings?: ControlProportionSettings;
+    purchaseInfo?: PurchaseInfoTest;
 }
 
 // The result of selecting a test+variant for a user

--- a/packages/shared/src/types/abTests/header.ts
+++ b/packages/shared/src/types/abTests/header.ts
@@ -1,7 +1,7 @@
 import { UserCohort, Test, Variant, TestStatus } from './shared';
 import { HeaderContent } from '../props';
 import { CountryGroupId } from '../../lib';
-import { PurchaseInfo } from '../targeting';
+import { PurchaseInfoTest } from '../abTests';
 
 export interface HeaderVariant extends Variant {
     name: string;
@@ -16,11 +16,7 @@ export interface HeaderTest extends Test<HeaderVariant> {
     status: TestStatus;
     locations: CountryGroupId[];
     userCohort: UserCohort;
-    purchaseInfo?: {
-        userType: PurchaseInfo['userType'][];
-        product: PurchaseInfo['product'][];
-    };
-    isSignedIn?: boolean;
+    purchaseInfo?: PurchaseInfoTest;
     variants: HeaderVariant[];
 }
 

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -1,4 +1,5 @@
 import { OphanComponentType, OphanProduct } from '../ophan';
+import { purchaseInfoProduct, purchaseInfoUser } from '../purchaseInfo';
 
 export type TestStatus = 'Live' | 'Draft' | 'Archived';
 
@@ -60,3 +61,8 @@ export type TestTracking = {
 };
 
 export type DeviceType = 'Mobile' | 'Desktop' | 'All';
+
+export interface PurchaseInfoTest {
+    userType: purchaseInfoUser[];
+    product: purchaseInfoProduct[];
+}

--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -12,7 +12,7 @@ import { OphanComponentEvent } from '../ophan';
 import * as z from 'zod';
 import { Prices } from '../prices';
 
-export const bannerChannelSchema = z.enum(['contributions', 'subscriptions']);
+export const bannerChannelSchema = z.enum(['contributions', 'subscriptions', 'signIn']);
 
 export type BannerChannel = z.infer<typeof bannerChannelSchema>;
 

--- a/packages/shared/src/types/purchaseInfo.ts
+++ b/packages/shared/src/types/purchaseInfo.ts
@@ -1,0 +1,2 @@
+export type purchaseInfoProduct = 'Contribution' | 'DigitalPack' | 'GuardianWeekly' | 'Paper';
+export type purchaseInfoUser = 'new' | 'guest' | 'current';

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -7,6 +7,7 @@ export type BannerTargeting = {
     showSupportMessaging: boolean;
     engagementBannerLastClosedAt?: string;
     subscriptionBannerLastClosedAt?: string;
+    signInBannerLastClosedAt?: string;
     mvtId: number;
     countryCode: string;
     weeklyArticleHistory?: WeeklyArticleHistory;

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -1,4 +1,4 @@
-import { PageTracking, WeeklyArticleHistory } from './shared';
+import { PageTracking, WeeklyArticleHistory, PurchaseInfo } from './shared';
 
 export type BannerTargeting = {
     alreadyVisitedCount: number;
@@ -17,6 +17,8 @@ export type BannerTargeting = {
     tagIds?: string[];
     contentType?: string;
     browserId?: string; // Only present if the user has consented to browserId-based targeting
+    purchaseInfo?: PurchaseInfo;
+    isSignedIn: boolean;
 };
 
 export type BannerPayload = {

--- a/packages/shared/src/types/targeting/header.ts
+++ b/packages/shared/src/types/targeting/header.ts
@@ -1,11 +1,6 @@
-import { PageTracking } from './shared';
+import { PageTracking, PurchaseInfo } from './shared';
 
 export type Edition = 'UK' | 'US' | 'AU' | 'INT';
-
-export interface PurchaseInfo {
-    userType: 'new' | 'guest' | 'current';
-    product: 'Contribution' | 'DigitalPack' | 'GuardianWeekly' | 'Paper';
-}
 
 export interface HeaderTargeting {
     showSupportMessaging: boolean;

--- a/packages/shared/src/types/targeting/shared.ts
+++ b/packages/shared/src/types/targeting/shared.ts
@@ -1,3 +1,5 @@
+import { purchaseInfoProduct, purchaseInfoUser } from '../purchaseInfo';
+
 export type PageTracking = {
     ophanPageId: string;
     platformId: string;
@@ -25,4 +27,9 @@ export interface LocalStorage {
     set(key: string, value: unknown): void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     get(key: string): any;
+}
+
+export interface PurchaseInfo {
+    userType: purchaseInfoUser;
+    product: purchaseInfoProduct;
 }


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[Trello card](https://trello.com/c/KbfJbwmK/4035-sign-in-after-checkout-banner-new-banner-to-prompt-recent-new-supporters-to-sign-in-s) for extra context.

Added a new type of banner which is intended to prompt users to sign in / register so they can benefit from a contribution they have made.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Can be tested with DCR by sending the appropriate values in the banner request payload.

Tested locally

- [x] Non signed in user with GU_CO_COMPLETE sees correct sign in prompt header and banner messaging
- [x] Non signed in user with the cookie who dismisses the sign in prompt banner will never see the banner again
- [x] Non signed in user without the cookie does NOT see sign in prompt banner but sees the correct yellow banner
- [x] Non signed in user without the cookie does NOT see sign in prompt header but sees correct header

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![image](https://user-images.githubusercontent.com/3338808/175034710-9d8bf8f4-4596-4087-99c6-71f87210ce60.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
