### PR TITLE
Raise 5xx alarm threshold to 0.5%

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -728,7 +728,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
             ],
           },
         ],
-        "AlarmDescription": "dotcom-components exceeded 0.1% error rate",
+        "AlarmDescription": "dotcom-components exceeded 0.5% error rate",
         "AlarmName": Object {
           "Fn::Join": Array [
             "",
@@ -819,7 +819,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
             "ReturnData": false,
           },
         ],
-        "Threshold": 0.1,
+        "Threshold": 0.5,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -137,7 +137,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
             },
             monitoringConfiguration: {
                 http5xxAlarm: {
-                    tolerated5xxPercentage: 0.1,
+                    tolerated5xxPercentage: 0.5,
                     numberOfMinutesAboveThresholdBeforeAlarm: 1,
                     alarmName: `URGENT 9-5 - high 5XX error rate on ${this.stage} support-dotcom-components`,
                 },


### PR DESCRIPTION
Most of the time when this alarm is triggered, the 5XX % is barely over 0.1%. During times with lower traffic this means a single 5XX can trigger the alarm.
Last week we had a genuine issue (an instance became unresponsive) and the alarm was triggered with 5XXs at 2.47%.

5XX counts over the last week (note the genuine issue on 5/10) -
![Screenshot 2022-10-10 at 14 14 03](https://user-images.githubusercontent.com/1513454/194874774-b7901b87-0aee-4659-8968-45462b7285f2.png)
