### PR TITLE
Re-enable targeting of recent single contributors

### DIFF
--- a/packages/server/src/lib/targeting.test.ts
+++ b/packages/server/src/lib/targeting.test.ts
@@ -33,15 +33,6 @@ describe('audienceMatches', () => {
         const got = audienceMatches(false, 'AllExistingSupporters');
         expect(got).toBe(true);
     });
-
-    it('returns true for old contributor if test is for AllNonSupporters', () => {
-        const got = audienceMatches(true, 'AllNonSupporters');
-        expect(got).toBe(true);
-    });
-    it('returns false for old contributor if test is for AllExistingSupporters', () => {
-        const got = audienceMatches(true, 'AllExistingSupporters');
-        expect(got).toBe(false);
-    });
 });
 
 describe('shouldThrottle', () => {

--- a/packages/server/src/lib/targeting.test.ts
+++ b/packages/server/src/lib/targeting.test.ts
@@ -34,36 +34,21 @@ describe('audienceMatches', () => {
         expect(got).toBe(true);
     });
 
-    it('returns false for recent contributor if test is for AllExistingSupporters', () => {
-        const got = audienceMatches(
-            false,
-            'AllExistingSupporters',
-            '2022-01-01',
-            new Date('2022-01-02'),
-        );
-        expect(got).toBe(false);
-    });
-    it('returns false for recent contributor if test is for AllNonSupporters', () => {
-        const got = audienceMatches(
-            false,
-            'AllNonSupporters',
-            '2022-01-01',
-            new Date('2022-01-02'),
-        );
-        expect(got).toBe(false);
-    });
+    // it('returns true for recent contributor if test is for AllExistingSupporters', () => {
+    //     const got = audienceMatches(true, 'AllExistingSupporters');
+    //     expect(got).toBe(true);
+    // });
+    // it('returns false for recent contributor if test is for AllNonSupporters', () => {
+    //     const got = audienceMatches(false, 'AllNonSupporters');
+    //     expect(got).toBe(false);
+    // });
 
     it('returns true for old contributor if test is for AllNonSupporters', () => {
-        const got = audienceMatches(true, 'AllNonSupporters', '2021-01-01', new Date('2022-01-02'));
+        const got = audienceMatches(true, 'AllNonSupporters');
         expect(got).toBe(true);
     });
     it('returns false for old contributor if test is for AllExistingSupporters', () => {
-        const got = audienceMatches(
-            true,
-            'AllExistingSupporters',
-            '2021-01-01',
-            new Date('2022-01-02'),
-        );
+        const got = audienceMatches(true, 'AllExistingSupporters');
         expect(got).toBe(false);
     });
 });

--- a/packages/server/src/lib/targeting.test.ts
+++ b/packages/server/src/lib/targeting.test.ts
@@ -34,15 +34,6 @@ describe('audienceMatches', () => {
         expect(got).toBe(true);
     });
 
-    // it('returns true for recent contributor if test is for AllExistingSupporters', () => {
-    //     const got = audienceMatches(true, 'AllExistingSupporters');
-    //     expect(got).toBe(true);
-    // });
-    // it('returns false for recent contributor if test is for AllNonSupporters', () => {
-    //     const got = audienceMatches(false, 'AllNonSupporters');
-    //     expect(got).toBe(false);
-    // });
-
     it('returns true for old contributor if test is for AllNonSupporters', () => {
         const got = audienceMatches(true, 'AllNonSupporters');
         expect(got).toBe(true);

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -1,5 +1,5 @@
 import { EpicTargeting, UserCohort, EpicViewLog, Test, Variant } from '@sdc/shared/types';
-import { daysSince, isRecentOneOffContributor } from './dates';
+import { daysSince } from './dates';
 
 const lowValueSections = ['money', 'education', 'games', 'teacher-network', 'careers'];
 
@@ -62,16 +62,7 @@ export const userIsInTest = <V extends Variant>(test: Test<V>, mvtId: number): b
 export const audienceMatches = (
     showSupportMessaging: boolean,
     testAudience: UserCohort,
-    lastOneOffContributionDate?: string,
-    now: Date = new Date(Date.now()),
 ): boolean => {
-    const recentContributor =
-        !!lastOneOffContributionDate &&
-        isRecentOneOffContributor(new Date(lastOneOffContributionDate), now);
-    if (recentContributor) {
-        // Recent contributors are excluded from all message tests
-        return false;
-    }
     switch (testAudience) {
         case 'AllNonSupporters':
             return showSupportMessaging;

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -157,11 +157,7 @@ export const selectBannerTest = (
             (enableHardcodedBannerTests || !test.isHardcoded) &&
             !targeting.shouldHideReaderRevenue &&
             !targeting.isPaidContent &&
-            audienceMatches(
-                targeting.showSupportMessaging,
-                test.userCohort,
-                targeting.lastOneOffContributionDate,
-            ) &&
+            audienceMatches(targeting.showSupportMessaging, test.userCohort) &&
             inCountryGroups(targeting.countryCode, test.locations) &&
             targeting.alreadyVisitedCount >= test.minPageViews &&
             !(test.articlesViewedSettings && targeting.hasOptedOutOfArticleCount) &&

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -185,7 +185,7 @@ describe('getUserCohort', () => {
         expect(got).toEqual(['AllExistingSupporters', 'Everyone']);
     });
 
-    it('should return [] when user has recent one-off contribution', () => {
+    it('should return "AllExistingSupporters" when user has recent one-off contribution', () => {
         const targeting: EpicTargeting = {
             ...targetingDefault,
             lastOneOffContributionDate: twoMonthsAgo,
@@ -193,7 +193,7 @@ describe('getUserCohort', () => {
 
         const got = withNowAs(now, () => getUserCohorts(targeting));
 
-        expect(got).toEqual([]);
+        expect(got).toEqual(['AllExistingSupporters', 'Everyone']);
     });
 
     it('should return "PostAskPauseSingleContributors" when user has older one-off contribution', () => {

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -32,11 +32,6 @@ export const getUserCohorts = (targeting: EpicTargeting): UserCohort[] => {
         ? new Date(targeting.lastOneOffContributionDate)
         : undefined;
 
-    if (isRecentOneOffContributor(lastOneOffContributionDate)) {
-        // Recent contributors are excluded from all message tests
-        return [];
-    }
-
     // User is a current supporter if she has a subscription or a recurring
     // donation or has made a one-off contribution in the past 3 months.
     const isSupporter =

--- a/packages/server/src/tests/headers/headerSelection.ts
+++ b/packages/server/src/tests/headers/headerSelection.ts
@@ -299,11 +299,7 @@ export const selectBestTest = (
 
         return (
             status === 'Live' &&
-            audienceMatches(
-                showSupportMessaging,
-                userCohort,
-                targeting.lastOneOffContributionDate,
-            ) &&
+            audienceMatches(showSupportMessaging, userCohort) &&
             inCountryGroups(countryCode, locations) &&
             userIsInTest(test, targeting.mvtId) &&
             deviceTypeMatches(test, isMobile) &&


### PR DESCRIPTION
## What does this change?

- Reverts changes done in #757 by removing `isRecentOneOffContributor`.

- The `lastOneOffContributionDate` in the banner is not removed.