### PR TITLE
Add moment template media query hook

### DIFF
--- a/packages/modules/src/hooks/useMediaQuery.ts
+++ b/packages/modules/src/hooks/useMediaQuery.ts
@@ -16,8 +16,6 @@ const useMediaQuery = (breakpoint: string): boolean => {
             setMatches(media.matches);
         }
 
-        media.addEventListener('change', handleChange);
-
         try {
             // Chrome & Firefox
             media.addEventListener('change', handleChange);

--- a/packages/modules/src/hooks/useMediaQuery.ts
+++ b/packages/modules/src/hooks/useMediaQuery.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+
+// breakpoint argument should be passed as follows: `from.<breakpoint>`
+const useMediaQuery = (breakpoint: string): boolean => {
+    const [matches, setMatches] = useState(false);
+
+    const handleChange = (e: { matches: boolean | ((prevState: boolean) => boolean) }) => {
+        setMatches(e.matches);
+    };
+
+    const query = breakpoint.replace('@media', '').trim();
+    const media = window.matchMedia(query);
+
+    useEffect(() => {
+        if (media.matches !== matches) {
+            setMatches(media.matches);
+        }
+
+        media.addEventListener('change', handleChange);
+
+        try {
+            // Chrome & Firefox
+            media.addEventListener('change', handleChange);
+        } catch (e1) {
+            try {
+                // Safari - addEventListener supported from v14
+                media.addListener(handleChange);
+            } catch (e2) {
+                console.error(e2);
+            }
+        }
+
+        return () => media.removeEventListener('change', handleChange);
+    }, [matches, query]);
+
+    return matches;
+};
+
+export default useMediaQuery;

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -23,20 +23,15 @@ export function MomentTemplateBannerBody({
 
     const isTabletOrAbove = useMediaQuery(from.tablet);
 
-    const bannerBodyMobile = createBannerBodyCopy(
-        mobileContent.paragraphs,
-        mobileContent.highlightedText,
-        styles,
-    );
-    const bannerBodyTabletAndAbove = createBannerBodyCopy(
-        mainContent.paragraphs,
-        mainContent.highlightedText,
-        styles,
-    );
-
     return (
         <div css={styles.container}>
-            {isTabletOrAbove ? bannerBodyTabletAndAbove : bannerBodyMobile}
+            {isTabletOrAbove
+                ? createBannerBodyCopy(mainContent.paragraphs, mainContent.highlightedText, styles)
+                : createBannerBodyCopy(
+                      mobileContent.paragraphs,
+                      mobileContent.highlightedText,
+                      styles,
+                  )}
         </div>
     );
 }

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -2,14 +2,11 @@ import React from 'react';
 import { css } from '@emotion/react';
 import { neutral } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { Hide } from '@guardian/src-layout';
 import { body } from '@guardian/src-foundations/typography';
-
 import { createBannerBodyCopy } from '../../common/BannerText';
 import { HighlightedTextSettings } from '../settings';
 import { BannerRenderedContent } from '../../common/types';
-
-// ---- Component ---- //
+import useMediaQuery from '../../../../hooks/useMediaQuery';
 
 interface MomentTemplateBannerBodyProps {
     mainContent: BannerRenderedContent;
@@ -24,24 +21,25 @@ export function MomentTemplateBannerBody({
 }: MomentTemplateBannerBodyProps): JSX.Element {
     const styles = getStyles(highlightedTextSettings);
 
+    const isTabletOrAbove = useMediaQuery(from.tablet);
+
+    const bannerBodyMobile = createBannerBodyCopy(
+        mobileContent.paragraphs,
+        mobileContent.highlightedText,
+        styles,
+    );
+    const bannerBodyTabletAndAbove = createBannerBodyCopy(
+        mainContent.paragraphs,
+        mainContent.highlightedText,
+        styles,
+    );
+
     return (
         <div css={styles.container}>
-            <Hide above="tablet">
-                {createBannerBodyCopy(
-                    mobileContent.paragraphs,
-                    mobileContent.highlightedText,
-                    styles,
-                )}
-            </Hide>
-
-            <Hide below="tablet">
-                {createBannerBodyCopy(mainContent.paragraphs, mainContent.highlightedText, styles)}
-            </Hide>
+            {isTabletOrAbove ? bannerBodyTabletAndAbove : bannerBodyMobile}
         </div>
     );
 }
-
-// ---- Styles ---- //
 
 const getStyles = (settings: HighlightedTextSettings) => ({
     container: css`


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds a media query hook using `matchMedia` which makes it possible to check for media query matches and change the UI based on results. 

The approach taken thus far within banner components, to display or hide different content across breakpoints, has been to make use of the `<Hide>` component from Source. This is not ideal as it has knock-on effects for css determination, any event listeners that may need to be applied as well as generally polluting the JSX. 

### The `useMediaQuery` hook
The `useMediaQuery` hook takes a `breakpoint` as it's argument (e.g `from.tablet`). Although, in order to get the string into the desired format (e.g. `"(min-width: 740px)"`), there's a little string manipulation necessary. So, an intermediate `query` variable is created. The window.[matchMedia()](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) method returns a MediaQueryList. This MediaQueryList contains a [`matches`](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/matches) property. 

So, this hook compares a `query` (e.g. "(min-width: 740px)") with the current screen width to provide a _**boolean value**_ as to whether or not they match.

**When the component first mounts**
- if the `matches` state has not yet been set, then the state is updated with any current matches
- a change event is added to the window object, which will update the matches state whenever a match has been found

**When the component unmounts**
- the event listener attached to the window object is removed

**_Note:_** The try/catch statements attempt two ways to add the matchMedia event listener. Prior to Safari v14, MediaQueryList was based on the EventTarget and therefore only supports `addListener`/`removeListener` for media queries.  

## How to test
Functionality can be tested using storybook, should be tested on CODE to ensure cross browser compatibility.
The banner body copy should display the correct text content on mobile as well as on tablet and above.
