### PR TITLE
Refocus on document.body when banner closes

### DIFF
--- a/packages/modules/src/modules/banners/hocs/withCloseable.tsx
+++ b/packages/modules/src/modules/banners/hocs/withCloseable.tsx
@@ -14,6 +14,7 @@ const withCloseable = (CloseableBanner: React.FC<CloseableBannerProps>): React.F
         const onClose = (): void => {
             setChannelClosedTimestamp(bannerProps.bannerChannel);
             setIsOpen(false);
+            document.body.focus();
         };
 
         useEscapeShortcut(onClose, []);


### PR DESCRIPTION
## What does this change?
A small change that should ensure that when a user closes a marketing banner (by whatever means) the tabbing focus returns to the top of the page

#### Screen capture (front)
https://user-images.githubusercontent.com/5357530/198039755-72d63f7b-1075-4681-9e94-9a48558ef4ee.mov

#### Screen capture (article)
[close-banner-demo_2022-11-04.webm](https://user-images.githubusercontent.com/5357530/199939339-82cc61e8-5fd7-4da7-ab1a-d45691d94bbe.webm)
