### PR TITLE
Moment template content refactor

### DIFF
--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/react';
 import { neutral, space } from '@guardian/src-foundations';
 import { Container, Hide } from '@guardian/src-layout';
-import { BannerRenderProps } from '../common/types';
+import { BannerEnrichedReminderCta, BannerRenderProps } from '../common/types';
 import { MomentTemplateBannerHeader } from './components/MomentTemplateBannerHeader';
 import { MomentTemplateBannerArticleCount } from './components/MomentTemplateBannerArticleCount';
 import { MomentTemplateBannerBody } from './components/MomentTemplateBannerBody';
@@ -16,8 +16,8 @@ import { MomentTemplateBannerReminder } from './components/MomentTemplateBannerR
 import MomentTemplateBannerTicker from './components/MomentTemplateBannerTicker';
 import { bannerSpacing } from './styles/templateStyles';
 import useReminder from '../../../hooks/useReminder';
+import useMediaQuery from '../../../hooks/useMediaQuery';
 
-// ---- Banner ---- //
 export function getMomentTemplateBanner(
     templateSettings: BannerTemplateSettings,
 ): React.FC<BannerRenderProps> {
@@ -36,6 +36,10 @@ export function getMomentTemplateBanner(
         const { isReminderActive, onReminderCtaClick, mobileReminderRef } = useReminder(
             reminderTracking,
         );
+
+        const isTabletOrAbove = useMediaQuery(from.tablet);
+
+        const mainOrMobileContent = isTabletOrAbove ? 'mainContent' : 'mobileContent';
 
         return (
             <div css={styles.outerContainer(templateSettings.containerSettings.backgroundColour)}>
@@ -146,8 +150,7 @@ export function getMomentTemplateBanner(
 
                             <section css={styles.ctasContainer}>
                                 <MomentTemplateBannerCtas
-                                    mainContent={content.mainContent}
-                                    mobileContent={content.mobileContent}
+                                    content={content}
                                     onPrimaryCtaClick={onCtaClick}
                                     onSecondaryCtaClick={onSecondaryCtaClick}
                                     onReminderCtaClick={onReminderCtaClick}
@@ -159,31 +162,19 @@ export function getMomentTemplateBanner(
                     </div>
                 </Container>
 
-                <Hide above="tablet">
-                    <div ref={mobileReminderRef}>
-                        {content.mobileContent.secondaryCta?.type ===
-                            SecondaryCtaType.ContributionsReminder &&
-                            isReminderActive && (
-                                <MomentTemplateBannerReminder
-                                    reminderCta={content.mobileContent.secondaryCta}
-                                    trackReminderSetClick={reminderTracking.onReminderSetClick}
-                                    setReminderCtaSettings={templateSettings.setReminderCtaSettings}
-                                />
-                            )}
-                    </div>
-                </Hide>
-
-                <Hide below="tablet">
-                    {content.mainContent.secondaryCta?.type ===
-                        SecondaryCtaType.ContributionsReminder &&
-                        isReminderActive && (
-                            <MomentTemplateBannerReminder
-                                reminderCta={content.mainContent.secondaryCta}
-                                trackReminderSetClick={reminderTracking.onReminderSetClick}
-                                setReminderCtaSettings={templateSettings.setReminderCtaSettings}
-                            />
-                        )}
-                </Hide>
+                {content[mainOrMobileContent].secondaryCta?.type ===
+                    SecondaryCtaType.ContributionsReminder &&
+                    isReminderActive && (
+                        <MomentTemplateBannerReminder
+                            reminderCta={
+                                content[mainOrMobileContent]
+                                    .secondaryCta as BannerEnrichedReminderCta
+                            }
+                            trackReminderSetClick={reminderTracking.onReminderSetClick}
+                            setReminderCtaSettings={templateSettings.setReminderCtaSettings}
+                            mobileReminderRef={mobileReminderRef}
+                        />
+                    )}
             </div>
         );
     }
@@ -191,7 +182,6 @@ export function getMomentTemplateBanner(
     return MomentTemplateBanner;
 }
 
-// ---- Styles ---- //
 const styles = {
     outerContainer: (background: string) => css`
         background: ${background};

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -150,7 +150,7 @@ export function getMomentTemplateBanner(
 
                             <section css={styles.ctasContainer}>
                                 <MomentTemplateBannerCtas
-                                    content={content}
+                                    mainOrMobileContent={content[mainOrMobileContent]}
                                     onPrimaryCtaClick={onCtaClick}
                                     onSecondaryCtaClick={onSecondaryCtaClick}
                                     onReminderCtaClick={onReminderCtaClick}

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -172,7 +172,7 @@ export function getMomentTemplateBanner(
                             }
                             trackReminderSetClick={reminderTracking.onReminderSetClick}
                             setReminderCtaSettings={templateSettings.setReminderCtaSettings}
-                            mobileReminderRef={mobileReminderRef}
+                            mobileReminderRef={isTabletOrAbove ? null : mobileReminderRef}
                         />
                     )}
             </div>

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
@@ -67,9 +67,7 @@ export function MomentTemplateBannerCtas({
                 </div>
             </div>
 
-            <div>
-                {primaryCta && <PaymentCards />}
-            </div>
+            <div>{primaryCta && <PaymentCards />}</div>
         </div>
     );
 }

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
@@ -3,14 +3,13 @@ import { css } from '@emotion/react';
 import { neutral, space } from '@guardian/src-foundations';
 import { Button, LinkButton } from '@guardian/src-button';
 import { SecondaryCtaType } from '@sdc/shared/types';
-import { BannerTextContent } from '../../common/types';
+import { BannerRenderedContent } from '../../common/types';
 import { buttonStyles } from '../styles/buttonStyles';
 import { CtaSettings } from '../settings';
 import { from } from '@guardian/src-foundations/mq';
-import useMediaQuery from '../../../../hooks/useMediaQuery';
 
 interface MomentTemplateBannerCtasProps {
-    content: BannerTextContent;
+    mainOrMobileContent: BannerRenderedContent;
     onPrimaryCtaClick: () => void;
     onSecondaryCtaClick: () => void;
     onReminderCtaClick: () => void;
@@ -19,16 +18,14 @@ interface MomentTemplateBannerCtasProps {
 }
 
 export function MomentTemplateBannerCtas({
-    content,
+    mainOrMobileContent,
     onPrimaryCtaClick,
     onSecondaryCtaClick,
     onReminderCtaClick,
     primaryCtaSettings,
     secondaryCtaSettings,
 }: MomentTemplateBannerCtasProps): JSX.Element {
-    const isTabletOrAbove = useMediaQuery(from.tablet);
-    const mainOrMobileContent = isTabletOrAbove ? 'mainContent' : 'mobileContent';
-    const { primaryCta, secondaryCta } = content[mainOrMobileContent];
+    const { primaryCta, secondaryCta } = mainOrMobileContent;
 
     return (
         <div css={styles.container}>
@@ -71,9 +68,7 @@ export function MomentTemplateBannerCtas({
             </div>
 
             <div>
-                {isTabletOrAbove
-                    ? content['mainContent'].primaryCta && <PaymentCards />
-                    : content['mobileContent'].primaryCta && <PaymentCards />}
+                {primaryCta && <PaymentCards />}
             </div>
         </div>
     );

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
@@ -1,19 +1,16 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import { neutral, space } from '@guardian/src-foundations';
-import { Hide } from '@guardian/src-layout';
 import { Button, LinkButton } from '@guardian/src-button';
 import { SecondaryCtaType } from '@sdc/shared/types';
-import { BannerRenderedContent } from '../../common/types';
+import { BannerTextContent } from '../../common/types';
 import { buttonStyles } from '../styles/buttonStyles';
 import { CtaSettings } from '../settings';
 import { from } from '@guardian/src-foundations/mq';
-
-// ---- Component ---- //
+import useMediaQuery from '../../../../hooks/useMediaQuery';
 
 interface MomentTemplateBannerCtasProps {
-    mainContent: BannerRenderedContent;
-    mobileContent: BannerRenderedContent;
+    content: BannerTextContent;
     onPrimaryCtaClick: () => void;
     onSecondaryCtaClick: () => void;
     onReminderCtaClick: () => void;
@@ -22,105 +19,65 @@ interface MomentTemplateBannerCtasProps {
 }
 
 export function MomentTemplateBannerCtas({
-    mainContent,
-    mobileContent,
+    content,
     onPrimaryCtaClick,
     onSecondaryCtaClick,
     onReminderCtaClick,
     primaryCtaSettings,
     secondaryCtaSettings,
 }: MomentTemplateBannerCtasProps): JSX.Element {
+    const isTabletOrAbove = useMediaQuery(from.tablet);
+    const mainOrMobileContent = isTabletOrAbove ? 'mainContent' : 'mobileContent';
+    const { primaryCta, secondaryCta } = content[mainOrMobileContent];
+
     return (
         <div css={styles.container}>
             <div>
-                <Hide above="tablet">
-                    <div css={styles.ctasContainer}>
-                        {mobileContent.primaryCta && (
-                            <LinkButton
-                                href={mobileContent.primaryCta.ctaUrl}
-                                onClick={onPrimaryCtaClick}
-                                size="small"
-                                priority="primary"
-                                cssOverrides={buttonStyles(primaryCtaSettings)}
-                            >
-                                {mobileContent.primaryCta.ctaText}
-                            </LinkButton>
-                        )}
+                <div css={styles.ctasContainer}>
+                    {primaryCta && (
+                        <LinkButton
+                            href={primaryCta?.ctaUrl}
+                            onClick={onPrimaryCtaClick}
+                            size="small"
+                            priority="primary"
+                            cssOverrides={buttonStyles(primaryCtaSettings)}
+                        >
+                            {primaryCta?.ctaText}
+                        </LinkButton>
+                    )}
 
-                        {mobileContent.secondaryCta?.type === SecondaryCtaType.Custom && (
-                            <LinkButton
-                                href={mobileContent.secondaryCta.cta.ctaUrl}
-                                onClick={onSecondaryCtaClick}
-                                size="small"
-                                priority="tertiary"
-                                cssOverrides={buttonStyles(secondaryCtaSettings)}
-                            >
-                                {mobileContent.secondaryCta.cta.ctaText}
-                            </LinkButton>
-                        )}
+                    {secondaryCta?.type === SecondaryCtaType.Custom && (
+                        <LinkButton
+                            href={secondaryCta?.cta.ctaUrl}
+                            onClick={onSecondaryCtaClick}
+                            size="small"
+                            priority="tertiary"
+                            cssOverrides={buttonStyles(secondaryCtaSettings)}
+                        >
+                            {secondaryCta.cta.ctaText}
+                        </LinkButton>
+                    )}
 
-                        {mobileContent.secondaryCta?.type ===
-                            SecondaryCtaType.ContributionsReminder && (
-                            <Button
-                                priority="subdued"
-                                onClick={onReminderCtaClick}
-                                cssOverrides={styles.reminderCta}
-                            >
-                                Remind me later
-                            </Button>
-                        )}
-                    </div>
-                </Hide>
-
-                <Hide below="tablet">
-                    <div css={styles.ctasContainer}>
-                        {mainContent.primaryCta && (
-                            <LinkButton
-                                href={mainContent.primaryCta.ctaUrl}
-                                onClick={onPrimaryCtaClick}
-                                size="small"
-                                priority="primary"
-                                cssOverrides={buttonStyles(primaryCtaSettings)}
-                            >
-                                {mainContent.primaryCta.ctaText}
-                            </LinkButton>
-                        )}
-
-                        {mainContent.secondaryCta?.type === SecondaryCtaType.Custom && (
-                            <LinkButton
-                                href={mainContent.secondaryCta.cta.ctaUrl}
-                                onClick={onSecondaryCtaClick}
-                                size="small"
-                                priority="tertiary"
-                                cssOverrides={buttonStyles(secondaryCtaSettings)}
-                            >
-                                {mainContent.secondaryCta.cta.ctaText}
-                            </LinkButton>
-                        )}
-
-                        {mainContent.secondaryCta?.type ===
-                            SecondaryCtaType.ContributionsReminder && (
-                            <Button
-                                priority="subdued"
-                                onClick={onReminderCtaClick}
-                                cssOverrides={styles.reminderCta}
-                            >
-                                Remind me later
-                            </Button>
-                        )}
-                    </div>
-                </Hide>
+                    {secondaryCta?.type === SecondaryCtaType.ContributionsReminder && (
+                        <Button
+                            priority="subdued"
+                            onClick={onReminderCtaClick}
+                            cssOverrides={styles.reminderCta}
+                        >
+                            Remind me later
+                        </Button>
+                    )}
+                </div>
             </div>
 
             <div>
-                <Hide above="tablet">{mobileContent.primaryCta && <PaymentCards />}</Hide>
-                <Hide below="tablet">{mainContent.primaryCta && <PaymentCards />}</Hide>
+                {isTabletOrAbove
+                    ? content['mainContent'].primaryCta && <PaymentCards />
+                    : content['mobileContent'].primaryCta && <PaymentCards />}
             </div>
         </div>
     );
 }
-
-// ---- Helper Components ---- //
 
 function PaymentCards() {
     return (
@@ -195,8 +152,6 @@ function PaymentCards() {
         </svg>
     );
 }
-
-// ---- Styles ---- //
 
 const styles = {
     container: css`

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
@@ -3,10 +3,8 @@ import { css } from '@emotion/react';
 import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
 import { neutral } from '@guardian/src-foundations/palette';
-import { Hide } from '@guardian/src-layout';
 import { HeaderSettings } from '../settings';
-
-// ---- Component ---- //
+import useMediaQuery from '../../../../hooks/useMediaQuery';
 
 interface MomentTemplateBannerHeaderProps {
     heading: JSX.Element | JSX.Element[] | null;
@@ -19,19 +17,16 @@ export function MomentTemplateBannerHeader({
     mobileHeading,
     headerSettings,
 }: MomentTemplateBannerHeaderProps): JSX.Element {
+    const isTabletOrAbove = useMediaQuery(from.tablet);
+
     return (
         <div css={styles.container}>
             <header css={styles.header(headerSettings)}>
-                <h2>
-                    <Hide above="tablet">{mobileHeading}</Hide>
-                    <Hide below="tablet">{heading}</Hide>
-                </h2>
+                <h2>{isTabletOrAbove ? heading : mobileHeading}</h2>
             </header>
         </div>
     );
 }
-
-// ---- Styles ---- //
 
 const styles = {
     container: css`

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerReminder.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerReminder.tsx
@@ -4,18 +4,18 @@ import { BannerEnrichedReminderCta } from '../../common/types';
 import { CtaSettings } from '../settings';
 import { MomentTemplateBannerReminderSignedOut } from './MomentTemplateBannerReminderSignedOut';
 
-// ---- Component ---- //
-
 export interface MomentTemplateBannerReminderProps {
     reminderCta: BannerEnrichedReminderCta;
     trackReminderSetClick: () => void;
     setReminderCtaSettings?: CtaSettings;
+    mobileReminderRef: React.RefObject<HTMLDivElement> | null;
 }
 
 export function MomentTemplateBannerReminder({
     reminderCta,
     trackReminderSetClick,
     setReminderCtaSettings,
+    mobileReminderRef,
 }: MomentTemplateBannerReminderProps): JSX.Element {
     const { reminderStatus, createReminder } = useContributionsReminderSignup(
         reminderCta.reminderFields.reminderPeriod,
@@ -31,11 +31,13 @@ export function MomentTemplateBannerReminder({
     };
 
     return (
-        <MomentTemplateBannerReminderSignedOut
-            reminderCta={reminderCta}
-            reminderStatus={reminderStatus}
-            onReminderSetClick={onReminderSetClick}
-            setReminderCtaSettings={setReminderCtaSettings}
-        />
+        <div ref={mobileReminderRef}>
+            <MomentTemplateBannerReminderSignedOut
+                reminderCta={reminderCta}
+                reminderStatus={reminderStatus}
+                onReminderSetClick={onReminderSetClick}
+                setReminderCtaSettings={setReminderCtaSettings}
+            />
+        </div>
     );
 }


### PR DESCRIPTION
## What does this change?
Following https://github.com/guardian/support-dotcom-components/pull/895 which added a `useMediaQuery` hook. This makes use of the new hook, for dynamically rendering content within moment template banner components based on device width. 

Removal of the remaining _content-based_ JSX duplication (this PR) and _css-based_ JSX duplication will be split into two PRs. PR for removing remaining css-based duplication to follow.

## How to test
There should be no change in the UI for the moment template banner:
- header
- banner ctas
- banner reminder (alternate cta)
