### PR TITLE
Remove epic holdback tests

### DIFF
--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -54,7 +54,6 @@ export const buildEpicRouter = (
     superModeArticles: ValueProvider<SuperModeArticle[]>,
     articleEpicTests: ValueProvider<EpicTest[]>,
     liveblogEpicTests: ValueProvider<EpicTest[]>,
-    holdbackEpicTests: ValueProvider<EpicTest[]>,
     choiceCardAmounts: ValueProvider<ModifiedChoiceCardAmounts>,
     tickerData: TickerDataProvider,
 ): Router => {
@@ -69,17 +68,7 @@ export const buildEpicRouter = (
             const hardcodedTests = enableHardcodedEpicTests ? hardcodedEpicTests : [];
 
             if (isForcingTest) {
-                return [
-                    ...hardcodedTests,
-                    ...articleEpicTests.get(),
-                    ...holdbackEpicTests.get(),
-                    fallbackEpicTest,
-                ];
-            }
-
-            const shouldHoldBack = mvtId % 100 === 0; // holdback 1% of the audience
-            if (shouldHoldBack) {
-                return holdbackEpicTests.get();
+                return [...hardcodedTests, ...articleEpicTests.get(), fallbackEpicTest];
             }
 
             return [...hardcodedTests, ...articleEpicTests.get(), fallbackEpicTest];

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -15,11 +15,7 @@ import { buildAmpEpicRouter } from './api/ampEpicRouter';
 import { buildModulesRouter } from './api/modulesRouter';
 import { buildChannelSwitchesReloader } from './channelSwitches';
 import { buildSuperModeArticlesReloader } from './lib/superMode';
-import {
-    buildEpicHoldbackTestsReloader,
-    buildEpicLiveblogTestsReloader,
-    buildEpicTestsReloader,
-} from './tests/epics/epicTests';
+import { buildEpicLiveblogTestsReloader, buildEpicTestsReloader } from './tests/epics/epicTests';
 import { buildChoiceCardAmountsReloader } from './choiceCardAmounts';
 import { buildTickerDataReloader } from './lib/fetchTickerData';
 import { buildProductPricesReloader } from './productPrices';
@@ -59,7 +55,6 @@ const buildApp = async (): Promise<Express> => {
         superModeArticles,
         articleEpicTests,
         liveblogEpicTests,
-        holdbackEpicTests,
         ampEpicTests,
         choiceCardAmounts,
         tickerData,
@@ -72,7 +67,6 @@ const buildApp = async (): Promise<Express> => {
         buildSuperModeArticlesReloader(),
         buildEpicTestsReloader(),
         buildEpicLiveblogTestsReloader(),
-        buildEpicHoldbackTestsReloader(),
         buildAmpEpicTestsReloader(),
         buildChoiceCardAmountsReloader(),
         buildTickerDataReloader(),
@@ -89,7 +83,6 @@ const buildApp = async (): Promise<Express> => {
             superModeArticles,
             articleEpicTests,
             liveblogEpicTests,
-            holdbackEpicTests,
             choiceCardAmounts,
             tickerData,
         ),

--- a/packages/server/src/tests/epics/epicTests.ts
+++ b/packages/server/src/tests/epics/epicTests.ts
@@ -30,6 +30,3 @@ export const buildEpicTestsReloader = (): Promise<ValueReloader<EpicTest[]>> =>
 
 export const buildEpicLiveblogTestsReloader = (): Promise<ValueReloader<EpicTest[]>> =>
     buildReloader(fetchConfiguredEpicTests('EpicLiveblog'), 60);
-
-export const buildEpicHoldbackTestsReloader = (): Promise<ValueReloader<EpicTest[]>> =>
-    buildReloader(fetchConfiguredEpicTests('EpicHoldback'), 60);


### PR DESCRIPTION
Marketing no longer want this feature.

Still to do - remove the holdback tool from support-admin-console