### PR TITLE
pd gw banner rebrand

### DIFF
--- a/packages/modules/src/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
@@ -6,7 +6,7 @@ import { BannerContent, BannerProps, SecondaryCtaType, Tracking } from '@sdc/sha
 
 export default {
     component: DigitalSubscriptionsBanner,
-    title: 'Components/DigitalSubscriptionsBanner',
+    title: 'Banners/DigitalSubscriptionsBanner',
     decorators: [
         withKnobs({
             escapeHTML: false,

--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -33,13 +33,13 @@ const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
 const desktopImg =
-    'https://i.guim.co.uk/img/media/060da9911ab00cab8ba1cbea1ef1f3e0aa3a5b3d/0_0_2652_1360/master/2652.png?width=2652&height=1360&quality=85&s=2d196b52268a96862f08cf069d02f3fd';
+    'https://i.guim.co.uk/img/media/4b36918edf028c506083be0495b31559074c018f/0_0_2562_1360/2562.png?width=2562&height=1360&quality=85&s=7a219628fd6da85f50cd8765f844df45';
 
 const tabletImg =
-    'https://i.guim.co.uk/img/media/dcec52aa7c6bc86a40707ef13d2f0f0cd3ecae5d/0_0_1340_1320/1340.png?width=1340&height=1320&quality=85&s=c6e2bad18f00b1c5919551d1708e334b ';
+    'https://i.guim.co.uk/img/media/304298d179d8ce1532bc5b24995cf4cdbe2dc0f2/0_0_1340_1320/1340.png?width=1340&height=1320&quality=85&s=be7c94e0957645ec744a40c1ecdc191b';
 
 const mobileImg =
-    'https://i.guim.co.uk/img/media/f28953842cda0a17b77eda99fd7afb7c95f669b1/0_0_1220_658/1220.png?width=1220&height=658&quality=85&s=14c48d29ff01b16ba3cc0259f4368115';
+    'https://i.guim.co.uk/img/media/bcab68214a87819d11297f639ddb3d188ca7a8a6/0_0_1220_658/1220.png?width=1220&height=658&quality=85&s=a6be539e33a4a8afe450eb7c8dda24f1';
 
 // Responsive image props
 const baseImg = {

--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -4,7 +4,7 @@ import { Container, Columns, Column, Inline } from '@guardian/src-layout';
 import { Button, LinkButton, buttonReaderRevenue } from '@guardian/src-button';
 import { Link } from '@guardian/src-link';
 import { SvgRoundelDefault } from '@guardian/src-brand';
-import { SvgCross } from '@guardian/src-icons';
+import { SvgArrowRightStraight, SvgCross } from '@guardian/src-icons';
 import {
     banner,
     closeButtonStyles,
@@ -33,13 +33,13 @@ const closeComponentId = `${bannerId} : close`;
 const signInComponentId = `${bannerId} : sign in`;
 
 const desktopImg =
-    'https://i.guim.co.uk/img/media/967ec1805daa9ec4db1bc67b03483b35eedbfdc8/0_0_2652_1360/2652.png?quality=85&s=9532422abba16964f23eca875c795ffa';
+    'https://i.guim.co.uk/img/media/060da9911ab00cab8ba1cbea1ef1f3e0aa3a5b3d/0_0_2652_1360/master/2652.png?width=2652&height=1360&quality=85&s=2d196b52268a96862f08cf069d02f3fd';
 
 const tabletImg =
-    'https://i.guim.co.uk/img/media/7d4e9663ded1545f85abcb8ce0b74e03727870cc/0_0_1340_1320/1340.png?quality=85&s=4baeef8070cc8142461c9426c4a6dc2c';
+    'https://i.guim.co.uk/img/media/dcec52aa7c6bc86a40707ef13d2f0f0cd3ecae5d/0_0_1340_1320/1340.png?width=1340&height=1320&quality=85&s=c6e2bad18f00b1c5919551d1708e334b ';
 
 const mobileImg =
-    'https://i.guim.co.uk/img/media/a042a19924ddccbc944a82342084889d164ab82c/0_0_1220_660/1220.png?quality=85&s=7ae997bbf3fe64290f8adee2c8e08fec';
+    'https://i.guim.co.uk/img/media/f28953842cda0a17b77eda99fd7afb7c95f669b1/0_0_1220_658/1220.png?width=1220&height=658&quality=85&s=14c48d29ff01b16ba3cc0259f4368115';
 
 // Responsive image props
 const baseImg = {
@@ -60,7 +60,7 @@ const images = [
     baseImg,
 ];
 
-const defaultCta = 'Subscribe';
+const defaultCta = 'Subscribe now';
 const defaultSecondaryCta = 'Not now';
 
 type ButtonPropTypes = {
@@ -122,6 +122,8 @@ const GuardianWeeklyBanner: React.FC<BannerRenderProps> = ({
                                             <LinkButton
                                                 href={primaryCta?.ctaUrl}
                                                 data-link-name={ctaComponentId}
+                                                icon={<SvgArrowRightStraight />}
+                                                iconSide="right"
                                                 onClick={onCtaClick}
                                                 tabIndex={0}
                                             >

--- a/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
@@ -28,7 +28,7 @@ const tracking: Tracking = {
 
 export const defaultStory = (): ReactElement => {
     const content: BannerContent = {
-        heading: text('heading', 'Read The Guardian in print'),
+        heading: text('heading', 'Open up your world view'),
         messageText: text(
             'messageText',
             'More people across Europe are reading the Guardian. Pause to consider a whole new perspective with the Guardian’s weekly news magazine. Home delivery available wherever you are.',
@@ -36,8 +36,8 @@ export const defaultStory = (): ReactElement => {
         paragraphs: array(
             'paragraphs',
             [
-                'Find clarity with the Guardian Weekly – an essential roundup of news, analysis and insight, handpicked from the Guardian and Observer editorial team from across the globe and delivered to your door.',
-                'For a limited time, save 30% on an annual subscription.',
+                'Gain a deeper understanding of the issues that matter with the Guardian Weekly magazine. Every week, take your time over handpicked articles from the Guardian and Observer, delivered for free to wherever you are in the world.',
+                'For a limited time, save 35% on an annual subscription.',
             ],
             '|',
         ),

--- a/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
@@ -6,7 +6,7 @@ import { BannerContent, BannerProps, Tracking } from '@sdc/shared/types';
 
 export default {
     component: GuardianWeeklyBanner,
-    title: 'Components/GuardianWeeklyBanner',
+    title: 'Banners/GuardianWeeklyBanner',
     decorators: [
         withKnobs({
             escapeHTML: false,

--- a/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
@@ -37,7 +37,7 @@ export const defaultStory = (): ReactElement => {
             'paragraphs',
             [
                 'Gain a deeper understanding of the issues that matter with the Guardian Weekly magazine. Every week, take your time over handpicked articles from the Guardian and Observer, delivered for free to wherever you are in the world.',
-                'For a limited time, save 35% on an annual subscription.',
+                '<strong>For a limited time, save 35% on an annual subscription.',
             ],
             '|',
         ),
@@ -53,6 +53,7 @@ export const defaultStory = (): ReactElement => {
             'Mobile paragraphs',
             [
                 'Gain a deeper understanding of the issues that matter with the Guardian Weekly magazine. Every week, take your time over handpicked articles from the Guardian and Observer, delivered for free to wherever you are in the world.',
+                '<strong>For a limited time, save 35% on an annual subscription.',
             ],
             '|',
         ),

--- a/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBanner.stories.tsx
@@ -44,14 +44,16 @@ export const defaultStory = (): ReactElement => {
     };
 
     const mobileContent: BannerContent = {
-        heading: text('Mobile heading', 'In print every week'),
+        heading: text('Mobile heading', 'Open up your world view'),
         messageText: text(
             'Mobile messageText',
-            "Make sense of a chaotic world with The Guardian's weekly news magazine.",
+            'Gain a deeper understanding of the issues that matter with the Guardian Weekly magazine.',
         ),
         paragraphs: array(
             'Mobile paragraphs',
-            ["Make sense of a chaotic world with The Guardian's weekly news magazine."],
+            [
+                'Gain a deeper understanding of the issues that matter with the Guardian Weekly magazine. Every week, take your time over handpicked articles from the Guardian and Observer, delivered for free to wherever you are in the world.',
+            ],
             '|',
         ),
     };

--- a/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -5,7 +5,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 import { height } from '@guardian/src-foundations/size';
 
-const mainBannerBackground = '#66c2e9';
+const mainBannerBackground = '#cadbe8';
 
 export const banner = css`
     html {


### PR DESCRIPTION
## What does this change?

Guardian Weekly is having a rebrand so we need to update some things accordingly - mainly packshots, colours and some copy here and there too. Banner component.

[**Trello Card**](https://trello.com/c/lEqUdsAx/660-guardian-weekly-rebrand-update-banner-support-dot-components)

## Screenshots

### Storybook : Banners/GuardianWeeklyBanner

#### Banner Desktop: Before
![image](https://user-images.githubusercontent.com/76729591/194542539-3c6b277c-90ac-4088-9bda-247efc4807be.png)

#### Banner Desktop: After
![image](https://user-images.githubusercontent.com/76729591/194544214-3aeb5727-b9f5-4d8a-9a77-bd41bedfbbf2.png)

#### Banner Tablet: Before
![image](https://user-images.githubusercontent.com/76729591/194542872-5cffb4cf-f17c-4e6e-b2d1-65738e7f216f.png)

#### Banner Tablet: After
![image](https://user-images.githubusercontent.com/76729591/194544076-c0a2da0b-c0bd-4545-afad-354268d839dc.png)

#### Banner Mobile: Before
![image](https://user-images.githubusercontent.com/76729591/194543115-493d586c-b656-4bc6-a3ff-ad214ba315bb.png)

#### Banner Mobile: After
![image](https://user-images.githubusercontent.com/76729591/194543917-bcc6e38d-6bd1-4da6-a389-7dc1e76e6ee5.png)