### PR TITLE
Ukraine template banner change to hires images and primary hover color

### DIFF
--- a/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { brand, culture, neutral } from '@guardian/src-foundations';
+import { brand, brandAlt, culture, neutral } from '@guardian/src-foundations';
 import { BannerProps, SecondaryCtaType } from '@sdc/shared/src/types';
 import { Meta, Story } from '@storybook/react';
 import { bannerWrapper } from '../common/BannerWrapper';
@@ -23,9 +23,8 @@ const UkraineMomentBanner = bannerWrapper(
                 textColour: 'white',
             },
             hover: {
-                backgroundColour: '#004E7C',
-                textColour: 'white',
-                border: '1px solid #004E7C',
+                backgroundColour: brandAlt[200],
+                textColour: brand[400],
             },
         },
         secondaryCtaSettings: {
@@ -56,13 +55,13 @@ const UkraineMomentBanner = bannerWrapper(
         },
         imageSettings: {
             mainUrl:
-                'https://i.guim.co.uk/img/media/77f5a525824c19d7c1ccd447db49f1a95557f12e/0_0_375_152/375.png?width=375&height=152&quality=75&s=fc6794bfbd1bf46853dbbe982ffa6877',
+                'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
             mobileUrl:
-                'https://i.guim.co.uk/img/media/77f5a525824c19d7c1ccd447db49f1a95557f12e/0_0_375_152/375.png?width=375&height=152&quality=75&s=fc6794bfbd1bf46853dbbe982ffa6877',
+                'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
             tabletUrl:
-                'https://i.guim.co.uk/img/media/8be245a70938a981ff69898eab033f94dab08b86/0_0_256_230/256.png?width=256&height=230&quality=75&s=4b53fcaee3b5f3bed4b6cb1d78b26a84',
+                'https://i.guim.co.uk/img/media/4f2ec5867b1a111b78927547f2fdceb0066695f9/0_0_1024_920/500.png?width=500&quality=75&s=ef15b7ff812d997251a68b59a1b4279c',
             desktopUrl:
-                'https://i.guim.co.uk/img/media/5325001b389aaf3bc3ad1aec25ec7b90761f02c2/0_0_320_292/320.png?width=320&height=292&quality=75&s=5b193b151d7c6b444141df7a817763be',
+                'https://i.guim.co.uk/img/media/8d9128c93a61155e0b84f0eb229edd57951ee3ff/0_0_1280_1168/500.png?width=500&quality=75&s=0d8ff342ffc3005186903969b22a4674',
             leftColUrl:
                 'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
             wideUrl:

--- a/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.tsx
@@ -1,4 +1,4 @@
-import { brand, culture, neutral } from '@guardian/src-foundations';
+import { brand, brandAlt, culture, neutral } from '@guardian/src-foundations';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
 
@@ -13,9 +13,8 @@ const UkraineMomentBanner = getMomentTemplateBanner({
             textColour: 'white',
         },
         hover: {
-            backgroundColour: '#004E7C',
-            textColour: 'white',
-            border: '1px solid #004E7C',
+            backgroundColour: brandAlt[200],
+            textColour: brand[400],
         },
     },
     secondaryCtaSettings: {
@@ -46,13 +45,13 @@ const UkraineMomentBanner = getMomentTemplateBanner({
     },
     imageSettings: {
         mainUrl:
-            'https://i.guim.co.uk/img/media/77f5a525824c19d7c1ccd447db49f1a95557f12e/0_0_375_152/375.png?width=375&height=152&quality=75&s=fc6794bfbd1bf46853dbbe982ffa6877',
+            'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
         mobileUrl:
-            'https://i.guim.co.uk/img/media/77f5a525824c19d7c1ccd447db49f1a95557f12e/0_0_375_152/375.png?width=375&height=152&quality=75&s=fc6794bfbd1bf46853dbbe982ffa6877',
+            'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
         tabletUrl:
-            'https://i.guim.co.uk/img/media/8be245a70938a981ff69898eab033f94dab08b86/0_0_256_230/256.png?width=256&height=230&quality=75&s=4b53fcaee3b5f3bed4b6cb1d78b26a84',
+            'https://i.guim.co.uk/img/media/4f2ec5867b1a111b78927547f2fdceb0066695f9/0_0_1024_920/500.png?width=500&quality=75&s=ef15b7ff812d997251a68b59a1b4279c',
         desktopUrl:
-            'https://i.guim.co.uk/img/media/5325001b389aaf3bc3ad1aec25ec7b90761f02c2/0_0_320_292/320.png?width=320&height=292&quality=75&s=5b193b151d7c6b444141df7a817763be',
+            'https://i.guim.co.uk/img/media/8d9128c93a61155e0b84f0eb229edd57951ee3ff/0_0_1280_1168/500.png?width=500&quality=75&s=0d8ff342ffc3005186903969b22a4674',
         leftColUrl:
             'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
         wideUrl:


### PR DESCRIPTION
## What does this change?
This PR corrects the 'Ukraine One Year On Banner Moment', higher resolution images and primary cta hover colour

[Trello]
https://trello.com/c/JVglKX6P/1088-update-images-and-hover-button-in-ukraine-banner

## Images
Post->
| 375px | 740px | 980px | 1300+px 
|--------|---------|---------|---------|
| ![Screenshot 2023-02-13 at 10 13 01](https://user-images.githubusercontent.com/76729591/218431367-7bcb199b-ba01-4994-b9aa-3a85013f4430.jpg) | ![Screenshot 2023-02-13 at 10 18 13](https://user-images.githubusercontent.com/76729591/218432885-f3c12901-a574-449f-a7a4-85cfc6a2c88c.jpg) | ![Screenshot 2023-02-13 at 10 19 25](https://user-images.githubusercontent.com/76729591/218432029-b776ccd7-892f-4d1e-a9b3-3d42788351be.jpg) | ![Screenshot 2023-02-13 at 10 20 52](https://user-images.githubusercontent.com/76729591/218432289-0596ee3d-586d-460a-b6a2-d89ae304e96e.jpg)

Hover->
![Screenshot 2023-02-16 at 18 33 46](https://user-images.githubusercontent.com/76729591/219456565-b18f0dec-e3fe-44df-99b9-4352ceae02e1.png)

