### PR TITLE
Add moment template ticker styling settings

### DIFF
--- a/packages/modules/src/modules/banners/climateCrisisMoment/ClimateCrisisMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/climateCrisisMoment/ClimateCrisisMomentBanner.stories.tsx
@@ -5,7 +5,7 @@ import { props } from '../utils/storybook';
 import { BannerProps, SecondaryCtaType } from '@sdc/shared/types';
 
 export default {
-    title: 'Banners/ClimateCrisis',
+    title: 'Banners/MomentTemplate',
     args: props,
 } as Meta;
 

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -149,12 +149,13 @@ export function getMomentTemplateBanner(
                                 />
                             </div>
 
-                            {tickerSettings?.tickerData && (
-                                <MomentTemplateBannerTicker
-                                    tickerSettings={tickerSettings}
-                                    stylingSettings={templateSettings.tickerStylingSettings}
-                                />
-                            )}
+                            {tickerSettings?.tickerData &&
+                                templateSettings.tickerStylingSettings && (
+                                    <MomentTemplateBannerTicker
+                                        tickerSettings={tickerSettings}
+                                        stylingSettings={templateSettings.tickerStylingSettings}
+                                    />
+                                )}
 
                             <section css={styles.ctasContainer}>
                                 <MomentTemplateBannerCtas

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -68,7 +68,7 @@ export function getMomentTemplateBanner(
                     </div>
 
                     {hasVisual && (
-                        <div css={styles.visualContainer}>
+                        <div css={styles.mobileVisualContainer}>
                             {templateSettings.imageSettings && (
                                 <MomentTemplateBannerVisual
                                     settings={templateSettings.imageSettings}
@@ -152,7 +152,7 @@ export function getMomentTemplateBanner(
                             {tickerSettings?.tickerData && (
                                 <MomentTemplateBannerTicker
                                     tickerSettings={tickerSettings}
-                                    accentColour={'#d42d1a'}
+                                    stylingSettings={templateSettings.tickerStylingSettings}
                                 />
                             )}
 
@@ -254,7 +254,7 @@ const styles = {
             display: none;
         }
     `,
-    visualContainer: css`
+    mobileVisualContainer: css`
         display: none;
 
         ${from.mobileMedium} {

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
@@ -19,7 +19,7 @@ const containerStyles = css`
     }
 `;
 
-const countLabelStyles = (colour?: string) => css`
+const countLabelStyles = (colour: string) => css`
     ${textSans.xsmall({ fontWeight: 'bold' })};
     font-size: 13px;
     color: ${colour};
@@ -40,7 +40,7 @@ const progressBarContainerStyles = css`
     margin-top: 40px;
 `;
 
-const progressBarStyles = (backgroundColour?: string) => css`
+const progressBarStyles = (backgroundColour: string) => css`
     overflow: hidden;
     width: 100%;
     background: ${backgroundColour};
@@ -75,7 +75,7 @@ const filledProgressStyles = (
     end: number,
     runningTotal: number,
     total: number,
-    colour?: string,
+    colour: string,
 ): SerializedStyles =>
     css`
         position: absolute;
@@ -95,7 +95,7 @@ const goalContainerStyles = css`
     text-align: right;
 `;
 
-const goalMarkerStyles = (transform: string, colour?: string): SerializedStyles => css`
+const goalMarkerStyles = (transform: string, colour: string): SerializedStyles => css`
     border-right: 2px solid ${colour};
     content: ' ';
     display: block;
@@ -107,7 +107,7 @@ const goalMarkerStyles = (transform: string, colour?: string): SerializedStyles 
 type MarkerProps = {
     goal: number;
     end: number;
-    colour?: string;
+    colour: string;
 };
 
 const Marker: React.FC<MarkerProps> = ({ goal, end, colour }: MarkerProps) => {

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { palette } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import { TickerSettings } from '@sdc/shared/types';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
 import useTicker from '../../../../hooks/useTicker';
 import { from, until } from '@guardian/src-foundations/mq';
+import { TickerStylingSettings } from '../settings';
 
 const containerStyles = css`
     position: relative;
@@ -19,10 +19,10 @@ const containerStyles = css`
     }
 `;
 
-const countLabelStyles = css`
+const countLabelStyles = (colour?: string) => css`
     ${textSans.xsmall({ fontWeight: 'bold' })};
     font-size: 13px;
-    color: #d42d1a;
+    color: ${colour};
     line-height: 1.3;
 
     ${from.desktop} {
@@ -35,16 +35,15 @@ const progressBarHeight = 12;
 const progressBarContainerStyles = css`
     width: 100%;
     height: ${progressBarHeight}px;
-    background-color: ${palette.neutral[86]};
     position: absolute;
     bottom: 0;
     margin-top: 40px;
 `;
 
-const progressBarStyles = css`
+const progressBarStyles = (backgroundColour?: string) => css`
     overflow: hidden;
     width: 100%;
-    background: #fff;
+    background: ${backgroundColour};
     height: ${progressBarHeight}px;
     position: absolute;
 `;
@@ -76,7 +75,7 @@ const filledProgressStyles = (
     end: number,
     runningTotal: number,
     total: number,
-    colour: string,
+    colour?: string,
 ): SerializedStyles =>
     css`
         position: absolute;
@@ -96,8 +95,8 @@ const goalContainerStyles = css`
     text-align: right;
 `;
 
-const goalMarkerStyles = (transform: string): SerializedStyles => css`
-    border-right: 2px solid #d42d1a;
+const goalMarkerStyles = (transform: string, colour?: string): SerializedStyles => css`
+    border-right: 2px solid ${colour};
     content: ' ';
     display: block;
     height: calc(100% + 6px);
@@ -108,27 +107,28 @@ const goalMarkerStyles = (transform: string): SerializedStyles => css`
 type MarkerProps = {
     goal: number;
     end: number;
+    colour?: string;
 };
 
-const Marker: React.FC<MarkerProps> = ({ goal, end }: MarkerProps) => {
+const Marker: React.FC<MarkerProps> = ({ goal, end, colour }: MarkerProps) => {
     if (end > goal) {
         const markerTranslate = (goal / end) * 100 - 100;
         const markerTransform = `translate3d(${markerTranslate}%, 0, 0)`;
 
-        return <div css={goalMarkerStyles(markerTransform)} />;
+        return <div css={goalMarkerStyles(markerTransform, colour)} />;
     } else {
-        return <div css={goalMarkerStyles('translate3d(-10%, 0, 0)')} />;
+        return <div css={goalMarkerStyles('translate3d(-10%, 0, 0)', colour)} />;
     }
 };
 
 type MomentTemplateBannerTickerProps = {
     tickerSettings: TickerSettings;
-    accentColour: string;
+    stylingSettings?: TickerStylingSettings;
 };
 
 const MomentTemplateBannerTicker: React.FC<MomentTemplateBannerTickerProps> = ({
     tickerSettings,
-    accentColour,
+    stylingSettings,
 }: MomentTemplateBannerTickerProps) => {
     const [readyToAnimate, setReadyToAnimate] = useState(false);
 
@@ -161,7 +161,7 @@ const MomentTemplateBannerTicker: React.FC<MomentTemplateBannerTickerProps> = ({
         <div ref={setNode} css={containerStyles}>
             <div>
                 <div css={soFarContainerStyles}>
-                    <div css={countLabelStyles}>
+                    <div css={countLabelStyles(stylingSettings?.textColour)}>
                         {!isGoalReached && currencySymbol}
                         {isGoalReached
                             ? tickerSettings.copy.goalReachedPrimary
@@ -175,7 +175,7 @@ const MomentTemplateBannerTicker: React.FC<MomentTemplateBannerTickerProps> = ({
                 </div>
 
                 <div css={goalContainerStyles}>
-                    <div css={countLabelStyles}>
+                    <div css={countLabelStyles(stylingSettings?.textColour)}>
                         {currencySymbol}
                         {isGoalReached ? runningTotal.toLocaleString() : goal.toLocaleString()}{' '}
                         <span>{isGoalReached ? tickerSettings.copy.countLabel : 'goal'}</span>
@@ -184,10 +184,17 @@ const MomentTemplateBannerTicker: React.FC<MomentTemplateBannerTickerProps> = ({
             </div>
 
             <div css={progressBarContainerStyles}>
-                <div css={progressBarStyles}>
-                    <div css={filledProgressStyles(end, runningTotal, total, accentColour)}></div>
+                <div css={progressBarStyles(stylingSettings?.progressBarBackgroundColour)}>
+                    <div
+                        css={filledProgressStyles(
+                            end,
+                            runningTotal,
+                            total,
+                            stylingSettings?.filledProgressColour,
+                        )}
+                    ></div>
                 </div>
-                <Marker goal={goal} end={end} />
+                <Marker goal={goal} end={end} colour={stylingSettings?.goalMarkerColour} />
             </div>
         </div>
     );

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
@@ -123,7 +123,7 @@ const Marker: React.FC<MarkerProps> = ({ goal, end, colour }: MarkerProps) => {
 
 type MomentTemplateBannerTickerProps = {
     tickerSettings: TickerSettings;
-    stylingSettings?: TickerStylingSettings;
+    stylingSettings: TickerStylingSettings;
 };
 
 const MomentTemplateBannerTicker: React.FC<MomentTemplateBannerTickerProps> = ({
@@ -161,7 +161,7 @@ const MomentTemplateBannerTicker: React.FC<MomentTemplateBannerTickerProps> = ({
         <div ref={setNode} css={containerStyles}>
             <div>
                 <div css={soFarContainerStyles}>
-                    <div css={countLabelStyles(stylingSettings?.textColour)}>
+                    <div css={countLabelStyles(stylingSettings.textColour)}>
                         {!isGoalReached && currencySymbol}
                         {isGoalReached
                             ? tickerSettings.copy.goalReachedPrimary
@@ -175,7 +175,7 @@ const MomentTemplateBannerTicker: React.FC<MomentTemplateBannerTickerProps> = ({
                 </div>
 
                 <div css={goalContainerStyles}>
-                    <div css={countLabelStyles(stylingSettings?.textColour)}>
+                    <div css={countLabelStyles(stylingSettings.textColour)}>
                         {currencySymbol}
                         {isGoalReached ? runningTotal.toLocaleString() : goal.toLocaleString()}{' '}
                         <span>{isGoalReached ? tickerSettings.copy.countLabel : 'goal'}</span>
@@ -184,17 +184,17 @@ const MomentTemplateBannerTicker: React.FC<MomentTemplateBannerTickerProps> = ({
             </div>
 
             <div css={progressBarContainerStyles}>
-                <div css={progressBarStyles(stylingSettings?.progressBarBackgroundColour)}>
+                <div css={progressBarStyles(stylingSettings.progressBarBackgroundColour)}>
                     <div
                         css={filledProgressStyles(
                             end,
                             runningTotal,
                             total,
-                            stylingSettings?.filledProgressColour,
+                            stylingSettings.filledProgressColour,
                         )}
                     ></div>
                 </div>
-                <Marker goal={goal} end={end} colour={stylingSettings?.goalMarkerColour} />
+                <Marker goal={goal} end={end} colour={stylingSettings.goalMarkerColour} />
             </div>
         </div>
     );

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -18,6 +18,13 @@ export interface HighlightedTextSettings {
     highlightColour?: string;
 }
 
+export interface TickerStylingSettings {
+    textColour: string;
+    filledProgressColour: string;
+    progressBarBackgroundColour: string;
+    goalMarkerColour: string;
+}
+
 export interface BannerTemplateSettings {
     backgroundColour: string;
     primaryCtaSettings: CtaSettings;
@@ -29,4 +36,5 @@ export interface BannerTemplateSettings {
     imageSettings?: Image;
     alternativeVisual?: ReactNode;
     bannerId?: BannerId;
+    tickerStylingSettings?: TickerStylingSettings;
 }

--- a/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentBanners.stories.tsx
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/PostElectionAuMomentBanners.stories.tsx
@@ -7,7 +7,7 @@ import { props } from '../utils/storybook';
 import { BannerProps, SecondaryCtaType } from '@sdc/shared/types';
 
 export default {
-    title: 'Banners/PostElectionAuMoment',
+    title: 'Banners/MomentTemplate/PostElectionAuMoment',
     args: props,
 } as Meta;
 

--- a/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.stories.tsx
@@ -56,6 +56,12 @@ const UsEoyMomentBanner = bannerWrapper(
                 'https://i.guim.co.uk/img/media/2494b0dd21a753c373fcb85c26d4c461e13c6b5b/149_0_1195_588/500.png?quality=85&s=3a55e291549838bfacbcbb495ca5be6b',
             altText: 'The United States Capitol Building',
         },
+        tickerStylingSettings: {
+            textColour: '#d42d1a',
+            filledProgressColour: '#d42d1a',
+            progressBarBackgroundColour: '#fff',
+            goalMarkerColour: '#d42d1a',
+        },
         bannerId: 'us-eoy-banner',
     }),
     'us-eoy-banner',


### PR DESCRIPTION
## What does this change?
Following a recent PR to add a ticker to the moment template https://github.com/guardian/support-dotcom-components/pull/796. This PR allows for the ticker styling to be configurable via props.
