### PR TITLE
Add reminder CTA option to Liveblog Epic variants

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -11,8 +11,6 @@ import {
 } from '@sdc/shared/lib';
 import { ContributionFrequency, EpicProps, epicPropsSchema, Stage } from '@sdc/shared/types';
 import { BylineWithHeadshot } from './BylineWithHeadshot';
-import { ContributionsEpicReminder } from './ContributionsEpicReminder';
-import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { ContributionsEpicTicker } from './ContributionsEpicTicker';
 import { replaceArticleCount } from '../../lib/replaceArticleCount';
 import { OphanTracking } from '../shared/ArticleCountOptOutPopup';
@@ -24,9 +22,9 @@ import { withParsedProps } from '../shared/ModuleWrapper';
 import { ChoiceCardSelection, ContributionsEpicChoiceCards } from './ContributionsEpicChoiceCards';
 import { ContributionsEpicSignInCta } from './ContributionsEpicSignInCta';
 import { countryCodeToCountryGroupId } from '@sdc/shared/lib';
-import { defineFetchEmail } from '../shared/helpers/definedFetchEmail';
 import { logEpicView } from '@sdc/shared/lib';
 import NewsletterSignup from './NewsletterSignup';
+import { ContributionsEpicCtas } from './ContributionsEpicCtas';
 
 const sendEpicViewEvent = (url: string, countryCode?: string, stage?: Stage): void => {
     const path = 'events/epic-view';
@@ -136,10 +134,6 @@ type BodyProps = {
     tracking?: OphanTracking;
     showAboveArticleCount: boolean;
 };
-
-interface OnReminderOpen {
-    buttonCopyAsString: string;
-}
 
 interface EpicHeaderProps {
     text: string;
@@ -279,19 +273,9 @@ const ContributionsEpic: React.FC<EpicProps> = ({
         },
     );
 
-    const [isReminderActive, setIsReminderActive] = useState(false);
     const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } = useArticleCountOptOut();
 
-    const [fetchedEmail, setFetchedEmail] = useState<string | undefined>(undefined);
-    const fetchEmailDefined = defineFetchEmail(email, fetchEmail);
-
-    const {
-        image,
-        showReminderFields,
-        tickerSettings,
-        showChoiceCards,
-        choiceCardAmounts,
-    } = variant;
+    const { image, tickerSettings, showChoiceCards, choiceCardAmounts } = variant;
 
     const [hasBeenSeen, setNode] = useHasBeenSeen({ threshold: 0 }, true) as HasBeenSeen;
 
@@ -343,10 +327,6 @@ const ContributionsEpic: React.FC<EpicProps> = ({
     const showAboveArticleCount = !!(
         variant.separateArticleCount?.type === 'above' && hasConsentForArticleCount
     );
-
-    const onCloseReminderClick = () => {
-        setIsReminderActive(false);
-    };
 
     return (
         <section ref={setNode} css={wrapperStyles}>
@@ -416,44 +396,14 @@ const ContributionsEpic: React.FC<EpicProps> = ({
             {variant.newsletterSignup ? (
                 <NewsletterSignup url={variant.newsletterSignup.url} />
             ) : (
-                <ContributionsEpicButtons
+                <ContributionsEpicCtas
                     variant={variant}
                     tracking={tracking}
                     countryCode={countryCode}
-                    onOpenReminderClick={(): void => {
-                        const buttonCopyAsString = showReminderFields?.reminderCta
-                            .toLowerCase()
-                            .replace(/\s/g, '-');
-
-                        // This callback lets the platform react to the user interaction with the
-                        // 'Remind me' button
-                        if (onReminderOpen) {
-                            onReminderOpen({
-                                buttonCopyAsString,
-                            } as OnReminderOpen);
-                        }
-
-                        fetchEmailDefined().then(resolvedEmail => {
-                            if (resolvedEmail) {
-                                setFetchedEmail(resolvedEmail);
-                            }
-                            setIsReminderActive(true);
-                        });
-                    }}
-                    submitComponentEvent={submitComponentEvent}
-                    isReminderActive={isReminderActive}
-                    isSignedIn={Boolean(fetchedEmail)}
-                    showChoiceCards={showChoiceCards}
-                    choiceCardSelection={choiceCardSelection}
-                    numArticles={articleCounts.for52Weeks}
-                />
-            )}
-
-            {isReminderActive && showReminderFields && (
-                <ContributionsEpicReminder
-                    initialEmailAddress={fetchedEmail}
-                    reminderFields={showReminderFields}
-                    onCloseReminderClick={onCloseReminderClick}
+                    articleCounts={articleCounts}
+                    onReminderOpen={onReminderOpen}
+                    email={email}
+                    fetchEmail={fetchEmail}
                     submitComponentEvent={submitComponentEvent}
                 />
             )}

--- a/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
@@ -63,7 +63,11 @@ const PrimaryCtaButton = ({
 
     return (
         <div css={buttonMargins}>
-            <Button onClickAction={urlWithRegionAndTracking} showArrow>
+            <Button
+                onClickAction={urlWithRegionAndTracking}
+                showArrow
+                data-ignore="global-link-styling"
+            >
                 {buttonText}
             </Button>
         </div>

--- a/packages/modules/src/modules/epics/ContributionsEpicCtas.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicCtas.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { createViewEventFromTracking, createInsertEventFromTracking } from '@sdc/shared/lib';
+import { EpicProps } from '@sdc/shared/types';
+import { ContributionsEpicReminder } from './ContributionsEpicReminder';
+import { ContributionsEpicButtons } from './ContributionsEpicButtons';
+import { defineFetchEmail } from '../shared/helpers/definedFetchEmail';
+
+interface OnReminderOpen {
+    buttonCopyAsString: string;
+}
+
+export const ContributionsEpicCtas: React.FC<EpicProps> = ({
+    variant,
+    countryCode,
+    articleCounts,
+    tracking,
+    submitComponentEvent,
+    onReminderOpen,
+    email,
+    fetchEmail,
+}: EpicProps): JSX.Element | null => {
+    useEffect(() => {
+        if (submitComponentEvent) {
+            submitComponentEvent(createViewEventFromTracking(tracking, tracking.campaignCode));
+            submitComponentEvent(createInsertEventFromTracking(tracking, tracking.campaignCode));
+        }
+    }, [submitComponentEvent]);
+
+    const [fetchedEmail, setFetchedEmail] = useState<string | undefined>(undefined);
+    const fetchEmailDefined = defineFetchEmail(email, fetchEmail);
+    const [isReminderActive, setIsReminderActive] = useState(false);
+    const showReminderFields = variant.showReminderFields;
+    const onCloseReminderClick = () => {
+        setIsReminderActive(false);
+    };
+
+    return (
+        <>
+            <ContributionsEpicButtons
+                variant={variant}
+                tracking={tracking}
+                countryCode={countryCode}
+                onOpenReminderClick={(): void => {
+                    const buttonCopyAsString = showReminderFields?.reminderCta
+                        .toLowerCase()
+                        .replace(/\s/g, '-');
+
+                    // This callback lets the platform react to the user interaction with the
+                    // 'Remind me' button
+                    if (onReminderOpen) {
+                        onReminderOpen({
+                            buttonCopyAsString,
+                        } as OnReminderOpen);
+                    }
+
+                    fetchEmailDefined().then(resolvedEmail => {
+                        if (resolvedEmail) {
+                            setFetchedEmail(resolvedEmail);
+                        }
+                        setIsReminderActive(true);
+                    });
+                }}
+                submitComponentEvent={submitComponentEvent}
+                isReminderActive={isReminderActive}
+                isSignedIn={Boolean(fetchedEmail)}
+                showChoiceCards={false}
+                choiceCardSelection={undefined}
+                numArticles={articleCounts.for52Weeks}
+            />
+
+            {isReminderActive && showReminderFields && (
+                <ContributionsEpicReminder
+                    initialEmailAddress={fetchedEmail}
+                    reminderFields={showReminderFields}
+                    onCloseReminderClick={onCloseReminderClick}
+                    submitComponentEvent={submitComponentEvent}
+                />
+            )}
+        </>
+    );
+};

--- a/packages/modules/src/modules/epics/ContributionsEpicCtas.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicCtas.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import { createViewEventFromTracking, createInsertEventFromTracking } from '@sdc/shared/lib';
+import React, { useState } from 'react';
 import { EpicProps } from '@sdc/shared/types';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { ContributionsEpicButtons } from './ContributionsEpicButtons';
@@ -19,13 +18,6 @@ export const ContributionsEpicCtas: React.FC<EpicProps> = ({
     email,
     fetchEmail,
 }: EpicProps): JSX.Element | null => {
-    useEffect(() => {
-        if (submitComponentEvent) {
-            submitComponentEvent(createViewEventFromTracking(tracking, tracking.campaignCode));
-            submitComponentEvent(createInsertEventFromTracking(tracking, tracking.campaignCode));
-        }
-    }, [submitComponentEvent]);
-
     const [fetchedEmail, setFetchedEmail] = useState<string | undefined>(undefined);
     const fetchEmailDefined = defineFetchEmail(email, fetchEmail);
     const [isReminderActive, setIsReminderActive] = useState(false);

--- a/packages/modules/src/modules/epics/ContributionsLiveblogEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsLiveblogEpic.stories.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { ContributionsLiveblogEpic } from './ContributionsLiveblogEpic';
 import { Story, Meta } from '@storybook/react';
-import { EpicProps } from '@sdc/shared/types';
+import { EpicProps, SecondaryCtaType } from '@sdc/shared/types';
 import { props } from './utils/storybook';
-import { WithReminder } from '../banners/contributions/ContributionsBanner.stories';
 
 export default {
     component: ContributionsLiveblogEpic,
@@ -13,24 +12,43 @@ export default {
 
 const Template: Story<EpicProps> = (props: EpicProps) => <ContributionsLiveblogEpic {...props} />;
 
-export const Default = Template.bind({});
-
-export const WithoutSupportUrl = Template.bind({});
-WithoutSupportUrl.args = {
-    ...WithReminder.args,
-    variant: {
-        ...props.variant,
-        cta: {
-            baseUrl: 'https://theguardian.com',
-            text: 'The Guardian',
-        },
-    },
-};
-
 export const WhenOnDCR = Template.bind({});
 WhenOnDCR.args = {
     tracking: {
         ...props.tracking,
         clientName: 'dcr',
     },
+    variant: {
+        ...props.variant,
+        secondaryCta: undefined,
+    },
 };
+
+export const WithoutSupportUrl = Template.bind({});
+WithoutSupportUrl.args = {
+    variant: {
+        ...props.variant,
+        cta: {
+            baseUrl: 'https://theguardian.com',
+            text: 'The Guardian',
+        },
+        secondaryCta: undefined,
+    },
+};
+
+export const WithReminderCta = Template.bind({});
+WithReminderCta.args = {
+    variant: {
+        ...props.variant,
+        secondaryCta: {
+            type: SecondaryCtaType.ContributionsReminder,
+        },
+        showReminderFields: {
+            reminderCta: 'Remind me in December',
+            reminderPeriod: '2022-12-01',
+            reminderLabel: 'December',
+        },
+    },
+};
+
+export const WithBespokeCta = Template.bind({});

--- a/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
@@ -1,25 +1,30 @@
-import React, { useEffect } from 'react';
-import { css, SerializedStyles } from '@emotion/react';
+import React, { useEffect, useState } from 'react';
+// import { css, SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { palette } from '@guardian/src-foundations';
 import { neutral, brandAlt } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
-import { LinkButton } from '@guardian/src-button';
+// import { LinkButton } from '@guardian/src-button';
 import {
     replaceNonArticleCountPlaceholders,
     containsNonArticleCountPlaceholder,
     createViewEventFromTracking,
     createInsertEventFromTracking,
-    isSupportUrl,
+    // isSupportUrl,
 } from '@sdc/shared/lib';
 import { EpicVariant, Tracking } from '@sdc/shared/types';
 import { replaceArticleCount } from '../../lib/replaceArticleCount';
-import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/lib';
+// import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/lib';
 import { ArticleCounts } from '@sdc/shared/types';
 import { HasBeenSeen, useHasBeenSeen } from '../../hooks/useHasBeenSeen';
 import { OphanComponentEvent } from '@sdc/shared/dist/types';
 import { logEpicView } from '@sdc/shared/lib';
+
+import { ContributionsEpicReminder } from './ContributionsEpicReminder';
+import { ContributionsEpicButtons } from './ContributionsEpicButtons';
+import { defineFetchEmail } from '../shared/helpers/definedFetchEmail';
 
 const container = (clientName: string) => css`
     padding: 6px 10px 28px 10px;
@@ -68,32 +73,32 @@ const textContainer = css`
     }
 `;
 
-const paymentMethods = css`
-    height: 28px;
-`;
+// const paymentMethods = css`
+//     height: 28px;
+// `;
 
-const cta: SerializedStyles = css`
-    color: ${neutral[7]};
-    background-color: ${brandAlt[400]};
+// const cta: SerializedStyles = css`
+//     color: ${neutral[7]};
+//     background-color: ${brandAlt[400]};
 
-    &:hover {
-        background-color: ${brandAlt[300]};
-    }
-`;
+//     &:hover {
+//         background-color: ${brandAlt[300]};
+//     }
+// `;
 
-const ctaContainer: SerializedStyles = css`
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    *:first-child {
-        margin-right: 25px;
-    }
+// const ctaContainer: SerializedStyles = css`
+//     display: flex;
+//     flex-wrap: wrap;
+//     align-items: center;
+//     *:first-child {
+//         margin-right: 25px;
+//     }
 
-    > * {
-        margin-top: 6px;
-        margin-bottom: 6px;
-    }
-`;
+//     > * {
+//         margin-top: 6px;
+//         margin-bottom: 6px;
+//     }
+// `;
 
 const yellowHeading = (clientName: string) => css`
     ${headline.medium({ fontWeight: 'bold' })};
@@ -146,47 +151,51 @@ const LiveblogEpicBody: React.FC<LiveblogEpicBodyProps> = ({
     );
 };
 
-const DEFAULT_CTA_TEXT = 'Make a contribution';
-const DEFAULT_CTA_BASE_URL = 'https://support.theguardian.com/uk/contribute';
+// const DEFAULT_CTA_TEXT = 'Make a contribution';
+// const DEFAULT_CTA_BASE_URL = 'https://support.theguardian.com/uk/contribute';
 
-interface LiveblogEpicCtaProps {
-    text?: string;
-    baseUrl?: string;
-    countryCode?: string;
-    numArticles?: number;
-    tracking: Tracking;
+// interface LiveblogEpicCtaProps {
+//     text?: string;
+//     baseUrl?: string;
+//     countryCode?: string;
+//     numArticles?: number;
+//     tracking: Tracking;
+// }
+
+// const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
+//     text,
+//     baseUrl,
+//     tracking,
+//     numArticles,
+//     countryCode,
+// }: LiveblogEpicCtaProps) => {
+//     const url = addRegionIdAndTrackingParamsToSupportUrl(
+//         baseUrl || DEFAULT_CTA_BASE_URL,
+//         tracking,
+//         numArticles,
+//         countryCode,
+//     );
+//     const hasSupportCta = !!baseUrl && isSupportUrl(baseUrl);
+
+//     return (
+//         <div css={ctaContainer}>
+//             <LinkButton css={cta} priority="primary" href={url} data-ignore="global-link-styling">
+//                 {text || DEFAULT_CTA_TEXT}
+//             </LinkButton>
+//             {hasSupportCta && (
+//                 <img
+//                     src="https://uploads.guim.co.uk/2021/02/04/liveblog-epic-cards.png"
+//                     alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+//                     css={paymentMethods}
+//                 />
+//             )}
+//         </div>
+//     );
+// };
+
+interface OnReminderOpen {
+    buttonCopyAsString: string;
 }
-
-const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
-    text,
-    baseUrl,
-    tracking,
-    numArticles,
-    countryCode,
-}: LiveblogEpicCtaProps) => {
-    const url = addRegionIdAndTrackingParamsToSupportUrl(
-        baseUrl || DEFAULT_CTA_BASE_URL,
-        tracking,
-        numArticles,
-        countryCode,
-    );
-    const hasSupportCta = !!baseUrl && isSupportUrl(baseUrl);
-
-    return (
-        <div css={ctaContainer}>
-            <LinkButton css={cta} priority="primary" href={url} data-ignore="global-link-styling">
-                {text || DEFAULT_CTA_TEXT}
-            </LinkButton>
-            {hasSupportCta && (
-                <img
-                    src="https://uploads.guim.co.uk/2021/02/04/liveblog-epic-cards.png"
-                    alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-                    css={paymentMethods}
-                />
-            )}
-        </div>
-    );
-};
 
 interface LiveblogEpicProps {
     variant: EpicVariant;
@@ -194,6 +203,11 @@ interface LiveblogEpicProps {
     countryCode?: string;
     articleCounts: ArticleCounts;
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
+
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    onReminderOpen?: Function;
+    email?: string;
+    fetchEmail?: () => Promise<string | null>;
 }
 
 export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
@@ -202,6 +216,10 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
     articleCounts,
     tracking,
     submitComponentEvent,
+    
+    onReminderOpen,
+    email,
+    fetchEmail,
 }: LiveblogEpicProps): JSX.Element | null => {
     const [hasBeenSeen, setNode] = useHasBeenSeen({ threshold: 0 }, true) as HasBeenSeen;
 
@@ -236,6 +254,31 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
         return null;
     }
 
+    const [fetchedEmail, setFetchedEmail] = useState<string | undefined>(undefined);
+    const fetchEmailDefined = defineFetchEmail(email, fetchEmail);
+    const [isReminderActive, setIsReminderActive] = useState(false);
+    const showReminderFields = variant.showReminderFields;
+    const onCloseReminderClick = () => {
+        setIsReminderActive(false);
+    };
+
+    // return (
+    //     <div data-cy="contributions-liveblog-epic" ref={setNode}>
+    //         {cleanHeading && <div css={yellowHeading(tracking.clientName)}>{cleanHeading}</div>}
+    //         <section css={container(tracking.clientName)}>
+    //             <LiveblogEpicBody
+    //                 paragraphs={cleanParagraphs}
+    //                 numArticles={articleCounts.forTargetedWeeks}
+    //             />
+    //             <LiveblogEpicCta
+    //                 text={variant.cta?.text}
+    //                 baseUrl={variant.cta?.baseUrl}
+    //                 tracking={tracking}
+    //             />
+    //         </section>
+    //     </div>
+    // );
+
     return (
         <div data-cy="contributions-liveblog-epic" ref={setNode}>
             {cleanHeading && <div css={yellowHeading(tracking.clientName)}>{cleanHeading}</div>}
@@ -244,11 +287,46 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
                     paragraphs={cleanParagraphs}
                     numArticles={articleCounts.forTargetedWeeks}
                 />
-                <LiveblogEpicCta
-                    text={variant.cta?.text}
-                    baseUrl={variant.cta?.baseUrl}
+                <ContributionsEpicButtons
+                    variant={variant}
                     tracking={tracking}
+                    countryCode={countryCode}
+                    onOpenReminderClick={(): void => {
+                        const buttonCopyAsString = showReminderFields?.reminderCta
+                            .toLowerCase()
+                            .replace(/\s/g, '-');
+
+                        // This callback lets the platform react to the user interaction with the
+                        // 'Remind me' button
+                        if (onReminderOpen) {
+                            onReminderOpen({
+                                buttonCopyAsString,
+                            } as OnReminderOpen);
+                        }
+
+                        fetchEmailDefined().then(resolvedEmail => {
+                            if (resolvedEmail) {
+                                setFetchedEmail(resolvedEmail);
+                            }
+                            setIsReminderActive(true);
+                        });
+                    }}
+                    submitComponentEvent={submitComponentEvent}
+                    isReminderActive={isReminderActive}
+                    isSignedIn={Boolean(fetchedEmail)}
+                    showChoiceCards={false}
+                    choiceCardSelection={undefined}
+                    numArticles={articleCounts.for52Weeks}
                 />
+
+                {isReminderActive && showReminderFields && (
+                    <ContributionsEpicReminder
+                        initialEmailAddress={fetchedEmail}
+                        reminderFields={showReminderFields}
+                        onCloseReminderClick={onCloseReminderClick}
+                        submitComponentEvent={submitComponentEvent}
+                    />
+                )}
             </section>
         </div>
     );

--- a/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsLiveblogEpic.tsx
@@ -1,30 +1,21 @@
-import React, { useEffect, useState } from 'react';
-// import { css, SerializedStyles } from '@emotion/react';
+import React, { useEffect } from 'react';
 import { css } from '@emotion/react';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { palette } from '@guardian/src-foundations';
 import { neutral, brandAlt } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
-// import { LinkButton } from '@guardian/src-button';
 import {
     replaceNonArticleCountPlaceholders,
     containsNonArticleCountPlaceholder,
     createViewEventFromTracking,
     createInsertEventFromTracking,
-    // isSupportUrl,
 } from '@sdc/shared/lib';
-import { EpicVariant, Tracking } from '@sdc/shared/types';
+import { EpicProps } from '@sdc/shared/types';
 import { replaceArticleCount } from '../../lib/replaceArticleCount';
-// import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/lib';
-import { ArticleCounts } from '@sdc/shared/types';
 import { HasBeenSeen, useHasBeenSeen } from '../../hooks/useHasBeenSeen';
-import { OphanComponentEvent } from '@sdc/shared/dist/types';
 import { logEpicView } from '@sdc/shared/lib';
-
-import { ContributionsEpicReminder } from './ContributionsEpicReminder';
-import { ContributionsEpicButtons } from './ContributionsEpicButtons';
-import { defineFetchEmail } from '../shared/helpers/definedFetchEmail';
+import { ContributionsEpicCtas } from './ContributionsEpicCtas';
 
 const container = (clientName: string) => css`
     padding: 6px 10px 28px 10px;
@@ -72,33 +63,6 @@ const textContainer = css`
         }
     }
 `;
-
-// const paymentMethods = css`
-//     height: 28px;
-// `;
-
-// const cta: SerializedStyles = css`
-//     color: ${neutral[7]};
-//     background-color: ${brandAlt[400]};
-
-//     &:hover {
-//         background-color: ${brandAlt[300]};
-//     }
-// `;
-
-// const ctaContainer: SerializedStyles = css`
-//     display: flex;
-//     flex-wrap: wrap;
-//     align-items: center;
-//     *:first-child {
-//         margin-right: 25px;
-//     }
-
-//     > * {
-//         margin-top: 6px;
-//         margin-bottom: 6px;
-//     }
-// `;
 
 const yellowHeading = (clientName: string) => css`
     ${headline.medium({ fontWeight: 'bold' })};
@@ -151,76 +115,16 @@ const LiveblogEpicBody: React.FC<LiveblogEpicBodyProps> = ({
     );
 };
 
-// const DEFAULT_CTA_TEXT = 'Make a contribution';
-// const DEFAULT_CTA_BASE_URL = 'https://support.theguardian.com/uk/contribute';
-
-// interface LiveblogEpicCtaProps {
-//     text?: string;
-//     baseUrl?: string;
-//     countryCode?: string;
-//     numArticles?: number;
-//     tracking: Tracking;
-// }
-
-// const LiveblogEpicCta: React.FC<LiveblogEpicCtaProps> = ({
-//     text,
-//     baseUrl,
-//     tracking,
-//     numArticles,
-//     countryCode,
-// }: LiveblogEpicCtaProps) => {
-//     const url = addRegionIdAndTrackingParamsToSupportUrl(
-//         baseUrl || DEFAULT_CTA_BASE_URL,
-//         tracking,
-//         numArticles,
-//         countryCode,
-//     );
-//     const hasSupportCta = !!baseUrl && isSupportUrl(baseUrl);
-
-//     return (
-//         <div css={ctaContainer}>
-//             <LinkButton css={cta} priority="primary" href={url} data-ignore="global-link-styling">
-//                 {text || DEFAULT_CTA_TEXT}
-//             </LinkButton>
-//             {hasSupportCta && (
-//                 <img
-//                     src="https://uploads.guim.co.uk/2021/02/04/liveblog-epic-cards.png"
-//                     alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-//                     css={paymentMethods}
-//                 />
-//             )}
-//         </div>
-//     );
-// };
-
-interface OnReminderOpen {
-    buttonCopyAsString: string;
-}
-
-interface LiveblogEpicProps {
-    variant: EpicVariant;
-    tracking: Tracking;
-    countryCode?: string;
-    articleCounts: ArticleCounts;
-    submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
-
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    onReminderOpen?: Function;
-    email?: string;
-    fetchEmail?: () => Promise<string | null>;
-}
-
-export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
+export const ContributionsLiveblogEpic: React.FC<EpicProps> = ({
     variant,
     countryCode,
     articleCounts,
     tracking,
     submitComponentEvent,
-    
     onReminderOpen,
     email,
     fetchEmail,
-}: LiveblogEpicProps): JSX.Element | null => {
+}: EpicProps): JSX.Element | null => {
     const [hasBeenSeen, setNode] = useHasBeenSeen({ threshold: 0 }, true) as HasBeenSeen;
 
     useEffect(() => {
@@ -254,31 +158,6 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
         return null;
     }
 
-    const [fetchedEmail, setFetchedEmail] = useState<string | undefined>(undefined);
-    const fetchEmailDefined = defineFetchEmail(email, fetchEmail);
-    const [isReminderActive, setIsReminderActive] = useState(false);
-    const showReminderFields = variant.showReminderFields;
-    const onCloseReminderClick = () => {
-        setIsReminderActive(false);
-    };
-
-    // return (
-    //     <div data-cy="contributions-liveblog-epic" ref={setNode}>
-    //         {cleanHeading && <div css={yellowHeading(tracking.clientName)}>{cleanHeading}</div>}
-    //         <section css={container(tracking.clientName)}>
-    //             <LiveblogEpicBody
-    //                 paragraphs={cleanParagraphs}
-    //                 numArticles={articleCounts.forTargetedWeeks}
-    //             />
-    //             <LiveblogEpicCta
-    //                 text={variant.cta?.text}
-    //                 baseUrl={variant.cta?.baseUrl}
-    //                 tracking={tracking}
-    //             />
-    //         </section>
-    //     </div>
-    // );
-
     return (
         <div data-cy="contributions-liveblog-epic" ref={setNode}>
             {cleanHeading && <div css={yellowHeading(tracking.clientName)}>{cleanHeading}</div>}
@@ -287,46 +166,17 @@ export const ContributionsLiveblogEpic: React.FC<LiveblogEpicProps> = ({
                     paragraphs={cleanParagraphs}
                     numArticles={articleCounts.forTargetedWeeks}
                 />
-                <ContributionsEpicButtons
+
+                <ContributionsEpicCtas
                     variant={variant}
                     tracking={tracking}
                     countryCode={countryCode}
-                    onOpenReminderClick={(): void => {
-                        const buttonCopyAsString = showReminderFields?.reminderCta
-                            .toLowerCase()
-                            .replace(/\s/g, '-');
-
-                        // This callback lets the platform react to the user interaction with the
-                        // 'Remind me' button
-                        if (onReminderOpen) {
-                            onReminderOpen({
-                                buttonCopyAsString,
-                            } as OnReminderOpen);
-                        }
-
-                        fetchEmailDefined().then(resolvedEmail => {
-                            if (resolvedEmail) {
-                                setFetchedEmail(resolvedEmail);
-                            }
-                            setIsReminderActive(true);
-                        });
-                    }}
+                    articleCounts={articleCounts}
+                    onReminderOpen={onReminderOpen}
+                    email={email}
+                    fetchEmail={fetchEmail}
                     submitComponentEvent={submitComponentEvent}
-                    isReminderActive={isReminderActive}
-                    isSignedIn={Boolean(fetchedEmail)}
-                    showChoiceCards={false}
-                    choiceCardSelection={undefined}
-                    numArticles={articleCounts.for52Weeks}
                 />
-
-                {isReminderActive && showReminderFields && (
-                    <ContributionsEpicReminder
-                        initialEmailAddress={fetchedEmail}
-                        reminderFields={showReminderFields}
-                        onCloseReminderClick={onCloseReminderClick}
-                        submitComponentEvent={submitComponentEvent}
-                    />
-                )}
             </section>
         </div>
     );


### PR DESCRIPTION
## What does this change?
Marketing have requested the ability to add a Reminder CTA button to Liveblog Epics. This PR enables the reminder CTA button, form and accompanying functionality work in Liveblog Epic messages.

To make this work, I've refactored the Contributions CTA+Reminder buttons into their own component which can be shared between classic Contributions epics, and Liveblog Epics

A second PR in the SAC repo makes the functionality available to Marketing in RRCP - https://github.com/guardian/support-admin-console/pull/387

**Screenshots**

![Screenshot 2022-09-22 at 11 13 49](https://user-images.githubusercontent.com/5357530/191726952-ba5a60ce-8536-41e3-8072-63c023b363fb.png)

![Screenshot 2022-09-22 at 11 14 37](https://user-images.githubusercontent.com/5357530/191726874-fb0784ff-eb83-442e-80c7-7371939ebecc.png)

![Screenshot 2022-09-22 at 11 15 45](https://user-images.githubusercontent.com/5357530/191726898-5631be55-49cf-4112-b93c-2b9a17e5d8fd.png)

![Screenshot 2022-09-22 at 11 30 22](https://user-images.githubusercontent.com/5357530/191727025-1f793054-7455-4ea4-a27a-491cdd57ae07.png)

![Screenshot 2022-09-22 at 11 30 36](https://user-images.githubusercontent.com/5357530/191727045-35a61bbc-5c9e-4a22-aa76-1172692bacf7.png)
