### PR TITLE
Top reader banner test

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -31,19 +31,42 @@ import { withParsedProps } from '../../shared/ModuleWrapper';
 import { buildReminderFields } from '@sdc/shared/lib';
 import { HasBeenSeen, useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 
+export enum TopReaderArticleCountTestVariant {
+    CONTROL,
+    V1_AC_LEAD,
+    V2_CONGRATS_LEAD,
+}
+
 // A separate article count is rendered as a subheading
 const buildSubheading = (
     numArticles: number,
     separateArticleCount: boolean,
+    topReaderAcTestVariant: TopReaderArticleCountTestVariant,
 ): JSX.Element | JSX.Element[] | null => {
     if (separateArticleCount && numArticles >= 5) {
         return replaceArticleCount(
-            `You’ve read %%ARTICLE_COUNT%% articles in the last year`,
+            getArticleCountSubheading(numArticles, topReaderAcTestVariant),
             numArticles,
             'banner',
         );
     }
     return null;
+};
+
+const getArticleCountSubheading = (
+    numArticles: number,
+    variant: TopReaderArticleCountTestVariant,
+): string => {
+    if (numArticles < 50 || variant === TopReaderArticleCountTestVariant.CONTROL) {
+        return "You've read %%ARTICLE_COUNT%% articles in the last year";
+    }
+
+    if (variant === TopReaderArticleCountTestVariant.V1_AC_LEAD) {
+        return "You've read %%ARTICLE_COUNT%% articles in the last year - congratulations on being one of our top readers";
+    }
+
+    // else variant is V2_CONGRATS_LEAD
+    return "Congratulations on being one of our top readers - you've read %%ARTICLE_COUNT%% articles in the last year ";
 };
 
 export const getParagraphsOrMessageText = (
@@ -63,6 +86,7 @@ export const getParagraphsOrMessageText = (
 const withBannerData = (
     Banner: React.FC<BannerRenderProps>,
     bannerId: BannerId,
+    topReaderAcTestVariant: TopReaderArticleCountTestVariant,
 ): React.FC<CloseableBannerProps> => bannerProps => {
     const {
         tracking,
@@ -184,7 +208,11 @@ const withBannerData = (
             ? replaceArticleCount(cleanHighlightedText, numArticles, 'banner')
             : null;
 
-        const subheading = buildSubheading(numArticles, !!separateArticleCount);
+        const subheading = buildSubheading(
+            numArticles,
+            !!separateArticleCount,
+            topReaderAcTestVariant,
+        );
 
         if (copyHasPlaceholder) {
             throw Error('Banner copy contains placeholders, abandoning.');
@@ -264,7 +292,8 @@ const withBannerData = (
 export const bannerWrapper = (
     Banner: React.FC<BannerRenderProps>,
     bannerId: BannerId,
-): React.FC<BannerProps> => withCloseable(withBannerData(Banner, bannerId));
+    topReaderAcTestVariant: TopReaderArticleCountTestVariant = TopReaderArticleCountTestVariant.CONTROL,
+): React.FC<BannerProps> => withCloseable(withBannerData(Banner, bannerId, topReaderAcTestVariant));
 
 const validate = (props: unknown): props is BannerProps => {
     const result = bannerSchema.safeParse(props);
@@ -274,7 +303,8 @@ const validate = (props: unknown): props is BannerProps => {
 export const validatedBannerWrapper = (
     Banner: React.FC<BannerRenderProps>,
     bannerId: BannerId,
+    topReaderAcTestVariant: TopReaderArticleCountTestVariant = TopReaderArticleCountTestVariant.CONTROL,
 ): React.FC<BannerProps> => {
-    const withoutValidation = bannerWrapper(Banner, bannerId);
+    const withoutValidation = bannerWrapper(Banner, bannerId, topReaderAcTestVariant);
     return withParsedProps(withoutValidation, validate);
 };

--- a/packages/modules/src/modules/banners/contributions/ContributionsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBanner.stories.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { ContributionsBannerUnvalidated as ContributionsBanner } from './ContributionsBanner';
+import { ContributionsBannerUnvalidated as ContributionsBannerTopReaderAcV1 } from './ContributionsBannerTopReaderArticleCountV1';
+import { ContributionsBannerUnvalidated as ContributionsBannerTopReaderAcV2 } from './ContributionsBannerTopReaderArticleCountV2';
 import { props, content } from '../utils/storybook';
 import { BannerProps, SecondaryCtaType } from '@sdc/shared/types';
 
@@ -48,3 +50,19 @@ WithoutSupportUrl.args = {
         },
     },
 };
+
+const TemplateV1: Story<BannerProps> = (props: BannerProps) => (
+    <ContributionsBannerTopReaderAcV1 {...props} />
+);
+
+export const WithTopReaderArticleCountV1 = TemplateV1.bind({});
+WithTopReaderArticleCountV1.args = {
+    numArticles: 99,
+};
+
+const TemplateV2: Story<BannerProps> = (props: BannerProps) => (
+    <ContributionsBannerTopReaderAcV2 {...props} />
+);
+
+export const WithTopReaderArticleCountV2 = TemplateV2.bind({});
+WithTopReaderArticleCountV2.args = WithTopReaderArticleCountV1.args;

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerTopReaderArticleCountV1.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerTopReaderArticleCountV1.tsx
@@ -1,0 +1,22 @@
+import { brandAlt } from '@guardian/src-foundations';
+import {
+    bannerWrapper,
+    TopReaderArticleCountTestVariant,
+    validatedBannerWrapper,
+} from '../common/BannerWrapper';
+import { getContributionsBanner } from './ContributionsBanner';
+
+const ContributionsBanner = getContributionsBanner(brandAlt[400]);
+
+const unvalidated = bannerWrapper(
+    ContributionsBanner,
+    'contributions-banner',
+    TopReaderArticleCountTestVariant.V1_AC_LEAD,
+);
+const validated = validatedBannerWrapper(
+    ContributionsBanner,
+    'contributions-banner',
+    TopReaderArticleCountTestVariant.V1_AC_LEAD,
+);
+
+export { validated as ContributionsBanner, unvalidated as ContributionsBannerUnvalidated };

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerTopReaderArticleCountV2.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerTopReaderArticleCountV2.tsx
@@ -1,0 +1,22 @@
+import { brandAlt } from '@guardian/src-foundations';
+import {
+    bannerWrapper,
+    TopReaderArticleCountTestVariant,
+    validatedBannerWrapper,
+} from '../common/BannerWrapper';
+import { getContributionsBanner } from './ContributionsBanner';
+
+const ContributionsBanner = getContributionsBanner(brandAlt[400]);
+
+const unvalidated = bannerWrapper(
+    ContributionsBanner,
+    'contributions-banner',
+    TopReaderArticleCountTestVariant.V2_CONGRATS_LEAD,
+);
+const validated = validatedBannerWrapper(
+    ContributionsBanner,
+    'contributions-banner',
+    TopReaderArticleCountTestVariant.V2_CONGRATS_LEAD,
+);
+
+export { validated as ContributionsBanner, unvalidated as ContributionsBannerUnvalidated };

--- a/packages/server/src/tests/banners/bannerTests.ts
+++ b/packages/server/src/tests/banners/bannerTests.ts
@@ -5,6 +5,10 @@ import {
     channel2BannersAllTestsGenerator,
 } from './channelBannerTests';
 import { DefaultContributionsBanner } from './DefaultContributionsBannerTest';
+import { topReaderArticleCount } from '../../tests/banners/topReaderArticleCount';
+
+const topReaderArticleCountTestGenerator: BannerTestGenerator = () =>
+    Promise.resolve([topReaderArticleCount]);
 
 const defaultBannerTestGenerator: BannerTestGenerator = () =>
     Promise.resolve([DefaultContributionsBanner]);
@@ -12,6 +16,7 @@ const defaultBannerTestGenerator: BannerTestGenerator = () =>
 const flattenArray = <T>(array: T[][]): T[] => ([] as T[]).concat(...array);
 
 const testGenerators: BannerTestGenerator[] = [
+    topReaderArticleCountTestGenerator,
     channel1BannersAllTestsGenerator,
     channel2BannersAllTestsGenerator,
     defaultBannerTestGenerator,

--- a/packages/server/src/tests/banners/topReaderArticleCount/content.ts
+++ b/packages/server/src/tests/banners/topReaderArticleCount/content.ts
@@ -1,0 +1,23 @@
+import { BannerContent, SecondaryCtaType } from '@sdc/shared/types';
+
+export const content: BannerContent = {
+    heading: 'Lend us a hand in 2022',
+    messageText:
+        "We are proud to say we're a reader-funded global news organisation, with more than 1.5 million supporters in 180 countries. This vital support keeps us fiercely independent, free from shareholders or a billionaire owner. It means we can keep our quality reporting open for everyone to read. We do this because we believe in information equality, and we know not everyone is in a position to pay for news. <strong>But if you are, we need you.</strong> You can make an investment in Guardian journalism today, so millions more can benefit from reliable information on the events shaping our world.",
+    paragraphs: [
+        "We are proud to say we're a reader-funded global news organisation, with more than 1.5 million supporters in 180 countries. This vital support keeps us fiercely independent, free from shareholders or a billionaire owner. It means we can keep our quality reporting open for everyone to read. We do this because we believe in information equality, and we know not everyone is in a position to pay for news. <strong>But if you are, we need you.</strong> You can make an investment in Guardian journalism today, so millions more can benefit from reliable information on the events shaping our world.",
+    ],
+    highlightedText: 'Support the Guardian today from as little as %%CURRENCY_SYMBOL%%1.',
+    cta: {
+        text: 'Support us monthly',
+        baseUrl: 'https://support.theguardian.com/contribute',
+    },
+    secondaryCta: {
+        type: SecondaryCtaType.Custom,
+        cta: {
+            text: 'Support just once',
+            baseUrl:
+                'https://support.theguardian.com/contribute?selected-contribution-type=ONE_OFF',
+        },
+    },
+};

--- a/packages/server/src/tests/banners/topReaderArticleCount/index.ts
+++ b/packages/server/src/tests/banners/topReaderArticleCount/index.ts
@@ -1,0 +1,46 @@
+import {
+    contributionsBanner,
+    contributionsBannerTopReaderArticleCountV1,
+    contributionsBannerTopReaderArticleCountV2,
+} from '@sdc/shared/config';
+import { BannerTest } from '@sdc/shared/types';
+import { content } from './content';
+
+export const topReaderArticleCount: BannerTest = {
+    name: 'TopReaderArticleCount',
+    status: 'Draft',
+    bannerChannel: 'contributions',
+    isHardcoded: true,
+    userCohort: 'AllNonSupporters',
+    minPageViews: 2,
+    articlesViewedSettings: {
+        minViews: 50,
+        periodInWeeks: 52,
+    },
+    variants: [
+        {
+            name: 'CONTROL',
+            modulePathBuilder: contributionsBanner.endpointPathBuilder,
+            moduleName: 'ContributionsBanner',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            bannerContent: content,
+            separateArticleCount: true,
+        },
+        {
+            name: 'V1_AC_LEAD',
+            modulePathBuilder: contributionsBannerTopReaderArticleCountV1.endpointPathBuilder,
+            moduleName: 'ContributionsBanner',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            bannerContent: content,
+            separateArticleCount: true,
+        },
+        {
+            name: 'V2_CONGRATS_LEAD',
+            modulePathBuilder: contributionsBannerTopReaderArticleCountV2.endpointPathBuilder,
+            moduleName: 'ContributionsBanner',
+            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            bannerContent: content,
+            separateArticleCount: true,
+        },
+    ],
+};

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -28,6 +28,16 @@ export const contributionsBanner: ModuleInfo = getDefaultModuleInfo(
     'banners/contributions/ContributionsBanner',
 );
 
+export const contributionsBannerTopReaderArticleCountV1: ModuleInfo = getDefaultModuleInfo(
+    'contributions-banner',
+    'banners/contributions/ContributionsBannerTopReaderArticleCountV1',
+);
+
+export const contributionsBannerTopReaderArticleCountV2: ModuleInfo = getDefaultModuleInfo(
+    'contributions-banner',
+    'banners/contributions/ContributionsBannerTopReaderArticleCountV2',
+);
+
 export const researchSurveyBanner: ModuleInfo = getDefaultModuleInfo(
     'research-survey-banner',
     'banners/researchSurveyBanner/ResearchSurveyBanner',
@@ -99,6 +109,8 @@ export const moduleInfos: ModuleInfo[] = [
     epic,
     liveblogEpic,
     contributionsBanner,
+    contributionsBannerTopReaderArticleCountV1,
+    contributionsBannerTopReaderArticleCountV2,
     researchSurveyBanner,
     contributionsBannerWithSignIn,
     investigationsMomentBanner,


### PR DESCRIPTION
## What does this change?

Adds the top reader article count test for banners. The test is in 'Draft' status. We can create a follow up PR to set the test live (will happen after upcoming investigation banner).

[**Trello card**](https://trello.com/c/xWhZsLrt/524-top-reader-banner-test)

## Images

|CONTROL|V1_AC_LEAD|V2_CONGRATS_LEAD|
|-------|----------|----------------|
|<img width="992" alt="Screenshot 2022-07-04 at 16 17 38" src="https://user-images.githubusercontent.com/17720442/177183031-098b5eae-b5e0-425b-b546-9e983ce6d275.png">|<img width="992" alt="Screenshot 2022-07-04 at 16 17 45" src="https://user-images.githubusercontent.com/17720442/177183039-c7b96b16-5624-4f2d-8ed6-a8456087ef51.png">|<img width="992" alt="Screenshot 2022-07-04 at 16 17 49" src="https://user-images.githubusercontent.com/17720442/177183042-037b31e3-d738-4bdb-9962-1460d326ef05.png">



