### PR TITLE
Lenore Aus hardcoded Epic test - update byline image

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -65,7 +65,7 @@ WithBylineAndHeadshot.args = {
             description: 'Editor, Guardian Australia',
             headshot: {
                 mainUrl:
-                    'https://i.guim.co.uk/img/uploads/2018/10/30/Lenore_Taylor,_R.png?width=300&quality=85&auto=format&fit=max&s=3912263e9fe2895681b281d3a6c7d1f1',
+                    'https://i.guim.co.uk/img/media/8eda1b06a686fe5ab4f7246bd6b5f8e63851088e/0_0_300_250/300.png?quality=85&s=f42e9642f335d705cab8b712bbbcb64e',
                 altText: 'Lenore Taylor staff byline photograph',
             },
         },

--- a/packages/server/src/tests/epics/epicLenoreWithImageTest_aus.ts
+++ b/packages/server/src/tests/epics/epicLenoreWithImageTest_aus.ts
@@ -105,7 +105,7 @@ export const epicLenoreWithImageTest_AUS: EpicTest = {
                 description: 'Editor, Guardian Australia',
                 headshot: {
                     mainUrl:
-                        'https://i.guim.co.uk/img/uploads/2018/10/30/Lenore_Taylor,_R.png?width=300&quality=85&auto=format&fit=max&s=3912263e9fe2895681b281d3a6c7d1f1',
+                        'https://i.guim.co.uk/img/media/8eda1b06a686fe5ab4f7246bd6b5f8e63851088e/0_0_300_250/300.png?quality=85&s=f42e9642f335d705cab8b712bbbcb64e',
                     altText: 'Lenore Taylor staff byline photograph',
                 },
             },


### PR DESCRIPTION
## What does this change?
This PR updates the image used in the hardcoded Lenore Epic test, which is currently live.

The updated image has been tested in Storybook. Screenshots:

![Screenshot 2022-07-27 at 13 04 50](https://user-images.githubusercontent.com/5357530/181243341-50232186-b193-4b1a-aeac-9a4d11010fc0.png)

![Screenshot 2022-07-27 at 13 05 32](https://user-images.githubusercontent.com/5357530/181243375-0d2d275a-c722-43bd-9434-2dacade26628.png)

