### PR TITLE
Fix banner tracking

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.stories.tsx
@@ -15,7 +15,7 @@ import { PageTracking, TestTracking, Tracking } from '@sdc/shared/src/types';
 
 export default {
     component: ChoiceCardsBanner,
-    title: 'Banners/Subscriptions/ChoiceCardsBanner',
+    title: 'Banners/ChoiceCardsBanner',
 } as Meta;
 
 type ChoiceCardStoryProps = Omit<

--- a/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/ChoiceCardsBanner.tsx
@@ -20,11 +20,9 @@ import {
     columnMarginOverrides,
     ctaOverridesBlue,
 } from './choiceCardsBannerStyles';
-import { createInsertEventFromTracking, getLocalCurrencySymbol } from '@sdc/shared/dist/lib';
-import { createViewEventFromTracking } from '@sdc/shared/dist/lib';
+import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib';
 import { ChoiceCards } from './components/ChoiceCards';
 import { ContributionFrequency } from '@sdc/shared/src/types';
-import { HasBeenSeen, useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import { ChoiceCardsBannerArticleCount } from './components/ChoiceCardsBannerArticleCount';
 import { SerializedStyles } from '@emotion/react';
 
@@ -84,20 +82,6 @@ export const ChoiceCardsBanner = ({
     const [choiceCardSelection, setChoiceCardSelection] = useState<
         ChoiceCardSelection | undefined
     >();
-    const [hasBeenSeen, setNode] = useHasBeenSeen({ threshold: 0 }, true) as HasBeenSeen;
-
-    useEffect(() => {
-        if (hasBeenSeen && tracking) {
-            // For ophan
-            if (submitComponentEvent) {
-                submitComponentEvent(createViewEventFromTracking(tracking, tracking.campaignCode));
-            }
-        }
-
-        if (submitComponentEvent && tracking) {
-            submitComponentEvent(createInsertEventFromTracking(tracking, tracking.campaignCode));
-        }
-    }, [hasBeenSeen, submitComponentEvent]);
 
     useEffect(() => {
         if (choiceCardAmounts?.amounts) {
@@ -128,7 +112,7 @@ export const ChoiceCardsBanner = ({
     const articleCount = <ChoiceCardsBannerArticleCount numArticles={numArticles ?? 0} />;
 
     return (
-        <section ref={setNode} css={banner(backgroundColor)} data-target={bannerId}>
+        <section css={banner(backgroundColor)} data-target={bannerId}>
             <Container
                 cssOverrides={
                     borderTopColorStyle

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
@@ -149,7 +149,7 @@ export const ChoiceCards: React.FC<ChoiceCardProps> = ({
                 submitComponentEvent({
                     component: {
                         componentType: 'ACQUISITIONS_OTHER',
-                        id: componentId,
+                        id: 'contributions-banner-choice-cards',
                     },
                     action: 'VIEW',
                     abTest: {

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -262,6 +262,7 @@ const withBannerData = (
                 separateArticleCount,
                 choiceCardAmounts,
                 tracking,
+                submitComponentEvent,
             };
 
             return (


### PR DESCRIPTION
The [PR for choice cards amounts](https://github.com/guardian/support-dotcom-components/pull/859) introduced a new `submitComponentEvent` prop for tracking extra events with ophan. This isn't currently working because the BannerWrapper doesn't pass it in

Ophan events:

Banner insert:
<img width="523" alt="Screenshot 2023-04-04 at 08 44 37" src="https://user-images.githubusercontent.com/1513454/229723385-d4bad84c-52d3-409a-ad0b-207953a990ff.png">

Choice cards view:
<img width="523" alt="Screenshot 2023-04-04 at 08 44 48" src="https://user-images.githubusercontent.com/1513454/229723393-c95bd84c-7f77-4c3f-81a4-611f0ff9c12d.png">

Banner view:
<img width="523" alt="Screenshot 2023-04-04 at 08 44 55" src="https://user-images.githubusercontent.com/1513454/229723397-75f196fd-d3a1-447b-adc0-341d3ab3e6f8.png">
