### PR TITLE
Change hardcoded environment banner heading

### DIFF
--- a/packages/modules/src/modules/banners/environmentMoment/EnvironmentMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/environmentMoment/EnvironmentMomentBanner.tsx
@@ -210,7 +210,7 @@ const EnvironmentMomentBanner: React.FC<BannerRenderProps> = ({
                         </div>
                     </div>
                     <div css={textContainer}>
-                        <EnvironmentMomentBannerHeader isSupporter={isSupporter ?? false} />
+                        <EnvironmentMomentBannerHeader />
 
                         <div css={bodyAndCtasContainer}>
                             {showArticleCount && (

--- a/packages/modules/src/modules/banners/environmentMoment/components/EnvironmentMomentBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/environmentMoment/components/EnvironmentMomentBannerHeader.tsx
@@ -117,13 +117,7 @@ const line = css`
     border-top: 1px solid ${GREEN_HEX};
 `;
 
-interface EnvironmentMomentBannerHeaderProps {
-    isSupporter: boolean;
-}
-
-export const EnvironmentMomentBannerHeader: React.FC<EnvironmentMomentBannerHeaderProps> = ({
-    isSupporter,
-}: EnvironmentMomentBannerHeaderProps) => (
+export const EnvironmentMomentBannerHeader: React.FC = () => (
     <header css={container}>
         <div css={iconAndTextContainer}>
             <Hide below="desktop">
@@ -140,10 +134,10 @@ export const EnvironmentMomentBannerHeader: React.FC<EnvironmentMomentBannerHead
                         </div>
                     </Hide>
 
-                    <span>{isSupporter ? 'You power urgent' : 'Support urgent'}</span>
+                    <span>Cop27:</span>
                 </div>
 
-                <span>climate journalism</span>
+                <span>no more hot air</span>
             </div>
         </div>
 


### PR DESCRIPTION
Marketing want to test this old banner against the new "climate banner", for Cop27.
We haven't committed to making this configurable yet.

![Screenshot 2022-11-07 at 09 46 19](https://user-images.githubusercontent.com/1513454/200279797-9eae9594-f07e-4663-b00c-6b05999b65e9.png)
![Screenshot 2022-11-07 at 09 46 40](https://user-images.githubusercontent.com/1513454/200279809-9b0161b1-e839-4db8-9f59-a745462ee373.png)
![Screenshot 2022-11-07 at 09 46 55](https://user-images.githubusercontent.com/1513454/200279811-6bd4e3c6-d3f2-41fe-9a16-b2c37409c51e.png)
