### PR TITLE
Fix banner forcing

### DIFF
--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -138,7 +138,7 @@ export const selectBannerTest = (
     now: Date = new Date(),
 ): BannerTestSelection | null => {
     if (forcedTestVariant) {
-        getForcedVariant(forcedTestVariant, tests, baseUrl, targeting);
+        return getForcedVariant(forcedTestVariant, tests, baseUrl, targeting);
     }
 
     const targetingTest = selectTargetingTest(targeting.mvtId, targeting, bannerTargetingTests);


### PR DESCRIPTION
a regression from [here](https://github.com/guardian/support-dotcom-components/pull/761)