### PR TITLE
Add `isSignedIn` to EpicTargeting

### DIFF
--- a/packages/shared/src/types/targeting/epic.ts
+++ b/packages/shared/src/types/targeting/epic.ts
@@ -27,6 +27,7 @@ export type EpicTargeting = {
     modulesVersion?: string;
     url?: string;
     browserId?: string; // Only present if the user has consented to browserId-based targeting
+    isSignedIn?: boolean;
 };
 
 export type EpicPayload = {


### PR DESCRIPTION
## What does this change?

Adds `isSignedIn` to `EpicTargeting` as part of the task to add  a new targeting option to RRCP (signed out/signed in).

<!-- ## How to test

Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. "

## How can we measure success?

Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc?

## Have we considered potential risks? 

What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? 

## Images

Usually only applicable to UI changes, what did it look like before and what will it look like after?

## Accessibility

 Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests 

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour) -->
