### PR TITLE
Add EUR to editions

### DIFF
--- a/packages/shared/src/types/targeting/header.ts
+++ b/packages/shared/src/types/targeting/header.ts
@@ -1,6 +1,6 @@
 import { PageTracking, PurchaseInfo } from './shared';
 
-export type Edition = 'UK' | 'US' | 'AU' | 'INT';
+export type Edition = 'UK' | 'US' | 'AU' | 'INT' | 'EUR';
 
 export interface HeaderTargeting {
     showSupportMessaging: boolean;


### PR DESCRIPTION
Co-authored-by: Olly Namey <olly.namey@guardian.co.uk>

## What does this change?

This adds the Europe edition to the list of existing editions (UK, US, AU, INT). The work is in progress to wire the new Europe edition into DCR and we ran into errors caused by the edition missing from this service.

## How to test

TBC

