### PR TITLE
Price Card Banner Keyline & Design Review Tweaks

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
@@ -29,6 +29,7 @@ const Template: Story<ChoiceCardStoryProps> = (props: ChoiceCardStoryProps) =>
             {...props}
             backgroundColor={props.backgroundColor}
             headingColor={props.headingColor}
+            borderTop={props.borderTop}
             bannerId={props.bannerId}
             onCloseClick={() => null}
             onSignInClick={() => null}
@@ -135,6 +136,7 @@ ChoiceCardsBannerBlue.args = {
     },
     backgroundColor: blueBannerBackgroundColor,
     headingColor: blueBannerHeadingColor,
+    borderTop: true,
     onCloseClick: () => null,
     separateArticleCount: true,
     numArticles: 15,
@@ -148,4 +150,5 @@ ChoiceCardsBannerYellow.args = {
     bannerId: 'choice-cards-banner-yellow',
     backgroundColor: yellowBannerBackgroundColor,
     headingColor: yellowBannerHeadingColor,
+    borderTop: false,
 };

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
@@ -151,5 +151,4 @@ ChoiceCardsBannerYellow.args = {
     bannerId: 'choice-cards-banner-yellow',
     backgroundColor: yellowBannerBackgroundColor,
     headingColor: yellowBannerHeadingColor,
-    borderTopColorStyle: undefined,
 };

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
@@ -5,6 +5,7 @@ import { BannerRenderProps } from '../common/types';
 import {
     backgroundColor as blueBannerBackgroundColor,
     headingColor as blueBannerHeadingColor,
+    borderTopColor as blueBorderTopColor,
 } from './ChoiceCardsBannerBlue';
 import {
     backgroundColor as yellowBannerBackgroundColor,
@@ -29,7 +30,7 @@ const Template: Story<ChoiceCardStoryProps> = (props: ChoiceCardStoryProps) =>
             {...props}
             backgroundColor={props.backgroundColor}
             headingColor={props.headingColor}
-            borderTop={props.borderTop}
+            borderTopColor={props.borderTopColor}
             bannerId={props.bannerId}
             onCloseClick={() => null}
             onSignInClick={() => null}
@@ -136,7 +137,7 @@ ChoiceCardsBannerBlue.args = {
     },
     backgroundColor: blueBannerBackgroundColor,
     headingColor: blueBannerHeadingColor,
-    borderTop: true,
+    borderTopColor: blueBorderTopColor,
     onCloseClick: () => null,
     separateArticleCount: true,
     numArticles: 15,
@@ -150,5 +151,5 @@ ChoiceCardsBannerYellow.args = {
     bannerId: 'choice-cards-banner-yellow',
     backgroundColor: yellowBannerBackgroundColor,
     headingColor: yellowBannerHeadingColor,
-    borderTop: false,
+    borderTopColor: undefined,
 };

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
@@ -124,8 +124,8 @@ ChoiceCardsBannerBlue.args = {
                 hideChooseYourAmount: false,
             },
             MONTHLY: {
-                amounts: [6, 12],
-                defaultAmount: 12,
+                amounts: [3, 6, 10],
+                defaultAmount: 10,
                 hideChooseYourAmount: true,
             },
             ANNUAL: {

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
@@ -5,7 +5,7 @@ import { BannerRenderProps } from '../common/types';
 import {
     backgroundColor as blueBannerBackgroundColor,
     headingColor as blueBannerHeadingColor,
-    borderTopColor as blueBorderTopColor,
+    borderTopColorStyle as blueBorderTopColorStyle,
 } from './ChoiceCardsBannerBlue';
 import {
     backgroundColor as yellowBannerBackgroundColor,
@@ -30,7 +30,7 @@ const Template: Story<ChoiceCardStoryProps> = (props: ChoiceCardStoryProps) =>
             {...props}
             backgroundColor={props.backgroundColor}
             headingColor={props.headingColor}
-            borderTopColor={props.borderTopColor}
+            borderTopColorStyle={props.borderTopColorStyle}
             bannerId={props.bannerId}
             onCloseClick={() => null}
             onSignInClick={() => null}
@@ -137,7 +137,7 @@ ChoiceCardsBannerBlue.args = {
     },
     backgroundColor: blueBannerBackgroundColor,
     headingColor: blueBannerHeadingColor,
-    borderTopColor: blueBorderTopColor,
+    borderTopColorStyle: blueBorderTopColorStyle,
     onCloseClick: () => null,
     separateArticleCount: true,
     numArticles: 15,
@@ -151,5 +151,5 @@ ChoiceCardsBannerYellow.args = {
     bannerId: 'choice-cards-banner-yellow',
     backgroundColor: yellowBannerBackgroundColor,
     headingColor: yellowBannerHeadingColor,
-    borderTopColor: undefined,
+    borderTopColorStyle: undefined,
 };

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
@@ -124,12 +124,12 @@ ChoiceCardsBannerBlue.args = {
                 hideChooseYourAmount: false,
             },
             MONTHLY: {
-                amounts: [6, 12, 18, 24],
+                amounts: [6, 12],
                 defaultAmount: 12,
                 hideChooseYourAmount: true,
             },
             ANNUAL: {
-                amounts: [50, 100, 150, 200],
+                amounts: [100],
                 defaultAmount: 100,
                 hideChooseYourAmount: true,
             },

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
@@ -66,20 +66,20 @@ ChoiceCardsBannerBlue.args = {
     countryCode: 'GB',
     content: {
         mainContent: {
-            heading: <>Lend us a hand in 2023</>,
+            heading: <>As 2023 unfolds, will you support us?</>,
             subheading: null,
             paragraphs: [
                 <>
-                    Shareholders or billionaire owner, we report on world events with accuracy, free
-                    from political and commercial influence. And unlike many others, we’re committed
-                    to keeping our reporting open for all readers. Every contribution, however big
-                    or small, makes a difference.
+                    We’re a reader-funded news organisation, with more than 1.5 million supporters
+                    in 180 countries. With this vital support, our reporting remains fiercely
+                    independent, and is never manipulated by commercial or political ties. And it’s
+                    free, for everyone. But if you can support us, we need you.
                 </>,
             ],
             highlightedText: (
                 <>
-                    Support us from as little as £1. If you can, please consider supporting us with
-                    a regular amount each month. Thank you.
+                    Give just once from £1, or better yet, power us every month with a little more.
+                    Thank you.
                 </>
             ),
             primaryCta: {
@@ -89,24 +89,24 @@ ChoiceCardsBannerBlue.args = {
             secondaryCta: null,
         },
         mobileContent: {
-            heading: <>Lend us a hand in 2023</>,
+            heading: <>As 2023 unfolds, will you support us?</>,
             subheading: null,
             paragraphs: [
                 <>
-                    Shareholders or billionaire owner, we report on world events with accuracy, free
-                    from political and commercial influence. And unlike many others, we’re committed
-                    to keeping our reporting open for all readers. Every contribution, however big
-                    or small, makes a difference.
+                    We’re a reader-funded news organisation, with more than 1.5 million supporters
+                    in 180 countries. With this vital support, our reporting remains fiercely
+                    independent, and is never manipulated by commercial or political ties. And it’s
+                    free, for everyone. But if you can support us, we need you.
                 </>,
             ],
             highlightedText: (
                 <>
-                    Support us from as little as £1. If you can, please consider supporting us with
-                    a regular amount each month. Thank you.
+                    Give just once from £1, or better yet, power us every month with a little more.
+                    Thank you.
                 </>
             ),
             primaryCta: {
-                ctaText: 'Support us',
+                ctaText: 'Continue',
                 ctaUrl: 'https://support.theguardian.com/contribute',
             },
             secondaryCta: null,

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
@@ -181,9 +181,9 @@ export const ChoiceCardsBanner = ({
                                 content={content}
                                 getCtaText={getCtaText}
                                 cssCtaOverides={
-                                    bannerId === 'choice-cards-banner-blue'
-                                        ? ctaOverridesYellow
-                                        : ctaOverridesBlue
+                                    bannerId === 'choice-cards-banner-yellow'
+                                        ? ctaOverridesBlue
+                                        : undefined
                                 }
                             />
                         )}

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
@@ -57,14 +57,14 @@ export type ChoiceCardsBannerRenderProps = {
     bannerId: BannerId;
     backgroundColor: string;
     headingColor: string;
-    borderTop: boolean;
+    borderTopColor?: string;
 };
 
 export const ChoiceCardsBanner = ({
     bannerId,
     backgroundColor,
     headingColor,
-    borderTop,
+    borderTopColor,
     onCloseClick,
     content,
     choiceCardAmounts,
@@ -127,7 +127,7 @@ export const ChoiceCardsBanner = ({
 
     return (
         <section ref={setNode} css={banner(backgroundColor)} data-target={bannerId}>
-            <Container cssOverrides={containerOverrides(borderTop, headingColor)}>
+            <Container cssOverrides={containerOverrides(borderTopColor)}>
                 <Columns>
                     <Column width={1} cssOverrides={iconAndClosePosition}>
                         <Inline space={1}>

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
@@ -25,6 +25,7 @@ import { ChoiceCards } from './components/ChoiceCards';
 import { ContributionFrequency } from '@sdc/shared/src/types';
 import { HasBeenSeen, useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import { ChoiceCardsBannerArticleCount } from './components/ChoiceCardsBannerArticleCount';
+import { SerializedStyles } from '@emotion/react';
 
 type ButtonPropTypes = {
     onClick: (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
@@ -57,14 +58,14 @@ export type ChoiceCardsBannerRenderProps = {
     bannerId: BannerId;
     backgroundColor: string;
     headingColor: string;
-    borderTopColor?: string;
+    borderTopColorStyle?: SerializedStyles;
 };
 
 export const ChoiceCardsBanner = ({
     bannerId,
     backgroundColor,
     headingColor,
-    borderTopColor,
+    borderTopColorStyle,
     onCloseClick,
     content,
     choiceCardAmounts,
@@ -127,7 +128,13 @@ export const ChoiceCardsBanner = ({
 
     return (
         <section ref={setNode} css={banner(backgroundColor)} data-target={bannerId}>
-            <Container cssOverrides={containerOverrides(borderTopColor)}>
+            <Container
+                cssOverrides={
+                    borderTopColorStyle
+                        ? [containerOverrides, borderTopColorStyle]
+                        : [containerOverrides]
+                }
+            >
                 <Columns>
                     <Column width={1} cssOverrides={iconAndClosePosition}>
                         <Inline space={1}>

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { Container, Columns, Column, Inline } from '@guardian/src-layout';
 import { Button } from '@guardian/src-button';
-import { SvgRoundelDefault } from '@guardian/src-brand';
+import { SvgRoundelBrand } from '@guardian/src-brand';
 import { SvgCross } from '@guardian/src-icons';
 import { BannerText } from '../common/BannerText';
 import { BannerId, BannerRenderProps } from '../common/types';
@@ -139,7 +139,7 @@ export const ChoiceCardsBanner = ({
                     <Column width={1} cssOverrides={iconAndClosePosition}>
                         <Inline space={1}>
                             <div css={logoContainer}>
-                                <SvgRoundelDefault />
+                                <SvgRoundelBrand />
                             </div>
                             <CloseButton onClick={onCloseClick} bannerId={bannerId} />
                         </Inline>

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
@@ -18,6 +18,8 @@ import {
     logoContainer,
     paragraph,
     columnMarginOverrides,
+    ctaOverridesBlue,
+    ctaOverridesYellow,
 } from './choiceCardsBannerStyles';
 import { createInsertEventFromTracking, getLocalCurrencySymbol } from '@sdc/shared/dist/lib';
 import { createViewEventFromTracking } from '@sdc/shared/dist/lib';
@@ -178,6 +180,11 @@ export const ChoiceCardsBanner = ({
                                 numArticles={numArticles}
                                 content={content}
                                 getCtaText={getCtaText}
+                                cssCtaOverides={
+                                    bannerId === 'choice-cards-banner-blue'
+                                        ? ctaOverridesYellow
+                                        : ctaOverridesBlue
+                                }
                             />
                         )}
                     </Column>

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
@@ -19,7 +19,6 @@ import {
     paragraph,
     columnMarginOverrides,
     ctaOverridesBlue,
-    ctaOverridesYellow,
 } from './choiceCardsBannerStyles';
 import { createInsertEventFromTracking, getLocalCurrencySymbol } from '@sdc/shared/dist/lib';
 import { createViewEventFromTracking } from '@sdc/shared/dist/lib';

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
@@ -57,12 +57,14 @@ export type ChoiceCardsBannerRenderProps = {
     bannerId: BannerId;
     backgroundColor: string;
     headingColor: string;
+    borderTop: boolean;
 };
 
 export const ChoiceCardsBanner = ({
     bannerId,
     backgroundColor,
     headingColor,
+    borderTop,
     onCloseClick,
     content,
     choiceCardAmounts,
@@ -125,7 +127,7 @@ export const ChoiceCardsBanner = ({
 
     return (
         <section ref={setNode} css={banner(backgroundColor)} data-target={bannerId}>
-            <Container cssOverrides={containerOverrides}>
+            <Container cssOverrides={containerOverrides(borderTop, headingColor)}>
                 <Columns>
                     <Column width={1} cssOverrides={iconAndClosePosition}>
                         <Inline space={1}>

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBannerBlue.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBannerBlue.tsx
@@ -7,6 +7,7 @@ import { ChoiceCardsBanner } from './ChoiceCardsBanner';
 const bannerId = 'choice-cards-banner-blue';
 export const backgroundColor = '#F1F8FC';
 export const headingColor = brand[400];
+export const borderTopColor = brand[400];
 
 const ChoiceCardsBannerBlue = ({
     onCloseClick,
@@ -30,7 +31,7 @@ const ChoiceCardsBannerBlue = ({
             numArticles={numArticles}
             backgroundColor={backgroundColor}
             headingColor={headingColor}
-            borderTop={true}
+            borderTopColor={borderTopColor}
             bannerId={bannerId}
             isSupporter={isSupporter}
             separateArticleCount={separateArticleCount}

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBannerBlue.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBannerBlue.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import { brand } from '@guardian/src-foundations';
 import React from 'react';
 import { validatedBannerWrapper, bannerWrapper } from '../common/BannerWrapper';
@@ -7,7 +8,9 @@ import { ChoiceCardsBanner } from './ChoiceCardsBanner';
 const bannerId = 'choice-cards-banner-blue';
 export const backgroundColor = '#F1F8FC';
 export const headingColor = brand[400];
-export const borderTopColor = brand[400];
+export const borderTopColorStyle = css`
+    border-top: 1px solid ${brand[400]};
+`;
 
 const ChoiceCardsBannerBlue = ({
     onCloseClick,
@@ -31,7 +34,7 @@ const ChoiceCardsBannerBlue = ({
             numArticles={numArticles}
             backgroundColor={backgroundColor}
             headingColor={headingColor}
-            borderTopColor={borderTopColor}
+            borderTopColorStyle={borderTopColorStyle}
             bannerId={bannerId}
             isSupporter={isSupporter}
             separateArticleCount={separateArticleCount}

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBannerBlue.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBannerBlue.tsx
@@ -30,6 +30,7 @@ const ChoiceCardsBannerBlue = ({
             numArticles={numArticles}
             backgroundColor={backgroundColor}
             headingColor={headingColor}
+            borderTop={true}
             bannerId={bannerId}
             isSupporter={isSupporter}
             separateArticleCount={separateArticleCount}

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBannerYellow.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBannerYellow.tsx
@@ -30,6 +30,7 @@ const ChoiceCardsBannerYellow = ({
             numArticles={numArticles}
             backgroundColor={backgroundColor}
             headingColor={headingColor}
+            borderTop={false}
             bannerId={bannerId}
             isSupporter={isSupporter}
             separateArticleCount={separateArticleCount}

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBannerYellow.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBannerYellow.tsx
@@ -7,6 +7,7 @@ import { ChoiceCardsBanner } from './ChoiceCardsBanner';
 const bannerId = 'choice-cards-banner-yellow';
 export const backgroundColor = brandAlt[400];
 export const headingColor = neutral[0];
+export const borderTopColor = neutral[0];
 
 const ChoiceCardsBannerYellow = ({
     onCloseClick,
@@ -30,7 +31,6 @@ const ChoiceCardsBannerYellow = ({
             numArticles={numArticles}
             backgroundColor={backgroundColor}
             headingColor={headingColor}
-            borderTop={false}
             bannerId={bannerId}
             isSupporter={isSupporter}
             separateArticleCount={separateArticleCount}

--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -91,7 +91,7 @@ export const highlightedTextBlueBanner = css`
 `;
 
 export const highlightedTextYellowBanner = css`
-    background-color: ${neutral[100]};
+    background-color: ${brandAlt[400]};
     font-weight: bold;
 `;
 

--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -121,14 +121,6 @@ export const logoContainer = css`
     }
 `;
 
-export const ctaOverridesYellow = css`
-    background: ${brandAlt[400]};
-    color: ${neutral[0]} !important;
-    &:hover {
-        background-color: ${brandAlt[200]};
-    }
-`;
-
 export const ctaOverridesBlue = css`
     background: ${neutral[0]};
     color: ${neutral[100]} !important;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -24,7 +24,11 @@ export const banner = (backgroundColor: string): SerializedStyles => css`
     }
 `;
 
-export const containerOverrides = css`
+export const containerOverrides = (
+    borderTop: boolean,
+    headingColor: string,
+): SerializedStyles => css`
+    border-top: ${borderTop ? 1 : 0}px solid ${headingColor};
     width: initial;
 
     max-width: 100%;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -24,11 +24,8 @@ export const banner = (backgroundColor: string): SerializedStyles => css`
     }
 `;
 
-export const containerOverrides = (
-    borderTop: boolean,
-    headingColor: string,
-): SerializedStyles => css`
-    border-top: ${borderTop ? 1 : 0}px solid ${headingColor};
+export const containerOverrides = (borderTopColor?: string): SerializedStyles => css`
+    border-top: ${borderTopColor ? 1 : 0}px solid ${borderTopColor};
     width: initial;
 
     max-width: 100%;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -37,7 +37,7 @@ export const containerOverrides = css`
 `;
 
 export const copyColumn = css`
-    padding-top: ${space[4]}px;
+    padding-top: ${space[2]}px;
 `;
 
 export const choiceCardsColumn = css`
@@ -77,11 +77,10 @@ export const heading = (headingColor: string): SerializedStyles => css`
 export const paragraph = css`
     ${body.small()};
     line-height: 135%;
-    margin: ${space[4]}px 0 ${space[1]}px;
+    margin: 0 0 ${space[3]}px;
     max-width: 100%;
 
     ${from.tablet} {
-        margin-bottom: ${space[5]}px;
         font-size: 17px;
     }
 `;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -41,10 +41,12 @@ export const copyColumn = css`
 `;
 
 export const choiceCardsColumn = css`
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
     align-items: center;
+    ${from.tablet} {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+    }
 `;
 
 export const columnMarginOverrides = css`

--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -24,8 +24,7 @@ export const banner = (backgroundColor: string): SerializedStyles => css`
     }
 `;
 
-export const containerOverrides = (borderTopColor?: string): SerializedStyles => css`
-    border-top: ${borderTopColor ? 1 : 0}px solid ${borderTopColor};
+export const containerOverrides = css`
     width: initial;
 
     max-width: 100%;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -1,7 +1,7 @@
 import { css, SerializedStyles } from '@emotion/react';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
-import { brandAlt, neutral, space } from '@guardian/src-foundations';
+import { brand, brandAlt, neutral, space } from '@guardian/src-foundations';
 import { height } from '@guardian/src-foundations/size';
 
 export const banner = (backgroundColor: string): SerializedStyles => css`
@@ -103,7 +103,7 @@ export const iconAndClosePosition = css`
 
 export const closeButtonStyles = css`
     z-index: 999;
-    border: 1px solid black;
+    border: 1px solid ${brand[400]};
 `;
 
 export const logoContainer = css`

--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -37,7 +37,7 @@ export const containerOverrides = css`
 `;
 
 export const copyColumn = css`
-    padding-top: ${space[2]}px;
+    padding-top: ${space[4]}px;
 `;
 
 export const choiceCardsColumn = css`
@@ -77,7 +77,7 @@ export const heading = (headingColor: string): SerializedStyles => css`
 export const paragraph = css`
     ${body.small()};
     line-height: 135%;
-    margin: 0 0 ${space[3]}px;
+    margin: 0 0 ${space[4]}px;
     max-width: 100%;
 
     ${from.tablet} {

--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -56,7 +56,7 @@ export const columnMarginOverrides = css`
 export const heading = (headingColor: string): SerializedStyles => css`
     ${headline.xxsmall({ fontWeight: 'bold' })};
     font-size: 22px;
-    margin: 0;
+    margin: 0 0 ${space[3]}px;
     color: ${headingColor};
 
     ${from.mobileMedium} {
@@ -65,11 +65,12 @@ export const heading = (headingColor: string): SerializedStyles => css`
     }
 
     ${from.tablet} {
-        font-size: 42px;
+        font-size: 34px;
         max-width: 100%;
     }
 
     ${from.desktop} {
+        font-size: 42px;
         line-height: 100%;
     }
 `;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -120,3 +120,20 @@ export const logoContainer = css`
         margin-left: ${space[3]}px;
     }
 `;
+
+export const ctaOverridesYellow = css`
+    background: ${brandAlt[400]};
+    color: ${neutral[0]} !important;
+    &:hover {
+        background-color: ${brandAlt[200]};
+    }
+`;
+
+export const ctaOverridesBlue = css`
+    background: ${neutral[0]};
+    color: ${neutral[100]} !important;
+
+    &:hover {
+        background-color: rgba(0, 0, 0, 0.75);
+    }
+`;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
@@ -22,7 +22,7 @@ const choiceCardsContainer = css`
     display: flex;
     flex-direction: row;
     margin-top: ${space[3]}px;
-    margin-bottom: ${space[3]}px;
+    margin-bottom: ${space[2]}px;
 
     > label {
         margin: 0 !important;
@@ -45,7 +45,7 @@ const choiceCardsContainer = css`
 `;
 
 const choiceCardOrOtherAmountContainer = css`
-    margin-bottom: ${space[3]}px;
+    margin-bottom: ${space[1]}px;
 `;
 
 const supporterPlusChoiceCardAmountOverrides = css`
@@ -156,9 +156,7 @@ export const ChoiceCardAmountButtons = ({
             </div>
 
             {hideChooseYourAmount ? (
-                <div css={!choiceCardAmounts[2] ? css`` : choiceCardOrOtherAmountContainer}>
-                    {choiceCardAmounts[2]}
-                </div>
+                <div css={choiceCardOrOtherAmountContainer}>{choiceCardAmounts[2]}</div>
             ) : (
                 <div css={choiceCardOrOtherAmountContainer}>
                     <ChoiceCard

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
@@ -45,6 +45,7 @@ const choiceCardsContainer = css`
 `;
 
 const supporterPlusChoiceCardAmountOverrides = css`
+    border-radius: ${space[3]}px;
     ${until.mobileMedium} {
         font-size: 10px;
     }
@@ -104,7 +105,15 @@ export const ChoiceCardAmountButtons = ({
     // Something is wrong with the data
     if (!Array.isArray(requiredAmounts) || !requiredAmounts.length) {
         return (
-            <ChoiceCard value="third" label="Other" id="choice-cards-banner-third" checked={true} />
+            <ChoiceCard
+                value="third"
+                label="Other"
+                id="choice-cards-banner-third"
+                checked={true}
+                cssOverrides={css`
+                    border-radius: ${space[3]}px;
+                `}
+            />
         );
     }
 

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
@@ -22,7 +22,7 @@ const choiceCardsContainer = css`
     display: flex;
     flex-direction: row;
     margin-top: ${space[3]}px;
-    margin-bottom: ${space[2]}px;
+    margin-bottom: ${space[3]}px;
 
     > label {
         margin: 0 !important;
@@ -42,10 +42,6 @@ const choiceCardsContainer = css`
             padding-right: 0 !important;
         }
     }
-`;
-
-const choiceCardOrOtherAmountContainer = css`
-    margin: ${space[2]}px 0;
 `;
 
 const supporterPlusChoiceCardAmountOverrides = css`
@@ -153,7 +149,7 @@ export const ChoiceCardAmountButtons = ({
                 {choiceCardAmounts[0]}
                 {choiceCardAmounts[1]}
             </div>
-            <div css={choiceCardOrOtherAmountContainer}>
+            <div>
                 {hideChooseYourAmount ? (
                     choiceCardAmounts[2]
                 ) : (

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
@@ -44,6 +44,11 @@ const choiceCardsContainer = css`
     }
 `;
 
+const choiceCardOrOtherAmountContainer = css`
+    border-radius: ${space[3]}px;
+    margin-bottom: ${space[3]}px;
+`;
+
 const supporterPlusChoiceCardAmountOverrides = css`
     border-radius: ${space[3]}px;
     ${until.mobileMedium} {
@@ -105,15 +110,7 @@ export const ChoiceCardAmountButtons = ({
     // Something is wrong with the data
     if (!Array.isArray(requiredAmounts) || !requiredAmounts.length) {
         return (
-            <ChoiceCard
-                value="third"
-                label="Other"
-                id="choice-cards-banner-third"
-                checked={true}
-                cssOverrides={css`
-                    border-radius: ${space[3]}px;
-                `}
-            />
+            <ChoiceCard value="third" label="Other" id="choice-cards-banner-third" checked={true} />
         );
     }
 
@@ -158,10 +155,11 @@ export const ChoiceCardAmountButtons = ({
                 {choiceCardAmounts[0]}
                 {choiceCardAmounts[1]}
             </div>
-            <div>
-                {hideChooseYourAmount ? (
-                    choiceCardAmounts[2]
-                ) : (
+
+            {hideChooseYourAmount ? (
+                choiceCardAmounts[2]
+            ) : (
+                <div css={choiceCardOrOtherAmountContainer}>
                     <ChoiceCard
                         value="other"
                         label="Other"
@@ -174,8 +172,8 @@ export const ChoiceCardAmountButtons = ({
                         }
                         cssOverrides={supporterPlusChoiceCardAmountOverrides}
                     />
-                )}
-            </div>
+                </div>
+            )}
         </div>
     );
 };

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
@@ -8,7 +8,7 @@ import {
 import { ContributionType, trackClick } from './ChoiceCardFrequencyTabs';
 import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
-import { between, until } from '@guardian/src-foundations/mq';
+import { between, from, until } from '@guardian/src-foundations/mq';
 import { ChoiceCardSelection } from '../ChoiceCardsBanner';
 import { ChoiceCardBannerComponentId } from './ChoiceCards';
 
@@ -45,6 +45,13 @@ const choiceCardsContainer = css`
 `;
 
 const choiceCardOrOtherAmountContainer = css`
+    margin-bottom: ${space[1]}px;
+    ${from.mobileLandscape} {
+        margin-bottom: ${space[3]}px;
+    }
+`;
+
+const choiceCardOrOtherAmountMissing = css`
     margin-bottom: ${space[1]}px;
 `;
 
@@ -156,7 +163,15 @@ export const ChoiceCardAmountButtons = ({
             </div>
 
             {hideChooseYourAmount ? (
-                <div css={choiceCardOrOtherAmountContainer}>{choiceCardAmounts[2]}</div>
+                <div
+                    css={
+                        !choiceCardAmounts[2]
+                            ? choiceCardOrOtherAmountMissing
+                            : choiceCardOrOtherAmountContainer
+                    }
+                >
+                    {choiceCardAmounts[2]}
+                </div>
             ) : (
                 <div css={choiceCardOrOtherAmountContainer}>
                     <ChoiceCard

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
@@ -156,7 +156,9 @@ export const ChoiceCardAmountButtons = ({
             </div>
 
             {hideChooseYourAmount ? (
-                <div css={choiceCardOrOtherAmountContainer}>{choiceCardAmounts[2]}</div>
+                <div css={!choiceCardAmounts[2] ? css`` : choiceCardOrOtherAmountContainer}>
+                    {choiceCardAmounts[2]}
+                </div>
             ) : (
                 <div css={choiceCardOrOtherAmountContainer}>
                     <ChoiceCard

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
@@ -45,7 +45,6 @@ const choiceCardsContainer = css`
 `;
 
 const choiceCardOrOtherAmountContainer = css`
-    border-radius: ${space[3]}px;
     margin-bottom: ${space[3]}px;
 `;
 
@@ -157,7 +156,7 @@ export const ChoiceCardAmountButtons = ({
             </div>
 
             {hideChooseYourAmount ? (
-                choiceCardAmounts[2]
+                <div css={choiceCardOrOtherAmountContainer}>{choiceCardAmounts[2]}</div>
             ) : (
                 <div css={choiceCardOrOtherAmountContainer}>
                     <ChoiceCard

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
@@ -54,6 +54,10 @@ const styles = {
         ${from.tablet} {
             margin: 60px 0 ${space[5]}px;
         }
+
+        ${from.desktop} {
+            max-width: 380px;
+        }
     `,
     bannerFrequenciesGroupOverrides: css`
         display: grid;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
@@ -68,6 +68,9 @@ const styles = {
         }
     `,
     hideChoiceCardGroupLegend: css`
+        label {
+            border-radius: 10px;
+        }
         legend {
             ${visuallyHidden};
         }

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
@@ -37,14 +37,18 @@ const styles = {
         // This position: relative is necessary to stop it jumping to the top of the page when a button is clicked
         position: relative;
         margin: ${space[3]}px 0 ${space[5]}px;
-        max-width: 300px;
+        max-width: 296px;
+
+        ${from.mobile} {
+            max-width: 351px;
+        }
 
         ${from.mobileMedium} {
-            max-width: 350px;
+            max-width: 456px;
         }
 
         ${from.mobileLandscape} {
-            max-width: 380px;
+            max-width: 716px;
         }
 
         ${from.tablet} {
@@ -52,8 +56,11 @@ const styles = {
         }
     `,
     bannerFrequenciesGroupOverrides: css`
-        grid-template-columns: repeat(3, minmax(100px, 200px));
         display: grid;
+
+        ${from.tablet} {
+            grid-template-columns: repeat(3, minmax(100px, 200px));
+        }
 
         > div:first-of-type {
             display: inline;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { ChoiceCardGroup } from '@guardian/src-choice-card';
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
@@ -29,6 +29,7 @@ interface ChoiceCardProps {
     bannerTracking?: Tracking;
     numArticles?: number;
     content?: BannerTextContent;
+    cssCtaOverides?: SerializedStyles;
 }
 
 const styles = {
@@ -119,6 +120,7 @@ export const ChoiceCards: React.FC<ChoiceCardProps> = ({
     bannerTracking,
     numArticles,
     getCtaText,
+    cssCtaOverides,
 }: ChoiceCardProps) => {
     if (!selection || !amounts) {
         return <></>;
@@ -191,6 +193,7 @@ export const ChoiceCards: React.FC<ChoiceCardProps> = ({
                         numArticles={numArticles ?? 0}
                         selection={selection}
                         getCtaText={getCtaText}
+                        cssOverrides={cssCtaOverides}
                     />
                     <PaymentCards cssOverrides={styles.paymentCardsSvgOverrides} />
                 </div>

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardsBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardsBannerArticleCount.tsx
@@ -9,8 +9,7 @@ const styles = {
     container: css`
         ${headline.xxxsmall({ fontWeight: 'bold' })}
         font-size: 15px;
-        margin: 0;
-        margin-top: ${space[1]}px;
+        margin: 0 0 ${space[1]}px;
 
         ${from.tablet} {
             font-size: 17px;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardsBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardsBannerArticleCount.tsx
@@ -10,7 +10,7 @@ const styles = {
         ${headline.xxxsmall({ fontWeight: 'bold' })}
         font-size: 15px;
         margin: 0;
-        margin-top: ${space[2]}px;
+        margin-top: ${space[1]}px;
 
         ${from.tablet} {
             font-size: 17px;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/dist/lib';
 import { Tracking } from '@sdc/shared/dist/types';
-import { neutral, space } from '@guardian/src-foundations';
-import { css } from '@emotion/react';
+import { brandAlt, neutral, space } from '@guardian/src-foundations';
+import { css, SerializedStyles } from '@emotion/react';
 import { Hide } from '@guardian/src-layout';
 import { Button } from './Button';
 import { ChoiceCardSelection } from '../ChoiceCardsBanner';
@@ -10,12 +10,12 @@ import { ChoiceCardSelection } from '../ChoiceCardsBanner';
 const buttonOverrides = css`
     margin-right: ${space[3]}px;
     margin-bottom: ${space[3]}px;
-    background: ${neutral[0]};
-    color: ${neutral[100]} !important;
+    // background: ${brandAlt[400]};
+    // color: ${neutral[0]} !important;
 
-    &:hover {
-        background-color: rgba(0, 0, 0, 0.75);
-    }
+    // &:hover {
+    //     background-color: ${brandAlt[200]};
+    // }
 `;
 
 export const SupportCta = ({
@@ -26,6 +26,7 @@ export const SupportCta = ({
     amountsVariantName,
     selection,
     getCtaText,
+    cssOverrides,
 }: {
     tracking: Tracking;
     numArticles: number;
@@ -34,6 +35,7 @@ export const SupportCta = ({
     amountsVariantName?: string;
     selection: ChoiceCardSelection;
     getCtaText: (contentType: 'mainContent' | 'mobileContent') => string;
+    cssOverrides?: SerializedStyles;
 }): JSX.Element | null => {
     const url = `https://support.theguardian.com/contribute?selected-contribution-type=${selection.frequency}&selected-amount=${selection.amount}`;
 
@@ -56,7 +58,7 @@ export const SupportCta = ({
                     onClickAction={supportUrl}
                     showArrow
                     data-ignore="global-link-styling"
-                    css={buttonOverrides}
+                    css={[buttonOverrides, cssOverrides]}
                 >
                     {mobileText}
                 </Button>
@@ -67,7 +69,7 @@ export const SupportCta = ({
                     onClickAction={supportUrl}
                     showArrow
                     data-ignore="global-link-styling"
-                    css={buttonOverrides}
+                    css={[buttonOverrides, cssOverrides]}
                 >
                     {desktopText}
                 </Button>

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/dist/lib';
 import { Tracking } from '@sdc/shared/dist/types';
-import { space } from '@guardian/src-foundations';
+import { brandAlt, neutral, space } from '@guardian/src-foundations';
 import { css, SerializedStyles } from '@emotion/react';
 import { Hide } from '@guardian/src-layout';
 import { Button } from './Button';
@@ -9,7 +9,12 @@ import { ChoiceCardSelection } from '../ChoiceCardsBanner';
 
 const buttonOverrides = css`
     margin-right: ${space[3]}px;
-    margin-bottom: ${space[3]}px;}
+    margin-bottom: ${space[3]}px;
+    background: ${brandAlt[400]};
+    color: ${neutral[0]} !important;
+    &:hover {
+        background-color: ${brandAlt[200]};
+    }
 `;
 
 export const SupportCta = ({

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/dist/lib';
 import { Tracking } from '@sdc/shared/dist/types';
-import { brandAlt, neutral, space } from '@guardian/src-foundations';
+import { space } from '@guardian/src-foundations';
 import { css, SerializedStyles } from '@emotion/react';
 import { Hide } from '@guardian/src-layout';
 import { Button } from './Button';
@@ -9,13 +9,7 @@ import { ChoiceCardSelection } from '../ChoiceCardsBanner';
 
 const buttonOverrides = css`
     margin-right: ${space[3]}px;
-    margin-bottom: ${space[3]}px;
-    // background: ${brandAlt[400]};
-    // color: ${neutral[0]} !important;
-
-    // &:hover {
-    //     background-color: ${brandAlt[200]};
-    // }
+    margin-bottom: ${space[3]}px;}
 `;
 
 export const SupportCta = ({

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/paymentFrequencyTabs/PaymentFrequencyTabsBox.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/paymentFrequencyTabs/PaymentFrequencyTabsBox.tsx
@@ -8,7 +8,7 @@ const mainStyles = css`
     overflow: hidden;
     background-color: ${neutral[100]};
     color: ${neutral[7]};
-    border: 1px solid ${neutral[86]};
+    border-top: 1px solid ${neutral[86]};
     border-radius: ${space[3]}px ${space[3]}px 0 0;
 
     :not(:last-child) {

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/paymentFrequencyTabs/PaymentFrequencyTabsBox.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/paymentFrequencyTabs/PaymentFrequencyTabsBox.tsx
@@ -8,6 +8,8 @@ const mainStyles = css`
     overflow: hidden;
     background-color: ${neutral[100]};
     color: ${neutral[7]};
+    border-left: 1px solid ${neutral[86]};
+    border-right: 1px solid ${neutral[86]};
     border-top: 1px solid ${neutral[86]};
     border-radius: ${space[3]}px ${space[3]}px 0 0;
 


### PR DESCRIPTION
## What does this change?
Add customisable border top line for the choice banner. Blue has a line, Yellow does not. Colour matches header colour.
[**Trello Card - PriceCard Banner Keyline**](https://trello.com/c/YvEj4iYh/1182-add-keyline-to-choice-cards-in-banner)


Visual Alterations To Banner

- Close CTA & SVG colour to Brand400 (blue)
- Continue CTA colour to BrandAlt400 (yellow)
- Remove lower grey tab on selected tab
- Round corners of (10px) price buttons
- Spacing 12px between buttons except 1st -> 2nd row 8px
- Text Spacing 16px->Title>12px->ArticleCount->4px->Paragraph>16px
- Price Card responsive up to tablet (740px)
- Price Card 340px up to 980px, 380px beyond
- Head font change at 740px->980px
[**Trello Card - PriceCard Banner Review**](https://trello.com/c/RiFRoHBg/1179-engineering-design-review-for-in-banner-price-cards)
Figma : https://www.figma.com/file/GWmoVDkwEsFgDDcrKjEc7j/choice-card-in-engagement-banner?node-id=492%3A19365

Post
![Screenshot 2023-03-21 at 14 48 05](https://user-images.githubusercontent.com/76729591/226643679-b98fd7b6-da55-4c07-9cc9-0653f0c2ca30.png)


[Following https://github.com/guardian/support-dotcom-components/pull/859]