### PR TITLE
Lower autoscaling threshold to 40% cpu

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -267,7 +267,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
           "PredefinedMetricSpecification": Object {
             "PredefinedMetricType": "ASGAverageCPUUtilization",
           },
-          "TargetValue": 50,
+          "TargetValue": 40,
         },
       },
       "Type": "AWS::AutoScaling::ScalingPolicy",

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -152,7 +152,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
         });
 
         ec2App.autoScalingGroup.scaleOnCpuUtilization('CpuScalingPolicy', {
-            targetUtilizationPercent: 50,
+            targetUtilizationPercent: 40,
         });
     }
 }


### PR DESCRIPTION
SDC failed to scale-out during high traffic after a big news event.
We do have autoscaling enabled, but for some reason it did not scale-out. Instead, instances intermittently failed health checks and were replaced.
Scale-out should happen at 50% cpu utilization but didn't - perhaps because instances kept failing health checks.
Here's the period where service was degraded and instances were being replaced:
<img width="1456" alt="Screen Shot 2022-09-08 at 20 24 54" src="https://user-images.githubusercontent.com/1513454/189367672-93e0cb8b-4b9e-4a52-9859-ebdeb0565d5b.png">

Average cpu utilization is typically in the 20s, so a 40% threshold should only trigger scale-out during high traffic moments -
![Screen Shot 2022-09-09 at 14 58 17](https://user-images.githubusercontent.com/1513454/189367936-aaf67669-171f-4350-9b57-e9f0209392d4.png)
