### PR TITLE
Ukraine template banner web preview hi-res wide image 

### DIFF
--- a/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.stories.tsx
@@ -64,9 +64,9 @@ const UkraineMomentBanner = bannerWrapper(
             desktopUrl:
                 'https://i.guim.co.uk/img/media/5325001b389aaf3bc3ad1aec25ec7b90761f02c2/0_0_320_292/320.png?width=320&height=292&quality=75&s=5b193b151d7c6b444141df7a817763be',
             leftColUrl:
-                'https://i.guim.co.uk/img/media/e3ede24eaa18d18766a06d65564fba352064bb5f/0_0_441_292/441.png?width=441&height=292&quality=75&s=6cd61bd9d1eede1f8f9684a58b9cf6c9',
+                'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
             wideUrl:
-                'https://i.guim.co.uk/img/media/e3ede24eaa18d18766a06d65564fba352064bb5f/0_0_441_292/441.png?width=441&height=292&quality=75&s=6cd61bd9d1eede1f8f9684a58b9cf6c9',
+                'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
             altText: 'Ukraine one year on',
         },
         bannerId: 'ukraine-moment-banner',

--- a/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.tsx
@@ -54,9 +54,9 @@ const UkraineMomentBanner = getMomentTemplateBanner({
         desktopUrl:
             'https://i.guim.co.uk/img/media/5325001b389aaf3bc3ad1aec25ec7b90761f02c2/0_0_320_292/320.png?width=320&height=292&quality=75&s=5b193b151d7c6b444141df7a817763be',
         leftColUrl:
-            'https://i.guim.co.uk/img/media/e3ede24eaa18d18766a06d65564fba352064bb5f/0_0_441_292/441.png?width=441&height=292&quality=75&s=6cd61bd9d1eede1f8f9684a58b9cf6c9',
+            'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
         wideUrl:
-            'https://i.guim.co.uk/img/media/e3ede24eaa18d18766a06d65564fba352064bb5f/0_0_441_292/441.png?width=441&height=292&quality=75&s=6cd61bd9d1eede1f8f9684a58b9cf6c9',
+            'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
         altText: 'Ukraine one year on',
     },
     bannerId: 'ukraine-moment-banner',

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -16,6 +16,7 @@ import {
     usEoyGivingTuesMomentBanner,
     ausEoyMomentBanner,
     usEoyMomentBannerV3,
+    ukraineMomentBanner,
 } from '@sdc/shared/config';
 import {
     BannerChannel,
@@ -51,6 +52,7 @@ export const BannerPaths: {
     [BannerTemplate.UsEoyGivingTuesMomentBanner]: usEoyGivingTuesMomentBanner.endpointPathBuilder,
     [BannerTemplate.AusEoyMomentBanner]: ausEoyMomentBanner.endpointPathBuilder,
     [BannerTemplate.UsEoyMomentBannerV3]: usEoyMomentBannerV3.endpointPathBuilder,
+    [BannerTemplate.UkraineMomentBanner]: ukraineMomentBanner.endpointPathBuilder,
 };
 
 export const BannerTemplateComponentTypes: {

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -31,6 +31,7 @@ export enum BannerTemplate {
     UsEoyMomentBannerV3 = 'UsEoyMomentBannerV3',
     UsEoyGivingTuesMomentBanner = 'UsEoyGivingTuesMomentBanner',
     AusEoyMomentBanner = 'AusEoyMomentBanner',
+    UkraineMomentBanner = 'UkraineMomentBanner',
 }
 
 export interface BannerVariant extends Variant {


### PR DESCRIPTION
## What does this change?
This PR corrects the 'Ukraine One Year On Banner Moment' enabling the RRCP Web Preview

[Trello]
https://trello.com/c/5Z1LPDKV/1042-ukraine-war-1-year-anniversary-campaign-build

## Images
Post->
| 375px | 740px | 980px | 1300+px 
|--------|---------|---------|---------|
| ![Screenshot 2023-02-13 at 10 13 01](https://user-images.githubusercontent.com/76729591/218431367-7bcb199b-ba01-4994-b9aa-3a85013f4430.jpg) | ![Screenshot 2023-02-13 at 10 18 13](https://user-images.githubusercontent.com/76729591/218432885-f3c12901-a574-449f-a7a4-85cfc6a2c88c.jpg) | ![Screenshot 2023-02-13 at 10 19 25](https://user-images.githubusercontent.com/76729591/218432029-b776ccd7-892f-4d1e-a9b3-3d42788351be.jpg) | ![Screenshot 2023-02-13 at 10 20 52](https://user-images.githubusercontent.com/76729591/218432289-0596ee3d-586d-460a-b6a2-d89ae304e96e.jpg)
 |
