### PR TITLE
Add choice cards and header image to moment template

### DIFF
--- a/packages/modules/src/hooks/useChoiceCards.ts
+++ b/packages/modules/src/hooks/useChoiceCards.ts
@@ -1,0 +1,59 @@
+import { ContributionFrequency, SelectedAmountsVariant } from '@sdc/shared/src/types/abTests/epic';
+import { useState, useEffect } from 'react';
+import { BannerTextContent } from '../modules/banners/common/types';
+import { getLocalCurrencySymbol } from '@sdc/shared/src/lib/geolocation';
+
+export interface ChoiceCardSelection {
+    frequency: ContributionFrequency;
+    amount: number | 'other';
+}
+
+const useChoiceCards = (
+    choiceCardAmounts: SelectedAmountsVariant | undefined,
+    countryCode: string | undefined,
+): {
+    choiceCardSelection: ChoiceCardSelection | undefined;
+    setChoiceCardSelection: (choiceCardSelection: ChoiceCardSelection) => void;
+    getCtaText: (
+        contentType: 'mainContent' | 'mobileContent',
+        content?: BannerTextContent,
+    ) => string;
+    currencySymbol: string;
+} => {
+    const [choiceCardSelection, setChoiceCardSelection] = useState<
+        ChoiceCardSelection | undefined
+    >();
+
+    useEffect(() => {
+        if (choiceCardAmounts?.amounts) {
+            const defaultFrequency: ContributionFrequency = 'MONTHLY';
+            const localAmounts = choiceCardAmounts.amounts[defaultFrequency];
+            const defaultAmount = localAmounts.defaultAmount || localAmounts.amounts[1] || 1;
+
+            setChoiceCardSelection({
+                frequency: defaultFrequency,
+                amount: defaultAmount,
+            });
+        }
+    }, [choiceCardAmounts]);
+
+    const getCtaText = (
+        contentType: 'mainContent' | 'mobileContent',
+        content?: BannerTextContent,
+    ): string => {
+        const primaryCtaText = content?.[contentType]?.primaryCta?.ctaText;
+
+        return primaryCtaText ? primaryCtaText : 'Contribute';
+    };
+
+    const currencySymbol = getLocalCurrencySymbol(countryCode);
+
+    return {
+        choiceCardSelection,
+        setChoiceCardSelection,
+        getCtaText,
+        currencySymbol,
+    };
+};
+
+export default useChoiceCards;

--- a/packages/modules/src/hooks/useChoiceCards.ts
+++ b/packages/modules/src/hooks/useChoiceCards.ts
@@ -1,7 +1,7 @@
 import { ContributionFrequency, SelectedAmountsVariant } from '@sdc/shared/src/types/abTests/epic';
 import { useState, useEffect } from 'react';
 import { BannerTextContent } from '../modules/banners/common/types';
-import { getLocalCurrencySymbol } from '@sdc/shared/src/lib/geolocation';
+import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib';
 
 export interface ChoiceCardSelection {
     frequency: ContributionFrequency;

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/Button.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from '@emotion/react';
+import { SerializedStyles, css } from '@emotion/react';
 import { palette } from '@guardian/src-foundations';
 import { ThemeProvider } from '@emotion/react';
 import { Button as DSButton, LinkButton } from '@guardian/src-button';
@@ -35,6 +35,7 @@ type Props = {
     priority?: 'primary' | 'secondary';
     showArrow?: boolean;
     isTertiary?: boolean;
+    cssOverrides?: SerializedStyles | SerializedStyles[];
 };
 
 // Overrides for tertiary button
@@ -55,6 +56,7 @@ export const Button: React.FC<Props> = (allProps: Props) => {
         showArrow = false,
         priority = 'primary',
         isTertiary,
+        cssOverrides,
         ...props
     } = allProps;
 
@@ -72,6 +74,7 @@ export const Button: React.FC<Props> = (allProps: Props) => {
                     rel="noopener noreferrer"
                     priority={isTertiary ? 'primary' : priority}
                     css={isTertiary ? tertiaryButtonOverrides : undefined}
+                    cssOverrides={cssOverrides}
                     {...props}
                 >
                     {children}

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
@@ -6,7 +6,7 @@ import {
     OphanComponentEvent,
 } from '@sdc/shared/dist/types';
 import { ContributionType, trackClick } from './ChoiceCardFrequencyTabs';
-import { css } from '@emotion/react';
+import { SerializedStyles, css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
 import { between, from, until } from '@guardian/src-foundations/mq';
 import { ChoiceCardSelection } from '../ChoiceCardsBanner';
@@ -68,12 +68,14 @@ const ChoiceCardAmount = ({
     label,
     checked,
     handleUpdateAmount,
+    cssOverrides
 }: {
     id: string;
     amount?: number;
     label: string;
     checked: boolean;
     handleUpdateAmount: (amount: number | 'other') => void;
+    cssOverrides: SerializedStyles
 }) => {
     if (amount) {
         return (
@@ -85,6 +87,7 @@ const ChoiceCardAmount = ({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     e.target.id === id ? handleUpdateAmount(amount) : null
                 }
+                cssOverrides={cssOverrides}
             />
         );
     }
@@ -151,7 +154,7 @@ export const ChoiceCardAmountButtons = ({
             label={`${currencySymbol}${amount} ${contributionType[selection.frequency].suffix}`}
             checked={selection.amount === amount}
             handleUpdateAmount={() => handleUpdateAmount(amount)}
-            css={supporterPlusChoiceCardAmountOverrides}
+            cssOverrides={supporterPlusChoiceCardAmountOverrides}
         />
     ));
 

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCardAmountButtons.tsx
@@ -68,14 +68,14 @@ const ChoiceCardAmount = ({
     label,
     checked,
     handleUpdateAmount,
-    cssOverrides
+    cssOverrides,
 }: {
     id: string;
     amount?: number;
     label: string;
     checked: boolean;
     handleUpdateAmount: (amount: number | 'other') => void;
-    cssOverrides: SerializedStyles
+    cssOverrides: SerializedStyles;
 }) => {
     if (amount) {
         return (

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/ChoiceCards.tsx
@@ -21,7 +21,10 @@ interface ChoiceCardProps {
     submitComponentEvent?: (event: OphanComponentEvent) => void;
     currencySymbol: string;
     componentId: ChoiceCardBannerComponentId;
-    getCtaText: (contentType: 'mainContent' | 'mobileContent') => string;
+    getCtaText: (
+        contentType: 'mainContent' | 'mobileContent',
+        content?: BannerTextContent,
+    ) => string;
     amounts?: ContributionAmounts;
     amountsTestName?: string;
     amountsVariantName?: string;
@@ -135,6 +138,7 @@ export const ChoiceCards: React.FC<ChoiceCardProps> = ({
     numArticles,
     getCtaText,
     cssCtaOverides,
+    content,
 }: ChoiceCardProps) => {
     if (!selection || !amounts) {
         return <></>;
@@ -208,6 +212,7 @@ export const ChoiceCards: React.FC<ChoiceCardProps> = ({
                         selection={selection}
                         getCtaText={getCtaText}
                         cssOverrides={cssCtaOverides}
+                        content={content}
                     />
                     <PaymentCards cssOverrides={styles.paymentCardsSvgOverrides} />
                 </div>

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
@@ -63,7 +63,7 @@ export const SupportCta = ({
                     onClickAction={supportUrl}
                     showArrow
                     data-ignore="global-link-styling"
-                    css={[buttonOverrides, cssOverrides]}
+                    cssOverrides={[buttonOverrides, cssOverrides ?? css``]}
                 >
                     {mobileText}
                 </Button>
@@ -74,7 +74,7 @@ export const SupportCta = ({
                     onClickAction={supportUrl}
                     showArrow
                     data-ignore="global-link-styling"
-                    css={[buttonOverrides, cssOverrides]}
+                    cssOverrides={[buttonOverrides, cssOverrides ?? css``]}
                 >
                     {desktopText}
                 </Button>

--- a/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsBanner/components/SupportCta.tsx
@@ -6,6 +6,7 @@ import { css, SerializedStyles } from '@emotion/react';
 import { Hide } from '@guardian/src-layout';
 import { Button } from './Button';
 import { ChoiceCardSelection } from '../ChoiceCardsBanner';
+import { BannerTextContent } from '../../common/types';
 
 const buttonOverrides = css`
     margin-right: ${space[3]}px;
@@ -26,6 +27,7 @@ export const SupportCta = ({
     selection,
     getCtaText,
     cssOverrides,
+    content,
 }: {
     tracking: Tracking;
     numArticles: number;
@@ -33,13 +35,17 @@ export const SupportCta = ({
     amountsTestName?: string;
     amountsVariantName?: string;
     selection: ChoiceCardSelection;
-    getCtaText: (contentType: 'mainContent' | 'mobileContent') => string;
+    getCtaText: (
+        contentType: 'mainContent' | 'mobileContent',
+        content?: BannerTextContent,
+    ) => string;
     cssOverrides?: SerializedStyles;
+    content?: BannerTextContent;
 }): JSX.Element | null => {
     const url = `https://support.theguardian.com/contribute?selected-contribution-type=${selection.frequency}&selected-amount=${selection.amount}`;
 
-    const mobileText = getCtaText('mobileContent');
-    const desktopText = getCtaText('mainContent');
+    const mobileText = getCtaText('mobileContent', content);
+    const desktopText = getCtaText('mainContent', content);
 
     const supportUrl = addRegionIdAndTrackingParamsToSupportUrl(
         url,

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/Button.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from '@emotion/react';
+import { SerializedStyles, css } from '@emotion/react';
 import { palette } from '@guardian/src-foundations';
 import { ThemeProvider } from '@emotion/react';
 import { Button as DSButton, LinkButton } from '@guardian/src-button';
@@ -35,6 +35,7 @@ type Props = {
     priority?: 'primary' | 'secondary';
     showArrow?: boolean;
     isTertiary?: boolean;
+    cssOverrides?: SerializedStyles | SerializedStyles[] | undefined;
 };
 
 // Overrides for tertiary button
@@ -55,6 +56,7 @@ export const Button: React.FC<Props> = (allProps: Props) => {
         showArrow = false,
         priority = 'primary',
         isTertiary,
+        cssOverrides,
         ...props
     } = allProps;
 
@@ -72,6 +74,7 @@ export const Button: React.FC<Props> = (allProps: Props) => {
                     rel="noopener noreferrer"
                     priority={isTertiary ? 'primary' : priority}
                     css={isTertiary ? tertiaryButtonOverrides : undefined}
+                    cssOverrides={cssOverrides}
                     {...props}
                 >
                     {children}

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardAmountButtons.tsx
@@ -6,7 +6,7 @@ import {
     OphanComponentEvent,
 } from '@sdc/shared/dist/types';
 import { ContributionType, trackClick } from './ChoiceCardFrequencyTabs';
-import { css } from '@emotion/react';
+import { SerializedStyles, css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
 import { between, from, until } from '@guardian/src-foundations/mq';
 import { ChoiceCardSelection } from '../ChoiceCardsButtonsBanner';
@@ -66,12 +66,14 @@ const ChoiceCardAmount = ({
     label,
     checked,
     handleUpdateAmount,
+    cssOverrides
 }: {
     id: string;
     amount?: number;
     label: string;
     checked: boolean;
     handleUpdateAmount: (amount: number | 'other') => void;
+    cssOverrides: SerializedStyles
 }) => {
     if (amount) {
         return (
@@ -83,6 +85,7 @@ const ChoiceCardAmount = ({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     e.target.id === id ? handleUpdateAmount(amount) : null
                 }
+                cssOverrides={cssOverrides}
             />
         );
     }
@@ -149,7 +152,7 @@ export const ChoiceCardAmountButtons = ({
             label={`${currencySymbol}${amount} ${contributionType[selection.frequency].suffix}`}
             checked={selection.amount === amount}
             handleUpdateAmount={() => handleUpdateAmount(amount)}
-            css={supporterPlusChoiceCardAmountOverrides}
+            cssOverrides={supporterPlusChoiceCardAmountOverrides}
         />
     ));
 

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardAmountButtons.tsx
@@ -66,14 +66,14 @@ const ChoiceCardAmount = ({
     label,
     checked,
     handleUpdateAmount,
-    cssOverrides
+    cssOverrides,
 }: {
     id: string;
     amount?: number;
     label: string;
     checked: boolean;
     handleUpdateAmount: (amount: number | 'other') => void;
-    cssOverrides: SerializedStyles
+    cssOverrides: SerializedStyles;
 }) => {
     if (amount) {
         return (

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/SupportCta.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/SupportCta.tsx
@@ -57,7 +57,7 @@ export const SupportCta = ({
                     onClickAction={supportUrl}
                     showArrow
                     data-ignore="global-link-styling"
-                    css={[buttonOverrides, cssOverrides]}
+                    cssOverrides={[buttonOverrides, cssOverrides ?? css``]}
                 >
                     {mobileText}
                 </Button>
@@ -68,7 +68,7 @@ export const SupportCta = ({
                     onClickAction={supportUrl}
                     showArrow
                     data-ignore="global-link-styling"
-                    css={[buttonOverrides, cssOverrides]}
+                    cssOverrides={[buttonOverrides, cssOverrides ?? css``]}
                 >
                     {desktopText}
                 </Button>

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.stories.tsx
@@ -4,7 +4,8 @@ import { getMomentTemplateBanner } from './MomentTemplateBanner';
 import { props } from '../utils/storybook';
 import { BannerProps, SecondaryCtaType } from '@sdc/shared/types';
 import { bannerWrapper } from '../common/BannerWrapper';
-import { neutral } from '@guardian/src-foundations';
+import { brand, brandAlt, neutral } from '@guardian/src-foundations';
+import { TopImage } from '../worldPressFreedomDay/components/TopImage';
 
 export default {
     title: 'Banners/MomentTemplate',
@@ -124,4 +125,256 @@ WithReminder.args = {
         },
     },
     numArticles: 50,
+};
+
+const BannerWithHeaderImage = bannerWrapper(
+    getMomentTemplateBanner({
+        containerSettings: {
+            backgroundColour: '#F1F8FC',
+        },
+        headerSettings: {
+            textColour: '#0077B6',
+            image: <TopImage />,
+        },
+        primaryCtaSettings: {
+            default: {
+                backgroundColour: '#0077B6',
+                textColour: 'white',
+            },
+            hover: {
+                backgroundColour: '#004E7C',
+                textColour: 'white',
+                border: '1px solid #004E7C',
+            },
+        },
+        secondaryCtaSettings: {
+            default: {
+                backgroundColour: '#F1F8FC',
+                textColour: '#004E7C',
+                border: '1px solid #004E7C',
+            },
+            hover: {
+                backgroundColour: '#E5E5E5',
+                textColour: '#004E7C',
+                border: '1px solid #004E7C',
+            },
+        },
+        closeButtonSettings: {
+            default: {
+                backgroundColour: '#F1F8FC',
+                textColour: brand[400],
+                border: `1px solid ${brand[400]}`,
+            },
+            hover: {
+                backgroundColour: '#E5E5E5',
+                textColour: brand[400],
+            },
+            theme: 'brand',
+        },
+        highlightedTextSettings: {
+            textColour: neutral[0],
+            highlightColour: brandAlt[400],
+        },
+        imageSettings: {
+            mainUrl:
+                'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
+            mobileUrl:
+                'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
+            tabletUrl:
+                'https://i.guim.co.uk/img/media/d1af2bcab927ca0ad247522105fe41a52a474d27/0_0_1080_1000/500.png?width=500&quality=75&s=af39fa30f36fce453eabaef3063a3180',
+            desktopUrl:
+                'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
+            wideUrl:
+                'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
+            altText: 'Guardian logo being held up by supporters of the Guardian',
+        },
+        bannerId: 'global-new-year-banner',
+    }),
+    'global-new-year-banner',
+);
+
+const BannerWithHeaderImageTemplate: Story<BannerProps> = (props: BannerProps) => (
+    <BannerWithHeaderImage {...props} />
+);
+
+export const WithHeaderImage = BannerWithHeaderImageTemplate.bind({});
+WithHeaderImage.args = {
+    ...props,
+    content: {
+        heading: 'Show your support for reader-funded journalism',
+        messageText:
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations. We do not shy away. And we provide all this for free, for everyone.',
+        paragraphs: [
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations.',
+            'We do not shy away. And we provide all this for free, for everyone.',
+        ],
+        highlightedText:
+            'Show your support today from just %%CURRENCY_SYMBOL%%1, or sustain us long term with a little more. Thank you.',
+        cta: {
+            text: 'Support once',
+            baseUrl: 'https://support.theguardian.com/contribute/one-off',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Support monthly',
+                baseUrl: 'https://support.theguardian.com/contribute/recurring',
+            },
+        },
+    },
+    mobileContent: {
+        heading: 'Show your support for reader-funded journalism',
+        messageText:
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations. We do not shy away. And we provide all this for free, for everyone.',
+        paragraphs: [
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations.',
+            'We do not shy away. And we provide all this for free, for everyone.',
+        ],
+        highlightedText:
+            'Show your support today from just %%CURRENCY_SYMBOL%%1, or sustain us long term with a little more. Thank you.',
+        cta: {
+            text: 'Support us',
+            baseUrl: 'https://support.theguardian.com/contribute/one-off',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Learn more',
+                baseUrl: 'https://support.theguardian.com/contribute/recurring',
+            },
+        },
+    },
+    numArticles: 50,
+    tickerSettings: undefined,
+};
+
+const BannerWithChoiceCards = bannerWrapper(
+    getMomentTemplateBanner({
+        containerSettings: {
+            backgroundColour: '#F1F8FC',
+        },
+        headerSettings: {
+            textColour: '#0077B6',
+        },
+        primaryCtaSettings: {
+            default: {
+                backgroundColour: '#0077B6',
+                textColour: 'white',
+            },
+            hover: {
+                backgroundColour: '#004E7C',
+                textColour: 'white',
+                border: '1px solid #004E7C',
+            },
+        },
+        secondaryCtaSettings: {
+            default: {
+                backgroundColour: '#F1F8FC',
+                textColour: '#004E7C',
+                border: '1px solid #004E7C',
+            },
+            hover: {
+                backgroundColour: '#E5E5E5',
+                textColour: '#004E7C',
+                border: '1px solid #004E7C',
+            },
+        },
+        closeButtonSettings: {
+            default: {
+                backgroundColour: '#F1F8FC',
+                textColour: brand[400],
+                border: `1px solid ${brand[400]}`,
+            },
+            hover: {
+                backgroundColour: '#E5E5E5',
+                textColour: brand[400],
+            },
+            theme: 'brand',
+        },
+        highlightedTextSettings: {
+            textColour: neutral[0],
+            highlightColour: brandAlt[400],
+        },
+        choiceCards: true,
+        bannerId: 'global-new-year-banner',
+    }),
+    'global-new-year-banner',
+);
+
+const BannerWithChoiceCardsTemplate: Story<BannerProps> = (props: BannerProps) => (
+    <BannerWithChoiceCards
+        {...props}
+        choiceCardAmounts={{
+            testName: 'Storybook_test',
+            variantName: 'Control',
+            amounts: {
+                ONE_OFF: {
+                    amounts: [5, 10, 15, 20],
+                    defaultAmount: 5,
+                    hideChooseYourAmount: false,
+                },
+                MONTHLY: {
+                    amounts: [3, 6, 10],
+                    defaultAmount: 10,
+                    hideChooseYourAmount: true,
+                },
+                ANNUAL: {
+                    amounts: [100],
+                    defaultAmount: 100,
+                    hideChooseYourAmount: true,
+                },
+            },
+        }}
+    />
+);
+
+export const WithChoiceCards = BannerWithChoiceCardsTemplate.bind({});
+WithChoiceCards.args = {
+    ...props,
+    content: {
+        heading: 'Show your support for reader-funded journalism',
+        messageText:
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations. We do not shy away. And we provide all this for free, for everyone.',
+        paragraphs: [
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations.',
+            'We do not shy away. And we provide all this for free, for everyone.',
+        ],
+        highlightedText:
+            'Show your support today from just %%CURRENCY_SYMBOL%%1, or sustain us long term with a little more. Thank you.',
+        cta: {
+            text: 'Support once',
+            baseUrl: 'https://support.theguardian.com/contribute/one-off',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Support monthly',
+                baseUrl: 'https://support.theguardian.com/contribute/recurring',
+            },
+        },
+    },
+    mobileContent: {
+        heading: 'Show your support for reader-funded journalism',
+        messageText:
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations. We do not shy away. And we provide all this for free, for everyone.',
+        paragraphs: [
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations.',
+            'We do not shy away. And we provide all this for free, for everyone.',
+        ],
+        highlightedText:
+            'Show your support today from just %%CURRENCY_SYMBOL%%1, or sustain us long term with a little more. Thank you.',
+        cta: {
+            text: 'Support us',
+            baseUrl: 'https://support.theguardian.com/contribute/one-off',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Learn more',
+                baseUrl: 'https://support.theguardian.com/contribute/recurring',
+            },
+        },
+    },
+    numArticles: 50,
+    tickerSettings: undefined,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -139,16 +139,18 @@ export function getMomentTemplateBanner(
                             />
                         )}
 
-                        <section css={styles.ctasContainer}>
-                            <MomentTemplateBannerCtas
-                                mainOrMobileContent={mainOrMobileContent}
-                                onPrimaryCtaClick={onCtaClick}
-                                onSecondaryCtaClick={onSecondaryCtaClick}
-                                onReminderCtaClick={onReminderCtaClick}
-                                primaryCtaSettings={templateSettings.primaryCtaSettings}
-                                secondaryCtaSettings={templateSettings.secondaryCtaSettings}
-                            />
-                        </section>
+                        {!templateSettings.choiceCards && (
+                            <section css={styles.ctasContainer}>
+                                <MomentTemplateBannerCtas
+                                    mainOrMobileContent={mainOrMobileContent}
+                                    onPrimaryCtaClick={onCtaClick}
+                                    onSecondaryCtaClick={onSecondaryCtaClick}
+                                    onReminderCtaClick={onReminderCtaClick}
+                                    primaryCtaSettings={templateSettings.primaryCtaSettings}
+                                    secondaryCtaSettings={templateSettings.secondaryCtaSettings}
+                                />
+                            </section>
+                        )}
                     </div>
                 </Container>
 

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -212,7 +212,6 @@ const styles = {
     `,
     bannerVisualContainer: (background: string, isChoiceCardsContainer?: boolean) => css`
         display: none;
-        pointer-events: none;
 
         ${from.mobileMedium} {
             display: block;
@@ -243,13 +242,14 @@ const styles = {
 
         ${isChoiceCardsContainer
             ? `
-            ${from.tablet} {
-                display: flex;
-                align-items: center;
-                width: 350px;
-            }
-        `
-            : ''}
+        ${from.tablet} {
+            display: flex;
+            align-items: center;
+            width: 350px;
+        }
+    `
+            : `pointer-events: none;
+        `}
     `,
     contentContainer: css`
         ${from.tablet} {

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -17,11 +17,16 @@ import MomentTemplateBannerTicker from './components/MomentTemplateBannerTicker'
 import { bannerSpacing } from './styles/templateStyles';
 import useReminder from '../../../hooks/useReminder';
 import useMediaQuery from '../../../hooks/useMediaQuery';
+import useChoiceCards from '../../../hooks/useChoiceCards';
+import { ChoiceCards } from '../choiceCardsBanner/components/ChoiceCards';
 
 export function getMomentTemplateBanner(
     templateSettings: BannerTemplateSettings,
 ): React.FC<BannerRenderProps> {
-    const hasVisual = templateSettings.imageSettings || templateSettings.alternativeVisual;
+    const hasVisual =
+        templateSettings.imageSettings ||
+        templateSettings.alternativeVisual ||
+        templateSettings.choiceCards;
 
     function MomentTemplateBanner({
         content,
@@ -32,6 +37,10 @@ export function getMomentTemplateBanner(
         reminderTracking,
         separateArticleCount,
         tickerSettings,
+        choiceCardAmounts,
+        countryCode,
+        submitComponentEvent,
+        tracking,
     }: BannerRenderProps): JSX.Element {
         const { isReminderActive, onReminderCtaClick, mobileReminderRef } = useReminder(
             reminderTracking,
@@ -39,9 +48,17 @@ export function getMomentTemplateBanner(
         const isTabletOrAbove = useMediaQuery(from.tablet);
         const mainOrMobileContent = isTabletOrAbove ? content.mainContent : content.mobileContent;
 
+        const {
+            choiceCardSelection,
+            setChoiceCardSelection,
+            getCtaText,
+            currencySymbol,
+        } = useChoiceCards(choiceCardAmounts, countryCode);
+        const showChoiceCards = !!(templateSettings.choiceCards && choiceCardAmounts?.amounts);
+
         return (
             <div css={styles.outerContainer(templateSettings.containerSettings.backgroundColour)}>
-                <Container cssOverrides={styles.containerOverrides}>
+                <Container cssOverrides={styles.containerOverrides(templateSettings.choiceCards)}>
                     <div css={styles.closeButtonContainer}>
                         <MomentTemplateBannerCloseButton
                             onCloseClick={onCloseClick}
@@ -53,6 +70,7 @@ export function getMomentTemplateBanner(
                         <div
                             css={styles.bannerVisualContainer(
                                 templateSettings.containerSettings.backgroundColour,
+                                templateSettings.choiceCards,
                             )}
                         >
                             {templateSettings.imageSettings && (
@@ -62,6 +80,23 @@ export function getMomentTemplateBanner(
                                 />
                             )}
                             {templateSettings.alternativeVisual}
+                            {showChoiceCards && (
+                                <ChoiceCards
+                                    setSelectionsCallback={setChoiceCardSelection}
+                                    selection={choiceCardSelection}
+                                    submitComponentEvent={submitComponentEvent}
+                                    currencySymbol={currencySymbol}
+                                    componentId={'choice-cards-banner-blue'}
+                                    amounts={choiceCardAmounts.amounts}
+                                    amountsTestName={choiceCardAmounts?.testName}
+                                    amountsVariantName={choiceCardAmounts?.variantName}
+                                    countryCode={countryCode}
+                                    bannerTracking={tracking}
+                                    numArticles={numArticles}
+                                    content={content}
+                                    getCtaText={getCtaText}
+                                />
+                            )}
                         </div>
                     )}
 
@@ -71,6 +106,7 @@ export function getMomentTemplateBanner(
                                 templateSettings.containerSettings.backgroundColour,
                                 content.mobileContent.secondaryCta?.type ===
                                     SecondaryCtaType.ContributionsReminder,
+                                templateSettings.choiceCards,
                             )}
                         >
                             <MomentTemplateBannerHeader
@@ -149,7 +185,7 @@ const styles = {
             border-top: 1px solid ${neutral[0]};
         }
     `,
-    containerOverrides: css`
+    containerOverrides: (isChoiceCardsContainer?: boolean) => css`
         ${from.tablet} {
             position: relative;
             width: 100%;
@@ -161,6 +197,10 @@ const styles = {
             display: flex;
             flex-direction: column;
 
+            ${isChoiceCardsContainer
+                ? 'flex-direction: column-reverse;'
+                : 'flex-direction: column;'}
+
             ${from.tablet} {
                 flex-direction: row-reverse;
             }
@@ -168,7 +208,7 @@ const styles = {
 
         ${bannerSpacing.heading};
     `,
-    bannerVisualContainer: (background: string) => css`
+    bannerVisualContainer: (background: string, isChoiceCardsContainer?: boolean) => css`
         display: none;
         pointer-events: none;
 
@@ -198,6 +238,16 @@ const styles = {
             width: 370px;
             margin-left: ${space[9]}px;
         }
+
+        ${isChoiceCardsContainer
+            ? `
+            ${from.tablet} {
+                display: flex;
+                align-items: center;
+                width: 350px;
+            }
+        `
+            : ''}
     `,
     contentContainer: css`
         ${from.tablet} {
@@ -213,7 +263,7 @@ const styles = {
             width: 780px;
         }
     `,
-    headerContainer: (background: string, hasReminderCta: boolean) => css`
+    headerContainer: (background: string, hasReminderCta: boolean, choiceCards?: boolean) => css`
         max-width: calc(100% - 46px); // 46px approx close button size
         ${bannerSpacing.heading};
 
@@ -225,7 +275,7 @@ const styles = {
             // Mobile Sticky Header Styles
             background: ${background};
             position: sticky;
-            top: 140px; // 140px for banner visual
+            top: ${choiceCards ? '0px' : '140px'}; // 140px for banner visual
             z-index: 100;
             ${hasReminderCta
                 ? `

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
@@ -22,7 +22,13 @@ export function MomentTemplateBannerHeader({
     return (
         <div css={styles.container}>
             <header css={styles.header(headerSettings)}>
-                <h2>{isTabletOrAbove ? heading : mobileHeading}</h2>
+                <h2>
+                    {headerSettings?.image
+                        ? headerSettings.image
+                        : isTabletOrAbove
+                        ? heading
+                        : mobileHeading}
+                </h2>
             </header>
         </div>
     );

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -48,6 +48,7 @@ export interface BannerTemplateSettings {
     articleCountTextColour?: string;
     imageSettings?: Image;
     alternativeVisual?: ReactNode;
+    choiceCards?: boolean;
     bannerId?: BannerId;
     tickerStylingSettings?: TickerStylingSettings;
     headerSettings?: HeaderSettings;

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -35,6 +35,7 @@ export interface TickerStylingSettings {
 
 export interface HeaderSettings {
     textColour: string;
+    image?: ReactNode;
 }
 
 export interface BannerTemplateSettings {

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/Button.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from '@emotion/react';
+import { SerializedStyles, css } from '@emotion/react';
 import { palette } from '@guardian/src-foundations';
 import { ThemeProvider } from '@emotion/react';
 import { Button as DSButton, LinkButton } from '@guardian/src-button';
@@ -35,6 +35,7 @@ type Props = {
     priority?: 'primary' | 'secondary';
     showArrow?: boolean;
     isTertiary?: boolean;
+    cssOverrides: SerializedStyles | SerializedStyles[] | undefined;
 };
 
 // Overrides for tertiary button
@@ -55,6 +56,7 @@ export const Button: React.FC<Props> = (allProps: Props) => {
         showArrow = false,
         priority = 'primary',
         isTertiary,
+        cssOverrides,
         ...props
     } = allProps;
 
@@ -72,6 +74,7 @@ export const Button: React.FC<Props> = (allProps: Props) => {
                     rel="noopener noreferrer"
                     priority={isTertiary ? 'primary' : priority}
                     css={isTertiary ? tertiaryButtonOverrides : undefined}
+                    cssOverrides={cssOverrides}
                     {...props}
                 >
                     {children}
@@ -87,6 +90,7 @@ export const Button: React.FC<Props> = (allProps: Props) => {
                 onClick={(): void => onClickAction()}
                 priority={isTertiary ? 'primary' : priority}
                 css={isTertiary ? tertiaryButtonOverrides : undefined}
+                cssOverrides={cssOverrides}
                 {...props}
             >
                 {children}

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/ChoiceCardAmountButtons.tsx
@@ -6,7 +6,7 @@ import {
     OphanComponentEvent,
 } from '@sdc/shared/dist/types';
 import { ContributionType, trackClick } from './FrequencyTabs';
-import { css } from '@emotion/react';
+import { SerializedStyles, css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
 import { between, from, until } from '@guardian/src-foundations/mq';
 import { ChoiceCardSelection } from '../WorldPressFreedomDayBanner';
@@ -67,12 +67,14 @@ const ChoiceCardAmount = ({
     label,
     checked,
     handleUpdateAmount,
+    cssOverrides
 }: {
     id: string;
     amount?: number;
     label: string;
     checked: boolean;
     handleUpdateAmount: (amount: number | 'other') => void;
+    cssOverrides: SerializedStyles
 }) => {
     if (amount) {
         return (
@@ -141,7 +143,7 @@ export const ChoiceCardAmountButtons = ({
             label={`${currencySymbol}${amount} ${contributionType[selection.frequency].suffix}`}
             checked={selection.amount === amount}
             handleUpdateAmount={() => handleUpdateAmount(amount)}
-            css={supporterPlusChoiceCardAmountOverrides}
+            cssOverrides={supporterPlusChoiceCardAmountOverrides}
         />
     ));
 

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/ChoiceCardAmountButtons.tsx
@@ -67,14 +67,14 @@ const ChoiceCardAmount = ({
     label,
     checked,
     handleUpdateAmount,
-    cssOverrides
+    cssOverrides,
 }: {
     id: string;
     amount?: number;
     label: string;
     checked: boolean;
     handleUpdateAmount: (amount: number | 'other') => void;
-    cssOverrides: SerializedStyles
+    cssOverrides: SerializedStyles;
 }) => {
     if (amount) {
         return (
@@ -86,6 +86,7 @@ const ChoiceCardAmount = ({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     e.target.id === id ? handleUpdateAmount(amount) : null
                 }
+                cssOverrides={cssOverrides}
             />
         );
     }

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/SupportCta.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/SupportCta.tsx
@@ -57,7 +57,7 @@ export const SupportCta = ({
                     onClickAction={supportUrl}
                     showArrow
                     data-ignore="global-link-styling"
-                    css={[buttonOverrides, cssOverrides]}
+                    cssOverrides={[buttonOverrides, cssOverrides ?? css``]}
                 >
                     {mobileText}
                 </Button>
@@ -68,7 +68,7 @@ export const SupportCta = ({
                     onClickAction={supportUrl}
                     showArrow
                     data-ignore="global-link-styling"
-                    css={[buttonOverrides, cssOverrides]}
+                    cssOverrides={[buttonOverrides, cssOverrides ?? css``]}
                 >
                     {desktopText}
                 </Button>


### PR DESCRIPTION
## What does this change?
Following https://github.com/guardian/support-dotcom-components/pull/901 this adds an optional header image and the choice cards component to the moment template banner.

| With Header Image | With Choice Cards |
| -- | -- |
| <img width="1113" alt="Screenshot 2023-05-22 at 15 42 38" src="https://github.com/guardian/support-dotcom-components/assets/44685872/a2a8e831-c707-4605-8d62-03b790dc2060"> | <img width="1115" alt="Screenshot 2023-05-22 at 15 42 57" src="https://github.com/guardian/support-dotcom-components/assets/44685872/b8d9142a-0076-45ea-b723-42ecb3291843"> |

When the choice cards are added to the template, the banner ctas willl be removed. This follows the functionality of the existing ~~moment template~~ choice cards banner.
