### PR TITLE
Exclude recent single contributors from all messaging

### DIFF
--- a/packages/dotcom/package.json
+++ b/packages/dotcom/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/support-dotcom-components",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "license": "MIT",
     "main": "dist/index.js",
     "module": "dist/index.esm.js",

--- a/packages/server/src/lib/targeting.test.ts
+++ b/packages/server/src/lib/targeting.test.ts
@@ -1,5 +1,5 @@
 import { factories } from '../factories';
-import { shouldNotRenderEpic, shouldThrottle } from './targeting';
+import { audienceMatches, shouldNotRenderEpic, shouldThrottle } from './targeting';
 
 describe('shouldNotRenderEpic', () => {
     it('returns true for blacklisted section', () => {
@@ -11,6 +11,59 @@ describe('shouldNotRenderEpic', () => {
     it('returns false for valid data', () => {
         const data = factories.targeting.build();
         const got = shouldNotRenderEpic(data);
+        expect(got).toBe(false);
+    });
+});
+
+describe('audienceMatches', () => {
+    it('returns true for non-supporter if test is for AllNonSupporters', () => {
+        const got = audienceMatches(true, 'AllNonSupporters');
+        expect(got).toBe(true);
+    });
+    it('returns false for non-supporter if test is for AllExistingSupporters', () => {
+        const got = audienceMatches(true, 'AllExistingSupporters');
+        expect(got).toBe(false);
+    });
+
+    it('returns false for supporter if test is for AllNonSupporters', () => {
+        const got = audienceMatches(false, 'AllNonSupporters');
+        expect(got).toBe(false);
+    });
+    it('returns true for supporter if test is for AllExistingSupporters', () => {
+        const got = audienceMatches(false, 'AllExistingSupporters');
+        expect(got).toBe(true);
+    });
+
+    it('returns false for recent contributor if test is for AllExistingSupporters', () => {
+        const got = audienceMatches(
+            false,
+            'AllExistingSupporters',
+            '2022-01-01',
+            new Date('2022-01-02'),
+        );
+        expect(got).toBe(false);
+    });
+    it('returns false for recent contributor if test is for AllNonSupporters', () => {
+        const got = audienceMatches(
+            false,
+            'AllNonSupporters',
+            '2022-01-01',
+            new Date('2022-01-02'),
+        );
+        expect(got).toBe(false);
+    });
+
+    it('returns true for old contributor if test is for AllNonSupporters', () => {
+        const got = audienceMatches(true, 'AllNonSupporters', '2021-01-01', new Date('2022-01-02'));
+        expect(got).toBe(true);
+    });
+    it('returns false for old contributor if test is for AllExistingSupporters', () => {
+        const got = audienceMatches(
+            true,
+            'AllExistingSupporters',
+            '2021-01-01',
+            new Date('2022-01-02'),
+        );
         expect(got).toBe(false);
     });
 });

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -63,10 +63,14 @@ export const audienceMatches = (
     showSupportMessaging: boolean,
     testAudience: UserCohort,
     lastOneOffContributionDate?: string,
+    now: Date = new Date(Date.now()),
 ): boolean => {
-    if (lastOneOffContributionDate) {
+    const recentContributor =
+        !!lastOneOffContributionDate &&
+        isRecentOneOffContributor(new Date(lastOneOffContributionDate), now);
+    if (recentContributor) {
         // Recent contributors are excluded from all message tests
-        return !isRecentOneOffContributor(new Date(lastOneOffContributionDate));
+        return false;
     }
     switch (testAudience) {
         case 'AllNonSupporters':

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -1,5 +1,5 @@
 import { EpicTargeting, UserCohort, EpicViewLog, Test, Variant } from '@sdc/shared/types';
-import { daysSince } from './dates';
+import { daysSince, isRecentOneOffContributor } from './dates';
 
 const lowValueSections = ['money', 'education', 'games', 'teacher-network', 'careers'];
 
@@ -62,7 +62,12 @@ export const userIsInTest = <V extends Variant>(test: Test<V>, mvtId: number): b
 export const audienceMatches = (
     showSupportMessaging: boolean,
     testAudience: UserCohort,
+    lastOneOffContributionDate?: string,
 ): boolean => {
+    if (lastOneOffContributionDate) {
+        // Recent contributors are excluded from all message tests
+        return !isRecentOneOffContributor(new Date(lastOneOffContributionDate));
+    }
     switch (testAudience) {
         case 'AllNonSupporters':
             return showSupportMessaging;

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -156,7 +156,11 @@ export const selectBannerTest = async (
             (enableHardcodedBannerTests || !test.isHardcoded) &&
             !targeting.shouldHideReaderRevenue &&
             !targeting.isPaidContent &&
-            audienceMatches(targeting.showSupportMessaging, test.userCohort) &&
+            audienceMatches(
+                targeting.showSupportMessaging,
+                test.userCohort,
+                targeting.lastOneOffContributionDate,
+            ) &&
             inCountryGroups(targeting.countryCode, test.locations) &&
             targeting.alreadyVisitedCount >= test.minPageViews &&
             !(test.articlesViewedSettings && targeting.hasOptedOutOfArticleCount) &&

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -185,7 +185,7 @@ describe('getUserCohort', () => {
         expect(got).toEqual(['AllExistingSupporters', 'Everyone']);
     });
 
-    it('should return "AllExistingSupporters" when user has recent one-off contribution', () => {
+    it('should return [] when user has recent one-off contribution', () => {
         const targeting: EpicTargeting = {
             ...targetingDefault,
             lastOneOffContributionDate: twoMonthsAgo,
@@ -193,7 +193,7 @@ describe('getUserCohort', () => {
 
         const got = withNowAs(now, () => getUserCohorts(targeting));
 
-        expect(got).toEqual(['AllExistingSupporters', 'Everyone']);
+        expect(got).toEqual([]);
     });
 
     it('should return "PostAskPauseSingleContributors" when user has older one-off contribution', () => {

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -32,6 +32,11 @@ export const getUserCohorts = (targeting: EpicTargeting): UserCohort[] => {
         ? new Date(targeting.lastOneOffContributionDate)
         : undefined;
 
+    if (isRecentOneOffContributor(lastOneOffContributionDate)) {
+        // Recent contributors are excluded from all message tests
+        return [];
+    }
+
     // User is a current supporter if she has a subscription or a recurring
     // donation or has made a one-off contribution in the past 3 months.
     const isSupporter =

--- a/packages/server/src/tests/headers/headerSelection.ts
+++ b/packages/server/src/tests/headers/headerSelection.ts
@@ -300,7 +300,11 @@ export const selectBestTest = (
 
         return (
             status === 'Live' &&
-            audienceMatches(showSupportMessaging, userCohort) &&
+            audienceMatches(
+                showSupportMessaging,
+                userCohort,
+                targeting.lastOneOffContributionDate,
+            ) &&
             inCountryGroups(countryCode, locations) &&
             userIsInTest(test, targeting.mvtId) &&
             deviceTypeMatches(test, isMobile) &&

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -20,6 +20,7 @@ export type BannerTargeting = {
     browserId?: string; // Only present if the user has consented to browserId-based targeting
     purchaseInfo?: PurchaseInfo;
     isSignedIn: boolean;
+    lastOneOffContributionDate?: string;
 };
 
 export type BannerPayload = {


### PR DESCRIPTION
We never want recent single contributors to see a message.
This PR uses the `lastOneOffContributionDate` provided by the client (dotcom).

- epic and header - already have `lastOneOffContributionDate` in the targeting payload (for targeting old contributors)
- banner did not already have `lastOneOffContributionDate`

Header and banner shared targeting logic (the `audienceMatches` function), but the epic targeting logic is separate. We should really consolidate them, but now is not the time!

This will require an npm release, as DCR/frontend will need to include `lastOneOffContributionDate` in the payload for banners.