### PR TITLE
Update automated banner deploy times

### DIFF
--- a/packages/server/src/tests/banners/bannerDeploySchedule.test.ts
+++ b/packages/server/src/tests/banners/bannerDeploySchedule.test.ts
@@ -36,6 +36,7 @@ describe('previousScheduledDate', () => {
     });
 });
 
+// Banner 2: Tuesday (9:00 AM)
 describe('lastScheduledDeploy, subscriptions', () => {
     it('returns previous Tuesday if currently Monday', () => {
         const result = getLastScheduledDeploy(
@@ -51,5 +52,32 @@ describe('lastScheduledDeploy, subscriptions', () => {
             defaultDeploySchedule.subscriptions,
         );
         expect(result).toEqual(new Date('2022-12-06 09:00:00'));
+    });
+});
+
+// Banner 1: Sunday + Thursday (9:00AM)
+describe('lastScheduledDeploy, contributions', () => {
+    it('returns previous Sunday if currently Monday', () => {
+        const result = getLastScheduledDeploy(
+            new Date('2022-12-12 09:00:00'),
+            defaultDeploySchedule.contributions,
+        );
+        expect(result).toEqual(new Date('2022-12-11 09:00:00'));
+    });
+
+    it('returns previous Thursday if currently Saturday', () => {
+        const result = getLastScheduledDeploy(
+            new Date('2022-12-17 09:00:00'),
+            defaultDeploySchedule.contributions,
+        );
+        expect(result).toEqual(new Date('2022-12-15 09:00:00'));
+    });
+
+    it('returns today (Thursday) if currently Thursday and within an hour of the last deploy', () => {
+        const result = getLastScheduledDeploy(
+            new Date('2022-12-15 09:30:00'),
+            defaultDeploySchedule.contributions,
+        );
+        expect(result).toEqual(new Date('2022-12-15 09:00:00'));
     });
 });

--- a/packages/server/src/tests/banners/bannerDeploySchedule.test.ts
+++ b/packages/server/src/tests/banners/bannerDeploySchedule.test.ts
@@ -37,27 +37,19 @@ describe('previousScheduledDate', () => {
 });
 
 describe('lastScheduledDeploy, subscriptions', () => {
-    it('returns previous monday if currently tuesday', () => {
+    it('returns previous Tuesday if currently Monday', () => {
         const result = getLastScheduledDeploy(
-            new Date('2021-11-09 09:00:00'),
+            new Date('2022-12-12 09:00:00'),
             defaultDeploySchedule.subscriptions,
         );
-        expect(result).toEqual(new Date('2021-11-08 08:00:00'));
+        expect(result).toEqual(new Date('2022-12-06 09:00:00'));
     });
 
-    it('returns previous friday if currently sunday', () => {
+    it('returns today (Tuesday) if currently Tuesday and within an hour of the last deploy', () => {
         const result = getLastScheduledDeploy(
-            new Date('2021-11-07 09:00:00'),
+            new Date('2022-12-06 09:30:00'),
             defaultDeploySchedule.subscriptions,
         );
-        expect(result).toEqual(new Date('2021-11-05 08:00:00'));
-    });
-
-    it('returns today (friday) if currently friday and within an hour of the last deploy', () => {
-        const result = getLastScheduledDeploy(
-            new Date('2021-11-26 08:30:00'),
-            defaultDeploySchedule.subscriptions,
-        );
-        expect(result).toEqual(new Date('2021-11-26 08:00:00'));
+        expect(result).toEqual(new Date('2022-12-06 09:00:00'));
     });
 });

--- a/packages/server/src/tests/banners/bannerDeploySchedule.ts
+++ b/packages/server/src/tests/banners/bannerDeploySchedule.ts
@@ -30,7 +30,7 @@ export const defaultDeploySchedule: ScheduledBannerDeploys = {
     // Banner 2: Tuesday (9:00 AM)
     subscriptions: [
         {
-            dayOfWeek: 1,
+            dayOfWeek: 2,
             hour: 9,
         },
     ],

--- a/packages/server/src/tests/banners/bannerDeploySchedule.ts
+++ b/packages/server/src/tests/banners/bannerDeploySchedule.ts
@@ -16,20 +16,22 @@ export interface ScheduledBannerDeploys {
 }
 
 export const defaultDeploySchedule: ScheduledBannerDeploys = {
+    // Banner 1: Sunday + Thursday (9:00AM)
     contributions: [
         {
             dayOfWeek: 0,
             hour: 9,
         },
+        {
+            dayOfWeek: 4,
+            hour: 9,
+        },
     ],
+    // Banner 2: Tuesday (9:00 AM)
     subscriptions: [
         {
             dayOfWeek: 1,
-            hour: 8,
-        },
-        {
-            dayOfWeek: 5,
-            hour: 8,
+            hour: 9,
         },
     ],
 };


### PR DESCRIPTION
## What does this change?
Marketing have requested a change to the automated deployment times for banner channels, as follows:

```
Banner 1 (== channel 1 conversions banner): Sunday + Thursday (9:00AM)
Banner 2 (== channel 2 subscriptions banner): Tuesday (9:00 AM)
```

#### Testing
Question: how do we test this?