### PR TITLE
Replace GW image in banner

### DIFF
--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -33,19 +33,19 @@ const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
 const desktopImg =
-    'https://i.guim.co.uk/img/media/cf4c09c3de6128d14bbf2ff316098d7b4eecebcb/0_0_2652_1360/2652.png?quality=85&s=2ecc7615da7424ebdb40dc68b2848adc';
+    'https://i.guim.co.uk/img/media/967ec1805daa9ec4db1bc67b03483b35eedbfdc8/0_0_2652_1360/2652.png?quality=85&s=9532422abba16964f23eca875c795ffa';
 
 const tabletImg =
-    'https://i.guim.co.uk/img/media/be2f827393917be2e88f7e1e3711b3c08e1861f6/0_0_1340_1320/1340.png?quality=85&s=00c655a579e2d5ff946ef64c254b8762';
+    'https://i.guim.co.uk/img/media/7d4e9663ded1545f85abcb8ce0b74e03727870cc/0_0_1340_1320/1340.png?quality=85&s=4baeef8070cc8142461c9426c4a6dc2c';
 
 const mobileImg =
-    'https://i.guim.co.uk/img/media/0dd8b1ecca213450fd6bc5f07fc97d31e5c2f979/0_0_1220_660/1220.png?quality=85&s=8b1465a1257889805569edb77c247be7';
+    'https://i.guim.co.uk/img/media/a042a19924ddccbc944a82342084889d164ab82c/0_0_1220_660/1220.png?quality=85&s=7ae997bbf3fe64290f8adee2c8e08fec';
 
 // Responsive image props
 const baseImg = {
     url: desktopImg,
     media: '(min-width: 980px)',
-    alt: 'The Guardian Weekly magazine - 40% off cover price',
+    alt: 'The Guardian Weekly magazine',
 };
 
 const images = [


### PR DESCRIPTION
## What does this change?

This updates the images for the Guardian Weekly banner. The new images do not have a roundel for savings/offers, these can be included in the copy of the banner so that we do not need to change the images too often until we add tooling for changing images.

## Images

**Mobile**
![Screenshot 2022-06-30 at 13 59 49](https://user-images.githubusercontent.com/99180049/176708903-e99cf953-4e8a-415a-a045-468f33ab4499.png)

**Tablet**
![Screenshot 2022-06-30 at 13 59 29](https://user-images.githubusercontent.com/99180049/176708969-36816c6d-0df4-466d-a011-ea6f02515744.png)

**Desktop**
![Screenshot 2022-06-30 at 13 59 11](https://user-images.githubusercontent.com/99180049/176709039-3475d470-e7e2-4c5f-8f23-adf1006bc721.png)