### PR TITLE
Remove edition field from header targeting

### DIFF
--- a/packages/dotcom/package.json
+++ b/packages/dotcom/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/support-dotcom-components",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "license": "MIT",
     "main": "dist/index.js",
     "module": "dist/index.esm.js",

--- a/packages/server/src/tests/headers/headerSelection.test.ts
+++ b/packages/server/src/tests/headers/headerSelection.test.ts
@@ -199,7 +199,7 @@ describe('selectBestTest', () => {
         // Mock targeting data: not a supporter, not in UK
         const mockTargetingObject_1: HeaderTargeting = {
             showSupportMessaging: true,
-            edition: 'UK',
+
             countryCode: 'ck', // Cook Islands (New Zealand dollar region)
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -230,7 +230,7 @@ describe('selectBestTest', () => {
         // Mock targeting data: is a supporter, not in UK
         const mockTargetingObject_2: HeaderTargeting = {
             showSupportMessaging: false,
-            edition: 'UK',
+
             countryCode: 'ck',
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -261,7 +261,7 @@ describe('selectBestTest', () => {
         // Mock targeting data: not a supporter, is in UK
         const mockTargetingObject_3: HeaderTargeting = {
             showSupportMessaging: true,
-            edition: 'UK',
+
             countryCode: 'im', // Isle of Man (UK sterling region)
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -292,7 +292,7 @@ describe('selectBestTest', () => {
         // Mock targeting data: is a supporter, is in UK
         const mockTargetingObject_4: HeaderTargeting = {
             showSupportMessaging: false,
-            edition: 'UK',
+
             countryCode: 'im',
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -324,7 +324,7 @@ describe('selectBestTest', () => {
         // Mock targeting data: not a supporter, is in UK
         const mockTargetingObject_5: HeaderTargeting = {
             showSupportMessaging: true,
-            edition: 'UK',
+
             countryCode: 'im', // Isle of Man (UK sterling region)
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -356,7 +356,7 @@ describe('selectBestTest', () => {
         // Mock targeting data: recent supporter, new user
         const mockTargetingObject_6: HeaderTargeting = {
             showSupportMessaging: false,
-            edition: 'UK',
+
             countryCode: 'im',
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -388,7 +388,7 @@ describe('selectBestTest', () => {
         // Mock targeting data: recent supporter, existing user
         const mockTargetingObject_7: HeaderTargeting = {
             showSupportMessaging: false,
-            edition: 'UK',
+
             countryCode: 'im',
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -420,7 +420,7 @@ describe('selectBestTest', () => {
         // Mock targeting data: recent supporter, new user, now signed in
         const mockTargetingObject_8: HeaderTargeting = {
             showSupportMessaging: false,
-            edition: 'UK',
+
             countryCode: 'im',
             modulesVersion: 'v3',
             mvtId: 900263,

--- a/packages/server/src/tests/headers/headerSelection.test.ts
+++ b/packages/server/src/tests/headers/headerSelection.test.ts
@@ -199,7 +199,6 @@ describe('selectBestTest', () => {
         // Mock targeting data: not a supporter, not in UK
         const mockTargetingObject_1: HeaderTargeting = {
             showSupportMessaging: true,
-
             countryCode: 'ck', // Cook Islands (New Zealand dollar region)
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -230,7 +229,6 @@ describe('selectBestTest', () => {
         // Mock targeting data: is a supporter, not in UK
         const mockTargetingObject_2: HeaderTargeting = {
             showSupportMessaging: false,
-
             countryCode: 'ck',
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -261,7 +259,6 @@ describe('selectBestTest', () => {
         // Mock targeting data: not a supporter, is in UK
         const mockTargetingObject_3: HeaderTargeting = {
             showSupportMessaging: true,
-
             countryCode: 'im', // Isle of Man (UK sterling region)
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -292,7 +289,6 @@ describe('selectBestTest', () => {
         // Mock targeting data: is a supporter, is in UK
         const mockTargetingObject_4: HeaderTargeting = {
             showSupportMessaging: false,
-
             countryCode: 'im',
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -324,7 +320,6 @@ describe('selectBestTest', () => {
         // Mock targeting data: not a supporter, is in UK
         const mockTargetingObject_5: HeaderTargeting = {
             showSupportMessaging: true,
-
             countryCode: 'im', // Isle of Man (UK sterling region)
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -356,7 +351,6 @@ describe('selectBestTest', () => {
         // Mock targeting data: recent supporter, new user
         const mockTargetingObject_6: HeaderTargeting = {
             showSupportMessaging: false,
-
             countryCode: 'im',
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -388,7 +382,6 @@ describe('selectBestTest', () => {
         // Mock targeting data: recent supporter, existing user
         const mockTargetingObject_7: HeaderTargeting = {
             showSupportMessaging: false,
-
             countryCode: 'im',
             modulesVersion: 'v3',
             mvtId: 900263,
@@ -420,7 +413,6 @@ describe('selectBestTest', () => {
         // Mock targeting data: recent supporter, new user, now signed in
         const mockTargetingObject_8: HeaderTargeting = {
             showSupportMessaging: false,
-
             countryCode: 'im',
             modulesVersion: 'v3',
             mvtId: 900263,

--- a/packages/shared/src/types/targeting/header.ts
+++ b/packages/shared/src/types/targeting/header.ts
@@ -1,10 +1,7 @@
 import { PageTracking, PurchaseInfo } from './shared';
 
-export type Edition = 'UK' | 'US' | 'AU' | 'INT';
-
 export interface HeaderTargeting {
     showSupportMessaging: boolean;
-    edition: Edition;
     countryCode: string;
     modulesVersion?: string;
     mvtId: number;


### PR DESCRIPTION
This field has not been used since we integrated SDC with RRCP for headers. We use countryCode instead.
There are follow-up changes to remove the field from DCR + frontend.

(this change was prompted by a new edition - https://github.com/guardian/support-dotcom-components/pull/778)