### PR TITLE
Fix modules when running locally

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -47,7 +47,7 @@ const buildApp = (): Promise<Express> => {
     // Only serve the modules from this server when running locally (DEV).
     // In PROD/CODE we serve them from S3 via fastly.
     if (isDev) {
-        buildModulesRouter();
+        app.use(buildModulesRouter());
     }
 
     app.use(errorHandlingMiddleware);


### PR DESCRIPTION
when running locally we serve the modules from the node server. My recent refactor broke this