### PR TITLE
Giving Tuesday 2022 reminders

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -4,6 +4,7 @@ import {
     createClickEventFromTracking,
     createInsertEventFromTracking,
     createViewEventFromTracking,
+    GIVING_TUESDAY_REMINDER_FIELDS,
     isProfileUrl,
 } from '@sdc/shared/lib';
 import React, { useEffect } from 'react';
@@ -154,7 +155,8 @@ const withBannerData = (
 
             return {
                 type: SecondaryCtaType.ContributionsReminder,
-                reminderFields: buildReminderFields(),
+                reminderFields:
+                    countryCode === 'US' ? GIVING_TUESDAY_REMINDER_FIELDS : buildReminderFields(),
             };
         };
 

--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -140,7 +140,7 @@ export const buildEpicRouter = (
 
         const tickerSettings =
             variant.tickerSettings && tickerData.addTickerDataToSettings(variant.tickerSettings);
-        const showReminderFields = getReminderFields(variant);
+        const showReminderFields = getReminderFields(variant, targeting.countryCode);
 
         const propsVariant = {
             ...variant,

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -29,6 +29,18 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-export const getReminderFields = (variant: EpicVariant): ReminderFields | undefined => {
-    return variant.showReminderFields ?? buildReminderFields();
+export const GIVING_TUESDAY_REMINDER_FIELDS: ReminderFields = {
+    reminderCta: 'Remind me on Giving Tuesday',
+    reminderPeriod: '2022-11-01',
+    reminderLabel: 'on Giving Tuesday',
+    reminderOption: 'giving-tuesday-2022',
+};
+
+export const getReminderFields = (
+    variant: EpicVariant,
+    countryCode?: string,
+): ReminderFields | undefined => {
+    return variant.showReminderFields ?? countryCode === 'US'
+        ? GIVING_TUESDAY_REMINDER_FIELDS
+        : buildReminderFields();
 };


### PR DESCRIPTION
## What does this change?

This changes adds reminder fields to be used for US readers in the period leading to Giving Tuesday (November 29).
The Epic and Banner reminder cta now says 'Remind me on Giving Tuesday'

## How to test

Has been tested on CODE.
For Epic and Banner with reminders, change geolocation and confirm US shows the Giving Tuesday reminder message, other countries will see the generic 'Remind me in {month}'.

## Images
**Epic**
| US | UK (also tested in CA and FR) |
| ---- | ---- |
| ![Screenshot 2022-11-07 at 09 24 37](https://user-images.githubusercontent.com/99180049/200277315-532b57de-8686-429e-8354-eaa5f2223e6e.png) | ![Screenshot 2022-11-07 at 09 23 58](https://user-images.githubusercontent.com/99180049/200277365-6f51c8a7-bd81-41a4-9235-aab3d2f68d54.png) |
| ![Screenshot 2022-11-07 at 09 24 54](https://user-images.githubusercontent.com/99180049/200277440-1db8600a-3e51-41cc-b8d2-0e2b0be4f7ea.png) | ![Screenshot 2022-11-07 at 09 24 17](https://user-images.githubusercontent.com/99180049/200277490-5e2eea1e-2272-4b34-99ec-a5a920c4dd2f.png) |
| ![Screenshot 2022-11-07 at 09 25 19](https://user-images.githubusercontent.com/99180049/200277569-e3acdd92-f1a3-4f30-8700-eda06b2405e0.png) | ![Screenshot 2022-11-07 at 09 22 59](https://user-images.githubusercontent.com/99180049/200277814-e526e861-ca3d-4418-aa47-79128b95839b.png) |

Banner
| US | UK (also tested in CA and FR) |
| ---- | ---- |
| ![Screenshot 2022-11-07 at 09 21 57](https://user-images.githubusercontent.com/99180049/200278186-795e75d4-c510-4eac-b1de-f905b70a3fbd.png) | ![Screenshot 2022-11-07 at 09 21 32](https://user-images.githubusercontent.com/99180049/200278226-76931f8f-6f73-4bf7-b41a-7af75b1947d3.png) |
| ![Screenshot 2022-11-07 at 09 22 22](https://user-images.githubusercontent.com/99180049/200278347-b15d0172-9357-4be9-9187-7ddc5507912b.png) | ![Screenshot 2022-11-07 at 09 21 18](https://user-images.githubusercontent.com/99180049/200278395-301c7215-7179-4421-a402-924791a38776.png) |

Note: these have also been checked on mobile.
