### PR TITLE
Limit email address length for reminders

### DIFF
--- a/packages/modules/src/hooks/useContributionsReminderEmailForm.ts
+++ b/packages/modules/src/hooks/useContributionsReminderEmailForm.ts
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { isValidEmail } from '../modules/utils/reminders';
+import { emailIsShortEnoughForIdentity, isValidEmail } from '../modules/utils/reminders';
 
 type SubmitHandler = (e: React.FormEvent<HTMLFormElement>) => void;
 
@@ -22,7 +22,7 @@ export function useContributionsReminderEmailForm(): ContributionsReminderEmailF
     };
 
     const isEmpty = email.trim().length === 0;
-    const isValid = isValidEmail(email);
+    const isValid = isValidEmail(email) && emailIsShortEnoughForIdentity(email);
 
     let inputError;
     if (isDirty && isEmpty) {

--- a/packages/modules/src/modules/utils/reminders.ts
+++ b/packages/modules/src/modules/utils/reminders.ts
@@ -44,3 +44,8 @@ export const isValidEmail = (email: string): boolean => {
     const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(String(email).toLowerCase());
 };
+
+export const emailIsShortEnoughForIdentity = (email: string): boolean => {
+    // Identity errors on email addresses longer than 100 characters
+    return email.length <= 100;
+};


### PR DESCRIPTION
Identity errors when email addresses are longer than 100 characters. This has been causing some alerts, so we’re adding server-side validation to handle long email addresses. This is the client-side counterpart to that validation.

See https://github.com/guardian/support-reminders/pull/61 for server-side validation.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

On PROD, find a support reminder form and request a reminder to an email address longer than 100 characters – after some delay while the backend processes, an error will be returned. On this branch, the email address should be rejected immediately. 

## How can we measure success?

This should decrease the number of errors we get from reminder signups.

## Have we considered potential risks?

If Identity change to support these long email addresses in future, our code will prevent them setting reminders even though they have an account – we will have to revert this change and the backend change at that point. I’m not sure how we can mitigate this risk.