### PR TITLE
Turn on usTopReaderCopyTest

### DIFF
--- a/packages/server/src/tests/epics/usTopReaderCopy/index.ts
+++ b/packages/server/src/tests/epics/usTopReaderCopy/index.ts
@@ -49,7 +49,7 @@ export const usTopReaderCopyTest: EpicTest = {
     hasCountryName: false,
     highPriority: true,
     isLiveBlog: false,
-    status: 'Draft',
+    status: 'Live',
     locations: ['UnitedStates'],
     name: 'usTopReaderCopyTest',
     sections: [],


### PR DESCRIPTION
## What does this change?

Turn on hardcoded `usTopReaderCopyTest` on the Epic.