### PR TITLE
Display logo from tablet in choice cards banner

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -110,7 +110,7 @@ export const closeButtonStyles = css`
 
 export const logoContainer = css`
     display: none;
-    ${from.mobileMedium} {
+    ${from.tablet} {
         display: block;
         width: ${height.ctaSmall}px;
         height: ${height.ctaSmall}px;


### PR DESCRIPTION
Based on the designs, this logo should be visible in the tablet breakpoint and not in the mobile medium breakpoint: looks like we made a mistake with the breakpoint when we made this in the first place.

Interestingly, this is a change from some other banners: the guardian weekly and print, for example. Those both display the logo from mobileMedium. Not having seen the designs, I don’t know whether that’s correct, but it has been that way for a long time so I assume so – I’ll check, but I think we can merge this in the meantime.

## How to test

Run `yarn modules storybook`, find the choice cards banner in the left hand menu under Subscriptions, use the button at the top to change the display size to check the break points.

## Images

### Before

Mobile medium:

<img width="398" alt="Before (mobileMedium, blue)" src="https://user-images.githubusercontent.com/23191049/229752082-ca290094-0757-4dd8-8987-ee892ca89112.png">
<img width="399" alt="Before (mobileMedium, yellow)" src="https://user-images.githubusercontent.com/23191049/229752084-08110a57-dfd4-4426-94ea-d32b7662a80b.png">

Tablet:

<img width="791" alt="Before (tablet, blue)" src="https://user-images.githubusercontent.com/23191049/229752093-37830b1f-f887-4eaf-8b49-d9b4b08d02c3.png">
<img width="778" alt="Before (tablet, yellow)" src="https://user-images.githubusercontent.com/23191049/229752092-011ecd99-dba2-426f-b799-5a1129fd727f.png">

### After

Mobile medium:

<img width="394" alt="After (mobileMedium, blue)" src="https://user-images.githubusercontent.com/23191049/229752076-76098a31-6c8d-40a9-a181-caf21a2a5b36.png">
<img width="408" alt="After (mobileMedium, yellow)" src="https://user-images.githubusercontent.com/23191049/229752065-2fa59842-0422-49a4-adae-dc72a0fbc3de.png">

Tablet:

<img width="779" alt="After (tablet, blue)" src="https://user-images.githubusercontent.com/23191049/229752097-2a048877-658d-41c1-a552-00501f2d1ad5.png">
<img width="772" alt="After (tablet, yellow)" src="https://user-images.githubusercontent.com/23191049/229752100-c90e586f-380c-4e24-b10a-64c5b24dce86.png">


## Accessibility

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [X] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
