### PR TITLE
New supporter targeting settings

### DIFF
--- a/packages/server/src/lib/dates.ts
+++ b/packages/server/src/lib/dates.ts
@@ -1,4 +1,4 @@
-const pauseDays = 90;
+const DefaultCutOffDays = 90;
 
 export const daysSince = (then: Date, now: Date): number => {
     const oneDayMs = 1000 * 60 * 60 * 24;
@@ -9,10 +9,11 @@ export const daysSince = (then: Date, now: Date): number => {
 export const isRecentOneOffContributor = (
     lastOneOffContributionDate?: Date,
     now: Date = new Date(Date.now()), // to mock out Date.now in tests
+    cutOffDays: number = DefaultCutOffDays,
 ): boolean => {
     if (!lastOneOffContributionDate) {
         return false;
     }
 
-    return daysSince(lastOneOffContributionDate, now) <= pauseDays;
+    return daysSince(lastOneOffContributionDate, now) <= cutOffDays;
 };

--- a/packages/server/src/lib/targeting.test.ts
+++ b/packages/server/src/lib/targeting.test.ts
@@ -1,5 +1,11 @@
 import { factories } from '../factories';
-import { audienceMatches, shouldNotRenderEpic, shouldThrottle } from './targeting';
+import {
+    audienceMatches,
+    shouldNotRenderEpic,
+    shouldThrottle,
+    supporterStatusMatches,
+} from './targeting';
+import { SupporterStatusRules } from '@sdc/shared/dist/types';
 
 describe('shouldNotRenderEpic', () => {
     it('returns true for blacklisted section', () => {
@@ -38,7 +44,7 @@ describe('audienceMatches', () => {
         const got = audienceMatches(
             false,
             'AllExistingSupporters',
-            '2022-01-01',
+            new Date('2022-01-01'),
             new Date('2022-01-02'),
         );
         expect(got).toBe(false);
@@ -47,24 +53,144 @@ describe('audienceMatches', () => {
         const got = audienceMatches(
             false,
             'AllNonSupporters',
-            '2022-01-01',
+            new Date('2022-01-01'),
             new Date('2022-01-02'),
         );
         expect(got).toBe(false);
     });
 
     it('returns true for old contributor if test is for AllNonSupporters', () => {
-        const got = audienceMatches(true, 'AllNonSupporters', '2021-01-01', new Date('2022-01-02'));
+        const got = audienceMatches(
+            true,
+            'AllNonSupporters',
+            new Date('2021-01-01'),
+            new Date('2022-01-02'),
+        );
         expect(got).toBe(true);
     });
     it('returns false for old contributor if test is for AllExistingSupporters', () => {
         const got = audienceMatches(
             true,
             'AllExistingSupporters',
-            '2021-01-01',
+            new Date('2021-01-01'),
             new Date('2022-01-02'),
         );
         expect(got).toBe(false);
+    });
+});
+
+describe('supporterStatusMatches', () => {
+    const date = new Date('2022-01-02');
+
+    describe('Not recurring supporter and no recent single contribution', () => {
+        const nonSupporterTargeting: SupporterStatusRules = {
+            include: [],
+            exclude: ['RecurringSupporter', 'RecentSingleContributor'],
+            recentSingleContributorCutOffInDays: 50,
+        };
+
+        it('returns true for "Not recurring supporter and no recent contribution" if not a supporter', () => {
+            const result = supporterStatusMatches(nonSupporterTargeting, false, undefined, date);
+            expect(result).toBe(true);
+        });
+        it('returns true for "Not recurring supporter and no recent contribution" if old contribution', () => {
+            const result = supporterStatusMatches(
+                nonSupporterTargeting,
+                false,
+                new Date('2021-01-01'),
+                date,
+            );
+            expect(result).toBe(true);
+        });
+        it('returns false for "Not recurring supporter and no recent contribution" if isRecurringSupporter', () => {
+            const result = supporterStatusMatches(nonSupporterTargeting, true, undefined, date);
+            expect(result).toBe(false);
+        });
+        it('returns false for "Not recurring supporter and no recent contribution" if recent contribution', () => {
+            const result = supporterStatusMatches(
+                nonSupporterTargeting,
+                false,
+                new Date('2022-01-01'),
+                date,
+            );
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('Recurring supporter without a recent single contribution', () => {
+        const recurringSupporterTargeting: SupporterStatusRules = {
+            include: ['RecurringSupporter'],
+            exclude: ['RecentSingleContributor'],
+            recentSingleContributorCutOffInDays: 50,
+        };
+
+        it('returns true for "Recurring supporter without a recent single contribution" if isRecurringSupporter', () => {
+            const result = supporterStatusMatches(
+                recurringSupporterTargeting,
+                true,
+                undefined,
+                date,
+            );
+            expect(result).toBe(true);
+        });
+        it('returns true for "Recurring supporter without a recent single contribution" if isRecurringSupporter and has old contribution', () => {
+            const result = supporterStatusMatches(
+                recurringSupporterTargeting,
+                true,
+                new Date('2021-01-01'),
+                date,
+            );
+            expect(result).toBe(true);
+        });
+        it('returns false for "Recurring supporter without a recent single contribution" if !isRecurringSupporter', () => {
+            const result = supporterStatusMatches(
+                recurringSupporterTargeting,
+                false,
+                undefined,
+                date,
+            );
+            expect(result).toBe(false);
+        });
+        it('returns false for "Recurring supporter without a recent single contribution" if isRecurringSupporter but has recent contribution', () => {
+            const result = supporterStatusMatches(
+                recurringSupporterTargeting,
+                true,
+                new Date('2022-01-01'),
+                date,
+            );
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('Recurring supporter and/or recent single contributor', () => {
+        const supporterTargeting: SupporterStatusRules = {
+            include: ['RecurringSupporter', 'RecentSingleContributor'],
+            exclude: [],
+            recentSingleContributorCutOffInDays: 50,
+        };
+
+        it('returns true for "Recurring supporter and/or recent single contributor" if isRecurringSupporter', () => {
+            const result = supporterStatusMatches(supporterTargeting, true, undefined, date);
+            expect(result).toBe(true);
+        });
+        it('returns true for "Recurring supporter and/or recent single contributor" if has recent contribution', () => {
+            const result = supporterStatusMatches(
+                supporterTargeting,
+                false,
+                new Date('2022-01-01'),
+                date,
+            );
+            expect(result).toBe(true);
+        });
+        it('returns false for "Recurring supporter and/or recent single contributor" if has old contribution', () => {
+            const result = supporterStatusMatches(
+                supporterTargeting,
+                false,
+                new Date('2021-01-01'),
+                date,
+            );
+            expect(result).toBe(false);
+        });
     });
 });
 

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -10,7 +10,11 @@ import {
 import { selectVariant } from '../../lib/ab';
 import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { TestVariant } from '../../lib/params';
-import { audienceMatches, deviceTypeMatches, userIsInTest } from '../../lib/targeting';
+import {
+    audienceOrSupporterStatusMatches,
+    deviceTypeMatches,
+    userIsInTest,
+} from '../../lib/targeting';
 import { BannerDeployTimesProvider, ReaderRevenueRegion } from './bannerDeployTimes';
 import { selectTargetingTest } from '../../lib/targetingTesting';
 import { bannerTargetingTests } from './bannerTargetingTests';
@@ -157,11 +161,7 @@ export const selectBannerTest = (
             (enableHardcodedBannerTests || !test.isHardcoded) &&
             !targeting.shouldHideReaderRevenue &&
             !targeting.isPaidContent &&
-            audienceMatches(
-                targeting.showSupportMessaging,
-                test.userCohort,
-                targeting.lastOneOffContributionDate,
-            ) &&
+            audienceOrSupporterStatusMatches(test, targeting, now) &&
             inCountryGroups(targeting.countryCode, test.locations) &&
             targeting.alreadyVisitedCount >= test.minPageViews &&
             !(test.articlesViewedSettings && targeting.hasOptedOutOfArticleCount) &&

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -82,6 +82,7 @@ const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTes
                         bannerChannel,
                         isHardcoded: false,
                         userCohort: testParams.userCohort,
+                        supporterStatus: testParams.supporterStatus,
                         locations: testParams.locations,
                         minPageViews: testParams.minArticlesBeforeShowingBanner,
                         articlesViewedSettings: testParams.articlesViewedSettings,

--- a/packages/server/src/tests/headers/headerSelection.ts
+++ b/packages/server/src/tests/headers/headerSelection.ts
@@ -3,7 +3,11 @@ import { inCountryGroups } from '@sdc/shared/lib';
 import { HeaderTargeting, HeaderTest, HeaderTestSelection, HeaderVariant } from '@sdc/shared/types';
 
 import { selectVariant } from '../../lib/ab';
-import { audienceMatches, deviceTypeMatches, userIsInTest } from '../../lib/targeting';
+import {
+    audienceOrSupporterStatusMatches,
+    deviceTypeMatches,
+    userIsInTest,
+} from '../../lib/targeting';
 
 import { TestVariant } from '../../lib/params';
 
@@ -292,18 +296,14 @@ export const selectBestTest = (
     isMobile: boolean,
     allTests: HeaderTest[],
 ): HeaderTestSelection | null => {
-    const { showSupportMessaging, countryCode, purchaseInfo, isSignedIn } = targeting;
+    const { countryCode, purchaseInfo, isSignedIn } = targeting;
 
     const selectedTest = allTests.find(test => {
-        const { status, userCohort, locations } = test;
+        const { status, locations } = test;
 
         return (
             status === 'Live' &&
-            audienceMatches(
-                showSupportMessaging,
-                userCohort,
-                targeting.lastOneOffContributionDate,
-            ) &&
+            audienceOrSupporterStatusMatches(test, targeting) &&
             inCountryGroups(countryCode, locations) &&
             userIsInTest(test, targeting.mvtId) &&
             deviceTypeMatches(test, isMobile) &&

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -3,6 +3,7 @@ import {
     ArticlesViewedSettings,
     ControlProportionSettings,
     DeviceType,
+    SupporterStatusRules,
     TargetingAbTest,
     Test,
     TestStatus,
@@ -49,7 +50,8 @@ export interface BannerTest extends Test<BannerVariant> {
     status: TestStatus;
     bannerChannel: BannerChannel;
     isHardcoded: boolean;
-    userCohort: UserCohort;
+    userCohort?: UserCohort; // Deprecated - use supporterStatus
+    supporterStatus?: SupporterStatusRules;
     canRun?: CanRun;
     minPageViews: number;
     variants: BannerVariant[];
@@ -83,7 +85,8 @@ export interface RawTestParams {
     nickname: string;
     status: TestStatus;
     minArticlesBeforeShowingBanner: number;
-    userCohort: UserCohort;
+    userCohort?: UserCohort;
+    supporterStatus?: SupporterStatusRules;
     locations: CountryGroupId[];
     variants: RawVariantParams[];
     articlesViewedSettings?: ArticlesViewedSettings;

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -2,6 +2,7 @@ import { CountryGroupId, ReminderFields } from '../../lib';
 import {
     ArticlesViewedSettings,
     ControlProportionSettings,
+    SupporterStatusRules,
     Test,
     TestStatus,
     UserCohort,
@@ -107,7 +108,8 @@ export interface EpicTest extends Test<EpicVariant> {
     excludedSections: string[];
     alwaysAsk: boolean;
     maxViews?: MaxViews;
-    userCohort: UserCohort;
+    userCohort?: UserCohort; // Deprecated - use supporterStatus
+    supporterStatus?: SupporterStatusRules;
     isLiveBlog: boolean;
     hasCountryName: boolean;
     variants: EpicVariant[];

--- a/packages/shared/src/types/abTests/header.ts
+++ b/packages/shared/src/types/abTests/header.ts
@@ -1,4 +1,4 @@
-import { UserCohort, Test, Variant, TestStatus } from './shared';
+import { UserCohort, Test, Variant, TestStatus, SupporterStatusRules } from './shared';
 import { HeaderContent } from '../props';
 import { CountryGroupId } from '../../lib';
 import { PurchaseInfoTest } from '../abTests';
@@ -15,7 +15,8 @@ export interface HeaderTest extends Test<HeaderVariant> {
     name: string;
     status: TestStatus;
     locations: CountryGroupId[];
-    userCohort: UserCohort;
+    userCohort?: UserCohort; // Deprecated - use supporterStatus
+    supporterStatus?: SupporterStatusRules;
     purchaseInfo?: PurchaseInfoTest;
     variants: HeaderVariant[];
 }

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -21,11 +21,20 @@ export interface ControlProportionSettings {
     offset: number;
 }
 
+// Deprecated - use SupporterStatusRules instead
 export type UserCohort =
     | 'AllExistingSupporters'
     | 'AllNonSupporters'
     | 'Everyone'
     | 'PostAskPauseSingleContributors';
+
+export type SupporterStatus = 'RecurringSupporter' | 'RecentSingleContributor';
+
+export interface SupporterStatusRules {
+    include: SupporterStatus[];
+    exclude: SupporterStatus[];
+    recentSingleContributorCutOffInDays: number;
+}
 
 export interface ArticlesViewedSettings {
     minViews: number;

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -4,7 +4,7 @@ export type BannerTargeting = {
     alreadyVisitedCount: number;
     shouldHideReaderRevenue?: boolean;
     isPaidContent?: boolean;
-    showSupportMessaging: boolean;
+    showSupportMessaging: boolean; // Deprecated - use isRecurringSupporter + lastOneOffContributionDate
     engagementBannerLastClosedAt?: string;
     subscriptionBannerLastClosedAt?: string;
     signInBannerLastClosedAt?: string;
@@ -21,6 +21,7 @@ export type BannerTargeting = {
     purchaseInfo?: PurchaseInfo;
     isSignedIn: boolean;
     lastOneOffContributionDate?: string;
+    isRecurringSupporter?: boolean;
 };
 
 export type BannerPayload = {

--- a/packages/shared/src/types/targeting/epic.ts
+++ b/packages/shared/src/types/targeting/epic.ts
@@ -21,9 +21,10 @@ export type EpicTargeting = {
     countryCode?: string;
     weeklyArticleHistory?: WeeklyArticleHistory;
     hasOptedOutOfArticleCount: boolean;
-    showSupportMessaging: boolean;
-    isRecurringContributor: boolean;
+    showSupportMessaging: boolean; // Deprecated - use isRecurringSupporter + lastOneOffContributionDate
+    isRecurringContributor: boolean; // Deprecated - use isRecurringSupporter
     lastOneOffContributionDate?: number; // Platform to send undefined or a timestamp date
+    isRecurringSupporter?: boolean;
     modulesVersion?: string;
     url?: string;
     browserId?: string; // Only present if the user has consented to browserId-based targeting

--- a/packages/shared/src/types/targeting/header.ts
+++ b/packages/shared/src/types/targeting/header.ts
@@ -1,11 +1,12 @@
 import { PageTracking, PurchaseInfo } from './shared';
 
 export interface HeaderTargeting {
-    showSupportMessaging: boolean;
+    showSupportMessaging: boolean; // Deprecated - use isRecurringSupporter + lastOneOffContributionDate
     countryCode: string;
     modulesVersion?: string;
     mvtId: number;
     lastOneOffContributionDate?: string;
+    isRecurringSupporter?: boolean;
     numArticles?: number;
     purchaseInfo?: PurchaseInfo;
     isSignedIn: boolean;


### PR DESCRIPTION
Deprecate `UserCohort` in favour of `SupporterStatusRules`.
This enables us to split single contributors out from recurring supporters