### PR TITLE
Investigations Moment Banner re-factor - browser fix

### DIFF
--- a/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerPolygon.tsx
+++ b/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerPolygon.tsx
@@ -37,8 +37,23 @@ const styles = {
 
         ${from.tablet} {
             bottom: 0;
-            width: auto;
-            height: auto;
+            width: 234px;
+            height: 316px;
+        }
+
+        ${from.desktop} {
+            width: 297px;
+            height: 257px;
+        }
+
+        ${from.leftCol} {
+            width: 297px;
+            height: 238px;
+        }
+
+        ${from.wide} {
+            width: 390px;
+            height: 315px;
         }
 
         svg {

--- a/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerPolygon.tsx
+++ b/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerPolygon.tsx
@@ -95,7 +95,7 @@ const styles = {
         ${from.wide} {
             height: 125px;
             width: 1250px;
-            right: auto;D
+            right: auto;
         }
 
         // The following styles will conditionally hide the svg polygon

--- a/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerPolygon.tsx
+++ b/packages/modules/src/modules/banners/investigationsMoment/components/InvestigationsMomentBannerPolygon.tsx
@@ -95,7 +95,6 @@ const styles = {
         ${from.wide} {
             height: 125px;
             width: 1250px;
-            right: auto;
         }
 
         // The following styles will conditionally hide the svg polygon


### PR DESCRIPTION
## What does this change?
This PR amends the 'Investigations Moment Banner'.

FIREFOX WIDTH/HEIGHT:AUTO AMMENDMENT

The JSX used to render the polygonal shapes on the Investigations Banner is repetitive and can be simplified  by creating two reusable react components for polygons in the top left and bottom right. These components are reactive based upon the breakpoints specified.

[**Trello Card**](https://trello.com/c/uA21eZ3Z/1154-investigative-banner-refactor-minimise-multiple-polygon-vector-components)
