### PR TITLE
New Year template banner image re-alignment re-size

### DIFF
--- a/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.stories.tsx
@@ -61,11 +61,7 @@ const GlobalNewYearBanner = bannerWrapper(
             mobileUrl:
                 'https://i.guim.co.uk/img/media/bd2f8e3aa73cb098d8b353326d757b6d69fa15e3/0_0_1172_560/500.png?quality=85&s=32368799f93ede3eed8d196b4c5de4fd',
             tabletUrl:
-                'https://i.guim.co.uk/img/media/ae8eb7a698d15cf45fc523640b7f171fcf8e2585/0_0_1080_1500/720.png?quality=85&s=58da1f597098fef5cf212ea8f1a34481',
-            desktopUrl:
-                'https://i.guim.co.uk/img/media/1fdc936af90c43d274a960262f874f77f4084e76/0_0_1428_1680/850.png?quality=85&s=3d749d44475cf6d1699e8f5e235394a7',
-            leftColUrl:
-                'https://i.guim.co.uk/img/media/f993cdadc7f9ec03f9b99bc0b5a0c58b134bb944/0_0_1428_1344/500.png?quality=85&s=707b13d33c9338b50f99036e6854a3c2',
+                'https://i.guim.co.uk/img/media/c509e87f984bc4084b3274cc243eca378fd28af2/0_0_1080_1000/500.png?width=500&quality=75&s=dd273acef8ae97d090dfeffd2e25ec8c',
             altText: 'Guardian logo being held up by supporters of the Guardian',
         },
         bannerId: 'global-new-year-banner',

--- a/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.stories.tsx
@@ -57,11 +57,15 @@ const GlobalNewYearBanner = bannerWrapper(
         },
         imageSettings: {
             mainUrl:
-                'https://i.guim.co.uk/img/media/f993cdadc7f9ec03f9b99bc0b5a0c58b134bb944/0_0_1428_1344/500.png?quality=85&s=707b13d33c9338b50f99036e6854a3c2',
+                'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
             mobileUrl:
-                'https://i.guim.co.uk/img/media/bd2f8e3aa73cb098d8b353326d757b6d69fa15e3/0_0_1172_560/500.png?quality=85&s=32368799f93ede3eed8d196b4c5de4fd',
+                'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
             tabletUrl:
-                'https://i.guim.co.uk/img/media/c509e87f984bc4084b3274cc243eca378fd28af2/0_0_1080_1000/500.png?width=500&quality=75&s=dd273acef8ae97d090dfeffd2e25ec8c',
+                'https://i.guim.co.uk/img/media/d1af2bcab927ca0ad247522105fe41a52a474d27/0_0_1080_1000/500.png?width=500&quality=75&s=af39fa30f36fce453eabaef3063a3180',
+            desktopUrl:
+                'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
+            wideUrl:
+                'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
             altText: 'Guardian logo being held up by supporters of the Guardian',
         },
         bannerId: 'global-new-year-banner',

--- a/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.tsx
@@ -47,11 +47,15 @@ const GlobalNewYearBanner = getMomentTemplateBanner({
     },
     imageSettings: {
         mainUrl:
-            'https://i.guim.co.uk/img/media/f993cdadc7f9ec03f9b99bc0b5a0c58b134bb944/0_0_1428_1344/500.png?quality=85&s=707b13d33c9338b50f99036e6854a3c2',
+            'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
         mobileUrl:
-            'https://i.guim.co.uk/img/media/bd2f8e3aa73cb098d8b353326d757b6d69fa15e3/0_0_1172_560/500.png?quality=85&s=32368799f93ede3eed8d196b4c5de4fd',
+            'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
         tabletUrl:
-            'https://i.guim.co.uk/img/media/c509e87f984bc4084b3274cc243eca378fd28af2/0_0_1080_1000/500.png?width=500&quality=75&s=dd273acef8ae97d090dfeffd2e25ec8c',
+            'https://i.guim.co.uk/img/media/d1af2bcab927ca0ad247522105fe41a52a474d27/0_0_1080_1000/500.png?width=500&quality=75&s=af39fa30f36fce453eabaef3063a3180',
+        desktopUrl:
+            'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
+        wideUrl:
+            'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
         altText: 'Guardian logo being held up by supporters of the Guardian',
     },
     bannerId: 'global-new-year-banner',

--- a/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.tsx
@@ -51,11 +51,7 @@ const GlobalNewYearBanner = getMomentTemplateBanner({
         mobileUrl:
             'https://i.guim.co.uk/img/media/bd2f8e3aa73cb098d8b353326d757b6d69fa15e3/0_0_1172_560/500.png?quality=85&s=32368799f93ede3eed8d196b4c5de4fd',
         tabletUrl:
-            'https://i.guim.co.uk/img/media/ae8eb7a698d15cf45fc523640b7f171fcf8e2585/0_0_1080_1500/720.png?quality=85&s=58da1f597098fef5cf212ea8f1a34481',
-        desktopUrl:
-            'https://i.guim.co.uk/img/media/1fdc936af90c43d274a960262f874f77f4084e76/0_0_1428_1680/850.png?quality=85&s=3d749d44475cf6d1699e8f5e235394a7',
-        leftColUrl:
-            'https://i.guim.co.uk/img/media/f993cdadc7f9ec03f9b99bc0b5a0c58b134bb944/0_0_1428_1344/500.png?quality=85&s=707b13d33c9338b50f99036e6854a3c2',
+            'https://i.guim.co.uk/img/media/c509e87f984bc4084b3274cc243eca378fd28af2/0_0_1080_1000/500.png?width=500&quality=75&s=dd273acef8ae97d090dfeffd2e25ec8c',
         altText: 'Guardian logo being held up by supporters of the Guardian',
     },
     bannerId: 'global-new-year-banner',

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -47,6 +47,7 @@ export function getMomentTemplateBanner(
             }
         }, [mobileReminderRef.current, isReminderActive]);
 
+        const isNewYearBanner = templateSettings.bannerId === 'global-new-year-banner';
         const isUsEoyBanner = templateSettings.bannerId === 'us-eoy-banner';
         const isUsEoyGivingTuesBanner = templateSettings.bannerId === 'us-eoy-giving-tues-banner';
         const isUsEoyV3Banner = templateSettings.bannerId === 'us-eoy-banner-v3';
@@ -133,12 +134,12 @@ export function getMomentTemplateBanner(
                                 css={
                                     isUsEoyGivingTuesBanner
                                         ? [
-                                              styles.desktopVisualContainer,
+                                              styles.desktopVisualContainer(isNewYearBanner),
                                               styles.desktopGivingTuesVisualContainer,
                                           ]
                                         : isUsEoyV3Banner
                                         ? styles.desktopUsEoyV3Container
-                                        : styles.desktopVisualContainer
+                                        : styles.desktopVisualContainer(isNewYearBanner)
                                 }
                             >
                                 {templateSettings.imageSettings && (
@@ -307,22 +308,22 @@ const styles = {
         margin-left: -${space[5]}px;
         margin-right: -${space[5]}px;
     `,
-    desktopVisualContainer: css`
+    desktopVisualContainer: (isNewYearBanner?: boolean) => css`
         display: none;
         pointer-events: none;
         position: relative;
 
         ${from.tablet} {
             display: block;
-            width: 238px;
+            width: ${isNewYearBanner ? 500 : 238}px;
             margin-left: ${space[3]}px;
         }
         ${from.desktop} {
-            width: 320px;
+            width: ${isNewYearBanner ? 520 : 320}px;
             margin-left: ${space[5]}px;
         }
         ${from.leftCol} {
-            width: 370px;
+            width: ${isNewYearBanner ? 540 : 370}px;
             margin-left: ${space[9]}px;
         }
     `,

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -134,12 +134,16 @@ export function getMomentTemplateBanner(
                                 css={
                                     isUsEoyGivingTuesBanner
                                         ? [
-                                              styles.desktopVisualContainer(isNewYearBanner),
+                                              styles.desktopVisualContainer,
+                                              isNewYearBanner && styles.desktopVisualContainerNY,
                                               styles.desktopGivingTuesVisualContainer,
                                           ]
                                         : isUsEoyV3Banner
                                         ? styles.desktopUsEoyV3Container
-                                        : styles.desktopVisualContainer(isNewYearBanner)
+                                        : [
+                                              styles.desktopVisualContainer,
+                                              isNewYearBanner && styles.desktopVisualContainerNY,
+                                          ]
                                 }
                             >
                                 {templateSettings.imageSettings && (
@@ -308,23 +312,34 @@ const styles = {
         margin-left: -${space[5]}px;
         margin-right: -${space[5]}px;
     `,
-    desktopVisualContainer: (isNewYearBanner?: boolean) => css`
+    desktopVisualContainer: css`
         display: none;
         pointer-events: none;
         position: relative;
 
         ${from.tablet} {
             display: block;
-            width: ${isNewYearBanner ? 500 : 238}px;
+            width: 238px;
             margin-left: ${space[3]}px;
         }
         ${from.desktop} {
-            width: ${isNewYearBanner ? 520 : 320}px;
+            width: 320px;
             margin-left: ${space[5]}px;
         }
         ${from.leftCol} {
-            width: ${isNewYearBanner ? 540 : 370}px;
+            width: 370px;
             margin-left: ${space[9]}px;
+        }
+    `,
+    desktopVisualContainerNY: css`
+        ${from.tablet} {
+            width: 500px;
+        }
+        ${from.desktop} {
+            width: 520px;
+        }
+        ${from.leftCol} {
+            width: 540px;
         }
     `,
     desktopGivingTuesVisualContainer: css`

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
@@ -48,12 +48,24 @@ export function MomentTemplateBannerVisual({
         }
     `;
 
+    const alignNewYearBanner = css`
+        ${from.tablet} {
+            align-items: center;
+            justify-content: initial;
+        }
+        ${from.desktop} {
+            align-items: flex-end;
+            justify-content: initial;
+        }
+    `;
+
     const alignment = css`
         ${from.tablet} {
             align-items: ${bannerId === 'us-eoy-banner' ? 'flex-start' : 'center'};
         }
 
         ${bannerId === 'aus-eoy-banner' && alignAusEoyBanner}
+        ${bannerId === 'global-new-year-banner' && alignNewYearBanner}
     `;
 
     return (


### PR DESCRIPTION
## What does this change?
This PR amends the 'Global New Year Banner Moment'

- 980px+ the image is aligned with the bottom of the banner
- 740px-979px the image is centred vertically.
- Non-confetti images used

[**Trello Card**](https://trello.com/c/ImZG9p6U/1086-new-year-banner-updates)

## Images
Pre->
| 320px | 375px | 740px | 980px | 1300+px 
|----------|--------|---------|---------|---------|
| ![Screenshot 2022-12-19 at 14 12 01](https://user-images.githubusercontent.com/76729591/208445896-7d674d27-76c9-4c75-9bc3-224217337a1f.png) | ![Screenshot 2022-12-19 at 14 12 12](https://user-images.githubusercontent.com/76729591/208445875-0e0892a2-8d9d-4292-85f0-f6f825afe825.png) | ![Screenshot 2022-12-19 at 14 12 28](https://user-images.githubusercontent.com/76729591/208445853-5fea2a24-3f2a-4989-91c4-fb00006a6b69.png) | ![Screenshot 2022-12-19 at 14 12 49](https://user-images.githubusercontent.com/76729591/208445815-a4f311e1-f1ed-4120-9203-defe05fbd7fb.png) | ![Screenshot 2022-12-19 at 14 13 24](https://user-images.githubusercontent.com/76729591/208445785-5a24efed-8266-444a-ad3e-4d08329e5ab7.png) |

Post->
| 320px | 375px | 740px | 980px | 1300+px 
|----------|--------|---------|---------|---------|
| ![Screenshot 2023-02-21 at 14 44 52](https://user-images.githubusercontent.com/76729591/220376937-21f48ae4-cbc7-4a6c-a6a5-5c11075388c6.png) | ![Screenshot 2023-02-21 at 14 45 13](https://user-images.githubusercontent.com/76729591/220377043-1b3055be-73a8-4c72-b797-91286e5dcdf5.png) | ![Screenshot 2023-02-21 at 14 45 34](https://user-images.githubusercontent.com/76729591/220377166-e83fb555-33b4-452f-8602-1a20b4424c0a.png) | ![Screenshot 2023-02-21 at 14 45 54](https://user-images.githubusercontent.com/76729591/220377331-5605b945-2d6f-4434-8ed1-c72edfacae1e.png) | ![Screenshot 2023-02-21 at 14 46 13](https://user-images.githubusercontent.com/76729591/220377468-74744ba6-fac2-4d9b-8dee-d67e6a197659.png) |
