### PR TITLE
Fix banner tickerSettings validation

### DIFF
--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -76,7 +76,7 @@ export const bannerSchema = z.object({
     mobileContent: bannerContentSchema.nullable().optional(),
     countryCode: z.string().optional(),
     isSupporter: z.boolean().optional(),
-    tickerSettings: tickerSettingsSchema.optional(),
+    tickerSettings: tickerSettingsSchema.nullable().optional(),
     submitComponentEvent: z.any(),
     numArticles: z.number().optional(),
     hasOptedOutOfArticleCount: z.boolean().optional(),


### PR DESCRIPTION
dynamodb stores `tickerSettings` as a null, but the validation in SDC only allows it to be undefined.
We need a better way of handling optional fields!