### PR TITLE
Fix banner ticker

### DIFF
--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -68,6 +68,7 @@ const BannerVariantFromParams = (forChannel: BannerChannel) => {
         componentType: BannerTemplateComponentTypes[forChannel],
         products: BannerTemplateProducts[variant.template],
         separateArticleCount: variant.separateArticleCount,
+        tickerSettings: variant.tickerSettings,
     });
 };
 
@@ -90,6 +91,7 @@ const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTes
                         variants: testParams.variants.map(BannerVariantFromParams(bannerChannel)),
                         controlProportionSettings: testParams.controlProportionSettings,
                         deviceType: testParams.deviceType,
+                        signedInStatus: testParams.signedInStatus,
                     };
                 },
             );

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -2,7 +2,8 @@ import { BannerChannel, BannerContent, TickerSettings } from '../props';
 import {
     ArticlesViewedSettings,
     ControlProportionSettings,
-    DeviceType, SignedInStatus,
+    DeviceType,
+    SignedInStatus,
     TargetingAbTest,
     Test,
     TestStatus,

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -2,7 +2,7 @@ import { BannerChannel, BannerContent, TickerSettings } from '../props';
 import {
     ArticlesViewedSettings,
     ControlProportionSettings,
-    DeviceType,
+    DeviceType, SignedInStatus,
     TargetingAbTest,
     Test,
     TestStatus,
@@ -77,6 +77,7 @@ export interface RawVariantParams {
     bannerContent: BannerContent;
     mobileBannerContent?: BannerContent;
     separateArticleCount?: boolean;
+    tickerSettings?: TickerSettings;
 }
 
 export interface RawTestParams {
@@ -90,4 +91,5 @@ export interface RawTestParams {
     articlesViewedSettings?: ArticlesViewedSettings;
     controlProportionSettings?: ControlProportionSettings;
     deviceType?: DeviceType;
+    signedInStatus?: SignedInStatus;
 }


### PR DESCRIPTION
There's some extra wiring required to get `tickerSettings` from the banner config.
I also added `signedInStatus`, which I noticed was missing as well.

I'll create a card to look into getting rid of this logic, I'm not sure it adds anything.