### PR TITLE
Exclude tests from articles tagged news/series/uber-files

### DIFF
--- a/packages/server/src/tests/epics/epicProfileWithImageTest_eu-row.ts
+++ b/packages/server/src/tests/epics/epicProfileWithImageTest_eu-row.ts
@@ -17,7 +17,7 @@ export const epicProfileWithImageTest_EUROW: EpicTest = {
     audience: 1,
     tagIds: ['world/russia', 'world/ukraine'],
     sections: [],
-    excludedTagIds: [],
+    excludedTagIds: ['news/series/uber-files'],
     excludedSections: [],
     alwaysAsk: false,
     maxViews: {

--- a/packages/server/src/tests/epics/epicProfileWithImageTest_uk-aus.ts
+++ b/packages/server/src/tests/epics/epicProfileWithImageTest_uk-aus.ts
@@ -17,7 +17,7 @@ export const epicProfileWithImageTest_UKAUS: EpicTest = {
     audience: 1,
     tagIds: ['world/russia', 'world/ukraine'],
     sections: [],
-    excludedTagIds: [],
+    excludedTagIds: ['news/series/uber-files'],
     excludedSections: [],
     alwaysAsk: false,
     maxViews: {

--- a/packages/server/src/tests/epics/epicProfileWithImageTest_us.ts
+++ b/packages/server/src/tests/epics/epicProfileWithImageTest_us.ts
@@ -17,7 +17,7 @@ export const epicProfileWithImageTest_US: EpicTest = {
     audience: 1,
     tagIds: ['world/russia', 'world/ukraine'],
     sections: [],
-    excludedTagIds: [],
+    excludedTagIds: ['news/series/uber-files'],
     excludedSections: [],
     alwaysAsk: false,
     maxViews: {


### PR DESCRIPTION
## What does this change?
Adds the `news/series/uber-files` tag to each hardcoded test's excludedTagIds array

We don't want the Herding message appearing under uber stories