### PR TITLE
Add highlighted text to US EOY v3 banner

### DIFF
--- a/packages/modules/src/modules/banners/momentTemplate/buttonStyles.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/buttonStyles.ts
@@ -2,10 +2,7 @@ import { css, SerializedStyles } from '@emotion/react';
 import { from, until } from '@guardian/src-foundations/mq';
 import { CtaSettings } from './settings';
 
-export function buttonStyles(settings?: CtaSettings): SerializedStyles {
-    if (!settings) {
-        return css``;
-    }
+export function buttonStyles(settings: CtaSettings): SerializedStyles {
     const { default: defaultSettings, mobile, desktop, hover } = settings;
 
     return css`

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -14,7 +14,7 @@ import { BannerRenderedContent } from '../../common/types';
 interface MomentTemplateBannerBodyProps {
     mainContent: BannerRenderedContent;
     mobileContent: BannerRenderedContent;
-    highlightedTextSettings: HighlightedTextSettings | undefined;
+    highlightedTextSettings: HighlightedTextSettings;
 }
 
 export function MomentTemplateBannerBody({
@@ -43,7 +43,7 @@ export function MomentTemplateBannerBody({
 
 // ---- Styles ---- //
 
-const getStyles = (settings?: HighlightedTextSettings) => ({
+const getStyles = (settings: HighlightedTextSettings) => ({
     container: css`
         ${body.small()}
         color: ${neutral[0]};
@@ -68,9 +68,9 @@ const getStyles = (settings?: HighlightedTextSettings) => ({
     `,
     highlightedText: css`
         display: inline;
-        color: ${settings?.textColour ?? neutral[7]};
+        color: ${settings.textColour};
 
-        ${settings?.highlightColour
+        ${settings.highlightColour
             ? `
             background: ${settings.highlightColour};
             box-shadow: 2px 0 0 ${settings.highlightColour}, -2px 0 0 ${settings.highlightColour};

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
@@ -18,7 +18,7 @@ interface MomentTemplateBannerCtasProps {
     onSecondaryCtaClick: () => void;
     onReminderCtaClick: () => void;
     primaryCtaSettings: CtaSettings;
-    secondaryCtaSettings?: CtaSettings;
+    secondaryCtaSettings: CtaSettings;
 }
 
 export function MomentTemplateBannerCtas({
@@ -47,18 +47,17 @@ export function MomentTemplateBannerCtas({
                             </LinkButton>
                         )}
 
-                        {mobileContent.secondaryCta?.type === SecondaryCtaType.Custom &&
-                            secondaryCtaSettings && (
-                                <LinkButton
-                                    href={mobileContent.secondaryCta.cta.ctaUrl}
-                                    onClick={onSecondaryCtaClick}
-                                    size="small"
-                                    priority="tertiary"
-                                    cssOverrides={buttonStyles(secondaryCtaSettings)}
-                                >
-                                    {mobileContent.secondaryCta.cta.ctaText}
-                                </LinkButton>
-                            )}
+                        {mobileContent.secondaryCta?.type === SecondaryCtaType.Custom && (
+                            <LinkButton
+                                href={mobileContent.secondaryCta.cta.ctaUrl}
+                                onClick={onSecondaryCtaClick}
+                                size="small"
+                                priority="tertiary"
+                                cssOverrides={buttonStyles(secondaryCtaSettings)}
+                            >
+                                {mobileContent.secondaryCta.cta.ctaText}
+                            </LinkButton>
+                        )}
 
                         {mobileContent.secondaryCta?.type ===
                             SecondaryCtaType.ContributionsReminder && (
@@ -87,18 +86,17 @@ export function MomentTemplateBannerCtas({
                             </LinkButton>
                         )}
 
-                        {mainContent.secondaryCta?.type === SecondaryCtaType.Custom &&
-                            secondaryCtaSettings && (
-                                <LinkButton
-                                    href={mainContent.secondaryCta.cta.ctaUrl}
-                                    onClick={onSecondaryCtaClick}
-                                    size="small"
-                                    priority="tertiary"
-                                    cssOverrides={buttonStyles(secondaryCtaSettings)}
-                                >
-                                    {mainContent.secondaryCta.cta.ctaText}
-                                </LinkButton>
-                            )}
+                        {mainContent.secondaryCta?.type === SecondaryCtaType.Custom && (
+                            <LinkButton
+                                href={mainContent.secondaryCta.cta.ctaUrl}
+                                onClick={onSecondaryCtaClick}
+                                size="small"
+                                priority="tertiary"
+                                cssOverrides={buttonStyles(secondaryCtaSettings)}
+                            >
+                                {mainContent.secondaryCta.cta.ctaText}
+                            </LinkButton>
+                        )}
 
                         {mainContent.secondaryCta?.type ===
                             SecondaryCtaType.ContributionsReminder && (

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
@@ -208,11 +208,11 @@ const styles = {
     `,
     ctasContainer: css`
         display: flex;
-        flex-direction: row;
-        align-items: center;
+        flex-wrap: wrap;
 
-        & > * + * {
-            margin-left: ${space[3]}px;
+        & a:not(:last-child) {
+            margin-right: ${space[3]}px;
+            margin-bottom: ${space[2]}px;
         }
     `,
     paymentMethods: css`

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -34,7 +34,7 @@ export interface HeaderSettings {
 export interface BannerTemplateSettings {
     backgroundColour: string;
     primaryCtaSettings: CtaSettings;
-    secondaryCtaSettings?: CtaSettings;
+    secondaryCtaSettings: CtaSettings;
     closeButtonSettings: CtaSettings;
     highlightedTextSettings: HighlightedTextSettings;
     setReminderCtaSettings?: CtaSettings;

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -36,7 +36,7 @@ export interface BannerTemplateSettings {
     primaryCtaSettings: CtaSettings;
     secondaryCtaSettings?: CtaSettings;
     closeButtonSettings: CtaSettings;
-    highlightedTextSettings?: HighlightedTextSettings;
+    highlightedTextSettings: HighlightedTextSettings;
     setReminderCtaSettings?: CtaSettings;
     articleCountTextColour?: string;
     imageSettings?: Image;

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
@@ -49,6 +49,10 @@ const UsEoyMomentBannerV3 = bannerWrapper(
                 textColour: neutral[0],
             },
         },
+        highlightedTextSettings: {
+            textColour: neutral[0],
+            highlightColour: neutral[100],
+        },
         alternativeVisual: <UsEoyMomentBannerVisualV3 />,
         tickerStylingSettings: {
             textColour: '#7D0068',
@@ -75,6 +79,7 @@ WithUnderfundedTicker.args = {
         paragraphs: [
             "We're proud to say that the Guardian is a reader-funded global news organisation, with more than 1.5 million supporters in 180 countries. Support from readers keeps us fiercely independent, with no shareholders to please or a billionaire owner. It allows us to keep our reporting open for all, because not everyone is in a position to pay for news. But if you can afford it, we need you. <strong>We are raising $1m to fund our journalism in 2023.</strong> Make an investment in quality journalism, so millions more can benefit.",
         ],
+        highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
         cta: {
             text: 'Support independent journalism',
             baseUrl: 'https://support.theguardian.com/contribute',

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { props } from '../utils/storybook';
-import { BannerProps, TickerCountType, TickerEndType } from '@sdc/shared/types';
+import { BannerProps, SecondaryCtaType, TickerCountType, TickerEndType } from '@sdc/shared/types';
 import { bannerWrapper } from '../common/BannerWrapper';
 import { neutral } from '@guardian/src-foundations';
 import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
@@ -81,8 +81,15 @@ WithUnderfundedTicker.args = {
         ],
         highlightedText: 'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1. Thank you.',
         cta: {
-            text: 'Support independent journalism',
+            text: 'Support us monthly',
             baseUrl: 'https://support.theguardian.com/contribute',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Support just once',
+                baseUrl: 'https://theguardian.com',
+            },
         },
     },
     mobileContent: undefined,

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.tsx
@@ -40,6 +40,10 @@ const UsEoyMomentBannerV3 = getMomentTemplateBanner({
             textColour: neutral[0],
         },
     },
+    highlightedTextSettings: {
+        textColour: neutral[0],
+        highlightColour: neutral[100],
+    },
     alternativeVisual: <UsEoyMomentBannerVisualV3 />,
     tickerStylingSettings: {
         textColour: '#7D0068',


### PR DESCRIPTION
## What does this change?
Following https://github.com/guardian/support-dotcom-components/pull/821 this adds highlighted text to the US EOY v3 banner and wraps banner ctas inside their flex container on smaller breakpoints. 

This also reverts some changes made in the previous PR around optional types as it would be best to tackle this separately. 

## Why are you doing this?
- To fulfil a request to add highlighted text to this banner
- The original requirement for the ctas on the moment template banner to be on one line has since changed
- Changes around optional and required types were made to tackle some inconsistencies in which template styling settings are optional or required. For example we require styling `secondaryCtaSettings` to always be defined but the `secondaryCta` element is optional. This would be best to handle separately

## Images
<img width="237" alt="Screenshot 2022-12-12 at 12 33 02" src="https://user-images.githubusercontent.com/44685872/207046364-9e7a0ece-ffad-4671-8688-2678c24a6906.png">
