### PR TITLE
Fix banner ticker progress bar

### DIFF
--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
@@ -66,7 +66,7 @@ const progressBarTransform = (end: number, runningTotal: number, total: number):
         return 'translateX(-100%)';
     }
 
-    const percentage = (total / end) * 100 - 110;
+    const percentage = (total / end) * 100 - 100;
 
     return `translate3d(${percentage >= 0 ? 0 : percentage}%, 0, 0)`;
 };


### PR DESCRIPTION
Before:
<img width="727" alt="Screenshot 2022-11-22 at 09 35 36" src="https://user-images.githubusercontent.com/1513454/203280838-4e0d4d28-97ff-4331-8415-5a57d62a3f7b.png">

After:
<img width="727" alt="Screenshot 2022-11-22 at 09 45 15" src="https://user-images.githubusercontent.com/1513454/203281174-bfe97384-bb9f-445b-8ea6-b8df0492d962.png">
