### PR TITLE
Update copy and design of Sign In Prompt header/banner

### DIFF
--- a/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.stories.tsx
@@ -17,7 +17,7 @@ const Template: ComponentStory<typeof SignInPromptBanner> = props => (
 const content = {
     heading: 'Thank you for subscribing',
     paragraphs: [
-        'One more step to enjoy the Guardian',
+        'Remember to sign in for a better experience',
         'Ad free',
         'Fewer interruptions',
         'Newsletters and comments',

--- a/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
+++ b/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ThemeProvider, css } from '@emotion/react';
 import { brand, brandAlt, space, neutral } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
+import { until } from '@guardian/src-foundations/mq';
 import { Button, LinkButton, buttonBrand } from '@guardian/src-button';
 import { SvgRoundelBrandInverse } from '@guardian/src-brand';
 import { SecondaryCtaType } from '@sdc/shared/types';
@@ -30,11 +31,18 @@ const mainColumn = css`
     position: relative;
 `;
 
+const asideColumn = css`
+    margin-right: 10px;
+`;
+
 const headingStyles = css`
     ${headline.medium({ fontWeight: 'bold' })}
     font-size: 32px;
     color: ${neutral[100]};
     margin: ${space[1]}px 0 0;
+    ${until.phablet} {
+        margin: ${space[1]}px 45px 0 0;
+    }
 `;
 
 const subHeadingStyles = css`
@@ -87,7 +95,9 @@ const SignInPromptBanner: React.FC<BannerRenderProps> = props => {
     return (
         <Container cssOverrides={bannerStyles}>
             <Columns>
-                <Column width={[0, 0, 0, 2, 3]}> </Column>
+                <Column width={[0, 0, 0, 2, 3]} cssOverrides={asideColumn}>
+                    {' '}
+                </Column>
                 <Column width={[4, 12, 12, 12, 13]} cssOverrides={mainColumn}>
                     <h1 css={headingStyles}>{heading}</h1>
                     <h2 css={subHeadingStyles}>{subheading}</h2>

--- a/packages/modules/src/modules/headers/SignInPromptHeader.stories.tsx
+++ b/packages/modules/src/modules/headers/SignInPromptHeader.stories.tsx
@@ -17,12 +17,12 @@ const Template: ComponentStory<typeof SignInPromptHeader> = props => (
 const baseArgs = {
     content: {
         heading: 'Thank you for subscribing',
-        subheading: 'One more step to enjoy the Guardian',
+        subheading: 'Remember to sign in for a better experience',
         primaryCta: {
             baseUrl: 'https://profile.theguardian.com/register',
             text: 'Complete registration',
         },
-        benefits: ['Ad free', 'Fewer interruptions', 'Newsletters and comments'],
+        benefits: ['Ad free', 'Fewer interruptions', 'Newsletters and comments', 'Ad free'],
     },
     mobileContent: {
         heading: '',

--- a/packages/modules/src/modules/headers/SignInPromptHeader.tsx
+++ b/packages/modules/src/modules/headers/SignInPromptHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ThemeProvider, css } from '@emotion/react';
 import { brandAlt, brandText, space } from '@guardian/src-foundations';
-import { headline } from '@guardian/src-foundations/typography';
+import { headline, lineHeights, textSans } from '@guardian/src-foundations/typography';
 import { LinkButton, buttonBrand } from '@guardian/src-button';
 import { Hide } from '@guardian/src-layout';
 import { from, until } from '@guardian/src-foundations/mq';
@@ -17,28 +17,29 @@ const headingStyles = () => css`
     ${headline.xxxsmall({ fontWeight: 'bold' })};
     margin: 0;
 
-    ${from.leftCol} {
+    ${from.desktop} {
         ${headline.xsmall({ fontWeight: 'bold' })};
     }
 `;
 
 const subHeadingStyles = css`
     color: ${brandAlt[400]};
-    ${headline.xxxsmall({ fontWeight: 'bold' })};
+    ${textSans.small({ fontWeight: 'regular' })};
+    line-height: ${lineHeights.tight} !important;
     margin: 0;
 
-    ${until.leftCol} {
-        font-size: 14px;
+    ${until.desktop} {
+        font-size: 12px;
     }
 `;
 
 const benefitsWrapper = css`
-    margin: 2px 0 ${space[2]}px;
+    margin: 0 0 ${space[1]}px;
     height: 16px;
     position: relative;
 
-    ${from.leftCol} {
-        margin: ${space[1]}px 0 ${space[2]}px;
+    ${from.desktop} {
+        margin: 0 0 ${space[2]}px;
         height: 20px;
     }
 `;
@@ -54,26 +55,28 @@ const dotsWrapper = css`
 
 const dotStyles = css`
     background: ${brandAlt[400]};
-    width: 11px;
-    height: 11px;
+    width: 9px;
+    height: 9px;
     border-radius: 50%;
-    margin-top: 3px;
+    margin-top: 4px;
     margin-right: ${space[1]}px;
 
-    ${from.leftCol} {
-        width: 13px;
-        height: 13px;
-        margin-top: ${space[1]}px;
-        margin-right: ${space[2]}px;
+    ${from.desktop} {
+        width: 11px;
+        height: 11px;
+        margin-top: 5px;
+        margin-right: 6px;
     }
 `;
 
 const benefitTextStyles = css`
     color: ${brandText.primary};
-    ${headline.xxxsmall()};
+    ${textSans.small()};
+    line-height: ${lineHeights.regular} !important;
 
-    ${until.leftCol} {
-        font-size: 14px;
+    ${until.desktop} {
+        line-height: 1rem !important;
+        font-size: 12px;
     }
 `;
 

--- a/packages/server/src/tests/banners/signInPromptTests.ts
+++ b/packages/server/src/tests/banners/signInPromptTests.ts
@@ -19,7 +19,7 @@ const baseSignInPromptVariant: Omit<BannerVariant, 'bannerContent'> = {
 
 const subscriberHeading = 'Thank you for subscribing';
 const supporterHeading = 'Thank you for your support';
-const subheading = 'One more step to enjoy the Guardian';
+const subheading = 'Remember to sign in for a better experience';
 
 const signInCTA = {
     baseUrl: 'https://profile.theguardian.com/signin',

--- a/packages/server/src/tests/headers/headerSelection.ts
+++ b/packages/server/src/tests/headers/headerSelection.ts
@@ -119,12 +119,12 @@ const baseSignInPromptVariant: Omit<HeaderVariant, 'content'> = {
 
 const subscriberContent = {
     heading: 'Thank you for subscribing',
-    subheading: 'One more step to enjoy the Guardian',
+    subheading: 'Remember to sign in for a better experience',
 };
 
 const supporterContent = {
     heading: 'Thank you for your support',
-    subheading: 'One more step to enjoy the Guardian',
+    subheading: 'Remember to sign in for a better experience',
 };
 
 const signInCTA = {
@@ -138,8 +138,9 @@ const registerCTA = {
 };
 
 const baseBenefits = ['Fewer interruptions', 'Newsletters and comments'];
-const normalBenefits = [...baseBenefits, 'Manage your account'];
-const digiSubBenefits = ['Ad free', ...baseBenefits];
+// Why are benefits repeated below? The header animation ends statically on last benefit so it should be the "strongest"
+const normalBenefits = [...baseBenefits, 'Manage your account', 'Fewer interruptions'];
+const digiSubBenefits = ['Ad free', ...baseBenefits, 'Ad free'];
 
 const signInPromptNewUserDigitalSubscriberTest: HeaderTest = {
     name: 'header-sign-in-prompt-new-user-digital-subscriber',


### PR DESCRIPTION
## What does this change?

- Updates the copy of the Sign In Prompt header and banner
- Updates the header animation to end statically on the main perceived strongest benefit. 
- Design updates on the header

 
### Existing user, contribution or print subscription:

**Banner:**
<img width="937" alt="image" src="https://user-images.githubusercontent.com/32312712/180245574-34082a4b-3261-4f39-a353-f560c74894ba.png">
**>Desktop Header**
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/32312712/180245824-92fba2a1-7a28-4baf-aec3-1518315e3aef.png">
**Tablet Header**
<img width="623" alt="image" src="https://user-images.githubusercontent.com/32312712/180245908-f693344d-dccc-4196-b85f-3027d94971b2.png">


### New user/guest, digital subscription:

**Banner:**
<img width="996" alt="image" src="https://user-images.githubusercontent.com/32312712/180244450-cef549b2-1218-4647-bfd2-28718db4c570.png">
**>Desktop Header**
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/32312712/180244912-5bff0fb2-566b-4882-82e2-edea3be5c319.png">
**Tablet Header**
<img width="623" alt="image" src="https://user-images.githubusercontent.com/32312712/180245018-84a7314e-adf2-4035-8c0b-51d62f52bdc8.png">


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
