### PR TITLE
Removes bucket names from Riff Raff config

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -26,5 +26,3 @@ deployments:
     dotcom-components:
         type: autoscaling
         dependencies: [ dotcom-components-cloudformation ]
-        parameters:
-            bucket: membership-dist


### PR DESCRIPTION
## What does this change?
Removes bucket names from Riff Raff config as recommended by DevX. By default the bucket will be discovered by looking it up in parameter store.

## How to test
Deploy to CODE via Riff Raff.