### PR TITLE
Add US EOY banner v3

### DIFF
--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -16,6 +16,7 @@ export type BannerId =
     | 'au-brand-moment-banner'
     | 'us-eoy-banner'
     | 'us-eoy-giving-tues-banner'
+    | 'us-eoy-v3-banner'
     | 'aus-eoy-banner';
 
 export interface BannerEnrichedCta {

--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -16,7 +16,7 @@ export type BannerId =
     | 'au-brand-moment-banner'
     | 'us-eoy-banner'
     | 'us-eoy-giving-tues-banner'
-    | 'us-eoy-v3-banner'
+    | 'us-eoy-banner-v3'
     | 'aus-eoy-banner';
 
 export interface BannerEnrichedCta {

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -49,7 +49,8 @@ export function getMomentTemplateBanner(
 
         const isUsEoyBanner = templateSettings.bannerId === 'us-eoy-banner';
         const isUsEoyGivingTuesBanner = templateSettings.bannerId === 'us-eoy-giving-tues-banner';
-        const isEoyBanner = isUsEoyBanner || isUsEoyGivingTuesBanner;
+        const isUsEoyV3Banner = templateSettings.bannerId === 'us-eoy-v3-banner';
+        const isEoyBanner = isUsEoyBanner || isUsEoyGivingTuesBanner || isUsEoyV3Banner;
 
         return (
             <div css={styles.outerContainer(templateSettings.backgroundColour)}>
@@ -91,10 +92,17 @@ export function getMomentTemplateBanner(
                         </div>
                     )}
 
-                    <div css={styles.headerContainer}>
+                    <div
+                        css={
+                            isUsEoyV3Banner
+                                ? [styles.headerContainer, styles.headerContainerUsEoyV3]
+                                : styles.headerContainer
+                        }
+                    >
                         <MomentTemplateBannerHeader
                             heading={content.mainContent.heading}
                             mobileHeading={content.mobileContent.heading}
+                            headerSettings={templateSettings.headerSettings}
                         />
 
                         <Hide above="mobileMedium" cssOverrides={styles.mobileCloseButtonContainer}>
@@ -125,6 +133,8 @@ export function getMomentTemplateBanner(
                                               styles.desktopVisualContainer,
                                               styles.desktopGivingTuesVisualContainer,
                                           ]
+                                        : isUsEoyV3Banner
+                                        ? styles.desktopUsEoyV3Container
                                         : styles.desktopVisualContainer
                                 }
                             >
@@ -143,6 +153,7 @@ export function getMomentTemplateBanner(
                                 <MomentTemplateBannerHeader
                                     heading={content.mainContent.heading}
                                     mobileHeading={content.mobileContent.heading}
+                                    headerSettings={templateSettings.headerSettings}
                                 />
                             </div>
 
@@ -294,6 +305,7 @@ const styles = {
     `,
     desktopVisualContainer: css`
         display: none;
+        position: relative;
 
         ${from.tablet} {
             display: block;
@@ -314,6 +326,27 @@ const styles = {
             display: flex;
             justify-content: center;
             align-items: center;
+        }
+    `,
+    desktopUsEoyV3Container: css`
+        display: none;
+        position: relative;
+
+        ${from.tablet} {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 238px;
+            margin-left: ${space[3]}px;
+        }
+        ${from.desktop} {
+            align-items: flex-end;
+            width: 320px;
+            margin-left: ${space[5]}px;
+        }
+        ${from.leftCol} {
+            width: 370px;
+            margin-left: ${space[9]}px;
         }
     `,
     contentContainer: css`
@@ -337,6 +370,9 @@ const styles = {
         ${from.mobileMedium} {
             margin-top: ${space[2]}px;
         }
+    `,
+    headerContainerUsEoyV3: css`
+        justify-content: space-between;
     `,
     desktopHeaderContainer: css`
         display: none;

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -49,7 +49,7 @@ export function getMomentTemplateBanner(
 
         const isUsEoyBanner = templateSettings.bannerId === 'us-eoy-banner';
         const isUsEoyGivingTuesBanner = templateSettings.bannerId === 'us-eoy-giving-tues-banner';
-        const isUsEoyV3Banner = templateSettings.bannerId === 'us-eoy-v3-banner';
+        const isUsEoyV3Banner = templateSettings.bannerId === 'us-eoy-banner-v3';
         const isEoyBanner = isUsEoyBanner || isUsEoyGivingTuesBanner || isUsEoyV3Banner;
 
         return (

--- a/packages/modules/src/modules/banners/momentTemplate/buttonStyles.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/buttonStyles.ts
@@ -2,7 +2,10 @@ import { css, SerializedStyles } from '@emotion/react';
 import { from, until } from '@guardian/src-foundations/mq';
 import { CtaSettings } from './settings';
 
-export function buttonStyles(settings: CtaSettings): SerializedStyles {
+export function buttonStyles(settings?: CtaSettings): SerializedStyles {
+    if (!settings) {
+        return css``;
+    }
     const { default: defaultSettings, mobile, desktop, hover } = settings;
 
     return css`

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -14,7 +14,7 @@ import { BannerRenderedContent } from '../../common/types';
 interface MomentTemplateBannerBodyProps {
     mainContent: BannerRenderedContent;
     mobileContent: BannerRenderedContent;
-    highlightedTextSettings: HighlightedTextSettings;
+    highlightedTextSettings: HighlightedTextSettings | undefined;
 }
 
 export function MomentTemplateBannerBody({
@@ -43,7 +43,7 @@ export function MomentTemplateBannerBody({
 
 // ---- Styles ---- //
 
-const getStyles = (settings: HighlightedTextSettings) => ({
+const getStyles = (settings?: HighlightedTextSettings) => ({
     container: css`
         ${body.small()}
         color: ${neutral[0]};
@@ -68,9 +68,9 @@ const getStyles = (settings: HighlightedTextSettings) => ({
     `,
     highlightedText: css`
         display: inline;
-        color: ${settings.textColour};
+        color: ${settings?.textColour ?? neutral[7]};
 
-        ${settings.highlightColour
+        ${settings?.highlightColour
             ? `
             background: ${settings.highlightColour};
             box-shadow: 2px 0 0 ${settings.highlightColour}, -2px 0 0 ${settings.highlightColour};

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
@@ -18,7 +18,7 @@ interface MomentTemplateBannerCtasProps {
     onSecondaryCtaClick: () => void;
     onReminderCtaClick: () => void;
     primaryCtaSettings: CtaSettings;
-    secondaryCtaSettings: CtaSettings;
+    secondaryCtaSettings?: CtaSettings;
 }
 
 export function MomentTemplateBannerCtas({
@@ -47,17 +47,18 @@ export function MomentTemplateBannerCtas({
                             </LinkButton>
                         )}
 
-                        {mobileContent.secondaryCta?.type === SecondaryCtaType.Custom && (
-                            <LinkButton
-                                href={mobileContent.secondaryCta.cta.ctaUrl}
-                                onClick={onSecondaryCtaClick}
-                                size="small"
-                                priority="tertiary"
-                                cssOverrides={buttonStyles(secondaryCtaSettings)}
-                            >
-                                {mobileContent.secondaryCta.cta.ctaText}
-                            </LinkButton>
-                        )}
+                        {mobileContent.secondaryCta?.type === SecondaryCtaType.Custom &&
+                            secondaryCtaSettings && (
+                                <LinkButton
+                                    href={mobileContent.secondaryCta.cta.ctaUrl}
+                                    onClick={onSecondaryCtaClick}
+                                    size="small"
+                                    priority="tertiary"
+                                    cssOverrides={buttonStyles(secondaryCtaSettings)}
+                                >
+                                    {mobileContent.secondaryCta.cta.ctaText}
+                                </LinkButton>
+                            )}
 
                         {mobileContent.secondaryCta?.type ===
                             SecondaryCtaType.ContributionsReminder && (
@@ -86,17 +87,18 @@ export function MomentTemplateBannerCtas({
                             </LinkButton>
                         )}
 
-                        {mainContent.secondaryCta?.type === SecondaryCtaType.Custom && (
-                            <LinkButton
-                                href={mainContent.secondaryCta.cta.ctaUrl}
-                                onClick={onSecondaryCtaClick}
-                                size="small"
-                                priority="tertiary"
-                                cssOverrides={buttonStyles(secondaryCtaSettings)}
-                            >
-                                {mainContent.secondaryCta.cta.ctaText}
-                            </LinkButton>
-                        )}
+                        {mainContent.secondaryCta?.type === SecondaryCtaType.Custom &&
+                            secondaryCtaSettings && (
+                                <LinkButton
+                                    href={mainContent.secondaryCta.cta.ctaUrl}
+                                    onClick={onSecondaryCtaClick}
+                                    size="small"
+                                    priority="tertiary"
+                                    cssOverrides={buttonStyles(secondaryCtaSettings)}
+                                >
+                                    {mainContent.secondaryCta.cta.ctaText}
+                                </LinkButton>
+                            )}
 
                         {mainContent.secondaryCta?.type ===
                             SecondaryCtaType.ContributionsReminder && (

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
@@ -4,21 +4,24 @@ import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
 import { neutral } from '@guardian/src-foundations/palette';
 import { Hide } from '@guardian/src-layout';
+import { HeaderSettings } from '../settings';
 
 // ---- Component ---- //
 
 interface MomentTemplateBannerHeaderProps {
     heading: JSX.Element | JSX.Element[] | null;
     mobileHeading: JSX.Element | JSX.Element[] | null;
+    headerSettings: HeaderSettings | undefined;
 }
 
 export function MomentTemplateBannerHeader({
     heading,
     mobileHeading,
+    headerSettings,
 }: MomentTemplateBannerHeaderProps): JSX.Element {
     return (
         <div css={styles.container}>
-            <header css={styles.header}>
+            <header css={styles.header(headerSettings)}>
                 <h2>
                     <Hide above="tablet">{mobileHeading}</Hide>
                     <Hide below="tablet">{heading}</Hide>
@@ -34,11 +37,11 @@ const styles = {
     container: css`
         position: relative;
     `,
-    header: css`
+    header: (headerSettings: HeaderSettings | undefined) => css`
         h2 {
             ${headline.xsmall({ fontWeight: 'bold' })}
             margin: 0;
-            color: ${neutral[0]};
+            color: ${headerSettings?.textColour ?? neutral[0]};
             font-size: 24px;
             line-height: 115%;
 

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -27,16 +27,21 @@ export interface TickerStylingSettings {
     goalMarkerColour: string;
 }
 
+export interface HeaderSettings {
+    textColour: string;
+}
+
 export interface BannerTemplateSettings {
     backgroundColour: string;
     primaryCtaSettings: CtaSettings;
-    secondaryCtaSettings: CtaSettings;
+    secondaryCtaSettings?: CtaSettings;
     closeButtonSettings: CtaSettings;
-    highlightedTextSettings: HighlightedTextSettings;
+    highlightedTextSettings?: HighlightedTextSettings;
     setReminderCtaSettings?: CtaSettings;
     articleCountTextColour?: string;
     imageSettings?: Image;
     alternativeVisual?: ReactNode;
     bannerId?: BannerId;
     tickerStylingSettings?: TickerStylingSettings;
+    headerSettings?: HeaderSettings;
 }

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { props } from '../utils/storybook';
+import { BannerProps, TickerCountType, TickerEndType } from '@sdc/shared/types';
+import { bannerWrapper } from '../common/BannerWrapper';
+import { neutral } from '@guardian/src-foundations';
+import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
+import { UsEoyMomentBannerVisualV3 } from './UsEoyMomentBannerVisualV3';
+
+export default {
+    title: 'Banners/MomentTemplate/US_EOY_V3_2022',
+    args: props,
+} as Meta;
+
+const UsEoyMomentBannerV3 = bannerWrapper(
+    getMomentTemplateBanner({
+        backgroundColour: '#EDEDED',
+        headerSettings: {
+            textColour: '#7D0068',
+        },
+        primaryCtaSettings: {
+            default: {
+                backgroundColour: '#7D0068',
+                textColour: 'white',
+            },
+            hover: {
+                backgroundColour: '#932881',
+                textColour: 'white',
+            },
+        },
+        closeButtonSettings: {
+            default: {
+                backgroundColour: neutral[86],
+                textColour: neutral[7],
+                border: `1px solid ${neutral[7]}`,
+            },
+            hover: {
+                backgroundColour: 'white',
+                textColour: neutral[0],
+            },
+        },
+        alternativeVisual: <UsEoyMomentBannerVisualV3 />,
+        tickerStylingSettings: {
+            textColour: '#7D0068',
+            filledProgressColour: '#7D0068',
+            progressBarBackgroundColour: '#fff',
+            goalMarkerColour: '#000',
+        },
+        bannerId: 'us-eoy-v3-banner',
+    }),
+    'us-eoy-v3-banner',
+);
+
+const UsEoyTemplateV3: Story<BannerProps> = (props: BannerProps) => (
+    <UsEoyMomentBannerV3 {...props} />
+);
+
+export const WithUnderfundedTicker = UsEoyTemplateV3.bind({});
+WithUnderfundedTicker.args = {
+    ...props,
+    content: {
+        heading: 'Lend us a hand in 2023',
+        messageText:
+            "We're proud to say that the Guardian is a reader-funded global news organisation, with more than 1.5 million supporters in 180 countries. Support from readers keeps us fiercely independent, with no shareholders to please or a billionaire owner. It allows us to keep our reporting open for all, because not everyone is in a position to pay for news. But if you can afford it, we need you. <strong>We are raising $1m to fund our journalism in 2023.</strong> Make an investment in quality journalism, so millions more can benefit.",
+        paragraphs: [
+            "We're proud to say that the Guardian is a reader-funded global news organisation, with more than 1.5 million supporters in 180 countries. Support from readers keeps us fiercely independent, with no shareholders to please or a billionaire owner. It allows us to keep our reporting open for all, because not everyone is in a position to pay for news. But if you can afford it, we need you. <strong>We are raising $1m to fund our journalism in 2023.</strong> Make an investment in quality journalism, so millions more can benefit.",
+        ],
+        cta: {
+            text: 'Support independent journalism',
+            baseUrl: 'https://support.theguardian.com/contribute',
+        },
+    },
+    mobileContent: undefined,
+    separateArticleCount: false,
+    numArticles: 50,
+    tickerSettings: {
+        countType: TickerCountType.money,
+        endType: TickerEndType.hardstop,
+        currencySymbol: '$',
+        copy: {
+            countLabel: 'raised',
+            goalReachedPrimary: "We've met our goal - thank you!",
+            goalReachedSecondary: '',
+        },
+        tickerData: {
+            total: 1_000_000,
+            goal: 1_250_000,
+        },
+        name: 'US_2022',
+    },
+};
+
+export const WithOverfundedTicker = UsEoyTemplateV3.bind({});
+WithOverfundedTicker.args = {
+    ...WithUnderfundedTicker.args,
+    tickerSettings: {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- underfunded tickerSettings will not be undefined
+        ...WithUnderfundedTicker.args.tickerSettings!,
+        tickerData: {
+            total: 1_500_000,
+            goal: 1_250_000,
+        },
+    },
+};

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
@@ -46,9 +46,9 @@ const UsEoyMomentBannerV3 = bannerWrapper(
             progressBarBackgroundColour: '#fff',
             goalMarkerColour: '#000',
         },
-        bannerId: 'us-eoy-v3-banner',
+        bannerId: 'us-eoy-banner-v3',
     }),
-    'us-eoy-v3-banner',
+    'us-eoy-banner-v3',
 );
 
 const UsEoyTemplateV3: Story<BannerProps> = (props: BannerProps) => (

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
@@ -28,6 +28,16 @@ const UsEoyMomentBannerV3 = bannerWrapper(
                 textColour: 'white',
             },
         },
+        secondaryCtaSettings: {
+            default: {
+                backgroundColour: neutral[86],
+                textColour: neutral[7],
+            },
+            hover: {
+                backgroundColour: neutral[100],
+                textColour: neutral[7],
+            },
+        },
         closeButtonSettings: {
             default: {
                 backgroundColour: neutral[86],

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.tsx
@@ -19,6 +19,16 @@ const UsEoyMomentBannerV3 = getMomentTemplateBanner({
             textColour: 'white',
         },
     },
+    secondaryCtaSettings: {
+        default: {
+            backgroundColour: neutral[86],
+            textColour: neutral[7],
+        },
+        hover: {
+            backgroundColour: neutral[100],
+            textColour: neutral[7],
+        },
+    },
     closeButtonSettings: {
         default: {
             backgroundColour: neutral[86],

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { neutral } from '@guardian/src-foundations';
+import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
+import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
+import { UsEoyMomentBannerVisualV3 } from './UsEoyMomentBannerVisualV3';
+
+const UsEoyMomentBannerV3 = getMomentTemplateBanner({
+    backgroundColour: '#EDEDED',
+    headerSettings: {
+        textColour: '#7D0068',
+    },
+    primaryCtaSettings: {
+        default: {
+            backgroundColour: '#7D0068',
+            textColour: 'white',
+        },
+        hover: {
+            backgroundColour: '#932881',
+            textColour: 'white',
+        },
+    },
+    closeButtonSettings: {
+        default: {
+            backgroundColour: neutral[86],
+            textColour: neutral[7],
+            border: `1px solid ${neutral[7]}`,
+        },
+        hover: {
+            backgroundColour: 'white',
+            textColour: neutral[0],
+        },
+    },
+    alternativeVisual: <UsEoyMomentBannerVisualV3 />,
+    tickerStylingSettings: {
+        textColour: '#7D0068',
+        filledProgressColour: '#7D0068',
+        progressBarBackgroundColour: '#fff',
+        goalMarkerColour: '#000',
+    },
+    bannerId: 'us-eoy-v3-banner',
+});
+
+const unvalidated = bannerWrapper(UsEoyMomentBannerV3, 'us-eoy-v3-banner');
+const validated = validatedBannerWrapper(UsEoyMomentBannerV3, 'us-eoy-v3-banner');
+
+export { validated as UsEoyMomentBannerV3, unvalidated as UsEoyMomentBannerUnvalidatedV3 };

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.tsx
@@ -37,10 +37,10 @@ const UsEoyMomentBannerV3 = getMomentTemplateBanner({
         progressBarBackgroundColour: '#fff',
         goalMarkerColour: '#000',
     },
-    bannerId: 'us-eoy-v3-banner',
+    bannerId: 'us-eoy-banner-v3',
 });
 
-const unvalidated = bannerWrapper(UsEoyMomentBannerV3, 'us-eoy-v3-banner');
-const validated = validatedBannerWrapper(UsEoyMomentBannerV3, 'us-eoy-v3-banner');
+const unvalidated = bannerWrapper(UsEoyMomentBannerV3, 'us-eoy-banner-v3');
+const validated = validatedBannerWrapper(UsEoyMomentBannerV3, 'us-eoy-banner-v3');
 
 export { validated as UsEoyMomentBannerV3, unvalidated as UsEoyMomentBannerUnvalidatedV3 };

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerVisualV3.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerVisualV3.tsx
@@ -1,0 +1,275 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { from } from '@guardian/src-foundations/mq';
+
+export const UsEoyMomentBannerVisualV3 = (): JSX.Element => {
+    return (
+        <div css={styles}>
+            <div className="year_number year_number1">
+                <div className="inside_number">2</div>
+            </div>
+            <div className="year_number year_number2">
+                <div className="inside_number">0</div>
+            </div>
+            <div className="year_number year_number3">
+                <div className="inside_number">2</div>
+            </div>
+            <div className="year_number year_number4">
+                <div className="number_animation">
+                    <div className="inside_number">3</div>
+                    <div className="inside_number">2</div>
+                    <div className="inside_number">1</div>
+                    <div className="inside_number">0</div>
+                    <div className="inside_number">1</div>
+                    <div className="inside_number">5</div>
+                    <div className="inside_number">7</div>
+                    <div className="inside_number">6</div>
+                    <div className="inside_number">9</div>
+                    <div className="inside_number">8</div>
+                    <div className="inside_number">1</div>
+                    <div className="inside_number">2</div>
+                    <div className="inside_number">3</div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+// ---- Styles ---- //
+
+const styles = css`
+    background-image: url(https://interactive.guim.co.uk/thrashers/us-eoy-2022-v3/hashed/mobile.8a0cfa8e.png);
+    position: relative;
+    width: 100%;
+    max-width: 100%;
+    height: 100%;
+    background-position: 100% 100%;
+    background-repeat: no-repeat;
+    background-size: contain;
+    margin: 32px auto 16px;
+
+    ${from.mobileMedium} {
+        width: 300px;
+        height: 108px;
+    }
+    ${from.mobileLandscape} {
+        width: 360px;
+        height: 130px;
+    }
+    ${from.phablet} {
+        width: 480px;
+        height: 172px;
+    }
+
+    ${from.tablet} {
+        width: 100%;
+        height: 250px;
+        margin-bottom: 0;
+
+        background-image: url(https://interactive.guim.co.uk/thrashers/us-eoy-2022-v3/hashed/desktop.90cec45d.png);
+        overflow: hidden;
+        bottom: 0px;
+        max-width: 100%;
+        background-position: 100% 100%;
+        background-repeat: no-repeat;
+        background-size: contain;
+    }
+
+    ${from.desktop} {
+        height: 290px;
+    }
+
+    ${from.leftCol} {
+        background-position-x: 50%;
+    }
+
+    & .year_number {
+        position: absolute;
+        font-size: 60px;
+        font-family: 'Guardian Titlepiece', 'Guardian Headline Full', 'Guardian Headline',
+            'Guardian Egyptian Web', Georgia, serif;
+        font-weight: bold;
+        width: 22%;
+        height: 80px;
+        line-height: 90px;
+        text-align: center;
+        overflow: hidden;
+    }
+
+    & .year_number .inside_number {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+
+    & .year_number1 {
+        bottom: 46%;
+        left: 11%;
+        color: #c70000;
+
+        ${from.tablet} {
+            bottom: 53%;
+            left: 4.2%;
+        }
+
+        ${from.desktop} {
+            bottom: 63%;
+            left: 4.2%;
+        }
+
+        ${from.leftCol} {
+            left: 8%;
+        }
+    }
+
+    & .year_number2 {
+        bottom: 56%;
+        left: 29.6%;
+        color: #e05e00;
+
+        ${from.tablet} {
+            bottom: 67%;
+            left: 27.6%;
+        }
+
+        ${from.desktop} {
+            bottom: 78%;
+            left: 27.6%;
+        }
+
+        ${from.leftCol} {
+            left: 28.6%;
+        }
+    }
+
+    & .year_number3 {
+        bottom: 35%;
+        left: 49%;
+        color: #0084c6;
+
+        ${from.phablet} {
+            bottom: 35.5%;
+        }
+
+        ${from.tablet} {
+            bottom: 47.5%;
+            left: 50%;
+        }
+
+        ${from.desktop} {
+            bottom: 55.5%;
+            left: 50%;
+        }
+
+        ${from.leftCol} {
+            left: 49%;
+        }
+    }
+
+    & .year_number4 {
+        bottom: 54.5%;
+        left: 68.5%;
+        color: #7d0068;
+
+        ${from.tablet} {
+            bottom: 152px;
+            left: 73.8%;
+        }
+
+        ${from.desktop} {
+            bottom: 205px;
+            left: 73.8%;
+        }
+
+        ${from.leftCol} {
+            left: 69.5%;
+        }
+    }
+
+    & .number_animation {
+        position: absolute;
+        bottom: -100%;
+        left: 0;
+        width: 100%;
+        height: 1300%;
+        -webkit-animation-duration: 7s;
+        animation-duration: 7s;
+        -webkit-animation-iteration-count: infinite;
+        animation-iteration-count: infinite;
+        -webkit-animation-name: bounce;
+        animation-name: bounce;
+        -webkit-animation-timing-function: cubic-bezier(0.67, 0.015, 0.26, 0.995);
+        animation-timing-function: cubic-bezier(0.67, 0.015, 0.26, 0.995);
+    }
+    @-webkit-keyframes bounce {
+        0% {
+            bottom: -100%;
+        }
+        40% {
+            bottom: -100%;
+        }
+        70% {
+            bottom: -1200%;
+        }
+        100% {
+            bottom: -1200%;
+        }
+    }
+    @keyframes bounce {
+        0% {
+            bottom: -100%;
+        }
+        40% {
+            bottom: -100%;
+        }
+        70% {
+            bottom: -1200%;
+        }
+        100% {
+            bottom: -1200%;
+        }
+    }
+    & .year_number4 .inside_number {
+        height: 7.6923076923%;
+        bottom: 0px;
+        vertical-align: text-bottom;
+    }
+    & .year_number4 .inside_number:nth-child(2) {
+        bottom: 7.6923076923%;
+    }
+    & .year_number4 .inside_number:nth-child(3) {
+        bottom: 15.3846153846%;
+    }
+    & .year_number4 .inside_number:nth-child(4) {
+        bottom: 23.0769230769%;
+    }
+    & .year_number4 .inside_number:nth-child(5) {
+        bottom: 30.7692307692%;
+    }
+    & .year_number4 .inside_number:nth-child(6) {
+        bottom: 38.4615384615%;
+    }
+    & .year_number4 .inside_number:nth-child(7) {
+        bottom: 46.1538461538%;
+    }
+    & .year_number4 .inside_number:nth-child(8) {
+        bottom: 53.8461538461%;
+    }
+    & .year_number4 .inside_number:nth-child(9) {
+        bottom: 61.5384615384%;
+    }
+    & .year_number4 .inside_number:nth-child(10) {
+        bottom: 69.2307692307%;
+    }
+    & .year_number4 .inside_number:nth-child(11) {
+        bottom: 76.923076923%;
+    }
+    & .year_number4 .inside_number:nth-child(12) {
+        bottom: 84.6153846153%;
+    }
+    & .year_number4 .inside_number:nth-child(13) {
+        bottom: 92.3076923076%;
+    }
+`;

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -13,6 +13,7 @@ import {
     usEoyMomentBanner,
     usEoyGivingTuesMomentBanner,
     ausEoyMomentBanner,
+    usEoyMomentBannerV3,
 } from '@sdc/shared/config';
 import {
     BannerChannel,
@@ -45,6 +46,7 @@ export const BannerPaths: {
     [BannerTemplate.UsEoyMomentBanner]: usEoyMomentBanner.endpointPathBuilder,
     [BannerTemplate.UsEoyGivingTuesMomentBanner]: usEoyGivingTuesMomentBanner.endpointPathBuilder,
     [BannerTemplate.AusEoyMomentBanner]: ausEoyMomentBanner.endpointPathBuilder,
+    [BannerTemplate.UsEoyMomentBannerV3]: usEoyMomentBannerV3.endpointPathBuilder,
 };
 
 export const BannerTemplateComponentTypes: {

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -104,6 +104,11 @@ export const ausEoyMomentBanner: ModuleInfo = getDefaultModuleInfo(
     'banners/ausEoyMoment/AusEoyMomentBanner',
 );
 
+export const usEoyMomentBannerV3: ModuleInfo = getDefaultModuleInfo(
+    'us-eoy-banner-v3',
+    'banners/usEoyMomentV3/UsEoyMomentBannerV3',
+);
+
 export const moduleInfos: ModuleInfo[] = [
     epic,
     liveblogEpic,

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -129,4 +129,5 @@ export const moduleInfos: ModuleInfo[] = [
     usEoyMomentBanner,
     usEoyGivingTuesMomentBanner,
     ausEoyMomentBanner,
+    usEoyMomentBannerV3,
 ];

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -26,6 +26,7 @@ export enum BannerTemplate {
     SignInPromptBanner = 'SignInPromptBanner',
     ClimateCrisisMomentBanner = 'ClimateCrisisMomentBanner',
     UsEoyMomentBanner = 'UsEoyMomentBanner',
+    UsEoyMomentBannerV3 = 'UsEoyMomentBannerV3',
     UsEoyGivingTuesMomentBanner = 'UsEoyGivingTuesMomentBanner',
     AusEoyMomentBanner = 'AusEoyMomentBanner',
 }


### PR DESCRIPTION
## What does this change?
This adds v3 of the US EOY moment banner.

## Images
| mobileMedium | tablet | desktop | Wide |
|----------|--------|---------|------|
| <img width="278" alt="Screenshot 2022-12-09 at 05 15 08" src="https://user-images.githubusercontent.com/44685872/206629341-32a92fde-4f7f-4239-b76e-913e28302f71.png"> | <img width="440" alt="Screenshot 2022-12-09 at 05 15 39" src="https://user-images.githubusercontent.com/44685872/206629346-d99b22a6-4c45-4779-a6f9-c4d2730cba53.png"> | <img width="586" alt="Screenshot 2022-12-09 at 05 16 08" src="https://user-images.githubusercontent.com/44685872/206629349-9a2c4967-9a67-4207-a63b-b57dd3c9ef28.png"> | <img width="815" alt="Screenshot 2022-12-09 at 05 16 33" src="https://user-images.githubusercontent.com/44685872/206629355-b16340c7-35b0-44e8-8ae5-f16e3c8c1d17.png"> |
