### PR TITLE
Add tracking to Sign In Prompt Banner / Header

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -1,8 +1,10 @@
 import {
     addRegionIdAndTrackingParamsToSupportUrl,
+    addTrackingParamsToProfileUrl,
     createClickEventFromTracking,
     createInsertEventFromTracking,
     createViewEventFromTracking,
+    isProfileUrl,
 } from '@sdc/shared/lib';
 import React, { useEffect } from 'react';
 import {
@@ -145,15 +147,24 @@ const withBannerData = (
 
     // For safety, this function throws if not all placeholders are replaced
     const buildRenderedContent = (bannerContent: BannerContent): BannerRenderedContent => {
-        const buildEnrichedCta = (cta: Cta): BannerEnrichedCta => ({
-            ctaUrl: addRegionIdAndTrackingParamsToSupportUrl(
-                cta.baseUrl,
-                tracking,
-                numArticles,
-                countryCode,
-            ),
-            ctaText: cta.text,
-        });
+        const buildEnrichedCta = (cta: Cta): BannerEnrichedCta => {
+            if (isProfileUrl(cta.baseUrl)) {
+                return {
+                    ctaUrl: addTrackingParamsToProfileUrl(cta.baseUrl, tracking),
+                    ctaText: cta.text,
+                };
+            }
+
+            return {
+                ctaUrl: addRegionIdAndTrackingParamsToSupportUrl(
+                    cta.baseUrl,
+                    tracking,
+                    numArticles,
+                    countryCode,
+                ),
+                ctaText: cta.text,
+            };
+        };
 
         const buildEnrichedSecondaryCta = (
             secondaryCta: SecondaryCta,

--- a/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
+++ b/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
@@ -109,6 +109,7 @@ const SignInPromptBanner: React.FC<BannerRenderProps> = props => {
                                 <LinkButton
                                     priority="primary"
                                     href={primaryCta.ctaUrl}
+                                    onClick={props.onCtaClick}
                                     size="small"
                                 >
                                     {primaryCta.ctaText}

--- a/packages/modules/src/modules/headers/HeaderWrapper.tsx
+++ b/packages/modules/src/modules/headers/HeaderWrapper.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect } from 'react';
 import { HeaderProps, Cta, headerSchema } from '@sdc/shared/types';
-import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/lib';
+import {
+    addRegionIdAndTrackingParamsToSupportUrl,
+    addTrackingParamsToProfileUrl,
+    createClickEventFromTracking,
+    isProfileUrl,
+} from '@sdc/shared/lib';
 import { OphanAction } from '@sdc/shared/types';
 import { HasBeenSeen, useHasBeenSeen } from '../../hooks/useHasBeenSeen';
 import { withParsedProps } from '../shared/ModuleWrapper';
@@ -33,15 +38,23 @@ export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<Hea
         submitComponentEvent,
         numArticles,
     }) => {
-        const buildEnrichedCta = (cta: Cta): HeaderEnrichedCta => ({
-            ctaUrl: addRegionIdAndTrackingParamsToSupportUrl(
-                cta.baseUrl,
-                tracking,
-                numArticles,
-                countryCode,
-            ),
-            ctaText: cta.text,
-        });
+        const buildEnrichedCta = (cta: Cta): HeaderEnrichedCta => {
+            if (isProfileUrl(cta.baseUrl)) {
+                return {
+                    ctaUrl: addTrackingParamsToProfileUrl(cta.baseUrl, tracking),
+                    ctaText: cta.text,
+                };
+            }
+            return {
+                ctaUrl: addRegionIdAndTrackingParamsToSupportUrl(
+                    cta.baseUrl,
+                    tracking,
+                    numArticles,
+                    countryCode,
+                ),
+                ctaText: cta.text,
+            };
+        };
 
         const primaryCta = content.primaryCta ? buildEnrichedCta(content.primaryCta) : null;
         const secondaryCta = content.secondaryCta ? buildEnrichedCta(content.secondaryCta) : null;

--- a/packages/modules/src/modules/headers/HeaderWrapper.tsx
+++ b/packages/modules/src/modules/headers/HeaderWrapper.tsx
@@ -21,6 +21,7 @@ export interface HeaderRenderedContent {
 export interface HeaderRenderProps {
     content: HeaderRenderedContent;
     mobileContent?: HeaderRenderedContent;
+    onCtaClick?: () => void; // only used by sign in prompt header
 }
 
 export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<HeaderProps> => {
@@ -73,6 +74,18 @@ export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<Hea
 
         const { abTestName, abTestVariant, componentType, campaignCode } = tracking;
 
+        const onCtaClick = (componentId: string) => {
+            return (): void => {
+                const componentClickEvent = createClickEventFromTracking(
+                    tracking,
+                    `${componentId} : cta`,
+                );
+                if (submitComponentEvent) {
+                    submitComponentEvent(componentClickEvent);
+                }
+            };
+        };
+
         const sendOphanEvent = (action: OphanAction): void =>
             submitComponentEvent &&
             submitComponentEvent({
@@ -107,7 +120,11 @@ export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<Hea
 
         return (
             <div ref={setNode}>
-                <Header content={renderedContent} mobileContent={renderedMobileContent} />
+                <Header
+                    content={renderedContent}
+                    mobileContent={renderedMobileContent}
+                    onCtaClick={onCtaClick(campaignCode)}
+                />
             </div>
         );
     };

--- a/packages/modules/src/modules/headers/HeaderWrapper.tsx
+++ b/packages/modules/src/modules/headers/HeaderWrapper.tsx
@@ -93,9 +93,7 @@ export const headerWrapper = (Header: React.FC<HeaderRenderProps>): React.FC<Hea
                     tracking,
                     `${componentId} : cta`,
                 );
-                if (submitComponentEvent) {
-                    submitComponentEvent(componentClickEvent);
-                }
+                submitComponentEvent && submitComponentEvent(componentClickEvent);
             };
         };
 

--- a/packages/modules/src/modules/headers/SignInPromptHeader.tsx
+++ b/packages/modules/src/modules/headers/SignInPromptHeader.tsx
@@ -206,7 +206,12 @@ const SignInPromptHeader: React.FC<HeaderRenderProps> = props => {
 
             {primaryCta && (
                 <ThemeProvider theme={buttonBrand}>
-                    <LinkButton priority="primary" href={primaryCta.ctaUrl} size="xsmall">
+                    <LinkButton
+                        priority="primary"
+                        href={primaryCta.ctaUrl}
+                        size="xsmall"
+                        onClick={props.onCtaClick}
+                    >
                         {primaryCta.ctaText}
                     </LinkButton>
                 </ThemeProvider>

--- a/packages/shared/src/lib/tracking.test.ts
+++ b/packages/shared/src/lib/tracking.test.ts
@@ -2,6 +2,7 @@ import {
     buildCampaignCode,
     addTrackingParams,
     addRegionIdAndTrackingParamsToSupportUrl,
+    addTrackingParamsToProfileUrl,
 } from './tracking';
 import { factories } from '../factories/';
 
@@ -99,6 +100,31 @@ describe('addRegionIdAndTrackingParamsToSupportUrl', () => {
 
         const want =
             'https://support.theguardian.com/uk/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTests%22%3A%5B%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%5D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=88';
+        expect(got).toEqual(want);
+    });
+});
+
+describe('addTrackingParamsToProfileUrl', () => {
+    const trackingData = factories.tracking.build();
+
+    it('should return the base URL for non profile URLs', () => {
+        const buttonBaseUrl = 'https://support.theguardian.com/contribute';
+        const got = addTrackingParamsToProfileUrl(buttonBaseUrl, trackingData);
+        const want = 'https://support.theguardian.com/contribute';
+        expect(got).toEqual(want);
+    });
+    it('should return a correctly formatted URL for a profile URL', () => {
+        const buttonBaseUrl = 'https://profile.theguardian.com/register';
+        const got = addTrackingParamsToProfileUrl(buttonBaseUrl, trackingData);
+        const want =
+            'https://profile.theguardian.com/register?componentEventParams=componentType%3DACQUISITIONS_EPIC%26componentId%3Dgdnwb_copts_memco_remote_epic_test_api%26abTestName%3Dremote_epic_test%26abTestVariant%3Dapi%26viewId%3Dk5nxn0mxg7ytwpkxuwms&returnUrl=http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit';
+        expect(got).toEqual(want);
+    });
+    it('should return a correctly formatted URL when the base URL already has a query string', () => {
+        const buttonBaseUrl = 'https://profile.theguardian.com/register?foo=bar';
+        const got = addTrackingParamsToProfileUrl(buttonBaseUrl, trackingData);
+        const want =
+            'https://profile.theguardian.com/register?foo=bar&componentEventParams=componentType%3DACQUISITIONS_EPIC%26componentId%3Dgdnwb_copts_memco_remote_epic_test_api%26abTestName%3Dremote_epic_test%26abTestVariant%3Dapi%26viewId%3Dk5nxn0mxg7ytwpkxuwms&returnUrl=http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit';
         expect(got).toEqual(want);
     });
 });

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -2,29 +2,6 @@ import { OphanAction, OphanComponentEvent } from '../types/ophan';
 import { addRegionIdToSupportUrl } from './geolocation';
 import { EpicTest, EpicVariant, Tracking } from '../types';
 import { BannerTest, BannerVariant } from '../types/abTests/banner';
-// import { getCookie } from '@sdc/modules/src/lib/cookies'; //todo move to shared
-
-//TODO move to shared
-const getCookieValues = (name: string): string[] => {
-    const nameEq = `${name}=`;
-    const cookies = document.cookie.split(';');
-
-    return cookies.reduce<string[]>((acc, cookie) => {
-        const cookieTrimmed = cookie.trim();
-
-        if (cookieTrimmed.startsWith(nameEq)) {
-            acc.push(cookieTrimmed.substring(nameEq.length, cookieTrimmed.length));
-        }
-
-        return acc;
-    }, []);
-};
-
-export const getCookie = (name: string): string | undefined => {
-    const cookieVal = getCookieValues(name);
-
-    return cookieVal[0];
-};
 
 // TRACKING VIA support.theguardian.com
 type LinkParams = {
@@ -101,8 +78,6 @@ type ProfileLinkParams = {
 };
 
 export const addProfileTrackingParams = (baseUrl: string, params: Tracking): string => {
-    console.log('adding profilee tracking params');
-
     const constructQuery = (query: { [key: string]: any }): string =>
         Object.keys(query)
             .map((param: string) => {
@@ -119,13 +94,11 @@ export const addProfileTrackingParams = (baseUrl: string, params: Tracking): str
         componentId: params.campaignCode,
         abTestName: params.abTestName,
         abTestVariant: params.abTestVariant,
-        browserId: getCookie('bwid') || undefined, // FIXME
-        visitId: getCookie('vsid') || undefined, // FIXME
         viewId: params.ophanPageId,
     };
 
     const trackingLinkParams: ProfileLinkParams = {
-        // Note: profile subdomain take uri encoded quray params NOT json
+        // Note: profile subdomain take uri encoded query params NOT json
         componentEventParams: encodeURIComponent(constructQuery(componentEventParamsData)),
         returnUrl: params.referrerUrl,
     };


### PR DESCRIPTION
## What does this change?

The new Sign In Prompt Header and Banner redirect users to profile.theguardian.com.

This PR adds:
- CTA click tracking for both components. 
- `componentEventParams` as query params on redirects to profile subdomain so that we can track how many users actually complete registration or sign in via the check out sign in prompt header/banner

**_Note:_** the code could be dryer, but I think best to keep support vs profile code separate for easy removal/deletion

## TODO

- [x] Add tests
- [ ] Add browserId and visitId - due to complexity with the build we are not adding these as not strictly needed 
- [x] Test tracking works via profile CODE. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
