### PR TITLE
US + AU ticker data

### DIFF
--- a/packages/modules/src/modules/banners/utils/storybook.ts
+++ b/packages/modules/src/modules/banners/utils/storybook.ts
@@ -4,6 +4,7 @@ import {
     TickerEndType,
     SecondaryCtaType,
     Tracking,
+    TickerSettings,
 } from '@sdc/shared/types';
 
 export const tracking: Tracking = {
@@ -41,7 +42,7 @@ export const content = {
     },
 };
 
-export const tickerSettings = {
+export const tickerSettings: TickerSettings = {
     countType: TickerCountType.money,
     endType: TickerEndType.hardstop,
     currencySymbol: '$',
@@ -54,6 +55,7 @@ export const tickerSettings = {
         total: 120_000,
         goal: 150_000,
     },
+    name: 'US_2022',
 };
 
 export const props: BannerProps = {

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -171,6 +171,7 @@ WithTicker.args = {
                 total: 10000,
                 goal: 100000,
             },
+            name: 'US_2022',
         },
     },
 };

--- a/packages/server/src/lib/fetchTickerData.ts
+++ b/packages/server/src/lib/fetchTickerData.ts
@@ -40,7 +40,7 @@ const getTickerDataForTickerTypeFetcher = (name: TickerName) => (): Promise<Tick
         .then(response => response.json())
         .then(parse)
         .catch(error => {
-            logError(`Error fetching ticker data: ${error}`);
+            logError(`Error fetching ${name} ticker data: ${error}`);
             return Promise.reject(error);
         });
 };

--- a/packages/server/src/lib/fetchTickerData.ts
+++ b/packages/server/src/lib/fetchTickerData.ts
@@ -77,11 +77,11 @@ export class TickerDataProvider {
 
 export const buildTickerDataReloader = async (): Promise<TickerDataProvider> => {
     const reloaders: TickerDataProviders = await Promise.all([
-        buildReloader(getTickerDataForTickerTypeFetcher('us22'), 60),
-        buildReloader(getTickerDataForTickerTypeFetcher('au22'), 60),
-    ]).then(([us22, au22]) => ({
-        us22,
-        au22,
+        buildReloader(getTickerDataForTickerTypeFetcher('US_2022'), 60),
+        buildReloader(getTickerDataForTickerTypeFetcher('AU_2022'), 60),
+    ]).then(([US_2022, AU_2022]) => ({
+        US_2022,
+        AU_2022,
     }));
     return new TickerDataProvider(reloaders);
 };

--- a/packages/server/src/lib/fetchTickerData.ts
+++ b/packages/server/src/lib/fetchTickerData.ts
@@ -2,8 +2,11 @@ import { TickerData, TickerSettings } from '@sdc/shared/types';
 import { Response } from 'node-fetch';
 import fetch from 'node-fetch';
 import { buildReloader, ValueProvider } from '../utils/valueReloader';
+import { logError } from '../utils/logging';
+import { TickerName } from '@sdc/shared/dist/types';
 
-const tickerUrl = 'https://support.theguardian.com/ticker.json';
+const tickerUrl = (name: TickerName): string =>
+    `https://support.theguardian.com/ticker/${name}.json`;
 
 const checkForErrors = (response: Response): Promise<Response> => {
     if (!response.ok) {
@@ -29,35 +32,56 @@ const parse = (json: any): Promise<TickerData> => {
     }
 };
 
-const getTickerDataForTickerTypeFetcher = () => {
-    return fetch(tickerUrl, {
+const getTickerDataForTickerTypeFetcher = (name: TickerName) => (): Promise<TickerData> => {
+    return fetch(tickerUrl(name), {
         timeout: 1000 * 20,
     })
         .then(response => checkForErrors(response))
         .then(response => response.json())
-        .then(parse);
+        .then(parse)
+        .catch(error => {
+            logError(`Error fetching ticker data: ${error}`);
+            return Promise.reject(error);
+        });
+};
+
+// Maps each ticker campaign name to a ValueProvider
+type TickerDataProviders = {
+    [name in TickerName]: ValueProvider<TickerData>;
 };
 
 export class TickerDataProvider {
-    provider: ValueProvider<TickerData>;
+    providers: TickerDataProviders;
 
-    constructor(providers: ValueProvider<TickerData>) {
-        this.provider = providers;
+    constructor(providers: TickerDataProviders) {
+        this.providers = providers;
     }
 
-    getTickerData(): TickerData {
-        return this.provider.get();
+    getTickerData(name: TickerName): TickerData | undefined {
+        const provider = this.providers[name];
+        if (provider) {
+            return provider.get();
+        }
     }
 
-    addTickerDataToSettings(tickerSettings: TickerSettings): TickerSettings {
-        return {
-            ...tickerSettings,
-            tickerData: this.getTickerData(),
-        };
+    addTickerDataToSettings(tickerSettings: TickerSettings): TickerSettings | undefined {
+        const tickerData = this.getTickerData(tickerSettings.name);
+        if (tickerData) {
+            return {
+                ...tickerSettings,
+                tickerData,
+            };
+        }
     }
 }
 
 export const buildTickerDataReloader = async (): Promise<TickerDataProvider> => {
-    const reloader = await buildReloader(getTickerDataForTickerTypeFetcher, 60);
-    return new TickerDataProvider(reloader);
+    const reloaders: TickerDataProviders = await Promise.all([
+        buildReloader(getTickerDataForTickerTypeFetcher('us22'), 60),
+        buildReloader(getTickerDataForTickerTypeFetcher('au22'), 60),
+    ]).then(([us22, au22]) => ({
+        us22,
+        au22,
+    }));
+    return new TickerDataProvider(reloaders);
 };

--- a/packages/server/src/tests/amp/ampEpicSelection.test.ts
+++ b/packages/server/src/tests/amp/ampEpicSelection.test.ts
@@ -1,9 +1,21 @@
 import { CountryGroupId } from '@sdc/shared/lib';
-import { TickerCountType, TickerEndType } from '@sdc/shared/types';
+import { TickerCountType, TickerEndType, TickerSettings } from '@sdc/shared/types';
 import { AmpVariantAssignments } from '../../lib/ampVariantAssignments';
 import { AMPEpic, AmpEpicTest } from './ampEpicModels';
 import { selectAmpEpic } from './ampEpicSelection';
 import { TickerDataProvider } from '../../lib/fetchTickerData';
+
+const tickerSettings: TickerSettings = {
+    endType: TickerEndType.unlimited,
+    countType: TickerCountType.money,
+    currencySymbol: '$',
+    copy: {
+        countLabel: 'contributions',
+        goalReachedPrimary: "We've hit our goal!",
+        goalReachedSecondary: 'but you can still support us',
+    },
+    name: 'US_2022',
+};
 
 const epicTest: AmpEpicTest = {
     name: 'TEST1',
@@ -21,16 +33,7 @@ const epicTest: AmpEpicTest = {
                 text: 'Show your support',
                 baseUrl: 'https://support.theguardian.com/contribute',
             },
-            tickerSettings: {
-                endType: TickerEndType.unlimited,
-                countType: TickerCountType.money,
-                currencySymbol: '$',
-                copy: {
-                    countLabel: 'contributions',
-                    goalReachedPrimary: "We've hit our goal!",
-                    goalReachedSecondary: 'but you can still support us',
-                },
-            },
+            tickerSettings,
         },
         {
             name: 'VARIANT',
@@ -42,16 +45,7 @@ const epicTest: AmpEpicTest = {
                 text: 'Show your support',
                 baseUrl: 'https://support.theguardian.com/contribute',
             },
-            tickerSettings: {
-                endType: TickerEndType.unlimited,
-                countType: TickerCountType.money,
-                currencySymbol: '$',
-                copy: {
-                    countLabel: 'contributions',
-                    goalReachedPrimary: "We've hit our goal!",
-                    goalReachedSecondary: 'but you can still support us',
-                },
-            },
+            tickerSettings,
         },
     ],
 };
@@ -84,7 +78,8 @@ const expectedAmpEpic: AMPEpic = {
 };
 
 const tickerDataReloader = new TickerDataProvider({
-    get: () => ({ total: 999, goal: 1000 }),
+    US_2022: { get: () => ({ total: 999, goal: 1000 }) },
+    AU_2022: { get: () => ({ total: 999, goal: 1000 }) },
 });
 
 describe('ampEpicTests', () => {

--- a/packages/server/src/tests/amp/ampEpicSelection.ts
+++ b/packages/server/src/tests/amp/ampEpicSelection.ts
@@ -59,7 +59,7 @@ export const selectAmpEpic = async (
 const selectAmpEpicTestAndVariant = async (
     tests: AmpEpicTest[],
     ampVariantAssignments: AmpVariantAssignments,
-    tickerData: TickerDataProvider,
+    tickerDataProvider: TickerDataProvider,
     countryCode?: string,
 ): Promise<AMPEpic | null> => {
     const test = tests.find(
@@ -103,7 +103,8 @@ const selectAmpEpicTestAndVariant = async (
             };
 
             if (variant.tickerSettings) {
-                const ticker = ampTicker(variant.tickerSettings, tickerData.getTickerData());
+                const tickerData = tickerDataProvider.getTickerData(variant.tickerSettings.name);
+                const ticker = tickerData && ampTicker(variant.tickerSettings, tickerData);
                 return { ...epicData, ticker };
             } else {
                 return epicData;

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -84,11 +84,15 @@ export const tickerDataSchema = z.object({
     goal: z.number(),
 });
 
+// Corresponds to .json file names in S3
+export type TickerName = 'us22' | 'au22';
+
 export interface TickerSettings {
     endType: TickerEndType;
     countType: TickerCountType;
     currencySymbol: string;
     copy: TickerCopy;
+    name: TickerName;
     tickerData?: TickerData;
 }
 

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -85,7 +85,7 @@ export const tickerDataSchema = z.object({
 });
 
 // Corresponds to .json file names in S3
-export type TickerName = 'us22' | 'au22';
+export type TickerName = 'US_2022' | 'AU_2022';
 
 export interface TickerSettings {
     endType: TickerEndType;


### PR DESCRIPTION
For the first time we want to run two tickers concurrently.
We're creating a separate ticker stack for the 2nd ticker. The 2 stacks will output to different files. (Changing the ticker calculator to handle multiple campaigns would be a bigger change).

SDC needs to poll both ticker files and use the correct one when returning channel message data to a client.
The RRCP will require users to select which ticker to use for each channel AB test.

This PR:
1. adds a `name` field to the `TickerSettings` type. These settings come from RRCP, so we'll need to add the name field there as well. (Note - in future we could link this name to a campaign, but let's keep it simple for now)
2. Updates the `TickerDataProvider` to poll both ticker files. The `name` field corresponds to a .json file. These are `US_2022.json` and `AU_2022.json`.