### PR TITLE
Choice card banner amounts buttons padding fix

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
@@ -5,15 +5,12 @@ import {
     ContributionFrequency,
     OphanComponentEvent,
 } from '@sdc/shared/dist/types';
-import {
-    ContributionType,
-    trackClick,
-} from '../../banners/choiceCardsBanner/components/ChoiceCardFrequencyTabs';
+import { ContributionType, trackClick } from './ChoiceCardFrequencyTabs';
 import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
-import { until } from '@guardian/src-foundations/mq';
-import { ChoiceCardSelection } from '../../banners/choiceCardsBanner/ChoiceCardsBanner';
-import { ChoiceCardBannerComponentId } from '../../banners/choiceCardsBanner/components/ChoiceCards';
+import { between, until } from '@guardian/src-foundations/mq';
+import { ChoiceCardSelection } from '../ChoiceCardsBanner';
+import { ChoiceCardBannerComponentId } from './ChoiceCards';
 
 const container = css`
     display: flex;
@@ -36,12 +33,15 @@ const choiceCardsContainer = css`
     }
 
     > label:last-of-type {
-        margin: 0 !important;
+        margin-right: 0 !important;
     }
 
-    /* > label > div:first-of-type {
-        padding: 0 !important;
-    } */
+    > label > div {
+        ${between.tablet.and.desktop} {
+            padding-left: 0 !important;
+            padding-right: 0 !important;
+        }
+    }
 `;
 
 const choiceCardOrOtherAmountContainer = css`

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
@@ -5,7 +5,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
 import { neutral, space } from '@guardian/src-foundations';
-import { ChoiceCardAmountButtons } from '../../../shared/choiceCard/ChoiceCardAmountButtons';
+import { ChoiceCardAmountButtons } from './ChoiceCardAmountButtons';
 import { ChoiceCardFrequencyTabs, ContributionType } from './ChoiceCardFrequencyTabs';
 import { SupportCta } from './SupportCta';
 import { PaymentCards } from './PaymentCards';


### PR DESCRIPTION
## What does this change?
Following https://github.com/guardian/support-dotcom-components/pull/859 this alters the default padding for the choice card amount buttons from source. Between tablet and desktop padding is removed from the left and right to ensure the button copy remains on one line.
