### PR TITLE
Epic body link tracking

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -712,3 +712,16 @@ WithNewsletterSignup.args = {
         },
     },
 };
+
+export const WithParagraphLinks = Template.bind({});
+WithParagraphLinks.args = {
+    variant: {
+        ...props.variant,
+        paragraphs: [
+            `... we have a small favour to ask. You've read %%ARTICLE_COUNT%% articles. More people, like you, are reading and supporting <a href="https://support.theguardian.com/">the Guardian’s</a> independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.`,
+            'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, <a href="https://example.com">around the world</a>, deserves access to accurate reporting with integrity at its heart.',
+            'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
+            'We hope you will consider supporting us today. We need your support to keep delivering quality journalism that’s open and independent. Every reader contribution, however big or small, is so valuable. ',
+        ],
+    },
+};

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -4,6 +4,7 @@ import { body, headline } from '@guardian/src-foundations/typography';
 import { palette, space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import {
+    addTrackingParamsToBodyLinks,
     containsNonArticleCountPlaceholder,
     createInsertEventFromTracking,
     createViewEventFromTracking,
@@ -307,9 +308,16 @@ const ContributionsEpic: React.FC<EpicProps> = ({
 
     const cleanHeading = replaceNonArticleCountPlaceholders(variant.heading, countryCode);
 
-    const cleanParagraphs = variant.paragraphs.map(paragraph =>
-        replaceNonArticleCountPlaceholders(paragraph, countryCode),
-    );
+    const cleanParagraphs = variant.paragraphs
+        .map(paragraph => replaceNonArticleCountPlaceholders(paragraph, countryCode))
+        .map(paragraph =>
+            addTrackingParamsToBodyLinks(
+                paragraph,
+                tracking,
+                articleCounts.for52Weeks,
+                countryCode,
+            ),
+        );
 
     if (
         [cleanHighlighted, cleanHeading, ...cleanParagraphs].some(

--- a/packages/shared/src/lib/tracking.test.ts
+++ b/packages/shared/src/lib/tracking.test.ts
@@ -3,6 +3,8 @@ import {
     addTrackingParams,
     addRegionIdAndTrackingParamsToSupportUrl,
     addTrackingParamsToProfileUrl,
+    addTrackingParamsToBodyLinks,
+    addLabelToTracking,
 } from './tracking';
 import { factories } from '../factories/';
 
@@ -141,5 +143,112 @@ describe('buildCampaignCode', () => {
         expect(campaignCode).toEqual(
             'gdnwb_copts_memco_enviro_fossil_fuel_r2_Epic__no_article_count_Control',
         );
+    });
+});
+
+describe('addTrackingParamsToBodyLinks', () => {
+    it('adds tracking params to HTML links to the support site in the passed text', () => {
+        const trackingData = factories.tracking.build({
+            ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
+            campaignCode:
+                'gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet',
+            campaignId: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestName: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestVariant: 'v2_stay_quiet',
+            referrerUrl:
+                'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
+        });
+        const numArticles = 88;
+        const countryCode = 'GB';
+        const text =
+            'Visit <a href="https://support.theguardian.com/uk/contribute/climate-pledge-2019">our support site</a> to support the Guardian';
+
+        const textWithTracking = addTrackingParamsToBodyLinks(
+            text,
+            trackingData,
+            numArticles,
+            countryCode,
+        );
+
+        const expected =
+            'Visit <a href="https://support.theguardian.com/uk/contribute/climate-pledge-2019?REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTests%22%3A%5B%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%5D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%2C%22labels%22%3A%5B%22body-link%22%5D%7D&numArticles=88">our support site</a> to support the Guardian';
+        expect(textWithTracking).toEqual(expected);
+    });
+
+    it('does not add tracking params to non support site URLs', () => {
+        const trackingData = factories.tracking.build({
+            ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
+            campaignCode:
+                'gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet',
+            campaignId: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestName: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestVariant: 'v2_stay_quiet',
+            referrerUrl:
+                'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
+        });
+        const numArticles = 88;
+        const countryCode = 'GB';
+        const text = 'Visit <a href="https://example.com/example">an example site</a> over here';
+
+        const textWithTracking = addTrackingParamsToBodyLinks(
+            text,
+            trackingData,
+            numArticles,
+            countryCode,
+        );
+
+        expect(textWithTracking).toEqual(text);
+    });
+
+    it('adds tracking params to multiple HTML links', () => {
+        const trackingData = factories.tracking.build({
+            ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
+            campaignCode:
+                'gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet',
+            campaignId: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestName: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestVariant: 'v2_stay_quiet',
+            referrerUrl:
+                'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
+        });
+        const numArticles = 88;
+        const countryCode = 'GB';
+        const text =
+            'Visit <a href="https://support.theguardian.com/one">our support site</a> to <a href="https://support.theguardian.com/two">support the Guardian</a><a href="https://example.com">No tracking</a>';
+
+        const textWithTracking = addTrackingParamsToBodyLinks(
+            text,
+            trackingData,
+            numArticles,
+            countryCode,
+        );
+
+        const expectedTrackingParams =
+            'REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTests%22%3A%5B%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%5D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%2C%22labels%22%3A%5B%22body-link%22%5D%7D&numArticles=88';
+        const expected = `Visit <a href="https://support.theguardian.com/one?${expectedTrackingParams}">our support site</a> to <a href="https://support.theguardian.com/two?${expectedTrackingParams}">support the Guardian</a><a href="https://example.com">No tracking</a>`;
+        expect(textWithTracking).toEqual(expected);
+    });
+});
+
+describe('addLabelToTracking', () => {
+    it('adds a label to tracking data', () => {
+        const trackingData = factories.tracking.build();
+
+        const label = 'example-label';
+        const newTrackingData = addLabelToTracking(trackingData, label);
+
+        expect(newTrackingData.labels).toEqual([label]);
+    });
+
+    it('adds a label to tracking data, appending to the list if there are already labels', () => {
+        const originalLabel = 'original-label';
+        const trackingData = factories.tracking.build({
+            labels: [originalLabel],
+        });
+
+        const newLabel = 'new-label';
+        const newTrackingData = addLabelToTracking(trackingData, newLabel);
+
+        expect(newTrackingData.labels).toEqual([originalLabel, newLabel]);
     });
 });

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -71,6 +71,26 @@ export const addRegionIdAndTrackingParamsToSupportUrl = (
         : baseUrl;
 };
 
+const hrefRegex = /href=\"(.*?)\"/g;
+export const addTrackingParamsToBodyLinks = (
+    text: string,
+    tracking: Tracking,
+    numArticles?: number,
+    countryCode?: string,
+): string => {
+    const trackingWithLabel = addLabelToTracking(tracking, 'body-link');
+
+    const replaceHref = (wholeMatch: string, url: string) =>
+        `href="${addRegionIdAndTrackingParamsToSupportUrl(
+            url,
+            trackingWithLabel,
+            numArticles,
+            countryCode,
+        )}"`;
+
+    return text.replace(hrefRegex, replaceHref);
+};
+
 // TRACKING VIA profile.theguardian.com
 type ProfileLinkParams = {
     componentEventParams: string;
@@ -166,6 +186,20 @@ const createEventFromTracking = (action: OphanAction) => {
             action,
         };
     };
+};
+
+export const addLabelToTracking = (tracking: Tracking, label: string): Tracking => {
+    if (tracking.labels) {
+        return {
+            ...tracking,
+            labels: [...tracking.labels, label],
+        };
+    } else {
+        return {
+            ...tracking,
+            labels: [label],
+        };
+    }
 };
 
 export const createClickEventFromTracking = createEventFromTracking('CLICK');


### PR DESCRIPTION
## What does this change?

Marketing would like to run a test around including links to the support site in the body of the epic. In order to evaluate the performance we need to be able to track these links.

This PR augments links to the support site in the body of the epic, adding the same tracking params we add to the CTA(s). We also add an additional `body-link` label, in order to be able to distinguish click throughs on these links from the CTA.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

`$ yarn test`

Also add a link to the epic body in storybook and hover to see tracking params added.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="1552" alt="Screenshot 2022-10-10 at 10 51 25" src="https://user-images.githubusercontent.com/379839/194840166-24b0ac14-7e91-477c-80f2-af0bafbdee28.png">


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
