### PR TITLE
Simplify banner test config processing

### DIFF
--- a/packages/server/src/tests/banners/DefaultContributionsBannerTest.ts
+++ b/packages/server/src/tests/banners/DefaultContributionsBannerTest.ts
@@ -8,12 +8,12 @@ export const DefaultContributionsBanner: BannerTest = {
     bannerChannel: 'contributions',
     isHardcoded: false,
     userCohort: 'AllNonSupporters',
-    minPageViews: 2,
+    minArticlesBeforeShowingBanner: 2,
     variants: [
         {
             name: 'control',
             modulePathBuilder: contributionsBanner.endpointPathBuilder,
-            moduleName: 'ContributionsBanner',
+            template: 'ContributionsBanner',
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             bannerContent: DefaultBannerContent,
         },

--- a/packages/server/src/tests/banners/DefaultContributionsBannerTest.ts
+++ b/packages/server/src/tests/banners/DefaultContributionsBannerTest.ts
@@ -1,5 +1,5 @@
 import { contributionsBanner } from '@sdc/shared/config';
-import { BannerTest } from '@sdc/shared/types';
+import { BannerTemplate, BannerTest } from '@sdc/shared/types';
 import { DefaultBannerContent } from './DefaultContributionsBannerContent';
 
 export const DefaultContributionsBanner: BannerTest = {
@@ -13,7 +13,7 @@ export const DefaultContributionsBanner: BannerTest = {
         {
             name: 'control',
             modulePathBuilder: contributionsBanner.endpointPathBuilder,
-            template: 'ContributionsBanner',
+            template: BannerTemplate.ContributionsBanner,
             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
             bannerContent: DefaultBannerContent,
         },

--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -65,12 +65,12 @@ describe('selectBannerTest', () => {
             bannerChannel: 'contributions',
             isHardcoded: false,
             userCohort: 'Everyone',
-            minPageViews: 2,
+            minArticlesBeforeShowingBanner: 2,
             variants: [
                 {
                     name: 'variant',
                     modulePathBuilder: contributionsBanner.endpointPathBuilder,
-                    moduleName: 'ContributionsBanner',
+                    template: BannerTemplate.ContributionsBanner,
                     bannerContent: {
                         messageText: 'body',
                         highlightedText: 'highlighted text',
@@ -215,12 +215,12 @@ describe('selectBannerTest', () => {
             bannerChannel: 'subscriptions',
             isHardcoded: false,
             userCohort: 'Everyone',
-            minPageViews: 2,
+            minArticlesBeforeShowingBanner: 2,
             variants: [
                 {
                     name: 'variant',
                     modulePathBuilder: digiSubs.endpointPathBuilder,
-                    moduleName: 'DigitalSubscriptionsBanner',
+                    template: BannerTemplate.DigitalSubscriptionsBanner,
                     bannerContent: {
                         messageText: 'body',
                         cta: {
@@ -326,12 +326,12 @@ describe('selectBannerTest', () => {
             isHardcoded: true,
             userCohort: 'Everyone',
             status: 'Live',
-            minPageViews: 0,
+            minArticlesBeforeShowingBanner: 0,
             variants: [
                 {
                     name: 'control',
                     modulePathBuilder: signInPromptBanner.endpointPathBuilder,
-                    moduleName: BannerTemplate.SignInPromptBanner,
+                    template: BannerTemplate.SignInPromptBanner,
                     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
                 },
             ],

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -105,7 +105,7 @@ const getForcedVariant = (
             test,
             variant,
             moduleUrl: `${baseUrl}/${variant.modulePathBuilder(targeting.modulesVersion)}`,
-            moduleName: variant.moduleName,
+            moduleName: variant.template,
         };
     }
     return null;
@@ -164,7 +164,7 @@ export const selectBannerTest = (
             !targeting.isPaidContent &&
             audienceMatches(targeting.showSupportMessaging, test.userCohort) &&
             inCountryGroups(targeting.countryCode, test.locations) &&
-            targeting.alreadyVisitedCount >= test.minPageViews &&
+            targeting.alreadyVisitedCount >= test.minArticlesBeforeShowingBanner &&
             !(test.articlesViewedSettings && targeting.hasOptedOutOfArticleCount) &&
             historyWithinArticlesViewedSettings(
                 test.articlesViewedSettings,
@@ -189,7 +189,7 @@ export const selectBannerTest = (
                 test,
                 variant,
                 moduleUrl: `${baseUrl}/${variant.modulePathBuilder(targeting.modulesVersion)}`,
-                moduleName: variant.moduleName,
+                moduleName: variant.template,
                 targetingAbTest: targetingTest ? targetingTest.test : undefined,
             };
         }

--- a/packages/server/src/tests/banners/signInPromptTests.ts
+++ b/packages/server/src/tests/banners/signInPromptTests.ts
@@ -7,13 +7,13 @@ const baseSignInPromptTest: Omit<BannerTest, 'name' | 'variants'> = {
     isHardcoded: true,
     userCohort: 'Everyone',
     status: 'Live',
-    minPageViews: 0,
+    minArticlesBeforeShowingBanner: 0,
 };
 
 const baseSignInPromptVariant: Omit<BannerVariant, 'bannerContent'> = {
     name: 'control',
     modulePathBuilder: signInPromptBanner.endpointPathBuilder,
-    moduleName: BannerTemplate.SignInPromptBanner,
+    template: BannerTemplate.SignInPromptBanner,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
 };
 

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -98,7 +98,7 @@ type ProfileLinkParams = {
 };
 
 export const addProfileTrackingParams = (baseUrl: string, params: Tracking): string => {
-    const constructQuery = (query: { [key: string]: any }): string =>
+    const constructQuery = (query: Partial<Tracking>): string =>
         Object.keys(query)
             .map((param: string) => {
                 const value = query[param];

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -2,8 +2,6 @@ import { BannerChannel, BannerContent, TickerSettings } from '../props';
 import {
     ArticlesViewedSettings,
     ControlProportionSettings,
-    DeviceType,
-    SignedInStatus,
     TargetingAbTest,
     Test,
     TestStatus,
@@ -34,7 +32,7 @@ export interface BannerVariant extends Variant {
     name: string;
     tickerSettings?: TickerSettings;
     modulePathBuilder: (version?: string) => string;
-    moduleName: string;
+    template: BannerTemplate;
     bannerContent?: BannerContent;
     mobileBannerContent?: BannerContent;
     componentType: OphanComponentType;
@@ -53,7 +51,7 @@ export interface BannerTest extends Test<BannerVariant> {
     isHardcoded: boolean;
     userCohort: UserCohort;
     canRun?: CanRun;
-    minPageViews: number;
+    minArticlesBeforeShowingBanner: number;
     variants: BannerVariant[];
     locations?: CountryGroupId[];
     articlesViewedSettings?: ArticlesViewedSettings;
@@ -72,25 +70,11 @@ export interface BannerTestSelection {
     targetingAbTest?: TargetingAbTest;
 }
 
-export interface RawVariantParams {
-    name: string;
-    template: BannerTemplate;
-    bannerContent: BannerContent;
-    mobileBannerContent?: BannerContent;
-    separateArticleCount?: boolean;
-    tickerSettings?: TickerSettings;
-}
-
-export interface RawTestParams {
-    name: string;
-    nickname: string;
-    status: TestStatus;
-    minArticlesBeforeShowingBanner: number;
-    userCohort: UserCohort;
-    locations: CountryGroupId[];
-    variants: RawVariantParams[];
-    articlesViewedSettings?: ArticlesViewedSettings;
-    controlProportionSettings?: ControlProportionSettings;
-    deviceType?: DeviceType;
-    signedInStatus?: SignedInStatus;
-}
+// Models for the config from the RRCP
+export type BannerVariantFromTool = Omit<
+    BannerVariant,
+    'modulePathBuilder' | 'componentType' | 'products'
+>;
+export type BannerTestFromTool = Omit<BannerTest, 'bannerChannel' | 'isHardcoded'> & {
+    variants: BannerVariantFromTool[];
+};


### PR DESCRIPTION
The model fetched from SAC differs from the internal SDC model. This is fine - the SDC model contains data and functions that are not relevant to SAC.

Currently there's some logic for transforming between these two models that needs to be updated any time we add a field. It's easy to forget ([recent example](https://github.com/guardian/support-dotcom-components/pull/800)).
This PR simplifies things to avoid this.

1. renames `minPageViews` to `minArticlesBeforeShowingBanner`, to be consistent with SAC
2. renames `moduleName` to `template`, to be consistent with SAC
3. Replaces the `RawTestParams` and `RawVariantParams` types with `BannerTestFromTool` and `BannerVariantFromTool` - hopefully a better name. I've also defined these in terms of the SDC `BannerTest` + `BannerVariant` models by using the [`Omit` keyword](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys).
4. The file that performs the transformation now only needs to care about fields that are not supplied by SAC.


Tested in CODE