### PR TITLE
Underline links in epic body

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -77,6 +77,12 @@ const headingStyles = css`
 const linkStyles = css`
     a {
         color: ${palette.news[400]};
+        text-decoration: none;
+        border-bottom: 1px solid ${palette.neutral[0]};
+    }
+
+    a:hover {
+        border-bottom: 1px solid ${palette.news[400]};
     }
 `;
 

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -77,11 +77,6 @@ const headingStyles = css`
 const linkStyles = css`
     a {
         color: ${palette.news[400]};
-        text-decoration: none;
-    }
-
-    a:hover {
-        text-decoration: underline;
     }
 `;
 

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -78,10 +78,6 @@ const linkStyles = css`
     a {
         color: ${palette.news[400]};
         text-decoration: none;
-        border-bottom: 1px solid ${palette.neutral[0]};
-    }
-
-    a:hover {
         border-bottom: 1px solid ${palette.news[400]};
     }
 `;


### PR DESCRIPTION
Currently it only underlines on hover, so it's not obvious it's a link.

Before:
<img width="370" alt="Screenshot 2022-11-09 at 15 54 04" src="https://user-images.githubusercontent.com/1513454/200883312-9e6163e0-b9a8-455a-b1d4-7d1891cd87b8.png">

After:
<img width="370" alt="Screenshot 2022-11-09 at 16 20 52" src="https://user-images.githubusercontent.com/1513454/200884048-6fc90d62-24be-4322-919d-e1bdaeabebfb.png">
