### PR TITLE
fix bold in epic

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -62,7 +62,8 @@ const wrapperStyles = css`
         }
     }
 
-    b {
+    b,
+    strong {
         font-weight: bold;
     }
 `;


### PR DESCRIPTION
DCR overrides `strong` tag styling