### PR TITLE
Don't show banner messages on Taylor Report pages

### DIFF
--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -182,6 +182,28 @@ describe('selectBannerTest', () => {
             );
             expect(result).toBe(null);
         });
+
+        it('returns null if page has Taylor Report tag', () => {
+            const targetingWithTaylorReportTag = {
+                tagIds: ['news/series/cotton-capital'],
+                ...targeting,
+            };
+
+            const result = selectBannerTest(
+                targetingWithTaylorReportTag,
+                tracking,
+                isMobile,
+                '',
+                [test],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
+                undefined,
+                now,
+            );
+
+            expect(result).toBe(null);
+        });
     });
 
     describe('Channel 2 banner rules', () => {

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -130,6 +130,10 @@ const purchaseMatches = (
     return productValid && userValid;
 };
 
+const TAYLOR_REPORT_TAG_ID = 'news/series/cotton-capital';
+const isTaylorReportPage = (targeting: BannerTargeting): boolean => {
+    return Boolean(targeting.tagIds?.includes(TAYLOR_REPORT_TAG_ID));
+};
 export const selectBannerTest = (
     targeting: BannerTargeting,
     pageTracking: PageTracking,
@@ -142,6 +146,10 @@ export const selectBannerTest = (
     forcedTestVariant?: TestVariant,
     now: Date = new Date(),
 ): BannerTestSelection | null => {
+    if (isTaylorReportPage(targeting)) {
+        return null;
+    }
+
     if (forcedTestVariant) {
         return getForcedVariant(forcedTestVariant, tests, baseUrl, targeting);
     }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Don't show banner messages on Taylor Report pages. This is a temporary change and will be reverted in future.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
