### PR TITLE
Change country names list

### DIFF
--- a/packages/shared/src/lib/geolocation.ts
+++ b/packages/shared/src/lib/geolocation.ts
@@ -332,7 +332,6 @@ const countryNames: CountryNameMap = {
     BR: 'Brazil',
     ZA: 'South Africa',
     TW: 'Taiwan',
-    IL: 'Israel',
     JP: 'Japan',
     CZ: 'the Czech Republic',
     GR: 'Greece',


### PR DESCRIPTION
Marketing have asked that we remove Israel from the list of country names that can be displayed in the channels