### PR TITLE
Refactor `MomentTemplateBanner.tsx`

### DIFF
--- a/packages/modules/src/hooks/useMediaQuery.ts
+++ b/packages/modules/src/hooks/useMediaQuery.ts
@@ -28,7 +28,10 @@ const useMediaQuery = (breakpoint: string): boolean => {
             }
         }
 
-        return () => media.removeEventListener('change', handleChange);
+        return () => {
+            media.removeEventListener('change', handleChange);
+            media.removeListener(handleChange);
+        }
     }, [matches, query]);
 
     return matches;

--- a/packages/modules/src/hooks/useMediaQuery.ts
+++ b/packages/modules/src/hooks/useMediaQuery.ts
@@ -31,7 +31,7 @@ const useMediaQuery = (breakpoint: string): boolean => {
         return () => {
             media.removeEventListener('change', handleChange);
             media.removeListener(handleChange);
-        }
+        };
     }, [matches, query]);
 
     return matches;

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -259,7 +259,6 @@ const styles = {
         margin-left: ${space[3]}px;
         z-index: 101;
         position: absolute;
-        margin-left: intial;
         top: ${space[2]}px;
         right: ${space[4]}px;
     `,

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -50,7 +50,11 @@ export function getMomentTemplateBanner(
                     </div>
 
                     {hasVisual && (
-                        <div css={styles.bannerVisualContainer(templateSettings.containerSettings.backgroundColour)}>
+                        <div
+                            css={styles.bannerVisualContainer(
+                                templateSettings.containerSettings.backgroundColour,
+                            )}
+                        >
                             {templateSettings.imageSettings && (
                                 <MomentTemplateBannerVisual
                                     settings={templateSettings.imageSettings}
@@ -62,11 +66,13 @@ export function getMomentTemplateBanner(
                     )}
 
                     <div css={styles.contentContainer}>
-                        <div css={styles.headerContainer(
-                        templateSettings.containerSettings.backgroundColour,
-                        content.mobileContent.secondaryCta?.type ===
-                            SecondaryCtaType.ContributionsReminder,
-                    )}>
+                        <div
+                            css={styles.headerContainer(
+                                templateSettings.containerSettings.backgroundColour,
+                                content.mobileContent.secondaryCta?.type ===
+                                    SecondaryCtaType.ContributionsReminder,
+                            )}
+                        >
                             <MomentTemplateBannerHeader
                                 heading={content.mainContent.heading}
                                 mobileHeading={content.mobileContent.heading}
@@ -115,8 +121,7 @@ export function getMomentTemplateBanner(
                     isReminderActive && (
                         <MomentTemplateBannerReminder
                             reminderCta={
-                                mainOrMobileContent
-                                    .secondaryCta as BannerEnrichedReminderCta
+                                mainOrMobileContent.secondaryCta as BannerEnrichedReminderCta
                             }
                             trackReminderSetClick={reminderTracking.onReminderSetClick}
                             setReminderCtaSettings={templateSettings.setReminderCtaSettings}
@@ -166,7 +171,7 @@ const styles = {
     bannerVisualContainer: (background: string) => css`
         display: none;
         pointer-events: none;
-        
+
         ${from.mobileMedium} {
             display: block;
 
@@ -188,7 +193,7 @@ const styles = {
             width: 320px;
             margin-left: ${space[5]}px;
         }
-        
+
         ${from.leftCol} {
             width: 370px;
             margin-left: ${space[9]}px;
@@ -208,10 +213,7 @@ const styles = {
             width: 780px;
         }
     `,
-    headerContainer: (
-        background: string,
-        hasReminderCta: boolean,
-    ) => css`
+    headerContainer: (background: string, hasReminderCta: boolean) => css`
         max-width: calc(100% - 46px); // 46px approx close button size
         ${bannerSpacing.heading};
 
@@ -219,7 +221,7 @@ const styles = {
             max-width: initial;
             margin-top: ${space[2]}px;
             padding-bottom: ${space[2]}px;
-            
+
             // Mobile Sticky Header Styles
             background: ${background};
             position: sticky;

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import { neutral, space } from '@guardian/src-foundations';
-import { Container, Hide } from '@guardian/src-layout';
+import { Container } from '@guardian/src-layout';
 import { BannerEnrichedReminderCta, BannerRenderProps } from '../common/types';
 import { MomentTemplateBannerHeader } from './components/MomentTemplateBannerHeader';
 import { MomentTemplateBannerArticleCount } from './components/MomentTemplateBannerArticleCount';
@@ -36,32 +36,21 @@ export function getMomentTemplateBanner(
         const { isReminderActive, onReminderCtaClick, mobileReminderRef } = useReminder(
             reminderTracking,
         );
-
         const isTabletOrAbove = useMediaQuery(from.tablet);
-
-        const mainOrMobileContent = isTabletOrAbove ? 'mainContent' : 'mobileContent';
+        const mainOrMobileContent = isTabletOrAbove ? content.mainContent : content.mobileContent;
 
         return (
             <div css={styles.outerContainer(templateSettings.containerSettings.backgroundColour)}>
-                <Container
-                    cssOverrides={styles.mobileStickyHeaderContainer(
-                        templateSettings.containerSettings.backgroundColour,
-                        content.mobileContent.secondaryCta?.type ===
-                            SecondaryCtaType.ContributionsReminder,
-                        templateSettings.containerSettings.paddingTop,
-                    )}
-                >
+                <Container cssOverrides={styles.containerOverrides}>
                     <div css={styles.closeButtonContainer}>
-                        <Hide below="mobileMedium">
-                            <MomentTemplateBannerCloseButton
-                                onCloseClick={onCloseClick}
-                                settings={templateSettings.closeButtonSettings}
-                            />
-                        </Hide>
+                        <MomentTemplateBannerCloseButton
+                            onCloseClick={onCloseClick}
+                            settings={templateSettings.closeButtonSettings}
+                        />
                     </div>
 
                     {hasVisual && (
-                        <div css={styles.mobileVisualContainer}>
+                        <div css={styles.bannerVisualContainer(templateSettings.containerSettings.backgroundColour)}>
                             {templateSettings.imageSettings && (
                                 <MomentTemplateBannerVisual
                                     settings={templateSettings.imageSettings}
@@ -72,102 +61,61 @@ export function getMomentTemplateBanner(
                         </div>
                     )}
 
-                    <div css={styles.headerContainer}>
-                        <MomentTemplateBannerHeader
-                            heading={content.mainContent.heading}
-                            mobileHeading={content.mobileContent.heading}
-                            headerSettings={templateSettings.headerSettings}
-                        />
-
-                        <Hide above="mobileMedium" cssOverrides={styles.mobileCloseButtonContainer}>
-                            <MomentTemplateBannerCloseButton
-                                onCloseClick={onCloseClick}
-                                settings={templateSettings.closeButtonSettings}
+                    <div css={styles.contentContainer}>
+                        <div css={styles.headerContainer(
+                        templateSettings.containerSettings.backgroundColour,
+                        content.mobileContent.secondaryCta?.type ===
+                            SecondaryCtaType.ContributionsReminder,
+                    )}>
+                            <MomentTemplateBannerHeader
+                                heading={content.mainContent.heading}
+                                mobileHeading={content.mobileContent.heading}
+                                headerSettings={templateSettings.headerSettings}
                             />
-                        </Hide>
-                    </div>
-                </Container>
-
-                <Container cssOverrides={styles.containerOverrides}>
-                    <div css={styles.container}>
-                        <div css={styles.closeButtonContainer}>
-                            <Hide below="tablet">
-                                <MomentTemplateBannerCloseButton
-                                    onCloseClick={onCloseClick}
-                                    settings={templateSettings.closeButtonSettings}
-                                />
-                            </Hide>
                         </div>
 
-                        {hasVisual && (
-                            <div css={styles.desktopVisualContainer}>
-                                {templateSettings.imageSettings && (
-                                    <MomentTemplateBannerVisual
-                                        settings={templateSettings.imageSettings}
-                                        bannerId={templateSettings.bannerId}
-                                    />
-                                )}
-                                {templateSettings.alternativeVisual}
-                            </div>
+                        {separateArticleCount && numArticles !== undefined && numArticles > 5 && (
+                            <MomentTemplateBannerArticleCount
+                                numArticles={numArticles}
+                                settings={templateSettings}
+                                textColour={templateSettings.articleCountTextColour}
+                            />
                         )}
 
-                        <div css={styles.contentContainer}>
-                            <div css={styles.desktopHeaderContainer}>
-                                <MomentTemplateBannerHeader
-                                    heading={content.mainContent.heading}
-                                    mobileHeading={content.mobileContent.heading}
-                                    headerSettings={templateSettings.headerSettings}
-                                />
-                            </div>
-
-                            {separateArticleCount &&
-                                numArticles !== undefined &&
-                                numArticles > 5 && (
-                                    <MomentTemplateBannerArticleCount
-                                        numArticles={numArticles}
-                                        settings={templateSettings}
-                                        textColour={templateSettings.articleCountTextColour}
-                                    />
-                                )}
-
-                            <div css={styles.bodyContainer}>
-                                <MomentTemplateBannerBody
-                                    mainContent={content.mainContent}
-                                    mobileContent={content.mobileContent}
-                                    highlightedTextSettings={
-                                        templateSettings.highlightedTextSettings
-                                    }
-                                />
-                            </div>
-
-                            {tickerSettings?.tickerData &&
-                                templateSettings.tickerStylingSettings && (
-                                    <MomentTemplateBannerTicker
-                                        tickerSettings={tickerSettings}
-                                        stylingSettings={templateSettings.tickerStylingSettings}
-                                    />
-                                )}
-
-                            <section css={styles.ctasContainer}>
-                                <MomentTemplateBannerCtas
-                                    mainOrMobileContent={content[mainOrMobileContent]}
-                                    onPrimaryCtaClick={onCtaClick}
-                                    onSecondaryCtaClick={onSecondaryCtaClick}
-                                    onReminderCtaClick={onReminderCtaClick}
-                                    primaryCtaSettings={templateSettings.primaryCtaSettings}
-                                    secondaryCtaSettings={templateSettings.secondaryCtaSettings}
-                                />
-                            </section>
+                        <div css={styles.bodyContainer}>
+                            <MomentTemplateBannerBody
+                                mainContent={content.mainContent}
+                                mobileContent={content.mobileContent}
+                                highlightedTextSettings={templateSettings.highlightedTextSettings}
+                            />
                         </div>
+
+                        {tickerSettings?.tickerData && templateSettings.tickerStylingSettings && (
+                            <MomentTemplateBannerTicker
+                                tickerSettings={tickerSettings}
+                                stylingSettings={templateSettings.tickerStylingSettings}
+                            />
+                        )}
+
+                        <section css={styles.ctasContainer}>
+                            <MomentTemplateBannerCtas
+                                mainOrMobileContent={mainOrMobileContent}
+                                onPrimaryCtaClick={onCtaClick}
+                                onSecondaryCtaClick={onSecondaryCtaClick}
+                                onReminderCtaClick={onReminderCtaClick}
+                                primaryCtaSettings={templateSettings.primaryCtaSettings}
+                                secondaryCtaSettings={templateSettings.secondaryCtaSettings}
+                            />
+                        </section>
                     </div>
                 </Container>
 
-                {content[mainOrMobileContent].secondaryCta?.type ===
+                {mainOrMobileContent.secondaryCta?.type ===
                     SecondaryCtaType.ContributionsReminder &&
                     isReminderActive && (
                         <MomentTemplateBannerReminder
                             reminderCta={
-                                content[mainOrMobileContent]
+                                mainOrMobileContent
                                     .secondaryCta as BannerEnrichedReminderCta
                             }
                             trackReminderSetClick={reminderTracking.onReminderSetClick}
@@ -197,71 +145,50 @@ const styles = {
         }
     `,
     containerOverrides: css`
-        position: relative;
-        width: 100%;
-        max-width: 1300px;
-        margin: 0 auto;
-    `,
-    container: css`
-        overflow: hidden;
-        display: flex;
-        flex-direction: column;
-
         ${from.tablet} {
-            flex-direction: row-reverse;
-            justify-content: flex-end;
+            position: relative;
+            width: 100%;
+            max-width: 1300px;
+            margin: 0 auto;
         }
-    `,
-    mobileStickyHeaderContainer: (
-        background: string,
-        hasReminderCta: boolean,
-        paddingTop?: string,
-    ) => css`
-        background: ${background};
-        position: sticky;
-        top: 0px;
-        z-index: 100;
-        border-top: 1px solid ${neutral[0]};
-        ${paddingTop && `padding-top: ${paddingTop}px`};
 
-        ${hasReminderCta
-            ? `
-                border-bottom: 1px solid ${neutral[0]};
-                padding-bottom: ${space[2]}px;
-            `
-            : ''}
+        & > div {
+            display: flex;
+            flex-direction: column;
 
-        ${from.tablet} {
-            display: none;
+            ${from.tablet} {
+                flex-direction: row-reverse;
+            }
         }
 
         ${bannerSpacing.heading};
     `,
-    mobileVisualContainer: css`
+    bannerVisualContainer: (background: string) => css`
         display: none;
         pointer-events: none;
-
+        
         ${from.mobileMedium} {
             display: block;
+
+            // Mobile Sticky Header Styles
+            background: ${background};
+            position: sticky;
+            top: 0px;
+            z-index: 100;
         }
-        ${from.tablet} {
-            display: none;
-        }
-    `,
-    desktopVisualContainer: css`
-        display: none;
-        pointer-events: none;
-        position: relative;
 
         ${from.tablet} {
-            display: block;
             width: 238px;
             margin-left: ${space[3]}px;
+            position: relative;
+            z-index: initial;
         }
+
         ${from.desktop} {
             width: 320px;
             margin-left: ${space[5]}px;
         }
+        
         ${from.leftCol} {
             width: 370px;
             margin-left: ${space[9]}px;
@@ -281,25 +208,38 @@ const styles = {
             width: 780px;
         }
     `,
-    headerContainer: css`
-        display: flex;
-        align-items: center;
+    headerContainer: (
+        background: string,
+        hasReminderCta: boolean,
+    ) => css`
+        max-width: calc(100% - 46px); // 46px approx close button size
+        ${bannerSpacing.heading};
 
         ${from.mobileMedium} {
+            max-width: initial;
             margin-top: ${space[2]}px;
+            padding-bottom: ${space[2]}px;
+            
+            // Mobile Sticky Header Styles
+            background: ${background};
+            position: sticky;
+            top: 140px; // 140px for banner visual
+            z-index: 100;
+            ${hasReminderCta
+                ? `
+                    border-bottom: 1px solid ${neutral[0]};
+                    padding-bottom: ${space[2]}px;
+                `
+                : ''}
         }
-
-        ${bannerSpacing.heading}
-    `,
-    desktopHeaderContainer: css`
-        display: none;
-        margin-top: ${space[2]}px;
 
         ${from.tablet} {
-            display: block;
+            position: relative;
+            z-index: initial;
+            border-bottom: initial;
+            top: initial;
+            max-width: initial;
         }
-
-        ${bannerSpacing.heading}
     `,
     bodyContainer: css`
         ${bannerSpacing.bodyCopyAndArticleCount}
@@ -313,11 +253,11 @@ const styles = {
             margin-top: ${space[6]}px;
         }
     `,
-    mobileCloseButtonContainer: css`
-        margin-left: ${space[3]}px;
-    `,
     closeButtonContainer: css`
+        margin-left: ${space[3]}px;
+        z-index: 101;
         position: absolute;
+        margin-left: intial;
         top: ${space[2]}px;
         right: ${space[4]}px;
     `,

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -47,6 +47,7 @@ export function MomentTemplateBannerCloseButton({
 const styles = {
     container: css`
         display: flex;
+        justify-content: end;
         position: relative;
         z-index: 100;
     `,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
In order to remove the remaining css & jsx duplication in the moment template banner, the top level component has been refactored. 

## How to test
The UI for the banner should be the same.
Locally - could create a before and after version of the moment template banner, then use both in stories for comparison.
