### PR TITLE
Revert "replaces the normal reminder month logic that decides on either 1 or …"

### DIFF
--- a/packages/shared/src/lib/reminderFields.test.ts
+++ b/packages/shared/src/lib/reminderFields.test.ts
@@ -1,7 +1,6 @@
 import { buildReminderFields } from './reminderFields';
 
-// This functionality is currently disabled, so tests are skipped. Will be re-enabled in December 2022.
-describe.skip('buildReminderFields', () => {
+describe('buildReminderFields', () => {
     it('should set date to the next calendar month if the current date is BEFORE the 20th', () => {
         const novemberNineteenth = new Date('2020-11-19');
 

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -6,7 +6,7 @@ export interface ReminderFields {
 }
 
 const getReminderDate = (date: Date): Date => {
-    const monthsAhead = 1;
+    const monthsAhead = date.getDate() < 20 ? 1 : 2;
     date.setMonth(date.getMonth() + monthsAhead);
 
     return date;


### PR DESCRIPTION
Reverts guardian/support-dotcom-components#813