### PR TITLE
Add nullable to props parsing

### DIFF
--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -27,13 +27,28 @@ export interface BannerContent {
 }
 
 const bannerContentSchema = z.object({
-    heading: z.string().optional(),
-    messageText: z.string().optional(),
-    paragraphs: z.array(z.string()).optional(),
-    mobileMessageText: z.string().optional(),
-    highlightedText: z.string().optional(),
-    cta: ctaSchema.optional(),
-    secondaryCta: secondaryCtaSchema.optional(),
+    heading: z
+        .string()
+        .nullable()
+        .optional(),
+    messageText: z
+        .string()
+        .nullable()
+        .optional(),
+    paragraphs: z
+        .array(z.string())
+        .nullable()
+        .optional(),
+    mobileMessageText: z
+        .string()
+        .nullable()
+        .optional(),
+    highlightedText: z
+        .string()
+        .nullable()
+        .optional(),
+    cta: ctaSchema.nullable().optional(),
+    secondaryCta: secondaryCtaSchema.nullable().optional(),
 });
 
 export interface BannerProps {
@@ -56,8 +71,8 @@ export interface BannerProps {
 export const bannerSchema = z.object({
     tracking: trackingSchema,
     bannerChannel: bannerChannelSchema,
-    content: bannerContentSchema.optional(),
-    mobileContent: bannerContentSchema.optional(),
+    content: bannerContentSchema.nullable().optional(),
+    mobileContent: bannerContentSchema.nullable().optional(),
     countryCode: z.string().optional(),
     isSupporter: z.boolean().optional(),
     tickerSettings: tickerSettingsSchema.optional(),
@@ -66,7 +81,10 @@ export const bannerSchema = z.object({
     hasOptedOutOfArticleCount: z.boolean().optional(),
     email: z.string().optional(),
     fetchEmail: z.any().optional(),
-    separateArticleCount: z.boolean().optional(),
+    separateArticleCount: z
+        .boolean()
+        .nullable()
+        .optional(),
 });
 
 export interface PuzzlesBannerProps extends Partial<BannerProps> {

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -59,19 +59,31 @@ const reminderFieldsSchema = z.object({
 
 const variantSchema = z.object({
     name: z.string(),
-    heading: z.string().optional(),
+    heading: z
+        .string()
+        .nullable()
+        .optional(),
     paragraphs: z.array(z.string()),
-    highlightedText: z.string().optional(),
-    tickerSettings: tickerSettingsSchema.optional(),
-    cta: ctaSchema.optional(),
-    secondaryCta: secondaryCtaSchema.optional(),
-    footer: z.string().optional(),
-    image: imageSchema.optional(),
-    showReminderFields: reminderFieldsSchema.optional(),
-    separateArticleCount: separateArticleCountSchema.optional(),
-    maxViews: maxViewsSchema.optional(),
-    showSignInLink: z.boolean().optional(),
-    bylineWithImage: bylineWithImageSchema.optional(),
+    highlightedText: z
+        .string()
+        .nullable()
+        .optional(),
+    tickerSettings: tickerSettingsSchema.nullable().optional(),
+    cta: ctaSchema.nullable().optional(),
+    secondaryCta: secondaryCtaSchema.nullable().optional(),
+    footer: z
+        .string()
+        .nullable()
+        .optional(),
+    image: imageSchema.nullable().optional(),
+    showReminderFields: reminderFieldsSchema.nullable().optional(),
+    separateArticleCount: separateArticleCountSchema.nullable().optional(),
+    maxViews: maxViewsSchema.nullable().optional(),
+    showSignInLink: z
+        .boolean()
+        .nullable()
+        .optional(),
+    bylineWithImage: bylineWithImageSchema.nullable().optional(),
 });
 
 export const epicPropsSchema = z.object({

--- a/packages/shared/src/types/props/header.ts
+++ b/packages/shared/src/types/props/header.ts
@@ -13,8 +13,8 @@ export interface HeaderContent {
 const headerContentSchema = z.object({
     heading: z.string(),
     subheading: z.string(),
-    primaryCta: ctaSchema.optional(),
-    secondaryCta: ctaSchema.optional(),
+    primaryCta: ctaSchema.nullable().optional(),
+    secondaryCta: ctaSchema.nullable().optional(),
 });
 
 export interface HeaderProps {
@@ -29,7 +29,7 @@ export interface HeaderProps {
 export const headerSchema = z.object({
     content: headerContentSchema,
     tracking: trackingSchema,
-    mobileContent: headerContentSchema.optional(),
+    mobileContent: headerContentSchema.nullable().optional(),
     countryCode: z.string().optional(),
     submitComponentEvent: z.any(),
     numArticles: z.number().optional(),


### PR DESCRIPTION
## What does this change?

Add `.nullable()` calls to the props schemas for epics, banners, and headers. A change on the admin console ([pr](https://github.com/guardian/support-admin-console/pull/358)) made it so `null`s were explicitly written to the dyanmo table. This is causing our prop parsing to fail. As a quick fix, we're updating the components to allow `null`s in the props data. We can revisit for a better fix next week.
