### PR TITLE
Banner accessibility fix

### DIFF
--- a/packages/modules/src/hooks/useHasBeenSeen.ts
+++ b/packages/modules/src/hooks/useHasBeenSeen.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import libDebounce from 'lodash.debounce';
 
-export type HasBeenSeen = [boolean, (el: HTMLDivElement) => void];
+export type HasBeenSeen = [boolean, (el: HTMLDivElement) => void, HTMLElement | null];
 
 const useHasBeenSeen = (options: IntersectionObserverInit, debounce?: boolean): HasBeenSeen => {
     const [hasBeenSeen, setHasBeenSeen] = useState<boolean>(false);
@@ -39,7 +39,7 @@ const useHasBeenSeen = (options: IntersectionObserverInit, debounce?: boolean): 
         }
     }, [node, options, intersectionCallback]);
 
-    return [hasBeenSeen, setNode];
+    return [hasBeenSeen, setNode, node];
 };
 
 export { useHasBeenSeen };

--- a/packages/modules/src/modules/banners/auBrandMoment/components/MomentTemplateBannerArticleCountOptOut.tsx
+++ b/packages/modules/src/modules/banners/auBrandMoment/components/MomentTemplateBannerArticleCountOptOut.tsx
@@ -159,6 +159,7 @@ const styles = {
         color: inherit;
         &:focus {
             outline: none !important;
+            border-bottom-width: 3px;
         }
     `,
     overlayContainer: css`

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -63,18 +63,25 @@ export const getParagraphsOrMessageText = (
 };
 
 const checkIfElementIsHidden = (el: HTMLElement): boolean => {
+    console.log('el', el);
     while (el && el.parentNode != null) {
         if (el && el.style) {
+            // console.log('el', el);
+            // console.log('style', el.style);
             if (el.style.display === 'none' || el.style.visibility === 'hidden') {
+                console.log('fail 1');
                 return true;
             }
             const computed = window.getComputedStyle(el);
+            // console.log('computed', computed);
             if (computed.display === 'none' || computed.visibility === 'hidden') {
+                console.log('fail 2');
                 return true;
             }
         }
         el = el.parentNode;
     }
+    console.log('PASS');
     return false;
 };
 
@@ -119,6 +126,14 @@ const withBannerData = (
 
     useEffect(() => {
         if (node != null) {
+            const closeButtonElements: HTMLElement[] = [
+                ...node.querySelectorAll<HTMLElement>('[aria-label="Close"]'),
+            ].filter(
+                el =>
+                    !el.hasAttribute('disabled') &&
+                    !el.getAttribute('aria-hidden') &&
+                    !checkIfElementIsHidden(el),
+            );
             const focusableElements: HTMLElement[] = [
                 ...node.querySelectorAll<HTMLElement>(
                     'button, a[href], input, [tabindex]:not([tabindex="-1"]',
@@ -129,23 +144,34 @@ const withBannerData = (
                     !el.getAttribute('aria-hidden') &&
                     !checkIfElementIsHidden(el),
             );
+            console.log('closeButtonElements', closeButtonElements);
+            console.log('focusableElements', focusableElements);
             const firstFocussableElement = focusableElements[0];
             const lastFocussableElement = focusableElements[focusableElements.length - 1];
+            console.log('firstFocussableElement', firstFocussableElement);
+            console.log('lastFocussableElement', lastFocussableElement);
 
-            firstFocussableElement.focus();
+            if (closeButtonElements[0] != null) {
+                closeButtonElements[0].focus();
+            } else {
+                focusableElements[0].focus();
+            }
 
             node.addEventListener('keydown', e => {
                 const isTabPressed = e.key === 'Tab' || e.keyCode === 9;
                 if (!isTabPressed) {
                     return;
                 }
+                console.log('tabbing', document.activeElement);
                 if (e.shiftKey) {
                     if (document.activeElement === firstFocussableElement) {
+                        console.log('focus on last focussable element');
                         lastFocussableElement.focus();
                         e.preventDefault();
                     }
                 } else {
                     if (document.activeElement === lastFocussableElement) {
+                        console.log('focus on first focussable element');
                         firstFocussableElement.focus();
                         e.preventDefault();
                     }

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -6,7 +6,7 @@ import {
     createViewEventFromTracking,
     isProfileUrl,
 } from '@sdc/shared/lib';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
     BannerContent,
     BannerProps,
@@ -82,7 +82,7 @@ const withBannerData = (
         separateArticleCount,
     } = bannerProps;
 
-    const [hasBeenSeen, setNode] = useHasBeenSeen(
+    const [hasBeenSeen, setNode, node] = useHasBeenSeen(
         {
             threshold: 0,
         },
@@ -100,6 +100,44 @@ const withBannerData = (
             submitComponentEvent(createInsertEventFromTracking(tracking, tracking.campaignCode));
         }
     }, [submitComponentEvent]);
+
+    useEffect(() => {
+        console.log('useEffect[node]', node);
+        if (node != null) {
+
+            const focusableElements = [...node.querySelectorAll('button, a[href], input, [tabindex]:not([tabindex="-1"]')].filter(el => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden'));
+            const firstFocussableElement = focusableElements[0];
+            const lastFocussableElement = focusableElements[focusableElements.length - 1];
+
+            firstFocussableElement.focus();
+
+            node.addEventListener('keydown', (e) => {
+                console.log('navigation', e.key, e.keyCode, e.shiftKey);
+                const isTabPressed = (e.key === 'Tab' || e.keyCode === 9);
+
+                if (!isTabPressed) {
+                    return;
+                }
+
+                console.log(document.activeElement)
+                console.log(firstFocussableElement)
+                console.log(lastFocussableElement)
+                if (e.shiftKey) {
+                    if (document.activeElement === firstFocussableElement) {
+                        console.log('focus on last');
+                        lastFocussableElement.focus();
+                        e.preventDefault();
+                    }
+                } else {
+                    if (document.activeElement === lastFocussableElement) {
+                        console.log('focus on first');
+                        firstFocussableElement.focus();
+                        e.preventDefault();
+                    }
+                }
+            });
+        }
+    }, [node]);
 
     const cleanParagraphsOrMessageText = (
         paras: string[] | undefined,

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -63,25 +63,18 @@ export const getParagraphsOrMessageText = (
 };
 
 const checkIfElementIsHidden = (el: HTMLElement): boolean => {
-    // console.log('el', el);
     while (el && el.parentNode != null) {
         if (el && el.style) {
-            // console.log('el', el);
-            // console.log('style', el.style);
             if (el.style.display === 'none' || el.style.visibility === 'hidden') {
-                // console.log('fail 1');
                 return true;
             }
             const computed = window.getComputedStyle(el);
-            // console.log('computed', computed);
             if (computed.display === 'none' || computed.visibility === 'hidden') {
-                // console.log('fail 2');
                 return true;
             }
         }
         el = el.parentNode;
     }
-    // console.log('PASS');
     return false;
 };
 
@@ -146,12 +139,8 @@ const withBannerData = (
                         !el.getAttribute('aria-hidden') &&
                         !checkIfElementIsHidden(el),
                 );
-                console.log('closeButtonElements', closeButtonElements);
-                console.log('focusableElements', focusableElements);
                 const firstFocussableElement = focusableElements[0];
                 const lastFocussableElement = focusableElements[focusableElements.length - 1];
-                console.log('firstFocussableElement', firstFocussableElement);
-                console.log('lastFocussableElement', lastFocussableElement);
 
                 if (closeButtonElements[0] != null) {
                     closeButtonElements[0].focus();
@@ -164,16 +153,13 @@ const withBannerData = (
                     if (!isTabPressed) {
                         return;
                     }
-                    console.log('tabbing', document.activeElement, firstFocussableElement, document.activeElement === firstFocussableElement, lastFocussableElement, document.activeElement === lastFocussableElement);
                     if (e.shiftKey) {
                         if (document.activeElement === firstFocussableElement) {
-                            console.log('focus on last focussable element');
                             lastFocussableElement.focus();
                             e.preventDefault();
                         }
                     } else {
                         if (document.activeElement === lastFocussableElement) {
-                            console.log('focus on first focussable element');
                             firstFocussableElement.focus();
                             e.preventDefault();
                         }

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -63,11 +63,7 @@ export const getParagraphsOrMessageText = (
 };
 
 const checkIfElementIsHidden = (el: HTMLElement): boolean => {
-    if (el && el.style && (el.style.display === 'none' || el.style.visibility === 'hidden')) {
-        return true;
-    }
     while (el && el.parentNode != null) {
-        el = el.parentNode;
         if (el && el.style) {
             if (el.style.display === 'none' || el.style.visibility === 'hidden') {
                 return true;
@@ -77,6 +73,7 @@ const checkIfElementIsHidden = (el: HTMLElement): boolean => {
                 return true;
             }
         }
+        el = el.parentNode;
     }
     return false;
 };

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -62,7 +62,7 @@ export const getParagraphsOrMessageText = (
     return bodyCopy;
 };
 
-const checkIfElementIsHidden = (el: HTMLElement): boolean => {
+const checkIfElementIsHidden = (el: HTMLElement | null): boolean => {
     while (el && el.parentNode != null) {
         if (el && el.style) {
             if (el.style.display === 'none' || el.style.visibility === 'hidden') {
@@ -73,7 +73,7 @@ const checkIfElementIsHidden = (el: HTMLElement): boolean => {
                 return true;
             }
         }
-        el = el.parentNode;
+        el = el.parentNode instanceof HTMLElement ? el.parentNode : null;
     }
     return false;
 };

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -126,57 +126,60 @@ const withBannerData = (
 
     useEffect(() => {
         if (node != null) {
-            const closeButtonElements: HTMLElement[] = [
-                ...node.querySelectorAll<HTMLElement>('[aria-label="Close"]'),
-            ].filter(
-                el =>
-                    !el.hasAttribute('disabled') &&
-                    !el.getAttribute('aria-hidden') &&
-                    !checkIfElementIsHidden(el),
-            );
-            const focusableElements: HTMLElement[] = [
-                ...node.querySelectorAll<HTMLElement>(
-                    'button, a[href], input, [tabindex]:not([tabindex="-1"]',
-                ),
-            ].filter(
-                el =>
-                    !el.hasAttribute('disabled') &&
-                    !el.getAttribute('aria-hidden') &&
-                    !checkIfElementIsHidden(el),
-            );
-            console.log('closeButtonElements', closeButtonElements);
-            console.log('focusableElements', focusableElements);
-            const firstFocussableElement = focusableElements[0];
-            const lastFocussableElement = focusableElements[focusableElements.length - 1];
-            console.log('firstFocussableElement', firstFocussableElement);
-            console.log('lastFocussableElement', lastFocussableElement);
+            // Timeout required to allow component to settle before identifying focussable elements within it
+            setTimeout(() => {
+                const closeButtonElements: HTMLElement[] = [
+                    ...node.querySelectorAll<HTMLElement>('[aria-label="Close"]'),
+                ].filter(
+                    el =>
+                        !el.hasAttribute('disabled') &&
+                        !el.getAttribute('aria-hidden') &&
+                        !checkIfElementIsHidden(el),
+                );
+                const focusableElements: HTMLElement[] = [
+                    ...node.querySelectorAll<HTMLElement>(
+                        'button, a[href], input, [tabindex]:not([tabindex="-1"]',
+                    ),
+                ].filter(
+                    el =>
+                        !el.hasAttribute('disabled') &&
+                        !el.getAttribute('aria-hidden') &&
+                        !checkIfElementIsHidden(el),
+                );
+                console.log('closeButtonElements', closeButtonElements);
+                console.log('focusableElements', focusableElements);
+                const firstFocussableElement = focusableElements[0];
+                const lastFocussableElement = focusableElements[focusableElements.length - 1];
+                console.log('firstFocussableElement', firstFocussableElement);
+                console.log('lastFocussableElement', lastFocussableElement);
 
-            if (closeButtonElements[0] != null) {
-                closeButtonElements[0].focus();
-            } else {
-                focusableElements[0].focus();
-            }
-
-            node.addEventListener('keydown', e => {
-                const isTabPressed = e.key === 'Tab' || e.keyCode === 9;
-                if (!isTabPressed) {
-                    return;
-                }
-                console.log('tabbing', document.activeElement);
-                if (e.shiftKey) {
-                    if (document.activeElement === firstFocussableElement) {
-                        console.log('focus on last focussable element');
-                        lastFocussableElement.focus();
-                        e.preventDefault();
-                    }
+                if (closeButtonElements[0] != null) {
+                    closeButtonElements[0].focus();
                 } else {
-                    if (document.activeElement === lastFocussableElement) {
-                        console.log('focus on first focussable element');
-                        firstFocussableElement.focus();
-                        e.preventDefault();
-                    }
+                    focusableElements[0].focus();
                 }
-            });
+
+                node.addEventListener('keydown', e => {
+                    const isTabPressed = e.key === 'Tab' || e.keyCode === 9;
+                    if (!isTabPressed) {
+                        return;
+                    }
+                    console.log('tabbing', document.activeElement, firstFocussableElement, document.activeElement === firstFocussableElement, lastFocussableElement, document.activeElement === lastFocussableElement);
+                    if (e.shiftKey) {
+                        if (document.activeElement === firstFocussableElement) {
+                            console.log('focus on last focussable element');
+                            lastFocussableElement.focus();
+                            e.preventDefault();
+                        }
+                    } else {
+                        if (document.activeElement === lastFocussableElement) {
+                            console.log('focus on first focussable element');
+                            firstFocussableElement.focus();
+                            e.preventDefault();
+                        }
+                    }
+                });
+            }, 1000);
         }
     }, [node]);
 

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -63,25 +63,25 @@ export const getParagraphsOrMessageText = (
 };
 
 const checkIfElementIsHidden = (el: HTMLElement): boolean => {
-    console.log('el', el);
+    // console.log('el', el);
     while (el && el.parentNode != null) {
         if (el && el.style) {
             // console.log('el', el);
             // console.log('style', el.style);
             if (el.style.display === 'none' || el.style.visibility === 'hidden') {
-                console.log('fail 1');
+                // console.log('fail 1');
                 return true;
             }
             const computed = window.getComputedStyle(el);
             // console.log('computed', computed);
             if (computed.display === 'none' || computed.visibility === 'hidden') {
-                console.log('fail 2');
+                // console.log('fail 2');
                 return true;
             }
         }
         el = el.parentNode;
     }
-    console.log('PASS');
+    // console.log('PASS');
     return false;
 };
 

--- a/packages/modules/src/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.stories.tsx
@@ -44,6 +44,10 @@ export const defaultStory = (): ReactElement => {
             ],
             '|',
         ),
+        cta: {
+            baseUrl: 'https://theguardian.com',
+            text: 'Subscribe',
+        },
     };
 
     const mobileContent: BannerContent = {
@@ -59,6 +63,10 @@ export const defaultStory = (): ReactElement => {
             ],
             '|',
         ),
+        cta: {
+            baseUrl: 'https://theguardian.com',
+            text: 'Subscribe',
+        },
         secondaryCta: {
             type: SecondaryCtaType.Custom,
             cta: {

--- a/packages/modules/src/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
+++ b/packages/modules/src/modules/banners/digitalSubscriptions/DigitalSubscriptionsBanner.tsx
@@ -147,6 +147,7 @@ const DigitalSubscriptionsBanner: React.FC<BannerRenderProps> = ({
                         <div css={iconPanel}>
                             <ThemeProvider theme={buttonBrand}>
                                 <Button
+                                    aria-label="Close"
                                     size="small"
                                     cssOverrides={closeButton}
                                     priority="tertiary"

--- a/packages/modules/src/modules/banners/environmentMoment/components/EnvironmentMomentBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/environmentMoment/components/EnvironmentMomentBannerCloseButton.tsx
@@ -15,7 +15,14 @@ export const EnvironmentMomentBannerCloseButton: React.FC<EnvironmentMomentBanne
     onClick,
 }: EnvironmentMomentBannerCloseButtonProps) => (
     <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
-        <Button onClick={onClick} css={button} size="small" icon={<SvgCross />} hideLabel>
+        <Button
+            aria-label="Close"
+            onClick={onClick}
+            css={button}
+            size="small"
+            icon={<SvgCross />}
+            hideLabel
+        >
             Dismiss the banner
         </Button>
     </ThemeProvider>

--- a/packages/modules/src/modules/banners/globalNewYear/components/GlobalNewYearBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/globalNewYear/components/GlobalNewYearBannerCloseButton.tsx
@@ -31,6 +31,7 @@ export function GlobalNewYearBannerCloseButton({
         <div css={styles.container}>
             <Hide above="tablet">
                 <Button
+                    aria-label="Close"
                     onClick={onCloseClick}
                     cssOverrides={styles.closeButton}
                     icon={<SvgCross />}
@@ -44,6 +45,7 @@ export function GlobalNewYearBannerCloseButton({
             <Hide below="tablet">
                 <div>
                     <Button
+                        aria-label="Close"
                         onClick={onCloseClick}
                         cssOverrides={styles.closeButton}
                         icon={<SvgCross />}

--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -69,6 +69,7 @@ type ButtonPropTypes = {
 
 const CloseButton = (props: ButtonPropTypes): ReactElement => (
     <Button
+        aria-label="Close"
         css={closeButtonStyles}
         data-link-name={closeComponentId}
         onClick={props.onClick}

--- a/packages/modules/src/modules/banners/hocs/withCloseable.tsx
+++ b/packages/modules/src/modules/banners/hocs/withCloseable.tsx
@@ -14,6 +14,7 @@ const withCloseable = (CloseableBanner: React.FC<CloseableBannerProps>): React.F
         const onClose = (): void => {
             setChannelClosedTimestamp(bannerProps.bannerChannel);
             setIsOpen(false);
+            document.body.focus();
         };
 
         useEscapeShortcut(onClose, []);

--- a/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerCloseButton.tsx
@@ -52,6 +52,7 @@ export function InvestigationsMomentBannerCloseButton({
         <div css={styles.container}>
             <Hide above="tablet">
                 <Button
+                    aria-label="Close"
                     onClick={onCloseClick}
                     cssOverrides={styles.closeButton}
                     icon={<SvgCross />}
@@ -71,6 +72,7 @@ export function InvestigationsMomentBannerCloseButton({
             <Hide below="tablet">
                 <div>
                     <Button
+                        aria-label="Close"
                         onClick={onCloseClick}
                         cssOverrides={styles.closeButton}
                         icon={<SvgCross />}

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
@@ -159,6 +159,7 @@ const styles = {
         color: inherit;
         &:focus {
             outline: none !important;
+            border-bottom-width: 3px;
         }
     `,
     overlayContainer: css`

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -26,6 +26,7 @@ export function MomentTemplateBannerCloseButton({
             </div>
 
             <Button
+                aria-label="Close"
                 onClick={onCloseClick}
                 cssOverrides={buttonStyles(settings)}
                 icon={<SvgCross />}

--- a/packages/modules/src/modules/shared/ArticleCountOptOutPopup.tsx
+++ b/packages/modules/src/modules/shared/ArticleCountOptOutPopup.tsx
@@ -52,6 +52,7 @@ const articleCountButton = css`
     color: inherit;
     &:focus {
         outline: none !important;
+        border-bottom-width: 3px;
     }
 `;
 


### PR DESCRIPTION
## What does this change?
We need to improve the accessibility of the Banner. Currently: 
+ Page focus is not transferred to the banner's close button when the banner appears;
+ Some banner close buttons do not include the appropriate ARIA label attribute;
+ User `tab` and `shift + tab` keyboard actions are not constrained to the banner while it is displayed; 
+ Some focusable elements within the banner do not update their presentation in an appropriate way (or at all) when they receive keyboard navigation focus; and
+ Page focus does not return to the top of the page after the user dismisses the banner

[TODO: complete PR details]