### PR TITLE
Use separateArticleCount prop in banners

### DIFF
--- a/packages/modules/src/modules/banners/auBrandMoment/components/getAuBrandMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/auBrandMoment/components/getAuBrandMomentBanner.tsx
@@ -24,6 +24,7 @@ export function getAuBrandMomentBanner(
         onCtaClick,
         onSecondaryCtaClick,
         reminderTracking,
+        separateArticleCount,
     }: BannerRenderProps): JSX.Element {
         const [isReminderActive, setIsReminderActive] = useState(false);
 
@@ -93,7 +94,7 @@ export function getAuBrandMomentBanner(
                                 />
                             </div>
 
-                            {numArticles !== undefined && numArticles > 5 && (
+                            {separateArticleCount && numArticles !== undefined && numArticles > 5 && (
                                 <div css={styles.articleCountContainer}>
                                     <MomentTemplateBannerArticleCount
                                         numArticles={numArticles}

--- a/packages/modules/src/modules/banners/environmentMoment/EnvironmentMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/environmentMoment/EnvironmentMomentBanner.tsx
@@ -188,7 +188,11 @@ const EnvironmentMomentBanner: React.FC<BannerRenderProps> = ({
     onSecondaryCtaClick,
     numArticles,
     isSupporter,
+    separateArticleCount,
 }: BannerRenderProps) => {
+    const showArticleCount =
+        separateArticleCount && !isSupporter && numArticles !== undefined && numArticles > 5;
+
     return (
         <div css={container}>
             <div css={lineContainer}>
@@ -209,7 +213,7 @@ const EnvironmentMomentBanner: React.FC<BannerRenderProps> = ({
                         <EnvironmentMomentBannerHeader isSupporter={isSupporter ?? false} />
 
                         <div css={bodyAndCtasContainer}>
-                            {!isSupporter && numArticles !== undefined && numArticles > 5 && (
+                            {showArticleCount && (
                                 <div>
                                     <EnvironmentMomentBannerArticleCount
                                         numArticles={numArticles}

--- a/packages/modules/src/modules/banners/globalNewYear/components/getGlobalNewYearBanner.tsx
+++ b/packages/modules/src/modules/banners/globalNewYear/components/getGlobalNewYearBanner.tsx
@@ -117,6 +117,7 @@ function getGlobalNewYearBanner(): React.FC<BannerRenderProps> {
         numArticles,
         onCtaClick,
         onSecondaryCtaClick,
+        separateArticleCount,
     }: BannerRenderProps) {
         return (
             <div css={styles.outerContainer}>
@@ -132,7 +133,7 @@ function getGlobalNewYearBanner(): React.FC<BannerRenderProps> {
                     <hr css={styles.horizontalRule} />
 
                     <div css={styles.bottomContainer}>
-                        {numArticles !== undefined && numArticles > 5 && (
+                        {separateArticleCount && numArticles !== undefined && numArticles > 5 && (
                             <section>
                                 <GlobalNewYearBannerArticleCount numArticles={numArticles} />
                             </section>

--- a/packages/modules/src/modules/banners/investigationsMoment/InvestigationsMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/investigationsMoment/InvestigationsMomentBanner.tsx
@@ -139,6 +139,7 @@ function InvestigationsMomentBanner({
     numArticles,
     onCtaClick,
     onSecondaryCtaClick,
+    separateArticleCount,
 }: BannerRenderProps) {
     return (
         <Container cssOverrides={styles.container}>
@@ -150,7 +151,7 @@ function InvestigationsMomentBanner({
             </div>
 
             <div css={styles.bottomContainer}>
-                {numArticles !== undefined && numArticles > 5 && (
+                {separateArticleCount && numArticles !== undefined && numArticles > 5 && (
                     <section>
                         <InvestigationsMomentBannerArticleCount numArticles={numArticles} />
                     </section>


### PR DESCRIPTION
Some banners have a "separate article count" feature, typically appearing as a subheading, and separate from the rest of the copy. This feature is toggled from RRCP.
Some of the Moment banners with this feature do not respect the toggle. This PR changes them to check the `separateArticleCount` field.