### PR TITLE
Rename Australia brand moment banner files

### DIFF
--- a/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerArticleCount.tsx
@@ -3,24 +3,24 @@ import { css } from '@emotion/react';
 import { neutral } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
-import { MomentTemplateArticleCountOptOut } from './MomentTemplateBannerArticleCountOptOut';
+import { AuMomentTemplateArticleCountOptOut } from './AuMomentTemplateBannerArticleCountOptOut';
 import { BannerTemplateSettings } from '../settings';
 
 // ---- Component ---- //
 
-interface MomentTemplateBannerArticleCountProps {
+interface AuMomentTemplateBannerArticleCountProps {
     numArticles: number;
     settings: BannerTemplateSettings;
 }
 
-export function MomentTemplateBannerArticleCount({
+export function AuMomentTemplateBannerArticleCount({
     numArticles,
     settings,
-}: MomentTemplateBannerArticleCountProps): JSX.Element {
+}: AuMomentTemplateBannerArticleCountProps): JSX.Element {
     return (
         <p css={styles.container}>
             You&apos;ve read{' '}
-            <MomentTemplateArticleCountOptOut
+            <AuMomentTemplateArticleCountOptOut
                 numArticles={numArticles}
                 nextWord=" articles"
                 settings={settings}

--- a/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerArticleCountOptOut.tsx
+++ b/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerArticleCountOptOut.tsx
@@ -14,17 +14,17 @@ import { buttonStyles } from '../buttonStyles';
 
 // ---- Component ---- //
 
-export interface MomentTemplateArticleCountOptOutProps {
+export interface AuMomentTemplateArticleCountOptOutProps {
     numArticles: number;
     nextWord: string | null;
     settings: BannerTemplateSettings;
 }
 
-export const MomentTemplateArticleCountOptOut: React.FC<MomentTemplateArticleCountOptOutProps> = ({
+export const AuMomentTemplateArticleCountOptOut: React.FC<AuMomentTemplateArticleCountOptOutProps> = ({
     numArticles,
     nextWord,
     settings,
-}: MomentTemplateArticleCountOptOutProps) => {
+}: AuMomentTemplateArticleCountOptOutProps) => {
     const [isOpen, setIsOpen] = useState(false);
     const [hasOptedOut, setHasOptedOut] = useState(false);
 

--- a/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerBody.tsx
@@ -11,17 +11,17 @@ import { BannerRenderedContent } from '../../common/types';
 
 // ---- Component ---- //
 
-interface MomentTemplateBannerBodyProps {
+interface AuMomentTemplateBannerBodyProps {
     mainContent: BannerRenderedContent;
     mobileContent: BannerRenderedContent;
     highlightedTextSettings: HighlightedTextSettings;
 }
 
-export function MomentTemplateBannerBody({
+export function AuMomentTemplateBannerBody({
     mainContent,
     mobileContent,
     highlightedTextSettings,
-}: MomentTemplateBannerBodyProps): JSX.Element {
+}: AuMomentTemplateBannerBodyProps): JSX.Element {
     const styles = getStyles(highlightedTextSettings);
 
     return (

--- a/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerCloseButton.tsx
@@ -10,15 +10,15 @@ import { space } from '@guardian/src-foundations';
 
 // ---- Component ---- //
 
-interface MomentTemplateBannerCloseButtonProps {
+interface AuMomentTemplateBannerCloseButtonProps {
     onCloseClick: () => void;
     settings: CtaSettings;
 }
 
-export function MomentTemplateBannerCloseButton({
+export function AuMomentTemplateBannerCloseButton({
     onCloseClick,
     settings,
-}: MomentTemplateBannerCloseButtonProps): JSX.Element {
+}: AuMomentTemplateBannerCloseButtonProps): JSX.Element {
     return (
         <div css={styles.container}>
             <div css={styles.roundelContainer}>

--- a/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerCtas.tsx
@@ -11,7 +11,7 @@ import { from } from '@guardian/src-foundations/mq';
 
 // ---- Component ---- //
 
-interface MomentTemplateBannerCtasProps {
+interface AuMomentTemplateBannerCtasProps {
     mainContent: BannerRenderedContent;
     mobileContent: BannerRenderedContent;
     onPrimaryCtaClick: () => void;
@@ -21,7 +21,7 @@ interface MomentTemplateBannerCtasProps {
     secondaryCtaSettings: CtaSettings;
 }
 
-export function MomentTemplateBannerCtas({
+export function AuMomentTemplateBannerCtas({
     mainContent,
     mobileContent,
     onPrimaryCtaClick,
@@ -29,7 +29,7 @@ export function MomentTemplateBannerCtas({
     onReminderCtaClick,
     primaryCtaSettings,
     secondaryCtaSettings,
-}: MomentTemplateBannerCtasProps): JSX.Element {
+}: AuMomentTemplateBannerCtasProps): JSX.Element {
     return (
         <div css={styles.container}>
             <div>

--- a/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerHeader.tsx
@@ -8,15 +8,15 @@ import { Hide } from '@guardian/src-layout';
 
 // ---- Component ---- //
 
-interface MomentTemplateBannerHeaderProps {
+interface AuMomentTemplateBannerHeaderProps {
     heading: JSX.Element | JSX.Element[] | null;
     mobileHeading: JSX.Element | JSX.Element[] | null;
 }
 
-export function MomentTemplateBannerHeader({
+export function AuMomentTemplateBannerHeader({
     heading,
     mobileHeading,
-}: MomentTemplateBannerHeaderProps): JSX.Element {
+}: AuMomentTemplateBannerHeaderProps): JSX.Element {
     return (
         <div css={styles.container}>
             <header css={styles.header}>

--- a/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerReminderSignedOut.tsx
+++ b/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerReminderSignedOut.tsx
@@ -16,19 +16,19 @@ import { ErrorCopy, InfoCopy, ThankYou } from '../../../shared/Reminders';
 
 // ---- Component ---- //
 
-export interface MomentTemplateBannerReminderSignedOutProps {
+export interface AuMomentTemplateBannerReminderSignedOutProps {
     reminderCta: BannerEnrichedReminderCta;
     reminderStatus: ReminderStatus;
     onReminderSetClick: (email: string) => void;
     setReminderCtaSettings?: CtaSettings;
 }
 
-export function MomentTemplateBannerReminderSignedOut({
+export function AuMomentTemplateBannerReminderSignedOut({
     reminderCta,
     reminderStatus,
     onReminderSetClick,
     setReminderCtaSettings,
-}: MomentTemplateBannerReminderSignedOutProps): JSX.Element {
+}: AuMomentTemplateBannerReminderSignedOutProps): JSX.Element {
     const reminderLabelWithPreposition = ensureHasPreposition(
         reminderCta.reminderFields.reminderLabel,
     );

--- a/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/auBrandMoment/components/AuMomentTemplateBannerVisual.tsx
@@ -6,13 +6,13 @@ import { Image } from '@sdc/shared/types';
 
 // ---- Component ---- //
 
-interface MomentTemplateBannerVisualProps {
+interface AuMomentTemplateBannerVisualProps {
     settings: Image;
 }
 
 export function MomentTemplateBannerVisual({
     settings,
-}: MomentTemplateBannerVisualProps): JSX.Element {
+}: AuMomentTemplateBannerVisualProps): JSX.Element {
     const baseImage: ImageAttrs = {
         url: settings.mainUrl,
         media: '',

--- a/packages/modules/src/modules/banners/auBrandMoment/components/getAuBrandMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/auBrandMoment/components/getAuBrandMomentBanner.tsx
@@ -3,12 +3,12 @@ import { css } from '@emotion/react';
 import { breakpoints, neutral, space } from '@guardian/src-foundations';
 import { Container, Hide } from '@guardian/src-layout';
 import { BannerRenderProps } from '../../common/types';
-import { MomentTemplateBannerHeader } from './MomentTemplateBannerHeader';
-import { MomentTemplateBannerArticleCount } from './MomentTemplateBannerArticleCount';
-import { MomentTemplateBannerBody } from './MomentTemplateBannerBody';
-import { MomentTemplateBannerCtas } from './MomentTemplateBannerCtas';
-import { MomentTemplateBannerCloseButton } from './MomentTemplateBannerCloseButton';
-import { MomentTemplateBannerVisual } from './MomentTemplateBannerVisual';
+import { AuMomentTemplateBannerHeader } from './AuMomentTemplateBannerHeader';
+import { AuMomentTemplateBannerArticleCount } from './AuMomentTemplateBannerArticleCount';
+import { AuMomentTemplateBannerBody } from './AuMomentTemplateBannerBody';
+import { AuMomentTemplateBannerCtas } from './AuMomentTemplateBannerCtas';
+import { AuMomentTemplateBannerCloseButton } from './AuMomentTemplateBannerCloseButton';
+import { MomentTemplateBannerVisual } from './AuMomentTemplateBannerVisual';
 import { BannerTemplateSettings } from '../settings';
 import { from } from '@guardian/src-foundations/mq';
 
@@ -50,7 +50,7 @@ export function getAuBrandMomentBanner(
                 >
                     <div css={styles.closeButtonContainer}>
                         <Hide below="mobileMedium">
-                            <MomentTemplateBannerCloseButton
+                            <AuMomentTemplateBannerCloseButton
                                 onCloseClick={onCloseClick}
                                 settings={templateSettings.closeButtonSettings}
                             />
@@ -62,13 +62,13 @@ export function getAuBrandMomentBanner(
                     </div>
 
                     <div css={styles.headerContainer}>
-                        <MomentTemplateBannerHeader
+                        <AuMomentTemplateBannerHeader
                             heading={content.mainContent.heading}
                             mobileHeading={content.mobileContent.heading}
                         />
 
                         <Hide above="mobileMedium" cssOverrides={styles.mobileCloseButtonContainer}>
-                            <MomentTemplateBannerCloseButton
+                            <AuMomentTemplateBannerCloseButton
                                 onCloseClick={onCloseClick}
                                 settings={templateSettings.closeButtonSettings}
                             />
@@ -79,7 +79,7 @@ export function getAuBrandMomentBanner(
                 <Container cssOverrides={styles.containerOverrides}>
                     <div css={styles.closeButtonContainer}>
                         <Hide below="tablet">
-                            <MomentTemplateBannerCloseButton
+                            <AuMomentTemplateBannerCloseButton
                                 onCloseClick={onCloseClick}
                                 settings={templateSettings.closeButtonSettings}
                             />
@@ -88,7 +88,7 @@ export function getAuBrandMomentBanner(
                     <div css={styles.container}>
                         <div css={styles.contentContainer}>
                             <div css={styles.desktopHeaderContainer}>
-                                <MomentTemplateBannerHeader
+                                <AuMomentTemplateBannerHeader
                                     heading={content.mainContent.heading}
                                     mobileHeading={content.mobileContent.heading}
                                 />
@@ -96,7 +96,7 @@ export function getAuBrandMomentBanner(
 
                             {separateArticleCount && numArticles !== undefined && numArticles > 5 && (
                                 <div css={styles.articleCountContainer}>
-                                    <MomentTemplateBannerArticleCount
+                                    <AuMomentTemplateBannerArticleCount
                                         numArticles={numArticles}
                                         settings={templateSettings}
                                     />
@@ -104,7 +104,7 @@ export function getAuBrandMomentBanner(
                             )}
 
                             <div css={styles.bodyContainer}>
-                                <MomentTemplateBannerBody
+                                <AuMomentTemplateBannerBody
                                     mainContent={content.mainContent}
                                     mobileContent={content.mobileContent}
                                     highlightedTextSettings={
@@ -114,7 +114,7 @@ export function getAuBrandMomentBanner(
                             </div>
 
                             <section css={styles.ctasContainer}>
-                                <MomentTemplateBannerCtas
+                                <AuMomentTemplateBannerCtas
                                     mainContent={content.mainContent}
                                     mobileContent={content.mobileContent}
                                     onPrimaryCtaClick={onCtaClick}


### PR DESCRIPTION
## What does this change?
This renames the Australia brand moment banner files and variables within those files so as not to conflict with the moment template banner. 

## Why are you doing this?
The Australia brand moment is currently unused but may be needed in future and was first introduced in https://github.com/guardian/support-dotcom-components/pull/729. We'd attempted to build this banner using the moment template but it did not fit all of the requirements. So, the approach taken was to duplicate the moment template files and tailor them to the specific moment. This had left us with a fair few files that are similarly named, albeit in different folders e.g. `.../banners/auBrandMoment/components/MomentTemplateBannerBody.tsx` vs `.../banners/momentTemplate/components/MomentTemplateBannerBody.tsx`
