### PR TITLE
Use nullish in zod validators

### DIFF
--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -28,28 +28,13 @@ export interface BannerContent {
 }
 
 const bannerContentSchema = z.object({
-    heading: z
-        .string()
-        .nullable()
-        .optional(),
-    messageText: z
-        .string()
-        .nullable()
-        .optional(),
-    paragraphs: z
-        .array(z.string())
-        .nullable()
-        .optional(),
-    mobileMessageText: z
-        .string()
-        .nullable()
-        .optional(),
-    highlightedText: z
-        .string()
-        .nullable()
-        .optional(),
-    cta: ctaSchema.nullable().optional(),
-    secondaryCta: secondaryCtaSchema.nullable().optional(),
+    heading: z.string().nullish(),
+    messageText: z.string().nullish(),
+    paragraphs: z.array(z.string()).nullish(),
+    mobileMessageText: z.string().nullish(),
+    highlightedText: z.string().nullish(),
+    cta: ctaSchema.nullish(),
+    secondaryCta: secondaryCtaSchema.nullish(),
 });
 
 export interface BannerProps extends EmotionJSX.IntrinsicAttributes {
@@ -72,20 +57,17 @@ export interface BannerProps extends EmotionJSX.IntrinsicAttributes {
 export const bannerSchema = z.object({
     tracking: trackingSchema,
     bannerChannel: bannerChannelSchema,
-    content: bannerContentSchema.nullable().optional(),
-    mobileContent: bannerContentSchema.nullable().optional(),
-    countryCode: z.string().optional(),
-    isSupporter: z.boolean().optional(),
-    tickerSettings: tickerSettingsSchema.nullable().optional(),
+    content: bannerContentSchema.nullish(),
+    mobileContent: bannerContentSchema.nullish(),
+    countryCode: z.string().nullish(),
+    isSupporter: z.boolean().nullish(),
+    tickerSettings: tickerSettingsSchema.nullish(),
     submitComponentEvent: z.any(),
-    numArticles: z.number().optional(),
-    hasOptedOutOfArticleCount: z.boolean().optional(),
-    email: z.string().optional(),
-    fetchEmail: z.any().optional(),
-    separateArticleCount: z
-        .boolean()
-        .nullable()
-        .optional(),
+    numArticles: z.number().nullish(),
+    hasOptedOutOfArticleCount: z.boolean().nullish(),
+    email: z.string().nullish(),
+    fetchEmail: z.any().nullish(),
+    separateArticleCount: z.boolean().nullish(),
 });
 
 export interface PuzzlesBannerProps extends Partial<BannerProps> {

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -52,7 +52,7 @@ const maxViewsSchema = z.object({
 
 const separateArticleCountSchema = z.object({
     type: z.string(),
-    copy: z.string().optional(),
+    copy: z.string().nullish(),
 });
 
 const reminderFieldsSchema = z.object({
@@ -63,43 +63,31 @@ const reminderFieldsSchema = z.object({
 
 const variantSchema = z.object({
     name: z.string(),
-    heading: z
-        .string()
-        .nullable()
-        .optional(),
+    heading: z.string().nullish(),
     paragraphs: z.array(z.string()),
-    highlightedText: z
-        .string()
-        .nullable()
-        .optional(),
-    tickerSettings: tickerSettingsSchema.nullable().optional(),
-    cta: ctaSchema.nullable().optional(),
-    secondaryCta: secondaryCtaSchema.nullable().optional(),
-    footer: z
-        .string()
-        .nullable()
-        .optional(),
-    image: imageSchema.nullable().optional(),
-    showReminderFields: reminderFieldsSchema.nullable().optional(),
-    separateArticleCount: separateArticleCountSchema.nullable().optional(),
-    maxViews: maxViewsSchema.nullable().optional(),
-    showSignInLink: z
-        .boolean()
-        .nullable()
-        .optional(),
-    bylineWithImage: bylineWithImageSchema.nullable().optional(),
+    highlightedText: z.string().nullish(),
+    tickerSettings: tickerSettingsSchema.nullish(),
+    cta: ctaSchema.nullish(),
+    secondaryCta: secondaryCtaSchema.nullish(),
+    footer: z.string().nullish(),
+    image: imageSchema.nullish(),
+    showReminderFields: reminderFieldsSchema.nullish(),
+    separateArticleCount: separateArticleCountSchema.nullish(),
+    maxViews: maxViewsSchema.nullish(),
+    showSignInLink: z.boolean().nullish(),
+    bylineWithImage: bylineWithImageSchema.nullish(),
 });
 
 export const epicPropsSchema = z.object({
     variant: variantSchema,
     tracking: trackingSchema,
-    countryCode: z.string().optional(),
+    countryCode: z.string().nullish(),
     articleCounts: articleCountsSchema,
-    onReminderOpen: z.any().optional(),
-    email: z.string().optional(),
-    fetchEmail: z.any().optional(),
-    submitComponentEvent: z.any().optional(),
-    openCmp: z.any().optional(),
-    hasConsentForArticleCount: z.boolean().optional(),
-    stage: z.string().optional(),
+    onReminderOpen: z.any().nullish(),
+    email: z.string().nullish(),
+    fetchEmail: z.any().nullish(),
+    submitComponentEvent: z.any().nullish(),
+    openCmp: z.any().nullish(),
+    hasConsentForArticleCount: z.boolean().nullish(),
+    stage: z.string().nullish(),
 });

--- a/packages/shared/src/types/props/header.ts
+++ b/packages/shared/src/types/props/header.ts
@@ -14,8 +14,8 @@ export interface HeaderContent {
 const headerContentSchema = z.object({
     heading: z.string(),
     subheading: z.string(),
-    primaryCta: ctaSchema.nullable().optional(),
-    secondaryCta: ctaSchema.nullable().optional(),
+    primaryCta: ctaSchema.nullish(),
+    secondaryCta: ctaSchema.nullish(),
 });
 
 export interface HeaderProps extends EmotionJSX.IntrinsicAttributes {
@@ -30,8 +30,8 @@ export interface HeaderProps extends EmotionJSX.IntrinsicAttributes {
 export const headerSchema = z.object({
     content: headerContentSchema,
     tracking: trackingSchema,
-    mobileContent: headerContentSchema.nullable().optional(),
-    countryCode: z.string().optional(),
+    mobileContent: headerContentSchema.nullish(),
+    countryCode: z.string().nullish(),
     submitComponentEvent: z.any(),
-    numArticles: z.number().optional(),
+    numArticles: z.number().nullish(),
 });

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -101,7 +101,7 @@ export const tickerSettingsSchema = z.object({
     countType: tickerCountTypeSchema,
     currencySymbol: z.string(),
     copy: tickerCopySchema,
-    tickerData: tickerDataSchema.optional(),
+    tickerData: tickerDataSchema.nullish(),
 });
 
 export const ophanProductSchema = z.enum([
@@ -126,8 +126,8 @@ export const trackingSchema = z.object({
     abTestVariant: z.string(),
     campaignCode: z.string(),
     componentType: ophanComponentTypeSchema,
-    products: z.array(ophanProductSchema).optional(),
-    labels: z.array(z.string()).optional(),
+    products: z.array(ophanProductSchema).nullish(),
+    labels: z.array(z.string()).nullish(),
     ophanPageId: z.string(),
     platformId: z.string(),
     referrerUrl: z.string(),
@@ -146,11 +146,11 @@ export interface Image {
 
 export const imageSchema = z.object({
     mainUrl: z.string(),
-    mobileUrl: z.string().optional(),
-    tabletUrl: z.string().optional(),
-    desktopUrl: z.string().optional(),
-    leftColUrl: z.string().optional(),
-    wideUrl: z.string().optional(),
+    mobileUrl: z.string().nullish(),
+    tabletUrl: z.string().nullish(),
+    desktopUrl: z.string().nullish(),
+    leftColUrl: z.string().nullish(),
+    wideUrl: z.string().nullish(),
     altText: z.string(),
 });
 
@@ -162,6 +162,6 @@ export interface BylineWithImage {
 
 export const bylineWithImageSchema = z.object({
     name: z.string(),
-    description: z.string().optional(),
-    headshot: imageSchema.optional(),
+    description: z.string().nullish(),
+    headshot: imageSchema.nullish(),
 });


### PR DESCRIPTION
We've had a couple of instances ([e.g.](https://github.com/guardian/support-dotcom-components/pull/801)) of client-side validation of props failing because a field is stored as `null` in dynamodb, but the zod validator only defines it as `optional` (which allows `undefined` but not `null`).

This PR changes all optional fields to `nullish`, which allows both undefined and null:
`nullish: <This extends this = this>() => ZodNullable<ZodOptional<This>>;`

This isn't perfect - it's still possible for a dev to add a new field as `optional()` and cause validation to fail. But now that all other fields are defined as `nullish`, it should be pretty obvious what the convention is.

If we're still not happy with this then I think the solution is to strip out nulls at the point of querying dynamodb (nulls in dynamodb or a RDBMS is perfectly normal).