### PR TITLE
Remove _2022 from ticker names

### DIFF
--- a/packages/modules/src/modules/banners/utils/storybook.ts
+++ b/packages/modules/src/modules/banners/utils/storybook.ts
@@ -55,7 +55,7 @@ export const tickerSettings: TickerSettings = {
         total: 120_000,
         goal: 150_000,
     },
-    name: 'US_2022',
+    name: 'US',
 };
 
 export const props: BannerProps = {

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -171,7 +171,7 @@ WithTicker.args = {
                 total: 10000,
                 goal: 100000,
             },
-            name: 'US_2022',
+            name: 'US',
         },
     },
 };

--- a/packages/server/src/lib/fetchTickerData.ts
+++ b/packages/server/src/lib/fetchTickerData.ts
@@ -3,10 +3,17 @@ import { Response } from 'node-fetch';
 import fetch from 'node-fetch';
 import { buildReloader, ValueProvider } from '../utils/valueReloader';
 import { logError } from '../utils/logging';
-import { TickerName } from '@sdc/shared/dist/types';
+import { TickerName, Stage } from '@sdc/shared/dist/types';
 
-const tickerUrl = (name: TickerName): string =>
-    `https://support.theguardian.com/ticker/${name}.json`;
+const tickerUrl = (stage: Stage, name: TickerName): string => {
+    switch (stage) {
+        case 'PROD':
+            return `https://support.theguardian.com/ticker/${name}.json`;
+        case 'CODE':
+        case 'DEV':
+            return `https://support.code.dev-theguardian.com/ticker/${name}.json`;
+    }
+};
 
 const checkForErrors = (response: Response): Promise<Response> => {
     if (!response.ok) {
@@ -32,8 +39,10 @@ const parse = (json: any): Promise<TickerData> => {
     }
 };
 
-const getTickerDataForTickerTypeFetcher = (name: TickerName) => (): Promise<TickerData> => {
-    return fetch(tickerUrl(name), {
+const getTickerDataForTickerTypeFetcher = (stage: Stage, name: TickerName) => (): Promise<
+    TickerData
+> => {
+    return fetch(tickerUrl(stage, name), {
         timeout: 1000 * 20,
     })
         .then(response => checkForErrors(response))
@@ -75,10 +84,10 @@ export class TickerDataProvider {
     }
 }
 
-export const buildTickerDataReloader = async (): Promise<TickerDataProvider> => {
+export const buildTickerDataReloader = async (stage: Stage): Promise<TickerDataProvider> => {
     const reloaders: TickerDataProviders = await Promise.all([
-        buildReloader(getTickerDataForTickerTypeFetcher('US'), 60),
-        buildReloader(getTickerDataForTickerTypeFetcher('AU'), 60),
+        buildReloader(getTickerDataForTickerTypeFetcher(stage, 'US'), 60),
+        buildReloader(getTickerDataForTickerTypeFetcher(stage, 'AU'), 60),
     ]).then(([US, AU]) => ({
         US,
         AU,

--- a/packages/server/src/lib/fetchTickerData.ts
+++ b/packages/server/src/lib/fetchTickerData.ts
@@ -77,11 +77,11 @@ export class TickerDataProvider {
 
 export const buildTickerDataReloader = async (): Promise<TickerDataProvider> => {
     const reloaders: TickerDataProviders = await Promise.all([
-        buildReloader(getTickerDataForTickerTypeFetcher('US_2022'), 60),
-        buildReloader(getTickerDataForTickerTypeFetcher('AU_2022'), 60),
-    ]).then(([US_2022, AU_2022]) => ({
-        US_2022,
-        AU_2022,
+        buildReloader(getTickerDataForTickerTypeFetcher('US'), 60),
+        buildReloader(getTickerDataForTickerTypeFetcher('AU'), 60),
+    ]).then(([US, AU]) => ({
+        US,
+        AU,
     }));
     return new TickerDataProvider(reloaders);
 };

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -49,6 +49,9 @@ const buildApp = async (): Promise<Express> => {
     app.use(loggingMiddleware);
     app.use(bodyParser.urlencoded({ extended: true }));
 
+    const stage =
+        process.env.stage === 'CODE' ? 'CODE' : process.env.stage === 'DEV' ? 'DEV' : 'PROD';
+
     // Initialise dependencies
     const [
         channelSwitches,
@@ -69,7 +72,7 @@ const buildApp = async (): Promise<Express> => {
         buildEpicLiveblogTestsReloader(),
         buildAmpEpicTestsReloader(),
         buildChoiceCardAmountsReloader(),
-        buildTickerDataReloader(),
+        buildTickerDataReloader(stage),
         buildProductPricesReloader(),
         buildBannerTestsReloader(),
         buildBannerDeployTimesReloader(),

--- a/packages/server/src/tests/amp/ampEpicSelection.test.ts
+++ b/packages/server/src/tests/amp/ampEpicSelection.test.ts
@@ -14,7 +14,7 @@ const tickerSettings: TickerSettings = {
         goalReachedPrimary: "We've hit our goal!",
         goalReachedSecondary: 'but you can still support us',
     },
-    name: 'US_2022',
+    name: 'US',
 };
 
 const epicTest: AmpEpicTest = {
@@ -78,8 +78,8 @@ const expectedAmpEpic: AMPEpic = {
 };
 
 const tickerDataReloader = new TickerDataProvider({
-    US_2022: { get: () => ({ total: 999, goal: 1000 }) },
-    AU_2022: { get: () => ({ total: 999, goal: 1000 }) },
+    US: { get: () => ({ total: 999, goal: 1000 }) },
+    AU: { get: () => ({ total: 999, goal: 1000 }) },
 });
 
 describe('ampEpicTests', () => {

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -85,7 +85,7 @@ export const tickerDataSchema = z.object({
 });
 
 // Corresponds to .json file names in S3
-export type TickerName = 'US_2022' | 'AU_2022';
+export type TickerName = 'US' | 'AU';
 
 export interface TickerSettings {
     endType: TickerEndType;


### PR DESCRIPTION
Rather than create a new ticker for each year, it seems sensible to
reuse them each year (if necessary). Therefore, let’s remove the year
from the name. Co-ordinated with changes to support-admin-console and
contributions-ticker-calculator.