### PR TITLE
Banner Choice Card at mobile CTA overwrites header

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/choiceCardsBannerStyles.ts
@@ -56,12 +56,12 @@ export const columnMarginOverrides = css`
 export const heading = (headingColor: string): SerializedStyles => css`
     ${headline.xxsmall({ fontWeight: 'bold' })};
     font-size: 22px;
+    max-width: calc(100% - ${height.ctaSmall * 2 + space[2]}px);
     margin: 0 0 ${space[3]}px;
     color: ${headingColor};
 
     ${from.mobileMedium} {
         font-size: 24px;
-        max-width: calc(100% - ${height.ctaSmall * 2 + space[2]}px);
     }
 
     ${from.tablet} {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Close button overwrites header below mobile medium (see screenshot below) ->

![5e4ed413-6cdc-47b6-8d1f-b2b7a93f6e0f](https://user-images.githubusercontent.com/76729591/235884721-025f540a-1af4-4e35-893c-5312c94c5e91.jpeg)

**Trello Card**]( https://trello.com/c/xQ0hpsfv/1267-banner-layout-issue-on-mobile)

## Is this an AB test?
- [x] No
