### PR TITLE
Moment banner, close button raise above banner visual

### DIFF
--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -292,6 +292,7 @@ const styles = {
     `,
     mobileVisualContainer: css`
         display: none;
+        pointer-events: none;
 
         ${from.mobileMedium} {
             display: block;
@@ -308,6 +309,7 @@ const styles = {
     `,
     desktopVisualContainer: css`
         display: none;
+        pointer-events: none;
         position: relative;
 
         ${from.tablet} {
@@ -333,6 +335,7 @@ const styles = {
     `,
     desktopUsEoyV3Container: css`
         display: none;
+        pointer-events: none;
         position: relative;
 
         ${from.tablet} {


### PR DESCRIPTION
## What does this change?

A sizing issue visible from tabletUrl width onwards, the background image (around certain breakpoints) can overlay the the CloseCta, making it not available to press.

Note: Check all affected template banners.

Before ->
![unnamed (1)](https://user-images.githubusercontent.com/76729591/217339167-97adb41b-e5fa-4ff8-94c8-cb8351fc6e44.png)

After (button highlightable in green box when overlayed with image below it) ->
![Untitled](https://user-images.githubusercontent.com/76729591/217340275-96323944-41aa-468b-8dce-9c00e1fad0c6.jpg)


[Trello]
https://trello.com/c/bqPFo5Y5/1074-moment-banners-close-button-fix