### PR TITLE
Fix epic choice cards

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -273,6 +273,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 ][1],
         },
     );
+    console.log(choiceCardSelection);
 
     const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } = useArticleCountOptOut();
 
@@ -413,6 +414,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                     email={email}
                     fetchEmail={fetchEmail}
                     submitComponentEvent={submitComponentEvent}
+                    showChoiceCards={showChoiceCards}
                     choiceCardSelection={choiceCardSelection}
                 />
             )}

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -413,6 +413,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                     email={email}
                     fetchEmail={fetchEmail}
                     submitComponentEvent={submitComponentEvent}
+                    choiceCardSelection={choiceCardSelection}
                 />
             )}
         </section>

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -273,7 +273,6 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 ][1],
         },
     );
-    console.log(choiceCardSelection);
 
     const { hasOptedOut, onArticleCountOptIn, onArticleCountOptOut } = useArticleCountOptOut();
 

--- a/packages/modules/src/modules/epics/ContributionsEpicCtas.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicCtas.tsx
@@ -3,12 +3,17 @@ import { EpicProps } from '@sdc/shared/types';
 import { ContributionsEpicReminder } from './ContributionsEpicReminder';
 import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { defineFetchEmail } from '../shared/helpers/definedFetchEmail';
+import { ChoiceCardSelection } from './ContributionsEpicChoiceCards';
 
 interface OnReminderOpen {
     buttonCopyAsString: string;
 }
 
-export const ContributionsEpicCtas: React.FC<EpicProps> = ({
+type ContributionsEpicCtasProps = EpicProps & {
+    choiceCardSelection?: ChoiceCardSelection;
+};
+
+export const ContributionsEpicCtas: React.FC<ContributionsEpicCtasProps> = ({
     variant,
     countryCode,
     articleCounts,
@@ -17,7 +22,8 @@ export const ContributionsEpicCtas: React.FC<EpicProps> = ({
     onReminderOpen,
     email,
     fetchEmail,
-}: EpicProps): JSX.Element | null => {
+    choiceCardSelection,
+}: ContributionsEpicCtasProps): JSX.Element | null => {
     const [fetchedEmail, setFetchedEmail] = useState<string | undefined>(undefined);
     const fetchEmailDefined = defineFetchEmail(email, fetchEmail);
     const [isReminderActive, setIsReminderActive] = useState(false);
@@ -56,7 +62,7 @@ export const ContributionsEpicCtas: React.FC<EpicProps> = ({
                 isReminderActive={isReminderActive}
                 isSignedIn={Boolean(fetchedEmail)}
                 showChoiceCards={false}
-                choiceCardSelection={undefined}
+                choiceCardSelection={choiceCardSelection}
                 numArticles={articleCounts.for52Weeks}
             />
 

--- a/packages/modules/src/modules/epics/ContributionsEpicCtas.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicCtas.tsx
@@ -10,6 +10,7 @@ interface OnReminderOpen {
 }
 
 type ContributionsEpicCtasProps = EpicProps & {
+    showChoiceCards?: boolean;
     choiceCardSelection?: ChoiceCardSelection;
 };
 
@@ -22,6 +23,7 @@ export const ContributionsEpicCtas: React.FC<ContributionsEpicCtasProps> = ({
     onReminderOpen,
     email,
     fetchEmail,
+    showChoiceCards,
     choiceCardSelection,
 }: ContributionsEpicCtasProps): JSX.Element | null => {
     const [fetchedEmail, setFetchedEmail] = useState<string | undefined>(undefined);
@@ -61,7 +63,7 @@ export const ContributionsEpicCtas: React.FC<ContributionsEpicCtasProps> = ({
                 submitComponentEvent={submitComponentEvent}
                 isReminderActive={isReminderActive}
                 isSignedIn={Boolean(fetchedEmail)}
-                showChoiceCards={false}
+                showChoiceCards={showChoiceCards}
                 choiceCardSelection={choiceCardSelection}
                 numArticles={articleCounts.for52Weeks}
             />


### PR DESCRIPTION
This bug was introduced during a refactor to share the ctas component with the liveblog epic (https://github.com/guardian/support-dotcom-components/pull/751)

The url querystring is supposed to include info about which choice cards were chosen.