### PR TITLE
AUS Anniversary Banner: Naming Changes

### DIFF
--- a/packages/modules/src/modules/banners/auElectionMoment/AusElectionMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/auElectionMoment/AusElectionMomentBanner.stories.tsx
@@ -78,7 +78,7 @@ const AusElectionBanner = bannerWrapper(
                 'Head shots of Anthony Albanese, leader of the Australian Labor Party, and Scott Morrison, current Prime Minister and leader of the Liberal Party of Australia, who are running for the office of Prime Minister in the Australian federal election, to be held on 21 May 2022.',
         },
     }),
-    'aus-moment-banner',
+    'aus-anniversary-banner',
 );
 
 const AusElectionTemplate: Story<BannerProps> = (props: BannerProps) => (

--- a/packages/modules/src/modules/banners/aus10yrAnniversaryMoment/Aus10yrAnniversaryMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/aus10yrAnniversaryMoment/Aus10yrAnniversaryMomentBanner.stories.tsx
@@ -66,9 +66,9 @@ const AusBanner = bannerWrapper(
             progressBarBackgroundColour: '#fff',
             goalMarkerColour: 'black',
         },
-        bannerId: 'aus-moment-banner',
+        bannerId: 'aus-anniversary-banner',
     }),
-    'aus-moment-banner',
+    'aus-anniversary-banner',
 );
 
 const AusBannerTemplate: Story<BannerProps> = (props: BannerProps) => <AusBanner {...props} />;

--- a/packages/modules/src/modules/banners/aus10yrAnniversaryMoment/Aus10yrAnniversaryMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/aus10yrAnniversaryMoment/Aus10yrAnniversaryMomentBanner.tsx
@@ -2,7 +2,7 @@ import { brand, brandAlt, neutral } from '@guardian/src-foundations';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
 
-const AusBanner = getMomentTemplateBanner({
+const AusAnniversaryBanner = getMomentTemplateBanner({
     containerSettings: {
         backgroundColour: neutral[93],
     },
@@ -56,13 +56,13 @@ const AusBanner = getMomentTemplateBanner({
         progressBarBackgroundColour: '#fff',
         goalMarkerColour: 'black',
     },
-    bannerId: 'aus-moment-banner',
+    bannerId: 'aus-anniversary-banner',
 });
 
-const unvalidated = bannerWrapper(AusBanner, 'aus-moment-banner');
-const validated = validatedBannerWrapper(AusBanner, 'aus-moment-banner');
+const unvalidated = bannerWrapper(AusAnniversaryBanner, 'aus-anniversary-banner');
+const validated = validatedBannerWrapper(AusAnniversaryBanner, 'aus-anniversary-banner');
 
 export {
-    validated as Aus10yrAnniversaryMomentBanner,
-    unvalidated as Aus10yrAnniversaryMomentBannerUnvalidated,
+    validated as AusAnniversaryBanner,
+    unvalidated as AusAnniversaryBannerUnvalidated,
 };

--- a/packages/modules/src/modules/banners/aus10yrAnniversaryMoment/Aus10yrAnniversaryMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/aus10yrAnniversaryMoment/Aus10yrAnniversaryMomentBanner.tsx
@@ -62,7 +62,4 @@ const AusAnniversaryBanner = getMomentTemplateBanner({
 const unvalidated = bannerWrapper(AusAnniversaryBanner, 'aus-anniversary-banner');
 const validated = validatedBannerWrapper(AusAnniversaryBanner, 'aus-anniversary-banner');
 
-export {
-    validated as AusAnniversaryBanner,
-    unvalidated as AusAnniversaryBannerUnvalidated,
-};
+export { validated as AusAnniversaryBanner, unvalidated as AusAnniversaryBannerUnvalidated };

--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -12,7 +12,7 @@ export type BannerId =
     | 'contributions-banner'
     | 'charity-appeal-banner'
     | 'research-survey-banner'
-    | 'aus-moment-banner'
+    | 'aus-anniversary-banner'
     | 'investigations-moment-banner'
     | 'environment-moment-banner'
     | 'subscription-banner'

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -12,7 +12,7 @@ import {
     globalNewYearBanner,
     signInPromptBanner,
     ukraineMomentBanner,
-    // ausMomentBanner,
+    ausAnniversaryBanner,
 } from '@sdc/shared/config';
 import {
     BannerChannel,
@@ -30,7 +30,7 @@ import { getTests } from '../testsStore';
 export const BannerPaths: {
     [key in BannerTemplate]: (version?: string) => string;
 } = {
-    [BannerTemplate.AusMomentBanner]: contributionsBanner.endpointPathBuilder,
+    [BannerTemplate.AusAnniversaryBanner]: ausAnniversaryBanner.endpointPathBuilder,
     [BannerTemplate.ContributionsBanner]: contributionsBanner.endpointPathBuilder,
     [BannerTemplate.ContributionsBannerWithSignIn]:
         contributionsBannerWithSignIn.endpointPathBuilder,

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -12,7 +12,7 @@ import {
     globalNewYearBanner,
     signInPromptBanner,
     ukraineMomentBanner,
-    ausMomentBanner,
+    // ausMomentBanner,
 } from '@sdc/shared/config';
 import {
     BannerChannel,
@@ -30,7 +30,7 @@ import { getTests } from '../testsStore';
 export const BannerPaths: {
     [key in BannerTemplate]: (version?: string) => string;
 } = {
-    [BannerTemplate.AusMomentBanner]: ausMomentBanner.endpointPathBuilder,
+    [BannerTemplate.AusMomentBanner]: contributionsBanner.endpointPathBuilder,
     [BannerTemplate.ContributionsBanner]: contributionsBanner.endpointPathBuilder,
     [BannerTemplate.ContributionsBannerWithSignIn]:
         contributionsBannerWithSignIn.endpointPathBuilder,

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -23,8 +23,8 @@ export const liveblogEpic: ModuleInfo = getDefaultModuleInfo(
     'epics/ContributionsLiveblogEpic',
 );
 
-export const ausMomentBanner: ModuleInfo = getDefaultModuleInfo(
-    'aus-moment-banner',
+export const ausAnniversaryBanner: ModuleInfo = getDefaultModuleInfo(
+    'aus-anniversary-banner',
     'banners/aus10yrAnniversaryMoment/Aus10yrAnniversaryMomentBanner',
 );
 
@@ -108,7 +108,7 @@ export const ukraineMomentBanner: ModuleInfo = getDefaultModuleInfo(
 export const moduleInfos: ModuleInfo[] = [
     epic,
     liveblogEpic,
-    ausMomentBanner,
+    ausAnniversaryBanner,
     contributionsBanner,
     charityAppealBanner,
     contributionsBannerWithSignIn,

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -14,7 +14,7 @@ import { BannerTargeting, PageTracking } from '../targeting';
 import { PurchaseInfoTest } from './shared';
 
 export enum BannerTemplate {
-    AusMomentBanner = 'AusMomentBanner',
+    AusAnniversaryBanner = 'AusAnniversaryBanner',
     ContributionsBanner = 'ContributionsBanner',
     CharityAppealBanner = 'CharityAppealBanner',
     ContributionsBannerWithSignIn = 'ContributionsBannerWithSignIn',


### PR DESCRIPTION
## What does this change?

This PR updates the references to the AUS Anniversary Banner in this repo so they match those used in  `support-admin-console`: https://github.com/guardian/support-admin-console/pull/448

There was a bug blocking the Banner from showing in the preview in RRCP that was down to a naming mismatch.

I suspect it could be the named export https://github.com/guardian/support-dotcom-components/pull/888/files#diff-e12d0f2d4ac300b36fd853f0feae026eab1fdcb888d01a88d81401a559f9dfb7R65 here. Previously it was named `Aus10yrAnniversaryMomentBanner` and support-admin-console was looking for a banner `AusMomentBanner`, now in both repos the banner's reference is `AusAnniversaryBanner` - I need to confirm this was the issue.
