### PR TITLE
Switch to disable scheduled banner deploys

### DIFF
--- a/packages/server/src/api/bannerRouter.ts
+++ b/packages/server/src/api/bannerRouter.ts
@@ -54,7 +54,12 @@ export const buildBannerRouter = (): Router => {
         params: Params,
         req: express.Request,
     ): Promise<BannerDataResponse> => {
-        const { enableBanners, enableHardcodedBannerTests } = await cachedChannelSwitches();
+        const {
+            enableBanners,
+            enableHardcodedBannerTests,
+            enableScheduledBannerDeploys,
+        } = await cachedChannelSwitches();
+
         if (!enableBanners) {
             return {};
         }
@@ -69,6 +74,7 @@ export const buildBannerRouter = (): Router => {
             getCachedTests,
             bannerDeployCaches,
             enableHardcodedBannerTests,
+            enableScheduledBannerDeploys,
             params.force,
         );
 

--- a/packages/server/src/channelSwitches.ts
+++ b/packages/server/src/channelSwitches.ts
@@ -9,12 +9,16 @@ interface ChannelSwitches {
     enableSuperMode: boolean;
     enableHardcodedEpicTests: boolean;
     enableHardcodedBannerTests: boolean;
+    enableScheduledBannerDeploys: boolean;
 }
 
 const getSwitches = (): Promise<ChannelSwitches> =>
-    fetchS3Data('support-admin-console', `${isProd ? 'PROD' : 'CODE'}/channel-switches.json`).then(
-        JSON.parse,
-    );
+    fetchS3Data('support-admin-console', `${isProd ? 'PROD' : 'CODE'}/channel-switches.json`)
+        .then(JSON.parse)
+        .then(switches => ({
+            enableScheduledBannerDeploys: false,
+            ...switches,
+        }));
 
 const cachedChannelSwitches = cacheAsync<ChannelSwitches>(getSwitches, { ttlSec: 60, warm: true });
 

--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -30,6 +30,7 @@ describe('selectBannerTest', () => {
     const secondDate = 'Mon Jul 06 2020 19:20:10 GMT+0100';
 
     const enableHardcodedBannerTests = true;
+    const enableScheduledBannerDeploys = true;
 
     describe('Contributions banner rules', () => {
         const now = new Date('2020-03-31T12:30:00');
@@ -96,6 +97,7 @@ describe('selectBannerTest', () => {
                 () => Promise.resolve([test]),
                 cache,
                 enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
                 undefined,
                 now,
             ).then(result => {
@@ -114,6 +116,7 @@ describe('selectBannerTest', () => {
                 () => Promise.resolve([{ ...test, isHardcoded: true }]),
                 cache,
                 false,
+                enableScheduledBannerDeploys,
                 undefined,
                 now,
             ).then(result => {
@@ -132,6 +135,7 @@ describe('selectBannerTest', () => {
                 () => Promise.resolve([test]),
                 cache,
                 enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
                 undefined,
                 now,
             ).then(result => {
@@ -156,6 +160,7 @@ describe('selectBannerTest', () => {
                     ]),
                 cache,
                 enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
                 undefined,
                 now,
             ).then(result => {
@@ -174,6 +179,7 @@ describe('selectBannerTest', () => {
                 () => Promise.resolve([test]),
                 cache,
                 enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
                 undefined,
                 now,
             ).then(result => {
@@ -246,6 +252,7 @@ describe('selectBannerTest', () => {
                 () => Promise.resolve([test]),
                 cache,
                 enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
                 undefined,
                 now,
             ).then(result => {
@@ -264,6 +271,7 @@ describe('selectBannerTest', () => {
                 () => Promise.resolve([test]),
                 cache,
                 enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
                 undefined,
                 now,
             ).then(result => {
@@ -288,6 +296,7 @@ describe('selectBannerTest', () => {
                     ]),
                 cache,
                 enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
                 undefined,
                 now,
             ).then(result => {
@@ -360,6 +369,7 @@ describe('selectBannerTest', () => {
                 () => Promise.resolve(tests),
                 cache,
                 enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
                 undefined,
                 now,
             );


### PR DESCRIPTION
We've been asked to disable scheduled deploys temporarily.
This is the second time, so I'm adding a switch (`enableScheduledBannerDeploys`) which can later be controlled from the RRCP channel switches page.