### PR TITLE
Remove redundant data from epic response

### DIFF
--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -5,7 +5,6 @@ import {
     EpicTargeting,
     EpicTest,
     EpicType,
-    EpicVariant,
     PageTracking,
     TestTracking,
     WeeklyArticleLog,

--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -35,7 +35,6 @@ interface EpicDataResponse {
             name: string;
             props: EpicProps;
         };
-        variant: EpicVariant;
         meta: TestTracking;
     };
     debug?: Debug;
@@ -170,7 +169,6 @@ export const buildEpicRouter = (
 
         return {
             data: {
-                variant: propsVariant,
                 meta: testTracking,
                 module: {
                     url: `${baseUrl}/${modulePathBuilder(targeting.modulesVersion)}`,


### PR DESCRIPTION
Currently SDC includes a `variant` field in the response. This is [not used by the client](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/components/SlotBodyEnd/ReaderRevenueEpic.tsx#L128), and duplicates data that's already under the `props` field

After:
<img width="516" alt="Screenshot 2023-01-25 at 08 51 10" src="https://user-images.githubusercontent.com/1513454/214519361-0e196afd-9e89-4c1d-b50b-ee350c3e4952.png">
