### PR TITLE
Add choice cards banner 'tabs' and 'buttons' variants

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBanner.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { ChoiceCardsBanner, ChoiceCardsBannerRenderProps } from './ChoiceCardsButtonsBanner';
+import { ChoiceCardsButtonsBanner, ChoiceCardsBannerRenderProps } from './ChoiceCardsButtonsBanner';
 import { BannerRenderProps } from '../common/types';
 import {
     backgroundColor as blueBannerBackgroundColor,
@@ -14,7 +14,7 @@ import {
 import { PageTracking, TestTracking, Tracking } from '@sdc/shared/src/types';
 
 export default {
-    component: ChoiceCardsBanner,
+    component: ChoiceCardsButtonsBanner,
     title: 'Banners/ChoiceCardsButtonsBanner',
 } as Meta;
 
@@ -26,7 +26,7 @@ type ChoiceCardStoryProps = Omit<
 
 const Template: Story<ChoiceCardStoryProps> = (props: ChoiceCardStoryProps) =>
     props.content && (
-        <ChoiceCardsBanner
+        <ChoiceCardsButtonsBanner
             {...props}
             backgroundColor={props.backgroundColor}
             headingColor={props.headingColor}

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBanner.tsx
@@ -60,7 +60,7 @@ export type ChoiceCardsBannerRenderProps = {
     borderTopColorStyle?: SerializedStyles;
 };
 
-export const ChoiceCardsBanner = ({
+export const ChoiceCardsButtonsBanner = ({
     bannerId,
     backgroundColor,
     headingColor,

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBannerBlue.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBannerBlue.tsx
@@ -3,7 +3,7 @@ import { brand } from '@guardian/src-foundations';
 import React from 'react';
 import { validatedBannerWrapper, bannerWrapper } from '../common/BannerWrapper';
 import { BannerRenderProps } from '../common/types';
-import { ChoiceCardsBanner } from './ChoiceCardsButtonsBanner';
+import { ChoiceCardsButtonsBanner } from './ChoiceCardsButtonsBanner';
 
 const bannerId = 'choice-cards-buttons-banner-blue';
 export const backgroundColor = '#F1F8FC';
@@ -24,7 +24,7 @@ const ChoiceCardsBannerBlue = ({
     separateArticleCount,
 }: BannerRenderProps) => {
     return (
-        <ChoiceCardsBanner
+        <ChoiceCardsButtonsBanner
             onCloseClick={onCloseClick}
             content={content}
             choiceCardAmounts={choiceCardAmounts}

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBannerYellow.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBannerYellow.tsx
@@ -2,7 +2,7 @@ import { brandAlt, neutral } from '@guardian/src-foundations';
 import React from 'react';
 import { validatedBannerWrapper, bannerWrapper } from '../common/BannerWrapper';
 import { BannerRenderProps } from '../common/types';
-import { ChoiceCardsBanner } from './ChoiceCardsButtonsBanner';
+import { ChoiceCardsButtonsBanner } from './ChoiceCardsButtonsBanner';
 
 const bannerId = 'choice-cards-buttons-banner-yellow';
 export const backgroundColor = brandAlt[400];
@@ -21,7 +21,7 @@ const ChoiceCardsBannerYellow = ({
     separateArticleCount,
 }: BannerRenderProps) => {
     return (
-        <ChoiceCardsBanner
+        <ChoiceCardsButtonsBanner
             onCloseClick={onCloseClick}
             content={content}
             choiceCardAmounts={choiceCardAmounts}

--- a/packages/modules/src/modules/banners/choiceCardsTabsBanner/ChoiceCardsTabsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsTabsBanner/ChoiceCardsTabsBanner.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { ChoiceCardsBanner, ChoiceCardsBannerRenderProps } from './ChoiceCardsTabsBanner';
+import { ChoiceCardsTabsBanner, ChoiceCardsBannerRenderProps } from './ChoiceCardsTabsBanner';
 import { BannerRenderProps } from '../common/types';
 import {
     backgroundColor as blueBannerBackgroundColor,
@@ -14,7 +14,7 @@ import {
 import { PageTracking, TestTracking, Tracking } from '@sdc/shared/src/types';
 
 export default {
-    component: ChoiceCardsBanner,
+    component: ChoiceCardsTabsBanner,
     title: 'Banners/ChoiceCardsTabsBanner',
 } as Meta;
 
@@ -26,7 +26,7 @@ type ChoiceCardStoryProps = Omit<
 
 const Template: Story<ChoiceCardStoryProps> = (props: ChoiceCardStoryProps) =>
     props.content && (
-        <ChoiceCardsBanner
+        <ChoiceCardsTabsBanner
             {...props}
             backgroundColor={props.backgroundColor}
             headingColor={props.headingColor}

--- a/packages/modules/src/modules/banners/choiceCardsTabsBanner/ChoiceCardsTabsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsTabsBanner/ChoiceCardsTabsBanner.tsx
@@ -60,7 +60,7 @@ export type ChoiceCardsBannerRenderProps = {
     borderTopColorStyle?: SerializedStyles;
 };
 
-export const ChoiceCardsBanner = ({
+export const ChoiceCardsTabsBanner = ({
     bannerId,
     backgroundColor,
     headingColor,

--- a/packages/modules/src/modules/banners/choiceCardsTabsBanner/ChoiceCardsTabsBannerBlue.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsTabsBanner/ChoiceCardsTabsBannerBlue.tsx
@@ -3,7 +3,7 @@ import { brand } from '@guardian/src-foundations';
 import React from 'react';
 import { validatedBannerWrapper, bannerWrapper } from '../common/BannerWrapper';
 import { BannerRenderProps } from '../common/types';
-import { ChoiceCardsBanner } from './ChoiceCardsTabsBanner';
+import { ChoiceCardsTabsBanner } from './ChoiceCardsTabsBanner';
 
 const bannerId = 'choice-cards-tabs-banner-blue';
 export const backgroundColor = '#F1F8FC';
@@ -24,7 +24,7 @@ const ChoiceCardsBannerBlue = ({
     separateArticleCount,
 }: BannerRenderProps) => {
     return (
-        <ChoiceCardsBanner
+        <ChoiceCardsTabsBanner
             onCloseClick={onCloseClick}
             content={content}
             choiceCardAmounts={choiceCardAmounts}

--- a/packages/modules/src/modules/banners/choiceCardsTabsBanner/ChoiceCardsTabsBannerYellow.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsTabsBanner/ChoiceCardsTabsBannerYellow.tsx
@@ -2,7 +2,7 @@ import { brandAlt, neutral } from '@guardian/src-foundations';
 import React from 'react';
 import { validatedBannerWrapper, bannerWrapper } from '../common/BannerWrapper';
 import { BannerRenderProps } from '../common/types';
-import { ChoiceCardsBanner } from './ChoiceCardsTabsBanner';
+import { ChoiceCardsTabsBanner } from './ChoiceCardsTabsBanner';
 
 const bannerId = 'choice-cards-tabs-banner-yellow';
 export const backgroundColor = brandAlt[400];
@@ -21,7 +21,7 @@ const ChoiceCardsBannerYellow = ({
     separateArticleCount,
 }: BannerRenderProps) => {
     return (
-        <ChoiceCardsBanner
+        <ChoiceCardsTabsBanner
             onCloseClick={onCloseClick}
             content={content}
             choiceCardAmounts={choiceCardAmounts}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds both 'Button' and 'Tabs' variants of the Choice Cards Banner, on top of the pre-existing coloured variants (see images below).

## Images
**Choice Cards Banner AB test variants:**
|  | With Buttons | With Tabs |
| -- | -- | -- |
| Blue |  <img width="1052" alt="Screenshot 2023-04-13 at 13 59 24" src="https://user-images.githubusercontent.com/44685872/231766943-e3fb2daa-7565-4ddd-ae4b-7478c3564e21.png"> | <img width="1052" alt="Screenshot 2023-04-13 at 13 59 43" src="https://user-images.githubusercontent.com/44685872/231766955-65c64cc0-7e4a-4692-918e-77aa8a5fa1a6.png"> |
| Yellow | <img width="1052" alt="Screenshot 2023-04-13 at 13 59 34" src="https://user-images.githubusercontent.com/44685872/231766951-39839890-ec41-42df-b62f-b14a054e8229.png"> | <img width="1052" alt="Screenshot 2023-04-13 at 13 59 48" src="https://user-images.githubusercontent.com/44685872/231766960-b769280a-4a04-40ea-9ab4-01f1d82df7f6.png"> |
