### PR TITLE
Remove hardcoded profile epic tests from payloads file

### DIFF
--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -36,10 +36,6 @@ import { fallbackEpicTest } from './tests/epics/fallback';
 import { selectHeaderTest } from './tests/headers/headerSelection';
 import { logWarn } from './utils/logging';
 import { cachedChoiceCardAmounts } from './choiceCardAmounts';
-import { epicProfileWithImageTest_US } from './tests/epics/epicProfileWithImageTest_us';
-import { epicProfileWithImageTest_EUROW } from './tests/epics/epicProfileWithImageTest_eu-row';
-import { epicProfileWithImageTest_UKAUS } from './tests/epics/epicProfileWithImageTest_uk-aus';
-import { epicLenoreWithImageTest_AUS } from './tests/epics/epicLenoreWithImageTest_aus';
 import { cachedProductPrices } from './productPrices';
 
 interface EpicDataResponse {
@@ -114,12 +110,7 @@ const fetchConfiguredLiveblogEpicTestsCached = cacheAsync(
 const fetchSuperModeArticlesCached = cacheAsync(fetchSuperModeArticles, { ttlSec: 60 });
 
 // Any hardcoded epic tests should go here. They will take priority over any tests from the epic tool.
-const hardcodedEpicTests: EpicTest[] = [
-    epicLenoreWithImageTest_AUS,
-    epicProfileWithImageTest_UKAUS,
-    epicProfileWithImageTest_US,
-    epicProfileWithImageTest_EUROW,
-];
+const hardcodedEpicTests: EpicTest[] = [];
 
 const getArticleEpicTests = async (
     mvtId: number,


### PR DESCRIPTION
## What does this change?
Marketing have asked us to suspend the currently running Harding and Lenore Epic-with-profile-images tests until further notice.

This PR removes the tests from the Epic hardcoded tests array, but does not clean out any of the code/files associated with creating the tests