### PR TITLE
Use separateArticleCount toggle in moment banner

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -258,6 +258,7 @@ const withBannerData = (
                 tickerSettings,
                 isSupporter,
                 numArticles,
+                separateArticleCount,
             };
             return (
                 <div ref={setNode}>

--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -66,4 +66,5 @@ export interface BannerRenderProps {
     tickerSettings?: TickerSettings;
     isSupporter?: boolean;
     numArticles?: number;
+    separateArticleCount?: boolean;
 }

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -28,6 +28,7 @@ export function getMomentTemplateBanner(
         onCtaClick,
         onSecondaryCtaClick,
         reminderTracking,
+        separateArticleCount,
     }: BannerRenderProps): JSX.Element {
         const [isReminderActive, setIsReminderActive] = useState(false);
 
@@ -118,7 +119,7 @@ export function getMomentTemplateBanner(
                                 />
                             </div>
 
-                            {numArticles !== undefined && numArticles > 5 && (
+                            {separateArticleCount && numArticles !== undefined && numArticles > 5 && (
                                 <div css={styles.articleCountContainer}>
                                     <MomentTemplateBannerArticleCount
                                         numArticles={numArticles}


### PR DESCRIPTION
Currently the moment banner ignores the flag for enabling the article count under the heading.
Tested in CODE