### PR TITLE
Epic environment article count test

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -349,17 +349,17 @@ const ContributionsEpic: React.FC<EpicProps> = ({
 
     return (
         <section ref={setNode} css={wrapperStyles}>
-            {showAboveArticleCount && variant.separateArticleCount && (
+            {showAboveArticleCount && (
                 <div css={articleCountAboveContainerStyles}>
                     <ContributionsEpicArticleCountAboveWithOptOut
                         articleCounts={articleCounts}
-                        copy={variant.separateArticleCount?.copy}
-                        countType={variant.separateArticleCount?.countType}
                         isArticleCountOn={!hasOptedOut}
                         onArticleCountOptOut={onArticleCountOptOut}
                         onArticleCountOptIn={onArticleCountOptIn}
                         openCmp={openCmp}
                         submitComponentEvent={submitComponentEvent}
+                        copy={variant.separateArticleCount?.copy}
+                        countType={variant.separateArticleCount?.countType}
                     />
                 </div>
             )}

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -358,7 +358,6 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                         onArticleCountOptIn={onArticleCountOptIn}
                         openCmp={openCmp}
                         submitComponentEvent={submitComponentEvent}
-                        aboveArticleCountByTag={false}
                         copy={variant.separateArticleCount?.copy}
                     />
                 </div>

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -349,16 +349,17 @@ const ContributionsEpic: React.FC<EpicProps> = ({
 
     return (
         <section ref={setNode} css={wrapperStyles}>
-            {showAboveArticleCount && (
+            {showAboveArticleCount && variant.separateArticleCount && (
                 <div css={articleCountAboveContainerStyles}>
                     <ContributionsEpicArticleCountAboveWithOptOut
                         articleCounts={articleCounts}
+                        copy={variant.separateArticleCount?.copy}
+                        countType={variant.separateArticleCount?.countType}
                         isArticleCountOn={!hasOptedOut}
                         onArticleCountOptOut={onArticleCountOptOut}
                         onArticleCountOptIn={onArticleCountOptIn}
                         openCmp={openCmp}
                         submitComponentEvent={submitComponentEvent}
-                        copy={variant.separateArticleCount?.copy}
                     />
                 </div>
             )}

--- a/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
@@ -27,7 +27,6 @@ export interface ContributionsEpicArticleCountAboveWithOptOutProps {
     onArticleCountOptIn: () => void;
     openCmp?: () => void;
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
-    aboveArticleCountByTag: boolean;
 }
 
 export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<ContributionsEpicArticleCountAboveWithOptOutProps> = ({
@@ -38,7 +37,6 @@ export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<Contribution
     onArticleCountOptIn,
     openCmp,
     submitComponentEvent,
-    aboveArticleCountByTag,
 }: ContributionsEpicArticleCountAboveWithOptOutProps) => {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -80,7 +78,6 @@ export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<Contribution
                 isArticleCountOn={isArticleCountOn}
                 articleCounts={articleCounts}
                 onToggleClick={onToggleClick}
-                aboveArticleCountByTag={aboveArticleCountByTag}
                 copy={copy}
             />
 
@@ -166,7 +163,6 @@ interface ArticleCountWithToggleProps {
     articleCounts: ArticleCounts;
     isArticleCountOn: boolean;
     onToggleClick: () => void;
-    aboveArticleCountByTag: boolean;
     copy?: string;
 }
 
@@ -174,28 +170,18 @@ const ArticleCountWithToggle: React.FC<ArticleCountWithToggleProps> = ({
     isArticleCountOn,
     articleCounts,
     onToggleClick,
-    aboveArticleCountByTag,
     copy,
 }: ArticleCountWithToggleProps) => {
-    // By default we display the 52-week count
-    const articleCount = aboveArticleCountByTag
-        ? articleCounts.forTargetedWeeks
-        : articleCounts.for52Weeks;
+    /**
+     * If copy is defined, use the `forTargetedWeeks` count.
+     * Otherwise display generic "in the last year" copy with the `for52Weeks` count.
+     */
+    const articleCount = copy ? articleCounts.forTargetedWeeks : articleCounts.for52Weeks;
 
     if (isArticleCountOn && articleCount >= 5) {
         return (
             <div css={articleCountOnHeaderContainerStyles}>
-                {articleCount < 50 && (
-                    <ArticleCount
-                        articleCount={articleCount}
-                        aboveArticleCountByTag={aboveArticleCountByTag}
-                        copy={copy}
-                    />
-                )}
-
-                {articleCount >= 50 && (
-                    <TopReaderArticleCount articleCount={articleCount} copy={copy} />
-                )}
+                <ArticleCount articleCount={articleCount} copy={copy} />
 
                 <div css={articleCountWrapperStyles}>
                     <div css={articleCountTextStyles}>Article count</div>
@@ -252,50 +238,25 @@ const CustomArticleCountCopy: React.FC<CustomArticleCountCopyProps> = ({ article
 
 interface ArticleCountProps {
     articleCount: number;
-    aboveArticleCountByTag: boolean;
     copy?: string;
 }
 
-const ArticleCount: React.FC<ArticleCountProps> = ({
-    articleCount,
-    aboveArticleCountByTag,
-    copy,
-}) => {
+const ArticleCount: React.FC<ArticleCountProps> = ({ articleCount, copy }) => {
     if (copy && containsArticleCountTemplate(copy)) {
+        // Custom article count message
         return <CustomArticleCountCopy articleCount={articleCount} copy={copy} />;
-    } else {
-        const timeWindowCopy = aboveArticleCountByTag ? (
-            <span>
-                about the
-                <br />
-                climate crisis in the last six weeks
-            </span>
-        ) : (
-            'in the last year'
-        );
-
-        return (
-            <div css={articleCountAboveContainerStyles}>
-                You&apos;ve read <span css={optOutContainer}>{articleCount} articles</span>{' '}
-                {timeWindowCopy}
-            </div>
-        );
-    }
-};
-
-interface TopReaderArticleCountProps {
-    articleCount: number;
-    copy?: string;
-}
-
-const TopReaderArticleCount: React.FC<TopReaderArticleCountProps> = ({ articleCount, copy }) => {
-    if (copy && containsArticleCountTemplate(copy)) {
-        return <CustomArticleCountCopy articleCount={articleCount} copy={copy} />;
-    } else {
+    } else if (articleCount >= 50) {
         return (
             <div css={articleCountAboveContainerStyles}>
                 Congratulations on being one of our top readers globally – you&apos;ve read{' '}
                 <span css={optOutContainer}>{articleCount} articles</span> in the last year
+            </div>
+        );
+    } else {
+        return (
+            <div css={articleCountAboveContainerStyles}>
+                You&apos;ve read <span css={optOutContainer}>{articleCount} articles</span> in the
+                last year
             </div>
         );
     }

--- a/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicArticleCountAboveWithOptOut.tsx
@@ -6,7 +6,7 @@ import { palette, space } from '@guardian/src-foundations';
 import { Button } from '@guardian/src-button';
 import { ButtonLink } from '@guardian/src-link';
 import { css } from '@emotion/react';
-import { ArticleCounts, OphanComponentEvent } from '@sdc/shared/types';
+import { ArticleCounts, ArticleCountType, OphanComponentEvent } from '@sdc/shared/types';
 import {
     OPHAN_COMPONENT_ARTICLE_COUNT_OPT_OUT_OPEN,
     OPHAN_COMPONENT_ARTICLE_COUNT_OPT_OUT_CLOSE,
@@ -22,6 +22,7 @@ import { from, until } from '@guardian/src-foundations/mq';
 export interface ContributionsEpicArticleCountAboveWithOptOutProps {
     articleCounts: ArticleCounts;
     copy?: string;
+    countType?: ArticleCountType;
     isArticleCountOn: boolean;
     onArticleCountOptOut: () => void;
     onArticleCountOptIn: () => void;
@@ -32,6 +33,7 @@ export interface ContributionsEpicArticleCountAboveWithOptOutProps {
 export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<ContributionsEpicArticleCountAboveWithOptOutProps> = ({
     articleCounts,
     copy,
+    countType,
     isArticleCountOn,
     onArticleCountOptOut,
     onArticleCountOptIn,
@@ -72,11 +74,13 @@ export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<Contribution
         submitComponentEvent && submitComponentEvent(OPHAN_COMPONENT_ARTICLE_COUNT_STAY_OUT);
     };
 
+    const articleCount = articleCounts[countType ?? 'for52Weeks'];
+
     return (
         <div css={topContainer}>
             <ArticleCountWithToggle
                 isArticleCountOn={isArticleCountOn}
-                articleCounts={articleCounts}
+                articleCount={articleCount}
                 onToggleClick={onToggleClick}
                 copy={copy}
             />
@@ -160,7 +164,7 @@ export const ContributionsEpicArticleCountAboveWithOptOut: React.FC<Contribution
 // --- Helper components --- //
 
 interface ArticleCountWithToggleProps {
-    articleCounts: ArticleCounts;
+    articleCount: number;
     isArticleCountOn: boolean;
     onToggleClick: () => void;
     copy?: string;
@@ -168,16 +172,10 @@ interface ArticleCountWithToggleProps {
 
 const ArticleCountWithToggle: React.FC<ArticleCountWithToggleProps> = ({
     isArticleCountOn,
-    articleCounts,
+    articleCount,
     onToggleClick,
     copy,
 }: ArticleCountWithToggleProps) => {
-    /**
-     * If copy is defined, use the `forTargetedWeeks` count.
-     * Otherwise display generic "in the last year" copy with the `for52Weeks` count.
-     */
-    const articleCount = copy ? articleCounts.forTargetedWeeks : articleCounts.for52Weeks;
-
     if (isArticleCountOn && articleCount >= 5) {
         return (
             <div css={articleCountOnHeaderContainerStyles}>

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -37,6 +37,7 @@ import { selectHeaderTest } from './tests/headers/headerSelection';
 import { logWarn } from './utils/logging';
 import { cachedChoiceCardAmounts } from './choiceCardAmounts';
 import { cachedProductPrices } from './productPrices';
+import environmentArticleCountTest from './tests/epics/environmentArticleCountTest';
 
 interface EpicDataResponse {
     data?: {
@@ -110,7 +111,7 @@ const fetchConfiguredLiveblogEpicTestsCached = cacheAsync(
 const fetchSuperModeArticlesCached = cacheAsync(fetchSuperModeArticles, { ttlSec: 60 });
 
 // Any hardcoded epic tests should go here. They will take priority over any tests from the epic tool.
-const hardcodedEpicTests: EpicTest[] = [];
+const hardcodedEpicTests: EpicTest[] = [...environmentArticleCountTest];
 
 const getArticleEpicTests = async (
     mvtId: number,

--- a/packages/server/src/payloads.ts
+++ b/packages/server/src/payloads.ts
@@ -212,8 +212,8 @@ export const buildEpicData = async (
         tracking: { ...pageTracking, ...testTracking },
         articleCounts: getArticleViewCounts(
             targeting.weeklyArticleHistory,
-            test.articlesViewedByTagSettings,
             test.articlesViewedSettings?.periodInWeeks,
+            test.articlesViewedSettings?.tagId,
         ),
         countryCode: targeting.countryCode,
     };

--- a/packages/server/src/tests/epics/environmentArticleCountTest.ts
+++ b/packages/server/src/tests/epics/environmentArticleCountTest.ts
@@ -28,7 +28,7 @@ const buildEnvironmentArticleCountTest = (
     name: ARTICLE_COUNT_BY_TAG_TEST_NAME,
     campaignId: ARTICLE_COUNT_BY_TAG_TEST_NAME,
     hasArticleCountInCopy: false,
-    status: 'Live',
+    status: 'Draft',
     locations: countries,
     audience: 1,
     tagIds: ['environment/environment'],

--- a/packages/server/src/tests/epics/environmentArticleCountTest.ts
+++ b/packages/server/src/tests/epics/environmentArticleCountTest.ts
@@ -64,7 +64,7 @@ const buildEnvironmentArticleCountTest = (
                 type: 'above',
                 countType: 'forTargetedWeeks',
                 copy:
-                    "Congratulations on being one of our top readers of climate content globally - did you know you've read %%ARTICLE_COUNT%% articles about the climate crisis in the last year?",
+                    "Congratulations on being one of our top readers of climate journalism - did you know you've read %%ARTICLE_COUNT%% articles about the climate crisis in the last year?",
             },
             showChoiceCards: true,
         },

--- a/packages/server/src/tests/epics/environmentArticleCountTest.ts
+++ b/packages/server/src/tests/epics/environmentArticleCountTest.ts
@@ -1,0 +1,83 @@
+import { CountryGroupId } from '@sdc/shared/dist/lib';
+import { EpicTest } from '@sdc/shared/dist/types';
+import { epic } from '@sdc/shared/dist/config/modules';
+
+export const ARTICLE_COUNT_BY_TAG_TEST_NAME = '2022-09-05_EpicEnvironmentArticleCountTest';
+
+const HIGHLIGHTED_TEXT =
+    'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. If you can, please consider supporting us with a regular amount each month. Thank you.';
+
+const buildParagraphs = (hasCountryName: boolean) => [
+    `… ${
+        hasCountryName ? 'as you’re joining us today from %%COUNTRY_NAME%%, ' : ''
+    }we have a small favour to ask. Tens of millions have placed their trust in the Guardian’s fearless journalism since we started publishing 200 years ago, turning to us in moments of crisis, uncertainty, solidarity and hope. More than 1.5 million supporters, from 180 countries, now power us financially – keeping us open to all, and fiercely independent.`,
+    'Unlike many others, the Guardian has no shareholders and no billionaire owner. Just the determination and passion to deliver high-impact global reporting, always free from commercial or political influence. Reporting like this is vital for democracy, for fairness and to demand better from the powerful.',
+    'And we provide all this for free, for everyone to read. We do this because we believe in information equality. Greater numbers of people can keep track of the events shaping our world, understand their impact on people and communities, and become inspired to take meaningful action. Millions can benefit from open access to quality, truthful news, regardless of their ability to pay for it.',
+    'Every contribution, however big or small, powers our journalism and sustains our future.',
+];
+
+const CTA = {
+    text: 'Support the Guardian',
+    baseUrl: 'https://support.theguardian.com/contribute',
+};
+
+const buildEnvironmentArticleCountTest = (
+    countries: CountryGroupId[],
+    paragraphs: string[],
+): EpicTest => ({
+    name: ARTICLE_COUNT_BY_TAG_TEST_NAME,
+    campaignId: ARTICLE_COUNT_BY_TAG_TEST_NAME,
+    hasArticleCountInCopy: false,
+    status: 'Live',
+    locations: countries,
+    audience: 1,
+    tagIds: ['environment/environment'],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: false,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
+    userCohort: 'AllNonSupporters',
+    isLiveBlog: false,
+    hasCountryName: true,
+    variants: [
+        {
+            name: 'control',
+            modulePathBuilder: epic.endpointPathBuilder,
+            paragraphs,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
+            separateArticleCount: { type: 'above' },
+            showChoiceCards: true,
+        },
+        {
+            name: 'v1',
+            modulePathBuilder: epic.endpointPathBuilder,
+            paragraphs,
+            highlightedText: HIGHLIGHTED_TEXT,
+            cta: CTA,
+            separateArticleCount: { type: 'above' },
+            showChoiceCards: true,
+        },
+    ],
+    highPriority: true,
+    useLocalViewLog: true,
+    articlesViewedSettings: {
+        minViews: 50,
+        periodInWeeks: 52,
+    },
+    articlesViewedByTagSettings: {
+        minViews: 50,
+        periodInWeeks: 52,
+        tagId: 'environment/environment',
+    },
+});
+
+export default [
+    buildEnvironmentArticleCountTest(['International', 'EURCountries'], buildParagraphs(true)),
+    buildEnvironmentArticleCountTest([], buildParagraphs(false)),
+];

--- a/packages/server/src/tests/epics/environmentArticleCountTest.ts
+++ b/packages/server/src/tests/epics/environmentArticleCountTest.ts
@@ -51,7 +51,7 @@ const buildEnvironmentArticleCountTest = (
             paragraphs,
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,
-            separateArticleCount: { type: 'above' },
+            separateArticleCount: { type: 'above', countType: 'for52Weeks' },
             showChoiceCards: true,
         },
         {
@@ -62,6 +62,7 @@ const buildEnvironmentArticleCountTest = (
             cta: CTA,
             separateArticleCount: {
                 type: 'above',
+                countType: 'forTargetedWeeks',
                 copy:
                     "Congratulations on being one of our top readers globally - Did you know you've read %%ARTICLE_COUNT%% articles about the climate crisis in the last year?",
             },

--- a/packages/server/src/tests/epics/environmentArticleCountTest.ts
+++ b/packages/server/src/tests/epics/environmentArticleCountTest.ts
@@ -64,7 +64,7 @@ const buildEnvironmentArticleCountTest = (
                 type: 'above',
                 countType: 'forTargetedWeeks',
                 copy:
-                    "Congratulations on being one of our top readers globally - did you know you've read %%ARTICLE_COUNT%% articles about the climate crisis in the last year?",
+                    "Congratulations on being one of our top readers of climate content globally - did you know you've read %%ARTICLE_COUNT%% articles about the climate crisis in the last year?",
             },
             showChoiceCards: true,
         },
@@ -72,7 +72,7 @@ const buildEnvironmentArticleCountTest = (
     highPriority: true,
     useLocalViewLog: true,
     articlesViewedSettings: {
-        minViews: 50,
+        minViews: 20,
         periodInWeeks: 52,
         tagId: 'environment/environment',
     },

--- a/packages/server/src/tests/epics/environmentArticleCountTest.ts
+++ b/packages/server/src/tests/epics/environmentArticleCountTest.ts
@@ -60,7 +60,11 @@ const buildEnvironmentArticleCountTest = (
             paragraphs,
             highlightedText: HIGHLIGHTED_TEXT,
             cta: CTA,
-            separateArticleCount: { type: 'above' },
+            separateArticleCount: {
+                type: 'above',
+                copy:
+                    "Congratulations on being one of our top readers globally - Did you know you've read %%ARTICLE_COUNT%% articles about the climate crisis in the last year?",
+            },
             showChoiceCards: true,
         },
     ],

--- a/packages/server/src/tests/epics/environmentArticleCountTest.ts
+++ b/packages/server/src/tests/epics/environmentArticleCountTest.ts
@@ -64,7 +64,7 @@ const buildEnvironmentArticleCountTest = (
                 type: 'above',
                 countType: 'forTargetedWeeks',
                 copy:
-                    "Congratulations on being one of our top readers globally - Did you know you've read %%ARTICLE_COUNT%% articles about the climate crisis in the last year?",
+                    "Congratulations on being one of our top readers globally - did you know you've read %%ARTICLE_COUNT%% articles about the climate crisis in the last year?",
             },
             showChoiceCards: true,
         },

--- a/packages/server/src/tests/epics/environmentArticleCountTest.ts
+++ b/packages/server/src/tests/epics/environmentArticleCountTest.ts
@@ -74,10 +74,6 @@ const buildEnvironmentArticleCountTest = (
     articlesViewedSettings: {
         minViews: 50,
         periodInWeeks: 52,
-    },
-    articlesViewedByTagSettings: {
-        minViews: 50,
-        periodInWeeks: 52,
         tagId: 'environment/environment',
     },
 });

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -1,4 +1,4 @@
-import { ArticlesViewedByTagSettings, SecondaryCtaType } from '@sdc/shared/types';
+import { ArticlesViewedSettings, SecondaryCtaType } from '@sdc/shared/types';
 import { EpicTargeting, EpicTest } from '@sdc/shared/types';
 import { SuperModeArticle } from '../../lib/superMode';
 import { withNowAs } from '../../utils/withNowAs';
@@ -14,7 +14,6 @@ import {
     matchesCountryGroups,
     userInTest,
     withinArticleViewedSettings,
-    withinArticleViewedByTagSettings,
     withinMaxViews,
     deviceTypeMatchesFilter,
 } from './epicSelection';
@@ -627,9 +626,9 @@ describe('withinArticleViewedSettings filter', () => {
     });
 });
 
-describe('withinArticleViewedByTagSettings filter', () => {
+describe('withinArticleViewedSettings filter by tag', () => {
     const now = new Date('2020-03-31T12:30:00');
-    const articlesViewedByTagSettings: ArticlesViewedByTagSettings = {
+    const articlesViewedSettings: ArticlesViewedSettings = {
         minViews: 5,
         periodInWeeks: 52,
         tagId: 'environment/climate-change',
@@ -641,7 +640,7 @@ describe('withinArticleViewedByTagSettings filter', () => {
             ...targetingDefault,
             weeklyArticleHistory: history,
         };
-        const filter = withinArticleViewedByTagSettings(history, now);
+        const filter = withinArticleViewedSettings(history, now);
 
         const got = filter.test({ ...testDefault }, targeting);
 
@@ -663,9 +662,9 @@ describe('withinArticleViewedByTagSettings filter', () => {
             ...targetingDefault,
             weeklyArticleHistory: history,
         };
-        const filter = withinArticleViewedByTagSettings(history, now);
+        const filter = withinArticleViewedSettings(history, now);
 
-        const got = filter.test({ ...testDefault, articlesViewedByTagSettings }, targeting);
+        const got = filter.test({ ...testDefault, articlesViewedSettings }, targeting);
 
         expect(got).toBe(false);
     });
@@ -685,9 +684,9 @@ describe('withinArticleViewedByTagSettings filter', () => {
             ...targetingDefault,
             weeklyArticleHistory: history,
         };
-        const filter = withinArticleViewedByTagSettings(history, now);
+        const filter = withinArticleViewedSettings(history, now);
 
-        const got = filter.test({ ...testDefault, articlesViewedByTagSettings }, targeting);
+        const got = filter.test({ ...testDefault, articlesViewedSettings }, targeting);
 
         expect(got).toBe(true);
     });

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -9,10 +9,7 @@ import {
 } from '@sdc/shared/types';
 import { selectVariant } from '../../lib/ab';
 import { isRecentOneOffContributor } from '../../lib/dates';
-import {
-    historyWithinArticlesViewedSettings,
-    historyWithinArticlesViewedSettingsByTag,
-} from '../../lib/history';
+import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { TestVariant } from '../../lib/params';
 import { SuperModeArticle } from '../../lib/superMode';
 import { isInSuperMode, superModeify } from '../../lib/superMode';
@@ -157,15 +154,6 @@ export const withinArticleViewedSettings = (
         historyWithinArticlesViewedSettings(test.articlesViewedSettings, history, now),
 });
 
-export const withinArticleViewedByTagSettings = (
-    history: WeeklyArticleHistory,
-    now: Date = new Date(),
-): Filter => ({
-    id: 'withinArticleViewedByTagSettings',
-    test: (test): boolean =>
-        historyWithinArticlesViewedSettingsByTag(test.articlesViewedByTagSettings, history, now),
-});
-
 export const inCorrectCohort = (userCohorts: UserCohort[], isSuperModePass: boolean): Filter => ({
     id: 'inCorrectCohort',
     test: (test): boolean => {
@@ -252,7 +240,7 @@ export const findTestAndVariant = (
             ...(isSuperModePass ? [] : [withinMaxViews(targeting.epicViewLog || [])]),
             respectArticleCountOptOut,
             withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
-            withinArticleViewedByTagSettings(targeting.weeklyArticleHistory || []),
+            // withinArticleViewedByTagSettings(targeting.weeklyArticleHistory || []),
             deviceTypeMatchesFilter(isMobile),
         ];
     };

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -240,7 +240,6 @@ export const findTestAndVariant = (
             ...(isSuperModePass ? [] : [withinMaxViews(targeting.epicViewLog || [])]),
             respectArticleCountOptOut,
             withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
-            // withinArticleViewedByTagSettings(targeting.weeklyArticleHistory || []),
             deviceTypeMatchesFilter(isMobile),
         ];
     };

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -1,6 +1,5 @@
 import { CountryGroupId, ReminderFields } from '../../lib';
 import {
-    ArticlesViewedByTagSettings,
     ArticlesViewedSettings,
     ControlProportionSettings,
     Test,
@@ -110,7 +109,6 @@ export interface EpicTest extends Test<EpicVariant> {
     highPriority: boolean;
     useLocalViewLog: boolean;
     articlesViewedSettings?: ArticlesViewedSettings;
-    articlesViewedByTagSettings?: ArticlesViewedByTagSettings;
     hasArticleCountInCopy: boolean;
 
     audience?: number;

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -29,7 +29,7 @@ export interface MaxViews {
 export interface SeparateArticleCount {
     type: 'above';
     copy?: string;
-    countType?: ArticleCountType;
+    countType?: ArticleCountType; // defaults to `for52Weeks`
 }
 
 export interface EpicVariant extends Variant {

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -9,7 +9,14 @@ import {
     Variant,
 } from './shared';
 import { EpicTargeting } from '../targeting';
-import { BylineWithImage, Cta, Image, SecondaryCta, TickerSettings } from '../props';
+import {
+    ArticleCountType,
+    BylineWithImage,
+    Cta,
+    Image,
+    SecondaryCta,
+    TickerSettings,
+} from '../props';
 
 export type EpicType = 'ARTICLE' | 'LIVEBLOG';
 
@@ -22,6 +29,7 @@ export interface MaxViews {
 export interface SeparateArticleCount {
     type: 'above';
     copy?: string;
+    countType?: ArticleCountType;
 }
 
 export interface EpicVariant extends Variant {

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -31,12 +31,7 @@ export interface ArticlesViewedSettings {
     minViews: number;
     maxViews?: number;
     periodInWeeks: number;
-}
-
-export interface ArticlesViewedByTagSettings {
-    tagId: string;
-    minViews: number;
-    periodInWeeks: number;
+    tagId?: string;
 }
 
 /**

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -14,7 +14,7 @@ import { EpicVariant } from '../abTests';
 
 export type ArticleCountType =
     | 'for52Weeks' // The user's total article view count, which currently goes back as far as 52 weeks
-    | 'forTargetedWeeks'; // The user's article view count for the configured periodInWeeks, and by tag if articlesViewedByTagSettings is set
+    | 'forTargetedWeeks'; // The user's article view count for the configured periodInWeeks/tag
 
 export type ArticleCounts = {
     [type in ArticleCountType]: number;

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -12,10 +12,13 @@ import {
 import { OphanComponentEvent } from '../ophan';
 import { EpicVariant } from '../abTests';
 
-export interface ArticleCounts {
-    for52Weeks: number; // The user's total article view count, which currently goes back as far as 52 weeks
-    forTargetedWeeks: number; // The user's article view count for the configured periodInWeeks, and by tag if articlesViewedByTagSettings is set
-}
+export type ArticleCountType =
+    | 'for52Weeks' // The user's total article view count, which currently goes back as far as 52 weeks
+    | 'forTargetedWeeks'; // The user's article view count for the configured periodInWeeks, and by tag if articlesViewedByTagSettings is set
+
+export type ArticleCounts = {
+    [type in ArticleCountType]: number;
+};
 
 export type EpicProps = {
     variant: EpicVariant;

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -14,7 +14,7 @@ import { EpicVariant } from '../abTests';
 
 export interface ArticleCounts {
     for52Weeks: number; // The user's total article view count, which currently goes back as far as 52 weeks
-    forTargetedWeeks: number; // The user's article view count for the configured periodInWeeks
+    forTargetedWeeks: number; // The user's article view count for the configured periodInWeeks, and by tag if articlesViewedByTagSettings is set
 }
 
 export type EpicProps = {


### PR DESCRIPTION
Last year we ran [a test](https://github.com/guardian/support-dotcom-components/pull/557) to display article count based on the environment tag.
This PR adds a similar hardcoded test.
It's simpler because it only has 1 variant (the original test had an extra variant for showing the environment count in the body copy as well as the main count above).

I've also done some refactoring, as the "above" article count logic has evolved since the last test:
1. removed the `aboveArticleCountByTag` field. This hasn't been used since the original test, and was specifically to enable the two variants (one of which put the count in the body).
2. adds the `separateArticleCount.countType` field to decide which article count (`for52Weeks` vs `forTargetedWeeks`) to use, per variant. This enables us to show the targeted (environment) count in the variant.
3. removes the `articlesViewedByTagSettings` field, which hasn't been used since the first test. Instead, I've added the `tagId` field into `articlesViewedSettings`. There's no longer any need to have these separate.
4. combines the `ArticleCount` and `TopReaderArticleCount` components - the check for >= 50 is done in here.

Note - point 2 changes the api, and so if we put the test live now there's a risk of cached versions of the epic module not being aware of it. So - this PR leaves the test status in `Draft` for now. A follow up PR can put it live.

None of this affects RRCP - which has never had any awareness of tag-level article counting.


### Control (>=50) - shows overall article count
<img width="575" alt="Screen Shot 2022-09-06 at 16 40 58" src="https://user-images.githubusercontent.com/1513454/188679085-0d21da00-1249-461d-91e1-be273061afe3.png">

### Control (<50) - shows overall article count
<img width="575" alt="Screen Shot 2022-09-06 at 16 41 35" src="https://user-images.githubusercontent.com/1513454/188679098-af4a3fcd-1dbf-4131-b370-7f4d9eaaf663.png">

### Variant - shows environment article count
![Screen Shot 2022-09-07 at 15 01 14](https://user-images.githubusercontent.com/1513454/188897720-3dc28044-f19d-4864-be56-64c83839af0f.png)
