### PR TITLE
refactor(deps): Update `@sdc/shared` install method

### DIFF
--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -23,7 +23,7 @@
     "@guardian/src-layout": "3.8.0",
     "@guardian/src-link": "3.8.0",
     "@guardian/src-text-input": "3.8.0",
-    "@sdc/shared": "1.0.0",
+    "@sdc/shared": "file:../shared",
     "@types/babel__standalone": "^7.1.2",
     "preact": "^10.5.12",
     "react-spring": "^9.5.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -39,7 +39,7 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@sdc/shared": "1.0.0",
+    "@sdc/shared": "file:../shared",
     "amp-toolbox-cors": "^1.2.0-alpha.2",
     "aws-sdk": "^2.862.0",
     "compression": "1.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3448,6 +3448,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sdc/shared@file:packages/shared":
+  version "1.0.0"
+  dependencies:
+    zod "^3.2.0"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"


### PR DESCRIPTION
## What does this change?
Install the shared module `@sdc/shared` with a [local path](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#local-paths). This allows it to appear in the `yarn.lock` file, which is relevant for https://github.com/guardian/.github/pull/49.

## How to test
Primarily, check the result of CI.

## How can we measure success?
TBD.

## Have we considered potential risks?
TBD.