### PR TITLE
Revert "Choice cards banner design update"

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -37,11 +37,7 @@ export const containerOverrides = css`
 `;
 
 export const copyColumn = css`
-    padding-top: 10px;
-
-    ${from.desktop} {
-        padding-top: ${space[3]}px;
-    }
+    padding-top: ${space[4]}px;
 `;
 
 export const choiceCardsColumn = css`
@@ -55,15 +51,12 @@ export const choiceCardsColumn = css`
 
 export const columnMarginOverrides = css`
     margin-right: 0 !important;
-    ${from.tablet} {
-        margin-bottom: ${space[4]}px !important;
-    }
 `;
 
 export const heading = (headingColor: string): SerializedStyles => css`
     ${headline.xxsmall({ fontWeight: 'bold' })};
     font-size: 22px;
-    margin: 0 0 ${space[4]}px;
+    margin: 0 0 ${space[3]}px;
     color: ${headingColor};
 
     ${from.mobileMedium} {
@@ -79,7 +72,6 @@ export const heading = (headingColor: string): SerializedStyles => css`
     ${from.desktop} {
         font-size: 42px;
         line-height: 100%;
-        margin-bottom: 22px;
     }
 `;
 

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
@@ -15,11 +15,13 @@ import { ChoiceCardBannerComponentId } from './ChoiceCards';
 const container = css`
     display: flex;
     flex-direction: column;
+    margin: 0 ${space[3]}px;
 `;
 
 const choiceCardsContainer = css`
     display: flex;
     flex-direction: row;
+    margin-top: ${space[3]}px;
     margin-bottom: ${space[2]}px;
 
     > label {

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardFrequencyTabs.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardFrequencyTabs.tsx
@@ -4,24 +4,10 @@ import {
     ContributionFrequency,
     OphanComponentEvent,
 } from '@sdc/shared/dist/types';
+import { BannerChoiceCardsPaymentFrequencyTabs } from './paymentFrequencyTabs/PaymentFrequencyTabs';
+import { Box } from './paymentFrequencyTabs/PaymentFrequencyTabsBox';
 import { ChoiceCardBannerComponentId } from './ChoiceCards';
 import { ChoiceCardSelection } from '../ChoiceCardsBanner';
-import { ChoiceCard } from '@guardian/src-choice-card';
-import { css } from '@emotion/react';
-import { space } from '@guardian/src-foundations';
-
-const container = css`
-    display: flex;
-
-    > label {
-        margin-right: ${space[2]}px !important;
-        margin-bottom: ${space[3]}px !important;
-    }
-
-    > label:last-of-type {
-        margin-right: 0 !important;
-    }
-`;
 
 interface ContributionTypeItem {
     label: string;
@@ -76,25 +62,23 @@ export const ChoiceCardFrequencyTabs = ({
     const getRecurringLabelText = (tabFrequency: ContributionFrequency) =>
         tabFrequency[0] + tabFrequency.slice(1).toLowerCase();
 
-    const tabList = tabFrequencies.map(tabFrequency => ({
-        frequency: tabFrequency,
-        id: `banner-${tabFrequency}`,
-        labelText: tabFrequency === 'ONE_OFF' ? 'Single' : getRecurringLabelText(tabFrequency),
-        selected: selection.frequency === tabFrequency,
-    }));
+    const getTabList = () => {
+        return tabFrequencies.map(tabFrequency => ({
+            frequency: tabFrequency,
+            id: `banner-${tabFrequency}`,
+            labelText: tabFrequency === 'ONE_OFF' ? 'Single' : getRecurringLabelText(tabFrequency),
+            selected: selection.frequency === tabFrequency,
+        }));
+    };
 
     return (
-        <div css={container}>
-            {tabList.map(tab => (
-                <ChoiceCard
-                    key={tab.id}
-                    label={tab.labelText}
-                    value={tab.labelText}
-                    id={tab.id}
-                    checked={tab.selected}
-                    onChange={() => updateFrequency(tab.frequency)}
-                />
-            ))}
-        </div>
+        <Box>
+            <BannerChoiceCardsPaymentFrequencyTabs
+                ariaLabel="payment frequency tabs"
+                tabs={getTabList()}
+                selectedTab={selection.frequency}
+                onTabChange={updateFrequency}
+            />
+        </Box>
     );
 };

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
@@ -4,7 +4,7 @@ import { css, SerializedStyles } from '@emotion/react';
 import { from } from '@guardian/src-foundations/mq';
 import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
-import { space } from '@guardian/src-foundations';
+import { neutral, space } from '@guardian/src-foundations';
 import { ChoiceCardAmountButtons } from './ChoiceCardAmountButtons';
 import { ChoiceCardFrequencyTabs, ContributionType } from './ChoiceCardFrequencyTabs';
 import { SupportCta } from './SupportCta';
@@ -52,12 +52,11 @@ const styles = {
         }
 
         ${from.tablet} {
-            margin: 108px 0 ${space[5]}px;
+            margin: 60px 0 ${space[5]}px;
         }
 
         ${from.desktop} {
             max-width: 380px;
-            margin-top: 120px;
         }
     `,
     bannerFrequenciesGroupOverrides: css`
@@ -81,6 +80,10 @@ const styles = {
         }
     `,
     bannerAmountsContainer: css`
+        background: ${neutral[100]};
+        border-left: 1px solid ${neutral[86]};
+        border-right: 1px solid ${neutral[86]};
+
         > div:first-of-type {
             display: block !important;
         }
@@ -89,6 +92,11 @@ const styles = {
     ctaAndPaymentCardsContainer: css`
         display: flex;
         align-items: center;
+        padding: 0 ${space[3]}px;
+        background: ${neutral[100]};
+        border-radius: 0 0 ${space[3]}px ${space[3]}px;
+        border: 1px solid ${neutral[86]};
+        border-top: none;
     `,
     paymentCardsSvgOverrides: css`
         margin-top: -10px;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardsBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardsBannerArticleCount.tsx
@@ -9,7 +9,7 @@ const styles = {
     container: css`
         ${headline.xxxsmall({ fontWeight: 'bold' })}
         font-size: 15px;
-        margin-bottom: ${space[1]}px;
+        margin: 0 0 ${space[1]}px;
 
         ${from.tablet} {
             font-size: 17px;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
@@ -9,6 +9,7 @@ import { ChoiceCardSelection } from '../ChoiceCardsBanner';
 
 const buttonOverrides = css`
     margin-right: ${space[3]}px;
+    margin-bottom: ${space[3]}px;
     background: ${brandAlt[400]};
     color: ${neutral[0]} !important;
     &:hover {

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/paymentFrequencyTabs/PaymentFrequencyTabButton.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/paymentFrequencyTabs/PaymentFrequencyTabButton.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { brand, neutral, space } from '@guardian/src-foundations';
+import { ReactNode } from 'react';
+import { textSans } from '@guardian/src-foundations/typography';
+
+const tabButtonStyles = css`
+	${textSans.medium({ fontWeight: 'bold' })}
+	background-color: ${brand[500]};
+	color: ${neutral[100]};
+	margin: 0;
+	border: none;
+	border-bottom: 1px solid ${neutral[86]};
+	flex-grow: 1;
+	padding: ${space[3]}px 0;
+	cursor: pointer;
+
+	/* .src-focus-disabled is added by the Source FocusStyleManager */
+	html:not(.src-focus-disabled) &:focus {
+		outline: 5px solid ${neutral[86]};
+		outline-offset: -5px;
+	}
+
+	:not(:last-of-type) {
+		border-right: 1px solid ${neutral[86]};
+	}
+
+	&[aria-selected='true'] {
+		background-color: ${neutral[100]};
+		color: ${neutral[7]};
+		border-bottom: none;
+
+		html:not(.src-focus-disabled) &:focus {
+			outline-color: #0077B6;
+		}
+	}
+
+	&[aria-selected='false'] {
+		color: ${neutral[100]};
+	}
+`;
+
+export type PaymentFrequencyTabButtonAttributes = {
+    role: 'tab';
+    id: string;
+    ariaSelected: 'true' | 'false';
+    ariaControls: string;
+};
+
+export type PaymentFrequencyTabButtonProps = PaymentFrequencyTabButtonAttributes & {
+    onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    children: ReactNode;
+};
+
+export function PaymentFrequencyTabButton({
+    role,
+    id,
+    ariaControls,
+    ariaSelected,
+    onClick,
+    children,
+}: PaymentFrequencyTabButtonProps): JSX.Element {
+    return (
+        <button
+            css={tabButtonStyles}
+            role={role}
+            id={id}
+            aria-controls={ariaControls}
+            aria-selected={ariaSelected}
+            onClick={onClick}
+        >
+            {children}
+        </button>
+    );
+}

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/paymentFrequencyTabs/PaymentFrequencyTabs.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/paymentFrequencyTabs/PaymentFrequencyTabs.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { PaymentFrequencyTabButtonAttributes } from './PaymentFrequencyTabButton';
+import { PaymentFrequencyTabButton } from './PaymentFrequencyTabButton';
+import { ContributionFrequency } from '@sdc/shared/dist/types';
+
+const tabListStyles = css`
+    display: flex;
+    position: relative;
+    z-index: 10;
+`;
+
+export type TabProps = {
+    id: string;
+    frequency: ContributionFrequency;
+    labelText: string;
+    selected: boolean;
+};
+
+export type PaymentFrequencyTabsRenderProps = {
+    ariaLabel: string;
+    tabs: TabProps[];
+    selectedTab: ContributionFrequency;
+    onTabChange: (frequency: ContributionFrequency) => void;
+};
+
+export type PaymentFrequencyTabsProps = PaymentFrequencyTabsRenderProps & {
+    TabController?: typeof PaymentFrequencyTabButton;
+};
+
+function getTabPanelId(tabId: string) {
+    return `${tabId}-tab`;
+}
+
+function getTabControllerAttributes(tab: TabProps): PaymentFrequencyTabButtonAttributes {
+    return {
+        role: 'tab',
+        id: tab.id,
+        ariaSelected: tab.selected ? 'true' : 'false',
+        ariaControls: getTabPanelId(tab.id),
+    };
+}
+
+export function BannerChoiceCardsPaymentFrequencyTabs({
+    ariaLabel,
+    tabs,
+    onTabChange,
+    TabController = PaymentFrequencyTabButton,
+}: PaymentFrequencyTabsProps): JSX.Element {
+    return (
+        <div>
+            <div role="tablist" aria-label={ariaLabel} css={tabListStyles}>
+                {tabs.map((tab: TabProps) => {
+                    return (
+                        <TabController
+                            key={tab.id}
+                            onClick={() => onTabChange(tab.frequency)}
+                            {...getTabControllerAttributes(tab)}
+                        >
+                            {tab.labelText}
+                        </TabController>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/paymentFrequencyTabs/PaymentFrequencyTabsBox.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/paymentFrequencyTabs/PaymentFrequencyTabsBox.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { css, SerializedStyles } from '@emotion/react';
+import { neutral, space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+
+const mainStyles = css`
+    display: block;
+    overflow: hidden;
+    background-color: ${neutral[100]};
+    color: ${neutral[7]};
+    border-left: 1px solid ${neutral[86]};
+    border-right: 1px solid ${neutral[86]};
+    border-top: 1px solid ${neutral[86]};
+    border-radius: ${space[3]}px ${space[3]}px 0 0;
+
+    :not(:last-child) {
+        margin-bottom: ${space[3]}px;
+
+        ${from.mobileLandscape} {
+            margin-bottom: ${space[4]}px;
+        }
+    }
+`;
+
+export interface BoxProps {
+    children: React.ReactNode;
+    cssOverrides?: SerializedStyles;
+}
+
+export function Box(props: BoxProps): JSX.Element {
+    return <section css={[mainStyles, props.cssOverrides ?? '']}>{props.children}</section>;
+}


### PR DESCRIPTION
Reverts guardian/support-dotcom-components#873

Change of plan: Rather than release we'd now like to AB test this against the old design.