### PR TITLE
Disable US-top-reader-copy hardcoded epic test

### DIFF
--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -41,7 +41,6 @@ import { epicProfileWithImageTest_EUROW } from './tests/epics/epicProfileWithIma
 import { epicProfileWithImageTest_UKAUS } from './tests/epics/epicProfileWithImageTest_uk-aus';
 import { epicLenoreWithImageTest_AUS } from './tests/epics/epicLenoreWithImageTest_aus';
 import { cachedProductPrices } from './productPrices';
-import { usTopReaderCopyTest } from './tests/epics/usTopReaderCopy';
 
 interface EpicDataResponse {
     data?: {

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -116,7 +116,6 @@ const fetchSuperModeArticlesCached = cacheAsync(fetchSuperModeArticles, { ttlSec
 
 // Any hardcoded epic tests should go here. They will take priority over any tests from the epic tool.
 const hardcodedEpicTests: EpicTest[] = [
-    usTopReaderCopyTest,
     epicLenoreWithImageTest_AUS,
     epicProfileWithImageTest_UKAUS,
     epicProfileWithImageTest_US,


### PR DESCRIPTION
## What does this change?
A small PR to disable the US top reader copy hardcoded test