### PR TITLE
Hide 'Other amount' button in Epic amounts choice card component

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -230,436 +230,161 @@ WithChoiceCards.args = {
         showChoiceCards: true,
         choiceCardAmounts: {
             GBPCountries: {
+                hideChooseYourAmount: true,
                 control: {
                     ONE_OFF: {
-                        amounts: [30, 60, 120, 240],
-                        defaultAmount: 60,
+                        amounts: [5],
+                        defaultAmount: 10,
                     },
                     MONTHLY: {
-                        amounts: [3, 6, 9, 15],
-                        defaultAmount: 9,
+                        amounts: [10, 15],
+                        defaultAmount: 20,
                     },
                     ANNUAL: {
-                        amounts: [60, 120, 240, 480],
-                        defaultAmount: 120,
+                        amounts: [5, 10, 15, 20],
+                        defaultAmount: 15,
                     },
                 },
                 test: {
-                    name: '2021-09-02_AMOUNTS_R5__UK',
-                    isLive: false,
+                    name: 'GBP_COUNTRIES_AMOUNTS_TEST',
+                    isLive: true,
                     variants: [
                         {
-                            name: 'V2_LOWER',
+                            name: 'V1',
                             amounts: {
                                 ONE_OFF: {
-                                    amounts: [30, 60, 120, 240],
-                                    defaultAmount: 60,
+                                    amounts: [5, 10, 20, 25, 30],
+                                    defaultAmount: 20,
                                 },
                                 MONTHLY: {
-                                    amounts: [3, 5, 10, 15],
-                                    defaultAmount: 5,
+                                    amounts: [5, 15, 30, 40, 80],
+                                    defaultAmount: 15,
                                 },
                                 ANNUAL: {
-                                    amounts: [60, 120, 240, 480],
-                                    defaultAmount: 120,
+                                    amounts: [100, 150, 250, 500],
+                                    defaultAmount: 250,
+                                },
+                            },
+                            hideChooseYourAmount: true,
+                        },
+                        {
+                            name: 'V2',
+                            amounts: {
+                                ONE_OFF: {
+                                    amounts: [10, 50, 100, 150],
+                                    defaultAmount: 100,
+                                },
+                                MONTHLY: {
+                                    amounts: [10, 20, 40, 50],
+                                    defaultAmount: 50,
+                                },
+                                ANNUAL: {
+                                    amounts: [150, 300, 500, 750],
+                                    defaultAmount: 500,
                                 },
                             },
                         },
                     ],
-                    seed: 917618,
+                    seed: 398375,
                 },
             },
             UnitedStates: {
                 control: {
                     ONE_OFF: {
-                        amounts: [25, 50, 100, 250],
-                        defaultAmount: 50,
+                        amounts: [5],
+                        defaultAmount: 5,
                     },
                     MONTHLY: {
-                        amounts: [7, 15, 30],
-                        defaultAmount: 15,
+                        amounts: [5, 10],
+                        defaultAmount: 10,
                     },
                     ANNUAL: {
-                        amounts: [50, 100, 250, 500],
-                        defaultAmount: 50,
+                        amounts: [5, 10, 15],
+                        defaultAmount: 10,
                     },
                 },
-                test: {
-                    name: '2021-03-11_AMOUNTS_R2__US',
-                    isLive: false,
-                    variants: [
-                        {
-                            name: 'V1_HIGHER_STRETCH',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [25, 50, 100, 250],
-                                    defaultAmount: 50,
-                                },
-                                MONTHLY: {
-                                    amounts: [7, 15, 30, 50],
-                                    defaultAmount: 15,
-                                },
-                                ANNUAL: {
-                                    amounts: [50, 100, 250, 500],
-                                    defaultAmount: 100,
-                                },
-                            },
-                        },
-                    ],
-                    seed: 930202,
-                },
+                hideChooseYourAmount: true,
             },
             EURCountries: {
                 control: {
                     ONE_OFF: {
-                        amounts: [25, 50, 100, 250],
-                        defaultAmount: 50,
+                        amounts: [],
+                        defaultAmount: 5,
                     },
                     MONTHLY: {
-                        amounts: [6, 10, 20],
-                        defaultAmount: 10,
+                        amounts: [20],
+                        defaultAmount: 5,
                     },
                     ANNUAL: {
-                        amounts: [50, 100, 250, 500],
-                        defaultAmount: 50,
+                        amounts: [10, 20],
+                        defaultAmount: 5,
                     },
                 },
-                test: {
-                    name: '2021-03-11_AMOUNTS_R2__EU',
-                    isLive: false,
-                    variants: [
-                        {
-                            name: 'V1_HIGHER_STRETCH',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [25, 50, 100, 250],
-                                    defaultAmount: 50,
-                                },
-                                MONTHLY: {
-                                    amounts: [6, 10, 25, 50],
-                                    defaultAmount: 10,
-                                },
-                                ANNUAL: {
-                                    amounts: [50, 100, 250, 500],
-                                    defaultAmount: 50,
-                                },
-                            },
-                        },
-                        {
-                            name: 'V2_HIGHER_DEFAULT',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [25, 50, 100, 250],
-                                    defaultAmount: 50,
-                                },
-                                MONTHLY: {
-                                    amounts: [6, 8, 12, 24],
-                                    defaultAmount: 12,
-                                },
-                                ANNUAL: {
-                                    amounts: [50, 100, 150, 200],
-                                    defaultAmount: 100,
-                                },
-                            },
-                        },
-                    ],
-                    seed: 628626,
-                },
+                hideChooseYourAmount: true,
             },
             AUDCountries: {
                 control: {
                     ONE_OFF: {
-                        amounts: [60, 100, 250, 500],
-                        defaultAmount: 100,
+                        amounts: [5, 10, 15, 20],
+                        defaultAmount: 5,
                     },
                     MONTHLY: {
-                        amounts: [10, 20, 40],
-                        defaultAmount: 20,
+                        amounts: [5, 10, 15, 20],
+                        defaultAmount: 5,
                     },
                     ANNUAL: {
-                        amounts: [80, 250, 500, 750],
-                        defaultAmount: 80,
+                        amounts: [5, 10, 15, 20],
+                        defaultAmount: 5,
                     },
-                },
-                test: {
-                    name: '2021-03-11_AMOUNTS_R2__AU',
-                    isLive: false,
-                    variants: [
-                        {
-                            name: 'V1_HIGHER_STRETCH',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [60, 100, 250, 500],
-                                    defaultAmount: 100,
-                                },
-                                MONTHLY: {
-                                    amounts: [10, 20, 40, 60],
-                                    defaultAmount: 20,
-                                },
-                                ANNUAL: {
-                                    amounts: [80, 250, 500, 750],
-                                    defaultAmount: 80,
-                                },
-                            },
-                        },
-                        {
-                            name: 'V2_HIGHER_DEFAULT',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [60, 100, 250, 500],
-                                    defaultAmount: 100,
-                                },
-                                MONTHLY: {
-                                    amounts: [10, 20, 30, 40],
-                                    defaultAmount: 30,
-                                },
-                                ANNUAL: {
-                                    amounts: [80, 150, 300, 500],
-                                    defaultAmount: 150,
-                                },
-                            },
-                        },
-                        {
-                            name: 'V3_LOWER_OPENING',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [60, 100, 250, 500],
-                                    defaultAmount: 100,
-                                },
-                                MONTHLY: {
-                                    amounts: [8, 20, 40],
-                                    defaultAmount: 20,
-                                },
-                                ANNUAL: {
-                                    amounts: [60, 250, 500, 750],
-                                    defaultAmount: 60,
-                                },
-                            },
-                        },
-                    ],
-                    seed: 605059,
                 },
             },
             International: {
+                hideChooseYourAmount: true,
                 control: {
                     ONE_OFF: {
-                        amounts: [25, 50, 100, 250],
+                        amounts: [],
                         defaultAmount: 50,
                     },
                     MONTHLY: {
-                        amounts: [5, 10, 20],
-                        defaultAmount: 10,
+                        amounts: [10, 15],
+                        defaultAmount: 15,
                     },
                     ANNUAL: {
-                        amounts: [60, 100, 250, 500],
-                        defaultAmount: 60,
+                        amounts: [100, 150, 200, 500],
+                        defaultAmount: 150,
                     },
-                },
-                test: {
-                    name: '2021-03-11_AMOUNTS_R2__INT',
-                    isLive: false,
-                    variants: [
-                        {
-                            name: 'V1_HIGHER_STRETCH',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [25, 50, 100, 250],
-                                    defaultAmount: 50,
-                                },
-                                MONTHLY: {
-                                    amounts: [6, 10, 25, 40],
-                                    defaultAmount: 10,
-                                },
-                                ANNUAL: {
-                                    amounts: [50, 100, 250, 500],
-                                    defaultAmount: 50,
-                                },
-                            },
-                        },
-                        {
-                            name: 'V2_HIGHER_DEFAULT',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [25, 50, 100, 250],
-                                    defaultAmount: 50,
-                                },
-                                MONTHLY: {
-                                    amounts: [6, 8, 12, 30],
-                                    defaultAmount: 12,
-                                },
-                                ANNUAL: {
-                                    amounts: [50, 100, 150, 200],
-                                    defaultAmount: 100,
-                                },
-                            },
-                        },
-                        {
-                            name: 'V3_LOWER_OPENING',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [25, 50, 100, 250],
-                                    defaultAmount: 50,
-                                },
-                                MONTHLY: {
-                                    amounts: [4, 10, 20],
-                                    defaultAmount: 10,
-                                },
-                                ANNUAL: {
-                                    amounts: [40, 100, 250, 500],
-                                    defaultAmount: 40,
-                                },
-                            },
-                        },
-                    ],
-                    seed: 943978,
                 },
             },
             NZDCountries: {
                 control: {
                     ONE_OFF: {
-                        amounts: [50, 100, 250, 500],
-                        defaultAmount: 100,
+                        amounts: [5, 10, 15, 20],
+                        defaultAmount: 5,
                     },
                     MONTHLY: {
-                        amounts: [10, 20, 50],
-                        defaultAmount: 20,
+                        amounts: [5, 10, 15, 20],
+                        defaultAmount: 5,
                     },
                     ANNUAL: {
-                        amounts: [50, 100, 250, 500],
-                        defaultAmount: 50,
+                        amounts: [5, 10, 15, 20],
+                        defaultAmount: 5,
                     },
-                },
-                test: {
-                    name: '2021-03-11_AMOUNTS_R2__NZ',
-                    isLive: false,
-                    variants: [
-                        {
-                            name: 'V1_HIGHER_STRETCH',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [50, 100, 250, 500],
-                                    defaultAmount: 100,
-                                },
-                                MONTHLY: {
-                                    amounts: [10, 20, 50, 100],
-                                    defaultAmount: 20,
-                                },
-                                ANNUAL: {
-                                    amounts: [50, 100, 500, 750],
-                                    defaultAmount: 50,
-                                },
-                            },
-                        },
-                        {
-                            name: 'V2_HIGHER_DEFAULT',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [50, 100, 250, 500],
-                                    defaultAmount: 100,
-                                },
-                                MONTHLY: {
-                                    amounts: [10, 15, 25, 50],
-                                    defaultAmount: 25,
-                                },
-                                ANNUAL: {
-                                    amounts: [50, 100, 500, 750],
-                                    defaultAmount: 100,
-                                },
-                            },
-                        },
-                        {
-                            name: 'V3_LOWER_OPENING',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [50, 100, 250, 500],
-                                    defaultAmount: 100,
-                                },
-                                MONTHLY: {
-                                    amounts: [8, 20, 50],
-                                    defaultAmount: 20,
-                                },
-                                ANNUAL: {
-                                    amounts: [40, 100, 500, 750],
-                                    defaultAmount: 40,
-                                },
-                            },
-                        },
-                    ],
-                    seed: 628456,
                 },
             },
             Canada: {
                 control: {
                     ONE_OFF: {
-                        amounts: [25, 50, 100, 250],
-                        defaultAmount: 50,
+                        amounts: [],
+                        defaultAmount: 5,
                     },
                     MONTHLY: {
-                        amounts: [5, 10, 20],
-                        defaultAmount: 10,
+                        amounts: [5, 10, 15],
+                        defaultAmount: 5,
                     },
                     ANNUAL: {
-                        amounts: [60, 100, 250, 500],
-                        defaultAmount: 60,
+                        amounts: [10, 15, 20],
+                        defaultAmount: 20,
                     },
-                },
-                test: {
-                    name: '2021-03-11_AMOUNTS_R2__CA',
-                    isLive: false,
-                    variants: [
-                        {
-                            name: 'V1_HIGHER_STRETCH',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [25, 50, 100, 250],
-                                    defaultAmount: 50,
-                                },
-                                MONTHLY: {
-                                    amounts: [5, 10, 25, 40],
-                                    defaultAmount: 10,
-                                },
-                                ANNUAL: {
-                                    amounts: [60, 100, 250, 500],
-                                    defaultAmount: 60,
-                                },
-                            },
-                        },
-                        {
-                            name: 'V2_HIGHER_DEFAULT',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [25, 50, 100, 250],
-                                    defaultAmount: 50,
-                                },
-                                MONTHLY: {
-                                    amounts: [6, 8, 12, 24],
-                                    defaultAmount: 12,
-                                },
-                                ANNUAL: {
-                                    amounts: [60, 100, 150, 200],
-                                    defaultAmount: 100,
-                                },
-                            },
-                        },
-                        {
-                            name: 'V3_LOWER_OPENING',
-                            amounts: {
-                                ONE_OFF: {
-                                    amounts: [25, 50, 100, 250],
-                                    defaultAmount: 50,
-                                },
-                                MONTHLY: {
-                                    amounts: [4, 10, 20],
-                                    defaultAmount: 10,
-                                },
-                                ANNUAL: {
-                                    amounts: [40, 100, 250, 500],
-                                    defaultAmount: 40,
-                                },
-                            },
-                        },
-                    ],
-                    seed: 775798,
                 },
             },
         },

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -230,19 +230,18 @@ WithChoiceCards.args = {
         showChoiceCards: true,
         choiceCardAmounts: {
             GBPCountries: {
-                hideChooseYourAmount: true,
                 control: {
                     ONE_OFF: {
-                        amounts: [5],
-                        defaultAmount: 10,
+                        amounts: [10, 20, 30, 40],
+                        defaultAmount: 30,
                     },
                     MONTHLY: {
-                        amounts: [10, 15],
-                        defaultAmount: 20,
+                        amounts: [5, 10, 15, 20],
+                        defaultAmount: 10,
                     },
                     ANNUAL: {
-                        amounts: [5, 10, 15, 20],
-                        defaultAmount: 15,
+                        amounts: [50, 100, 150, 200],
+                        defaultAmount: 50,
                     },
                 },
                 test: {
@@ -253,34 +252,56 @@ WithChoiceCards.args = {
                             name: 'V1',
                             amounts: {
                                 ONE_OFF: {
-                                    amounts: [5, 10, 20, 25, 30],
+                                    amounts: [10, 20, 30, 40],
                                     defaultAmount: 20,
                                 },
                                 MONTHLY: {
-                                    amounts: [5, 15, 30, 40, 80],
-                                    defaultAmount: 15,
+                                    amounts: [5, 10, 15, 20],
+                                    defaultAmount: 10,
+                                    hideChooseYourAmount: true,
                                 },
                                 ANNUAL: {
-                                    amounts: [100, 150, 250, 500],
-                                    defaultAmount: 250,
+                                    amounts: [50, 100, 150, 200],
+                                    defaultAmount: 150,
+                                    hideChooseYourAmount: true,
                                 },
                             },
-                            hideChooseYourAmount: true,
                         },
                         {
                             name: 'V2',
                             amounts: {
                                 ONE_OFF: {
-                                    amounts: [10, 50, 100, 150],
-                                    defaultAmount: 100,
+                                    amounts: [],
+                                    defaultAmount: 10,
                                 },
                                 MONTHLY: {
-                                    amounts: [10, 20, 40, 50],
-                                    defaultAmount: 50,
+                                    amounts: [],
+                                    defaultAmount: 10,
+                                    hideChooseYourAmount: true,
                                 },
                                 ANNUAL: {
-                                    amounts: [150, 300, 500, 750],
-                                    defaultAmount: 500,
+                                    amounts: [50],
+                                    defaultAmount: 50,
+                                    hideChooseYourAmount: true,
+                                },
+                            },
+                        },
+                        {
+                            name: 'V3',
+                            amounts: {
+                                ONE_OFF: {
+                                    amounts: [10],
+                                    defaultAmount: 10,
+                                },
+                                MONTHLY: {
+                                    amounts: [10, 20],
+                                    defaultAmount: 10,
+                                    hideChooseYourAmount: true,
+                                },
+                                ANNUAL: {
+                                    amounts: [50, 100, 150],
+                                    defaultAmount: 50,
+                                    hideChooseYourAmount: true,
                                 },
                             },
                         },
@@ -291,99 +312,99 @@ WithChoiceCards.args = {
             UnitedStates: {
                 control: {
                     ONE_OFF: {
-                        amounts: [5],
-                        defaultAmount: 5,
+                        amounts: [10, 20, 30, 40],
+                        defaultAmount: 20,
                     },
                     MONTHLY: {
-                        amounts: [5, 10],
+                        amounts: [5, 10, 15, 20],
                         defaultAmount: 10,
                     },
                     ANNUAL: {
-                        amounts: [5, 10, 15],
-                        defaultAmount: 10,
+                        amounts: [50, 100, 150, 200],
+                        defaultAmount: 50,
                     },
                 },
-                hideChooseYourAmount: true,
             },
             EURCountries: {
                 control: {
                     ONE_OFF: {
-                        amounts: [],
-                        defaultAmount: 5,
+                        amounts: [10, 20, 30, 40],
+                        defaultAmount: 20,
                     },
                     MONTHLY: {
-                        amounts: [20],
-                        defaultAmount: 5,
+                        amounts: [5, 10, 15, 20],
+                        defaultAmount: 10,
                     },
                     ANNUAL: {
-                        amounts: [10, 20],
-                        defaultAmount: 5,
+                        amounts: [50, 100, 150, 200],
+                        defaultAmount: 50,
                     },
                 },
-                hideChooseYourAmount: true,
             },
             AUDCountries: {
                 control: {
                     ONE_OFF: {
-                        amounts: [5, 10, 15, 20],
-                        defaultAmount: 5,
+                        amounts: [10, 20, 30, 40],
+                        defaultAmount: 20,
                     },
                     MONTHLY: {
                         amounts: [5, 10, 15, 20],
-                        defaultAmount: 5,
+                        defaultAmount: 10,
                     },
                     ANNUAL: {
-                        amounts: [5, 10, 15, 20],
-                        defaultAmount: 5,
+                        amounts: [50, 100, 150, 200],
+                        defaultAmount: 50,
                     },
                 },
             },
             International: {
-                hideChooseYourAmount: true,
                 control: {
                     ONE_OFF: {
-                        amounts: [],
-                        defaultAmount: 50,
+                        amounts: [10, 20, 30, 40],
+                        defaultAmount: 20,
+                        hideChooseYourAmount: false,
                     },
                     MONTHLY: {
-                        amounts: [10, 15],
-                        defaultAmount: 15,
+                        amounts: [5, 10, 15, 20],
+                        defaultAmount: 10,
+                        hideChooseYourAmount: true,
                     },
                     ANNUAL: {
-                        amounts: [100, 150, 200, 500],
-                        defaultAmount: 150,
+                        amounts: [50, 100, 150, 200],
+                        defaultAmount: 50,
+                        hideChooseYourAmount: true,
                     },
                 },
             },
             NZDCountries: {
                 control: {
                     ONE_OFF: {
-                        amounts: [5, 10, 15, 20],
-                        defaultAmount: 5,
+                        amounts: [10, 20, 30, 40],
+                        defaultAmount: 30,
                     },
                     MONTHLY: {
                         amounts: [5, 10, 15, 20],
-                        defaultAmount: 5,
+                        defaultAmount: 10,
                     },
                     ANNUAL: {
-                        amounts: [5, 10, 15, 20],
-                        defaultAmount: 5,
+                        amounts: [50, 100, 150, 200],
+                        defaultAmount: 50,
                     },
                 },
             },
             Canada: {
                 control: {
                     ONE_OFF: {
-                        amounts: [],
-                        defaultAmount: 5,
+                        amounts: [10, 20, 30, 40],
+                        defaultAmount: 30,
                     },
                     MONTHLY: {
-                        amounts: [5, 10, 15],
-                        defaultAmount: 5,
+                        amounts: [5, 10, 15, 20],
+                        defaultAmount: 10,
                     },
                     ANNUAL: {
-                        amounts: [10, 15, 20],
-                        defaultAmount: 20,
+                        amounts: [50, 100, 150, 200],
+                        defaultAmount: 50,
                     },
                 },
             },

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -261,10 +261,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
     stage,
 }: EpicProps) => {
     const countryGroupId = countryCodeToCountryGroupId(countryCode || 'GBPCountries');
-
     const defaultFrequency: ContributionFrequency = variant.defaultChoiceCardFrequency || 'MONTHLY';
-
-    // This code needs to change in a world where we show amounts AB variants in the epic choice card? Also, this code feels fragile?
     const [choiceCardSelection, setChoiceCardSelection] = useState<ChoiceCardSelection | undefined>(
         variant.choiceCardAmounts && {
             frequency: defaultFrequency,

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -261,7 +261,10 @@ const ContributionsEpic: React.FC<EpicProps> = ({
     stage,
 }: EpicProps) => {
     const countryGroupId = countryCodeToCountryGroupId(countryCode || 'GBPCountries');
+
     const defaultFrequency: ContributionFrequency = variant.defaultChoiceCardFrequency || 'MONTHLY';
+
+    // This code needs to change in a world where we show amounts AB variants in the epic choice card? Also, this code feels fragile?
     const [choiceCardSelection, setChoiceCardSelection] = useState<ChoiceCardSelection | undefined>(
         variant.choiceCardAmounts && {
             frequency: defaultFrequency,

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -140,7 +140,6 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
         const requiredAmounts = productData.amounts;
         const hideChooseYourAmount = productData.hideChooseYourAmount ?? false;
         const defaultAmount = amountsTestVariant[selection.frequency].defaultAmount;
-        console.log(defaultAmount, requiredAmounts);
 
         // Something is wrong with the data
         if (!Array.isArray(requiredAmounts) || !requiredAmounts.length) {

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -190,29 +190,6 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
                 {generateChoiceCardFrequencyTab('ONE_OFF')}
                 {generateChoiceCardFrequencyTab('MONTHLY')}
                 {generateChoiceCardFrequencyTab('ANNUAL')}
-                {/*
-                <ChoiceCard
-                    label={contributionType.ONE_OFF.label}
-                    value={contributionType.ONE_OFF.value}
-                    id={contributionType.ONE_OFF.value}
-                    checked={selection.frequency === contributionType.ONE_OFF.frequency}
-                    onChange={() => updateFrequency(contributionType.ONE_OFF.frequency)}
-                />
-                <ChoiceCard
-                    label={contributionType.MONTHLY.label}
-                    value={contributionType.MONTHLY.value}
-                    id={contributionType.MONTHLY.value}
-                    checked={selection.frequency === contributionType.MONTHLY.frequency}
-                    onChange={() => updateFrequency(contributionType.MONTHLY.frequency)}
-                />
-                <ChoiceCard
-                    label={contributionType.ANNUAL.label}
-                    value={contributionType.ANNUAL.value}
-                    id={contributionType.ANNUAL.value}
-                    checked={selection.frequency === contributionType.ANNUAL.frequency}
-                    onChange={() => updateFrequency(contributionType.ANNUAL.frequency)}
-                />
-*/}
             </ChoiceCardGroup>
             <br />
             <ChoiceCardGroup

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -139,7 +139,6 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
         const productData = amountsTestVariant[selection.frequency];
         const requiredAmounts = productData.amounts;
         const hideChooseYourAmount = productData.hideChooseYourAmount ?? false;
-        const defaultAmount = amountsTestVariant[selection.frequency].defaultAmount;
 
         // Something is wrong with the data
         if (!Array.isArray(requiredAmounts) || !requiredAmounts.length) {

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -46,7 +46,6 @@ interface EpicChoiceCardProps {
 
 interface ContributionTypeItem {
     label: string;
-    value: string;
     frequency: ContributionFrequency;
     suffix: string;
 }
@@ -57,19 +56,16 @@ type ContributionType = {
 const contributionType: ContributionType = {
     ONE_OFF: {
         label: 'Single',
-        value: 'one_off',
         frequency: 'ONE_OFF',
         suffix: '',
     },
     MONTHLY: {
         label: 'Monthly',
-        value: 'monthly',
         frequency: 'MONTHLY',
         suffix: 'per month',
     },
     ANNUAL: {
         label: 'Annual',
-        value: 'annual',
         frequency: 'ANNUAL',
         suffix: 'per year',
     },
@@ -165,13 +161,14 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
     };
 
     const generateChoiceCardFrequencyTab = (frequency: ContributionFrequency) => {
+        const frequencyVal = contributionType[frequency].frequency;
         return (
             <ChoiceCard
                 label={contributionType[frequency].label}
-                value={contributionType[frequency].value}
-                id={contributionType[frequency].value}
-                checked={selection.frequency === contributionType[frequency].frequency}
-                onChange={() => updateFrequency(contributionType[frequency].frequency)}
+                value={frequencyVal}
+                id={frequencyVal}
+                checked={selection.frequency === frequencyVal}
+                onChange={() => updateFrequency(frequencyVal)}
             />
         );
     };

--- a/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicChoiceCards.tsx
@@ -146,16 +146,16 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
                         <ChoiceCard
                             value="second"
                             label={`${currencySymbol}${requiredAmounts[1]}${frequencySuffix()}`}
-                            id="first"
+                            id="second"
                             checked={selection.amount === requiredAmounts[1]}
                             onChange={() => updateAmount(requiredAmounts[1])}
                         />
                     )}
                     {requiredAmounts[2] != null && (
                         <ChoiceCard
-                            value="second"
+                            value="third"
                             label={`${currencySymbol}${requiredAmounts[2]}${frequencySuffix()}`}
-                            id="first"
+                            id="third"
                             checked={selection.amount === requiredAmounts[2]}
                             onChange={() => updateAmount(requiredAmounts[2])}
                         />
@@ -178,7 +178,7 @@ export const ContributionsEpicChoiceCards: React.FC<EpicChoiceCardProps> = ({
                         <ChoiceCard
                             value="second"
                             label={`${currencySymbol}${requiredAmounts[1]}${frequencySuffix()}`}
-                            id="first"
+                            id="second"
                             checked={selection.amount === requiredAmounts[1]}
                             onChange={() => updateAmount(requiredAmounts[1])}
                         />

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -70,6 +70,7 @@ export type ContributionFrequency = 'ONE_OFF' | 'MONTHLY' | 'ANNUAL';
 export interface AmountSelection {
     amounts: number[];
     defaultAmount: number;
+    hideChooseYourAmount?: boolean;
 }
 
 export type ContributionAmounts = {
@@ -79,7 +80,6 @@ export type ContributionAmounts = {
 export interface AmountsTestVariant {
     name: string;
     amounts: ContributionAmounts;
-    hideChooseYourAmount?: boolean;
 }
 
 export interface AmountsTest {
@@ -92,7 +92,6 @@ export interface AmountsTest {
 export type ConfiguredRegionAmounts = {
     control: ContributionAmounts;
     test?: AmountsTest;
-    hideChooseYourAmount?: boolean;
 };
 
 export type ChoiceCardAmounts = {

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -79,6 +79,7 @@ export type ContributionAmounts = {
 export interface AmountsTestVariant {
     name: string;
     amounts: ContributionAmounts;
+    hideChooseYourAmount?: boolean;
 }
 
 export interface AmountsTest {
@@ -91,6 +92,7 @@ export interface AmountsTest {
 export type ConfiguredRegionAmounts = {
     control: ContributionAmounts;
     test?: AmountsTest;
+    hideChooseYourAmount?: boolean;
 };
 
 export type ChoiceCardAmounts = {


### PR DESCRIPTION
## What does this change?
We've added a boolean `hideChooseYourAmount` attribute to the Contributions Amounts model generated by RRCP and stored in S3. This PR updates the Epic amounts choice card component to adapt its display accordingly.

The component has also been updated to display the appropriate number of amount choice buttons, dependant on the number of amount data points supplied to the component for a given particular region and contribution frequency

NOTE: this PR **must not be merged** until Marketing colleagues have been informed and given us the go-ahead to do so!

This PR is one of three PRs across three repos, all of which need to be merged at the same time:
+ PR in `support-admin-control` - https://github.com/guardian/support-admin-console/pull/428
+ PR in `support-dotcom-components` - https://github.com/guardian/support-dotcom-components/pull/832
+ PR in `support-frontend` - https://github.com/guardian/support-frontend/pull/4672 

## Screenshots

### Including 'Other' button: 0 data points
Expected: only the 'Other' button will appear
![Screenshot 2023-01-12 at 14 58 23](https://user-images.githubusercontent.com/5357530/212108003-51af178f-c8e0-43f7-9c57-7b5138f37ca1.png)


### Including 'Other' button: 1 data point
Expected: two buttons will appear, including the 'Other' button on the right
![Screenshot 2023-01-12 at 14 58 56](https://user-images.githubusercontent.com/5357530/212108058-5fbfc382-b63e-4068-9664-b7d32b69c15e.png)


### Including 'Other' button: 2 data points
Expected: three buttons will appear, including the 'Other' button on the right
![Screenshot 2023-01-12 at 14 59 07](https://user-images.githubusercontent.com/5357530/212108135-b79f55e8-d551-4e5c-8ba2-137785d64dce.png)


### Including 'Other' button: 3 or more data points
Expected: three buttons will appear, including the 'Other' button on the right; the two suggested amounts will be the lowest value amounts available
![Screenshot 2023-01-12 at 14 59 20](https://user-images.githubusercontent.com/5357530/212108203-13cf76b7-a017-49ee-b2ad-63b30c80bcf8.png)


### Suppressing 'Other' button: 0 data points
Expected: only the 'Other' button will appear (in spite of it being suppressed)
![Screenshot 2023-01-12 at 15 00 48](https://user-images.githubusercontent.com/5357530/212108275-2544e698-0872-48ad-b225-a8d2b67ff8e0.png)


### Suppressing 'Other' button: 1 data points
Expected: one amounts button will appear
![Screenshot 2023-01-12 at 14 59 56](https://user-images.githubusercontent.com/5357530/212108334-a98f2bff-eca7-4ee8-ba49-4a26397d5b86.png)


### Suppressing 'Other' button: 2 data points
Expected: two amounts buttons will appear
![Screenshot 2023-01-12 at 15 00 07](https://user-images.githubusercontent.com/5357530/212108418-fbe42e5b-04ac-4faf-bb3e-ea92f492f800.png)


### Suppressing 'Other' button: 3 or more data points
Expected: two amounts buttons will appear; the suggested amounts will be the lowest value amounts available
![Screenshot 2023-01-12 at 15 00 17](https://user-images.githubusercontent.com/5357530/212108459-38d0c26d-bb49-40c0-b41b-e3c960e18eb2.png)


