### PR TITLE
Remove conditional styling in moment banner child components in favour of props

### DIFF
--- a/packages/modules/src/modules/banners/auElectionMoment/AusElectionMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/auElectionMoment/AusElectionMomentBanner.stories.tsx
@@ -13,7 +13,9 @@ export default {
 
 const AusElectionBanner = bannerWrapper(
     getMomentTemplateBanner({
-        backgroundColour: '#e4e4e3',
+        containerSettings: {
+            backgroundColour: '#e4e4e3',
+        },
         primaryCtaSettings: {
             default: {
                 backgroundColour: '#121212',

--- a/packages/modules/src/modules/banners/ausEoyMoment/AusEoyMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/ausEoyMoment/AusEoyMomentBanner.stories.tsx
@@ -13,7 +13,9 @@ export default {
 
 const AusEoyMomentBanner = bannerWrapper(
     getMomentTemplateBanner({
-        backgroundColour: '#DCDCDC',
+        containerSettings: {
+            backgroundColour: '#DCDCDC',
+        },
         primaryCtaSettings: {
             default: {
                 backgroundColour: neutral[7],

--- a/packages/modules/src/modules/banners/ausEoyMoment/AusEoyMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/ausEoyMoment/AusEoyMomentBanner.tsx
@@ -3,7 +3,9 @@ import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
 
 const AusEoyMomentBanner = getMomentTemplateBanner({
-    backgroundColour: '#DCDCDC',
+    containerSettings: {
+        backgroundColour: '#DCDCDC',
+    },
     primaryCtaSettings: {
         default: {
             backgroundColour: neutral[7],

--- a/packages/modules/src/modules/banners/climateCrisisMoment/settings.ts
+++ b/packages/modules/src/modules/banners/climateCrisisMoment/settings.ts
@@ -2,7 +2,9 @@ import { neutral, news } from '@guardian/src-foundations';
 import { BannerTemplateSettings } from '../momentTemplate/settings';
 
 export const settings: Omit<BannerTemplateSettings, 'imageSettings'> = {
-    backgroundColour: '#FBF6EF',
+    containerSettings: {
+        backgroundColour: '#FBF6EF',
+    },
     articleCountTextColour: news[400],
     primaryCtaSettings: {
         default: {

--- a/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.stories.tsx
@@ -13,7 +13,9 @@ export default {
 
 const GlobalNewYearBanner = bannerWrapper(
     getMomentTemplateBanner({
-        backgroundColour: '#F1F8FC',
+        containerSettings: {
+            backgroundColour: '#F1F8FC',
+        },
         headerSettings: {
             textColour: '#0077B6',
         },

--- a/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.stories.tsx
@@ -52,6 +52,7 @@ const GlobalNewYearBanner = bannerWrapper(
                 backgroundColour: '#E5E5E5',
                 textColour: brand[400],
             },
+            theme: 'brand',
         },
         highlightedTextSettings: {
             textColour: neutral[0],

--- a/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.tsx
@@ -3,7 +3,9 @@ import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
 
 const GlobalNewYearBanner = getMomentTemplateBanner({
-    backgroundColour: '#F1F8FC',
+    containerSettings: {
+        backgroundColour: '#F1F8FC',
+    },
     headerSettings: {
         textColour: '#0077B6',
     },

--- a/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/globalNYMoment/GlobalNYMomentBanner.tsx
@@ -42,6 +42,7 @@ const GlobalNewYearBanner = getMomentTemplateBanner({
             backgroundColour: '#E5E5E5',
             textColour: brand[400],
         },
+        theme: 'brand',
     },
     highlightedTextSettings: {
         textColour: neutral[0],

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -97,7 +97,6 @@ export function getMomentTemplateBanner(
                             <MomentTemplateBannerCloseButton
                                 onCloseClick={onCloseClick}
                                 settings={templateSettings.closeButtonSettings}
-                                bannerId={templateSettings.bannerId}
                             />
                         </Hide>
                     </div>
@@ -125,7 +124,6 @@ export function getMomentTemplateBanner(
                             <MomentTemplateBannerCloseButton
                                 onCloseClick={onCloseClick}
                                 settings={templateSettings.closeButtonSettings}
-                                bannerId={templateSettings.bannerId}
                             />
                         </Hide>
                     </div>
@@ -138,7 +136,6 @@ export function getMomentTemplateBanner(
                                 <MomentTemplateBannerCloseButton
                                     onCloseClick={onCloseClick}
                                     settings={templateSettings.closeButtonSettings}
-                                    bannerId={templateSettings.bannerId}
                                 />
                             </Hide>
                         </div>

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import { neutral, space } from '@guardian/src-foundations';
 import { Container, Hide } from '@guardian/src-layout';
-import { BannerRenderProps } from '../common/types';
+import { BannerId, BannerRenderProps } from '../common/types';
 import { MomentTemplateBannerHeader } from './components/MomentTemplateBannerHeader';
 import { MomentTemplateBannerArticleCount } from './components/MomentTemplateBannerArticleCount';
 import { MomentTemplateBannerBody } from './components/MomentTemplateBannerBody';
@@ -15,8 +15,38 @@ import { SecondaryCtaType } from '@sdc/shared/types';
 import { MomentTemplateBannerReminder } from './components/MomentTemplateBannerReminder';
 import MomentTemplateBannerTicker from './components/MomentTemplateBannerTicker';
 
-// ---- Banner ---- //
+// ---- CSS Styling Helpers ---- //
+const getDesktopVisualContainerStyle = (
+    bannerId?: BannerId,
+): SerializedStyles | SerializedStyles[] => {
+    switch (bannerId) {
+        case 'us-eoy-giving-tues-banner':
+            return [styles.desktopVisualContainer, styles.desktopGivingTuesVisualContainer];
 
+        case 'global-new-year-banner':
+            return [styles.desktopVisualContainer, styles.desktopVisualContainerNY];
+
+        case 'us-eoy-banner-v3':
+            return styles.desktopUsEoyV3Container;
+
+        default:
+            return styles.desktopVisualContainer;
+    }
+};
+
+const getMobileVisualContainerStyle = (
+    bannerId?: BannerId,
+): SerializedStyles | SerializedStyles[] =>
+    bannerId === 'us-eoy-giving-tues-banner'
+        ? [styles.mobileVisualContainer, styles.mobileVisualContainerGivingTues]
+        : styles.mobileVisualContainer;
+
+const getHeaderContainerStyle = (bannerId?: BannerId): SerializedStyles | SerializedStyles[] =>
+    bannerId === 'us-eoy-banner-v3'
+        ? [styles.headerContainer, styles.headerContainerUsEoyV3]
+        : styles.headerContainer;
+
+// ---- Banner ---- //
 export function getMomentTemplateBanner(
     templateSettings: BannerTemplateSettings,
 ): React.FC<BannerRenderProps> {
@@ -47,11 +77,10 @@ export function getMomentTemplateBanner(
             }
         }, [mobileReminderRef.current, isReminderActive]);
 
-        const isNewYearBanner = templateSettings.bannerId === 'global-new-year-banner';
-        const isUsEoyBanner = templateSettings.bannerId === 'us-eoy-banner';
-        const isUsEoyGivingTuesBanner = templateSettings.bannerId === 'us-eoy-giving-tues-banner';
-        const isUsEoyV3Banner = templateSettings.bannerId === 'us-eoy-banner-v3';
-        const isEoyBanner = isUsEoyBanner || isUsEoyGivingTuesBanner || isUsEoyV3Banner;
+        const isEoyBanner =
+            templateSettings.bannerId === 'us-eoy-banner' ||
+            templateSettings.bannerId === 'us-eoy-giving-tues-banner' ||
+            templateSettings.bannerId === 'us-eoy-banner-v3';
 
         return (
             <div css={styles.outerContainer(templateSettings.containerSettings.backgroundColour)}>
@@ -74,16 +103,7 @@ export function getMomentTemplateBanner(
                     </div>
 
                     {hasVisual && (
-                        <div
-                            css={
-                                isUsEoyGivingTuesBanner
-                                    ? [
-                                          styles.mobileVisualContainer,
-                                          styles.visualContainerGivingTues,
-                                      ]
-                                    : styles.mobileVisualContainer
-                            }
-                        >
+                        <div css={getMobileVisualContainerStyle(templateSettings.bannerId)}>
                             {templateSettings.imageSettings && (
                                 <MomentTemplateBannerVisual
                                     settings={templateSettings.imageSettings}
@@ -94,13 +114,7 @@ export function getMomentTemplateBanner(
                         </div>
                     )}
 
-                    <div
-                        css={
-                            isUsEoyV3Banner
-                                ? [styles.headerContainer, styles.headerContainerUsEoyV3]
-                                : styles.headerContainer
-                        }
-                    >
+                    <div css={getHeaderContainerStyle(templateSettings.bannerId)}>
                         <MomentTemplateBannerHeader
                             heading={content.mainContent.heading}
                             mobileHeading={content.mobileContent.heading}
@@ -130,22 +144,7 @@ export function getMomentTemplateBanner(
                         </div>
 
                         {hasVisual && (
-                            <div
-                                css={
-                                    isUsEoyGivingTuesBanner
-                                        ? [
-                                              styles.desktopVisualContainer,
-                                              isNewYearBanner && styles.desktopVisualContainerNY,
-                                              styles.desktopGivingTuesVisualContainer,
-                                          ]
-                                        : isUsEoyV3Banner
-                                        ? styles.desktopUsEoyV3Container
-                                        : [
-                                              styles.desktopVisualContainer,
-                                              isNewYearBanner && styles.desktopVisualContainerNY,
-                                          ]
-                                }
-                            >
+                            <div css={getDesktopVisualContainerStyle(templateSettings.bannerId)}>
                                 {templateSettings.imageSettings && (
                                     <MomentTemplateBannerVisual
                                         settings={templateSettings.imageSettings}
@@ -306,7 +305,7 @@ const styles = {
             display: none;
         }
     `,
-    visualContainerGivingTues: css`
+    mobileVisualContainerGivingTues: css`
         max-height: 180px;
         overflow: hidden;
         margin-left: -${space[5]}px;

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -54,13 +54,13 @@ export function getMomentTemplateBanner(
         const isEoyBanner = isUsEoyBanner || isUsEoyGivingTuesBanner || isUsEoyV3Banner;
 
         return (
-            <div css={styles.outerContainer(templateSettings.backgroundColour)}>
+            <div css={styles.outerContainer(templateSettings.containerSettings.backgroundColour)}>
                 <Container
                     cssOverrides={styles.mobileStickyHeaderContainer(
-                        templateSettings.backgroundColour,
+                        templateSettings.containerSettings.backgroundColour,
                         content.mobileContent.secondaryCta?.type ===
                             SecondaryCtaType.ContributionsReminder,
-                        isUsEoyGivingTuesBanner,
+                        templateSettings.containerSettings.paddingTop,
                     )}
                 >
                     <div css={styles.closeButtonContainer}>
@@ -275,14 +275,14 @@ const styles = {
     mobileStickyHeaderContainer: (
         background: string,
         hasReminderCta: boolean,
-        isUsEoyGivingTuesBanner?: boolean,
+        paddingTop?: string,
     ) => css`
         background: ${background};
         position: sticky;
         top: 0px;
         z-index: 100;
         border-top: 1px solid ${neutral[0]};
-        padding-top: ${isUsEoyGivingTuesBanner ? 0 : space[2]}px;
+        padding-top: ${paddingTop ?? space[2]}px;
 
         ${hasReminderCta
             ? `

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -10,41 +10,10 @@ import { MomentTemplateBannerCtas } from './components/MomentTemplateBannerCtas'
 import { MomentTemplateBannerCloseButton } from './components/MomentTemplateBannerCloseButton';
 import { MomentTemplateBannerVisual } from './components/MomentTemplateBannerVisual';
 import { BannerTemplateSettings } from './settings';
-import { from } from '@guardian/src-foundations/mq';
+import { between, from } from '@guardian/src-foundations/mq';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { MomentTemplateBannerReminder } from './components/MomentTemplateBannerReminder';
 import MomentTemplateBannerTicker from './components/MomentTemplateBannerTicker';
-
-// ---- CSS Styling Helpers ---- //
-const getDesktopVisualContainerStyle = (
-    bannerId?: BannerId,
-): SerializedStyles | SerializedStyles[] => {
-    switch (bannerId) {
-        case 'us-eoy-giving-tues-banner':
-            return [styles.desktopVisualContainer, styles.desktopGivingTuesVisualContainer];
-
-        case 'global-new-year-banner':
-            return [styles.desktopVisualContainer, styles.desktopVisualContainerNY];
-
-        case 'us-eoy-banner-v3':
-            return styles.desktopUsEoyV3Container;
-
-        default:
-            return styles.desktopVisualContainer;
-    }
-};
-
-const getMobileVisualContainerStyle = (
-    bannerId?: BannerId,
-): SerializedStyles | SerializedStyles[] =>
-    bannerId === 'us-eoy-giving-tues-banner'
-        ? [styles.mobileVisualContainer, styles.mobileVisualContainerGivingTues]
-        : styles.mobileVisualContainer;
-
-const getHeaderContainerStyle = (bannerId?: BannerId): SerializedStyles | SerializedStyles[] =>
-    bannerId === 'us-eoy-banner-v3'
-        ? [styles.headerContainer, styles.headerContainerUsEoyV3]
-        : styles.headerContainer;
 
 // ---- Banner ---- //
 export function getMomentTemplateBanner(
@@ -107,6 +76,9 @@ export function getMomentTemplateBanner(
                                 <MomentTemplateBannerVisual
                                     settings={templateSettings.imageSettings}
                                     bannerId={templateSettings.bannerId}
+                                    cssOverrides={getBannerVisualCssOverrides(
+                                        templateSettings.bannerId,
+                                    )}
                                 />
                             )}
                             {templateSettings.alternativeVisual}
@@ -146,6 +118,9 @@ export function getMomentTemplateBanner(
                                     <MomentTemplateBannerVisual
                                         settings={templateSettings.imageSettings}
                                         bannerId={templateSettings.bannerId}
+                                        cssOverrides={getBannerVisualCssOverrides(
+                                            templateSettings.bannerId,
+                                        )}
                                     />
                                 )}
                                 {templateSettings.alternativeVisual}
@@ -236,8 +211,56 @@ export function getMomentTemplateBanner(
     return MomentTemplateBanner;
 }
 
-// ---- Styles ---- //
+// ---- Styling Helpers ---- //
+const getDesktopVisualContainerStyle = (
+    bannerId?: BannerId,
+): SerializedStyles | SerializedStyles[] => {
+    switch (bannerId) {
+        case 'us-eoy-giving-tues-banner':
+            return [styles.desktopVisualContainer, styles.desktopGivingTuesVisualContainer];
 
+        case 'global-new-year-banner':
+            return [styles.desktopVisualContainer, styles.desktopVisualContainerNY];
+
+        case 'us-eoy-banner-v3':
+            return styles.desktopUsEoyV3Container;
+
+        default:
+            return styles.desktopVisualContainer;
+    }
+};
+
+const getMobileVisualContainerStyle = (
+    bannerId?: BannerId,
+): SerializedStyles | SerializedStyles[] =>
+    bannerId === 'us-eoy-giving-tues-banner'
+        ? [styles.mobileVisualContainer, styles.mobileVisualContainerGivingTues]
+        : styles.mobileVisualContainer;
+
+const getHeaderContainerStyle = (bannerId?: BannerId): SerializedStyles | SerializedStyles[] =>
+    bannerId === 'us-eoy-banner-v3'
+        ? [styles.headerContainer, styles.headerContainerUsEoyV3]
+        : styles.headerContainer;
+
+const getBannerVisualCssOverrides = (
+    bannerId?: BannerId,
+): SerializedStyles | SerializedStyles[] => {
+    switch (bannerId) {
+        case 'us-eoy-banner':
+            return styles.bannerVisualOverridesUSEoy;
+        case 'us-eoy-giving-tues-banner':
+            return styles.bannerVisualOverridesUSGivingTues;
+        case 'aus-eoy-banner':
+            return styles.bannerVisualOverridesAus;
+        case 'global-new-year-banner':
+            return styles.bannerVisualOverridesGlobalNY;
+
+        default:
+            return css``;
+    }
+};
+
+// ---- Styles ---- //
 const styles = {
     outerContainer: (background: string) => css`
         background: ${background};
@@ -429,5 +452,32 @@ const styles = {
         position: absolute;
         top: ${space[2]}px;
         right: ${space[4]}px;
+    `,
+    bannerVisualOverridesUSEoy: css`
+        ${from.tablet} {
+            align-items: flex-start;
+        }
+    `,
+    bannerVisualOverridesUSGivingTues: css`
+        img {
+            object-fit: cover;
+        }
+    `,
+    bannerVisualOverridesAus: css`
+        ${between.tablet.and.desktop} {
+            align-items: baseline;
+            margin-top: 70px;
+            margin-left: ${space[5]}px;
+        }
+    `,
+    bannerVisualOverridesGlobalNY: css`
+        ${from.tablet} {
+            align-items: center;
+            justify-content: initial;
+        }
+        ${from.desktop} {
+            align-items: flex-end;
+            justify-content: initial;
+        }
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
@@ -80,7 +80,7 @@ const Overlay: React.FC<OverlayProps> = ({
     settings,
 }: OverlayProps) => {
     return (
-        <div css={overlayStyles.overlayContainer(settings.backgroundColour)}>
+        <div css={overlayStyles.overlayContainer(settings.containerSettings.backgroundColour)}>
             <div css={overlayStyles.overlayHeader}>
                 <div css={overlayStyles.overlayHeaderText}>
                     {hasOptedOut ? "You've opted out" : "What's this?"}

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -7,28 +7,25 @@ import { CtaSettings } from '../settings';
 import { SvgRoundelBrand, SvgRoundelDefault } from '@guardian/src-brand';
 import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
-import { BannerId } from '../../common/types';
 
 // ---- Component ---- //
 
 interface MomentTemplateBannerCloseButtonProps {
     onCloseClick: () => void;
     settings: CtaSettings;
-    bannerId?: BannerId;
 }
 
 export function MomentTemplateBannerCloseButton({
     onCloseClick,
     settings,
-    bannerId,
 }: MomentTemplateBannerCloseButtonProps): JSX.Element {
     return (
         <div css={styles.container}>
             <div css={styles.roundelContainer}>
-                {bannerId === 'global-new-year-banner' || bannerId === 'ukraine-moment-banner' ? (
-                    <SvgRoundelBrand />
-                ) : (
+                {settings.theme === 'default' || !settings.theme ? (
                     <SvgRoundelDefault />
+                ) : (
+                    <SvgRoundelBrand />
                 )}
             </div>
 

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
-import { css } from '@emotion/react';
-import { between, from } from '@guardian/src-foundations/mq';
+import { css, SerializedStyles } from '@emotion/react';
+import { from } from '@guardian/src-foundations/mq';
 import { ImageAttrs, ResponsiveImage } from '../../../shared/ResponsiveImage';
 import { Image } from '@sdc/shared/types';
 import { BannerId } from '../../common/types';
-import { space } from '@guardian/src-foundations';
 
 // ---- Component ---- //
 
 interface MomentTemplateBannerVisualProps {
     settings: Image;
     bannerId?: BannerId;
+    cssOverrides: SerializedStyles | SerializedStyles[];
 }
 
 export function MomentTemplateBannerVisual({
     settings,
     bannerId,
+    cssOverrides,
 }: MomentTemplateBannerVisualProps): JSX.Element {
     const baseImage: ImageAttrs = {
         url: settings.mainUrl,
@@ -40,36 +41,10 @@ export function MomentTemplateBannerVisual({
         images.push({ url: settings.wideUrl, media: '' });
     }
 
-    const alignAusEoyBanner = css`
-        ${between.tablet.and.desktop} {
-            align-items: baseline;
-            margin-top: 70px;
-            margin-left: ${space[5]}px;
-        }
-    `;
-
-    const alignNewYearBanner = css`
-        ${from.tablet} {
-            align-items: center;
-            justify-content: initial;
-        }
-        ${from.desktop} {
-            align-items: flex-end;
-            justify-content: initial;
-        }
-    `;
-
-    const alignment = css`
-        ${from.tablet} {
-            align-items: ${bannerId === 'us-eoy-banner' ? 'flex-start' : 'center'};
-        }
-
-        ${bannerId === 'aus-eoy-banner' && alignAusEoyBanner}
-        ${bannerId === 'global-new-year-banner' && alignNewYearBanner}
-    `;
+    console.log(cssOverrides);
 
     return (
-        <div css={[container(bannerId), alignment]}>
+        <div css={[styles.container(cssOverrides)]}>
             <ResponsiveImage baseImage={baseImage} images={images} bannerId={bannerId} />
         </div>
     );
@@ -77,20 +52,25 @@ export function MomentTemplateBannerVisual({
 
 // ---- Styles ---- //
 
-const container = (bannerId?: BannerId) => css`
-    height: 140px;
-    display: flex;
-    justify-content: center;
+const styles = {
+    container: (cssOverrides?: SerializedStyles | SerializedStyles[]) => css`
+        height: 140px;
+        display: flex;
+        justify-content: center;
 
-    img {
-        height: 100%;
-        width: 100%;
-        object-fit: ${bannerId === 'us-eoy-giving-tues-banner' ? 'cover' : 'contain'};
-        display: block;
-    }
+        img {
+            height: 100%;
+            width: 100%;
+            object-fit: contain;
+            display: block;
+        }
 
-    ${from.tablet} {
-        height: 100%;
-        width: 100%;
-    }
-`;
+        ${from.tablet} {
+            height: 100%;
+            width: 100%;
+            align-items: center;
+        }
+
+        ${cssOverrides};
+    `,
+};

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
@@ -41,8 +41,6 @@ export function MomentTemplateBannerVisual({
         images.push({ url: settings.wideUrl, media: '' });
     }
 
-    console.log(cssOverrides);
-
     return (
         <div css={[styles.container(cssOverrides)]}>
             <ResponsiveImage baseImage={baseImage} images={images} bannerId={bannerId} />

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -18,6 +18,7 @@ export interface CtaSettings {
     hover: CtaStateSettings;
     mobile?: CtaStateSettings;
     desktop?: CtaStateSettings;
+    theme?: 'default' | 'brand';
 }
 
 export interface HighlightedTextSettings {

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -2,6 +2,11 @@ import { Image } from '@sdc/shared/src/types';
 import { ReactNode } from 'react';
 import { BannerId } from '../common/types';
 
+export type ContainerSettings = {
+    backgroundColour: string;
+    paddingTop?: string;
+};
+
 export type CtaStateSettings = {
     textColour: string;
     backgroundColour: string;
@@ -32,7 +37,7 @@ export interface HeaderSettings {
 }
 
 export interface BannerTemplateSettings {
-    backgroundColour: string;
+    containerSettings: ContainerSettings;
     primaryCtaSettings: CtaSettings;
     secondaryCtaSettings: CtaSettings;
     closeButtonSettings: CtaSettings;

--- a/packages/modules/src/modules/banners/postElectionAuMoment/settings.ts
+++ b/packages/modules/src/modules/banners/postElectionAuMoment/settings.ts
@@ -2,7 +2,9 @@ import { neutral } from '@guardian/src-foundations';
 import { BannerTemplateSettings } from '../momentTemplate/settings';
 
 export const settings: Omit<BannerTemplateSettings, 'imageSettings'> = {
-    backgroundColour: '#ffe500',
+    containerSettings: {
+        backgroundColour: '#ffe500',
+    },
     primaryCtaSettings: {
         default: {
             backgroundColour: '#121212',

--- a/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.stories.tsx
@@ -51,6 +51,7 @@ const UkraineMomentBanner = bannerWrapper(
                 backgroundColour: '#E5E5E5',
                 textColour: brand[400],
             },
+            theme: 'brand',
         },
         highlightedTextSettings: {
             textColour: neutral[0],

--- a/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.stories.tsx
@@ -13,7 +13,9 @@ export default {
 
 const UkraineMomentBanner = bannerWrapper(
     getMomentTemplateBanner({
-        backgroundColour: culture[800],
+        containerSettings: {
+            backgroundColour: culture[800],
+        },
         headerSettings: {
             textColour: brand[400],
         },

--- a/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.tsx
@@ -30,6 +30,7 @@ const UkraineMomentBanner = getMomentTemplateBanner({
             textColour: brand[400],
             border: '1px solid #052962',
         },
+        theme: 'brand',
     },
     closeButtonSettings: {
         default: {

--- a/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/ukraineMoment/UkraineMomentBanner.tsx
@@ -3,7 +3,9 @@ import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
 
 const UkraineMomentBanner = getMomentTemplateBanner({
-    backgroundColour: culture[800],
+    containerSettings: {
+        backgroundColour: culture[800],
+    },
     headerSettings: {
         textColour: brand[400],
     },

--- a/packages/modules/src/modules/banners/usEoyGivingTuesMoment/UsEoyGivingTuesMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyGivingTuesMoment/UsEoyGivingTuesMomentBanner.stories.tsx
@@ -13,7 +13,10 @@ export default {
 
 const UsEoyGivingTuesBanner = bannerWrapper(
     getMomentTemplateBanner({
-        backgroundColour: '#e2e1e0',
+        containerSettings: {
+            backgroundColour: '#e2e1e0',
+            paddingTop: '0',
+        },
         primaryCtaSettings: {
             default: {
                 backgroundColour: neutral[7],

--- a/packages/modules/src/modules/banners/usEoyGivingTuesMoment/UsEoyGivingTuesMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/usEoyGivingTuesMoment/UsEoyGivingTuesMomentBanner.tsx
@@ -3,7 +3,10 @@ import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
 
 const UsEoyGivingTuesMomentBanner = getMomentTemplateBanner({
-    backgroundColour: '#e2e1e0',
+    containerSettings: {
+        backgroundColour: '#e2e1e0',
+        paddingTop: '0',
+    },
     primaryCtaSettings: {
         default: {
             backgroundColour: neutral[7],

--- a/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.stories.tsx
@@ -13,7 +13,9 @@ export default {
 
 const UsEoyMomentBanner = bannerWrapper(
     getMomentTemplateBanner({
-        backgroundColour: '#deded9',
+        containerSettings: {
+            backgroundColour: '#deded9',
+        },
         primaryCtaSettings: {
             default: {
                 backgroundColour: neutral[7],

--- a/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/usEoyMoment/UsEoyMomentBanner.tsx
@@ -3,7 +3,9 @@ import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
 
 const UsEoyMomentBanner = getMomentTemplateBanner({
-    backgroundColour: '#deded9',
+    containerSettings: {
+        backgroundColour: '#deded9',
+    },
     primaryCtaSettings: {
         default: {
             backgroundColour: neutral[7],

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.stories.tsx
@@ -14,7 +14,9 @@ export default {
 
 const UsEoyMomentBannerV3 = bannerWrapper(
     getMomentTemplateBanner({
-        backgroundColour: '#EDEDED',
+        containerSettings: {
+            backgroundColour: '#EDEDED',
+        },
         headerSettings: {
             textColour: '#7D0068',
         },

--- a/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.tsx
+++ b/packages/modules/src/modules/banners/usEoyMomentV3/UsEoyMomentBannerV3.tsx
@@ -5,7 +5,9 @@ import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner'
 import { UsEoyMomentBannerVisualV3 } from './UsEoyMomentBannerVisualV3';
 
 const UsEoyMomentBannerV3 = getMomentTemplateBanner({
-    backgroundColour: '#EDEDED',
+    containerSettings: {
+        backgroundColour: '#EDEDED',
+    },
     headerSettings: {
         textColour: '#7D0068',
     },


### PR DESCRIPTION
## What does this change?
This pulls up any conditional styling we had within child components of the `MomentTemplateBanner.tsx` up into the banner itself.  Some child components previously received a `bannerId` prop which has now been removed as it was used solely for conditional styling. The styles previously defined within these child components are now either configurable and have been added to the `BannerTemplateSettings` type or are now defined within the top-level banner component and passed down as props.

This change is a necessary first step towards the eventual transition to banners being configurable in the RRCP.

## How to test
- Compare the moment template banner stories in this branch with the stories on the main branch
- Compare live banners on this branch on CODE with the main branch on PROD

## How can we measure success?
No visual regressions are introduced
