### PR TITLE
Exclude cartoons from epic targeting

### DIFF
--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -3,7 +3,11 @@ import { daysSince } from './dates';
 
 const lowValueSections = ['money', 'education', 'games', 'teacher-network', 'careers'];
 
-const lowValueTags = ['tone/matchreports', 'guardian-masterclasses/guardian-masterclasses'];
+const lowValueTags = [
+    'tone/matchreports',
+    'guardian-masterclasses/guardian-masterclasses',
+    'tone/cartoon',
+];
 
 export interface ThrottleConfig {
     maxViewsDays: number;


### PR DESCRIPTION
we will soon target `interactive` type articles. But we do not want to show epics on cartoons