### PR TITLE
Update moment template close button

### DIFF
--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -14,7 +14,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { MomentTemplateBannerReminder } from './components/MomentTemplateBannerReminder';
 import MomentTemplateBannerTicker from './components/MomentTemplateBannerTicker';
-import { bannerSpacing } from './styles/templateStyles';
+import { templateSpacing } from './styles/templateStyles';
 import useReminder from '../../../hooks/useReminder';
 import useMediaQuery from '../../../hooks/useMediaQuery';
 import useChoiceCards from '../../../hooks/useChoiceCards';
@@ -208,7 +208,7 @@ const styles = {
             }
         }
 
-        ${bannerSpacing.heading};
+        ${templateSpacing.heading};
     `,
     bannerVisualContainer: (background: string, isChoiceCardsContainer?: boolean) => css`
         display: none;
@@ -267,7 +267,7 @@ const styles = {
     `,
     headerContainer: (background: string, hasReminderCta: boolean, choiceCards?: boolean) => css`
         max-width: calc(100% - 46px); // 46px approx close button size
-        ${bannerSpacing.heading};
+        ${templateSpacing.heading};
 
         ${from.mobileMedium} {
             max-width: initial;
@@ -296,7 +296,7 @@ const styles = {
         }
     `,
     bodyContainer: css`
-        ${bannerSpacing.bodyCopyAndArticleCount}
+        ${templateSpacing.bodyCopyAndArticleCount}
     `,
     ctasContainer: css`
         display: flex;

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -8,8 +8,6 @@ import { SvgRoundelBrand, SvgRoundelDefault } from '@guardian/src-brand';
 import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
-// ---- Component ---- //
-
 interface MomentTemplateBannerCloseButtonProps {
     onCloseClick: () => void;
     settings: CtaSettings;
@@ -31,7 +29,7 @@ export function MomentTemplateBannerCloseButton({
 
             <Button
                 onClick={onCloseClick}
-                cssOverrides={buttonStyles(settings)}
+                cssOverrides={buttonStyles(settings, styles.closeButtonOverrides)}
                 icon={<SvgCross />}
                 size="small"
                 hideLabel
@@ -42,8 +40,6 @@ export function MomentTemplateBannerCloseButton({
     );
 }
 
-// ---- Styles ---- //
-
 const styles = {
     container: css`
         display: flex;
@@ -53,10 +49,11 @@ const styles = {
     `,
     roundelContainer: css`
         display: none;
-        height: 36px;
+        height: 40px;
 
         svg {
-            height: 100%;
+            height: 40px;
+            width: 40px;
         }
 
         ${from.tablet} {
@@ -64,4 +61,9 @@ const styles = {
             margin-right: ${space[2]}px;
         }
     `,
+    closeButtonOverrides: css`
+        height: 40px;
+        min-height: 40px;
+        width: 40px;
+        min-width: 40px;`
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -65,5 +65,6 @@ const styles = {
         height: 40px;
         min-height: 40px;
         width: 40px;
-        min-width: 40px;`
+        min-width: 40px;
+    `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
@@ -7,7 +7,7 @@ import useTicker from '../../../../hooks/useTicker';
 import { from } from '@guardian/src-foundations/mq';
 import { TickerStylingSettings } from '../settings';
 import { space } from '@guardian/src-foundations';
-import { bannerSpacing } from '../styles/templateStyles';
+import { templateSpacing } from '../styles/templateStyles';
 
 const progressBarHeight = 12;
 const tickerFillOffset = 15;
@@ -16,7 +16,7 @@ const overFilledTickerOffset = 10;
 const styles = {
     containerStyles: css`
         position: relative;
-        ${bannerSpacing.ticker}
+        ${templateSpacing.tickerContainer}
     `,
     tickerLabelsContainer: css`
         display: flex;

--- a/packages/modules/src/modules/banners/momentTemplate/styles/buttonStyles.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/styles/buttonStyles.ts
@@ -2,7 +2,10 @@ import { css, SerializedStyles } from '@emotion/react';
 import { from, until } from '@guardian/src-foundations/mq';
 import { CtaSettings } from '../settings';
 
-export function buttonStyles(settings: CtaSettings, cssOverrides?: SerializedStyles): SerializedStyles {
+export function buttonStyles(
+    settings: CtaSettings,
+    cssOverrides?: SerializedStyles,
+): SerializedStyles {
     const { default: defaultSettings, mobile, desktop, hover } = settings;
 
     return css`

--- a/packages/modules/src/modules/banners/momentTemplate/styles/buttonStyles.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/styles/buttonStyles.ts
@@ -2,7 +2,7 @@ import { css, SerializedStyles } from '@emotion/react';
 import { from, until } from '@guardian/src-foundations/mq';
 import { CtaSettings } from '../settings';
 
-export function buttonStyles(settings: CtaSettings): SerializedStyles {
+export function buttonStyles(settings: CtaSettings, cssOverrides?: SerializedStyles): SerializedStyles {
     const { default: defaultSettings, mobile, desktop, hover } = settings;
 
     return css`
@@ -19,6 +19,8 @@ export function buttonStyles(settings: CtaSettings): SerializedStyles {
         &:hover {
             ${toCssString(hover)}
         }
+
+        ${cssOverrides};
     `;
 }
 

--- a/packages/modules/src/modules/banners/momentTemplate/styles/templateStyles.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/styles/templateStyles.ts
@@ -4,7 +4,7 @@ import { from, until } from '@guardian/src-foundations/mq';
 
 // WIP - Any styling changes made to base moment template styling here should be reviewed by a designer!
 
-export const bannerSpacing = {
+const templateSpacing = {
     heading: css`
         ${until.mobileMedium} {
             padding-top: 10px;
@@ -34,7 +34,7 @@ export const bannerSpacing = {
     `,
     // bannerVisual: {
     // },
-    ticker: css`
+    tickerContainer: css`
         ${until.tablet} {
             margin-bottom: ${space[4]}px;
         }
@@ -45,3 +45,7 @@ export const bannerSpacing = {
     // bannerCtas: {
     // },
 };
+
+// const template
+
+export {templateSpacing}

--- a/packages/modules/src/modules/banners/momentTemplate/styles/templateStyles.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/styles/templateStyles.ts
@@ -46,6 +46,4 @@ const templateSpacing = {
     // },
 };
 
-// const template
-
-export {templateSpacing}
+export { templateSpacing };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This updates the moment template close button in line with the design guidelines. 
This enlarges the button from 36px to 40px for improved a11y. 

## Images
<img width="755" alt="Screenshot 2023-06-05 at 10 48 17" src="https://github.com/guardian/support-dotcom-components/assets/44685872/363f44f7-b627-4581-9c69-8414bcced532">
