### PR TITLE
Test of scroll depth render delay for banners - animation

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -106,7 +106,7 @@ const withBannerData = (
 
     useScrollDepth(
         depthPercent => {
-            if (depthPercent > 25) {
+            if (depthPercent > 5) {
                 setCanShow(true);
             }
         },

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -84,7 +84,7 @@ const withBannerData = (
         choiceCardAmounts,
     } = bannerProps;
 
-    const [startAnimation, setStartAnimation] = useState<boolean>(false);
+    const [canShow, setCanShow] = useState<boolean>(false);
     const [hasBeenSeen, setNode] = useHasBeenSeen(
         {
             threshold: 0,
@@ -108,7 +108,7 @@ const withBannerData = (
     useScrollDepth(
         depthPercent => {
             if (depthPercent > 25) {
-                setStartAnimation(true);
+                setCanShow(true);
             }
         },
         [],
@@ -250,7 +250,7 @@ const withBannerData = (
         const renderedContent = content && buildRenderedContent(content);
         const renderedMobileContent = mobileContent && buildRenderedContent(mobileContent);
 
-        if (renderedContent && startAnimation) {
+        if (renderedContent && canShow) {
             const props: BannerRenderProps = {
                 onCtaClick,
                 onSecondaryCtaClick,
@@ -279,7 +279,7 @@ const withBannerData = (
 
             return (
                 <SlideIn
-                    startAnimation={startAnimation}
+                    canShow={canShow}
                     bannerRefClientHeight={slideInRef.current && slideInRef.current.clientHeight}
                 >
                     <div ref={setNode}>

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -33,7 +33,7 @@ import { withParsedProps } from '../../shared/ModuleWrapper';
 import { HasBeenSeen, useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import { getReminderFields } from '@sdc/shared/dist/lib';
 import { useScrollDepth } from '../../../hooks/useScrollDepth';
-import FadeIn from './FadeIn';
+import SlideIn from './SlideIn';
 
 // A separate article count is rendered as a subheading
 const buildSubheading = (
@@ -277,11 +277,11 @@ const withBannerData = (
             };
 
             return (
-                <FadeIn canShow={canShow}>
+                <SlideIn canShow={canShow}>
                     <div ref={setNode}>
                         <Banner {...props} />
                     </div>
-                </FadeIn>
+                </SlideIn>
             );
         }
     } catch (err) {

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -6,7 +6,7 @@ import {
     createViewEventFromTracking,
     isProfileUrl,
 } from '@sdc/shared/lib';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
     BannerContent,
     BannerProps,
@@ -33,6 +33,7 @@ import { withParsedProps } from '../../shared/ModuleWrapper';
 import { HasBeenSeen, useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import { getReminderFields } from '@sdc/shared/dist/lib';
 import { useScrollDepth } from '../../../hooks/useScrollDepth';
+import SlideIn from './SlideIn';
 
 // A separate article count is rendered as a subheading
 const buildSubheading = (
@@ -83,13 +84,14 @@ const withBannerData = (
         choiceCardAmounts,
     } = bannerProps;
 
-    const [canShow, setCanShow] = useState<boolean>(false);
+    const [startAnimation, setStartAnimation] = useState<boolean>(false);
     const [hasBeenSeen, setNode] = useHasBeenSeen(
         {
             threshold: 0,
         },
         true,
     ) as HasBeenSeen;
+    const slideInRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (hasBeenSeen && submitComponentEvent) {
@@ -106,7 +108,7 @@ const withBannerData = (
     useScrollDepth(
         depthPercent => {
             if (depthPercent > 25) {
-                setCanShow(true);
+                setStartAnimation(true);
             }
         },
         [],
@@ -248,7 +250,7 @@ const withBannerData = (
         const renderedContent = content && buildRenderedContent(content);
         const renderedMobileContent = mobileContent && buildRenderedContent(mobileContent);
 
-        if (renderedContent && canShow) {
+        if (renderedContent && startAnimation) {
             const props: BannerRenderProps = {
                 onCtaClick,
                 onSecondaryCtaClick,
@@ -276,9 +278,14 @@ const withBannerData = (
             };
 
             return (
-                <div ref={setNode}>
-                    <Banner {...props} />
-                </div>
+                <SlideIn
+                    startAnimation={startAnimation}
+                    bannerRefClientHeight={slideInRef.current && slideInRef.current.clientHeight}
+                >
+                    <div ref={setNode}>
+                        <Banner {...props} />
+                    </div>
+                </SlideIn>
             );
         }
     } catch (err) {

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -33,7 +33,7 @@ import { withParsedProps } from '../../shared/ModuleWrapper';
 import { HasBeenSeen, useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import { getReminderFields } from '@sdc/shared/dist/lib';
 import { useScrollDepth } from '../../../hooks/useScrollDepth';
-import SlideIn from './SlideIn';
+import FadeIn from './SlideIn';
 
 // A separate article count is rendered as a subheading
 const buildSubheading = (
@@ -91,7 +91,6 @@ const withBannerData = (
         },
         true,
     ) as HasBeenSeen;
-    // const slideInRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (hasBeenSeen && submitComponentEvent) {
@@ -278,14 +277,13 @@ const withBannerData = (
             };
 
             return (
-                <SlideIn
+                <FadeIn
                     canShow={canShow}
-                    // bannerRefClientHeight={slideInRef.current && slideInRef.current.clientHeight}
                 >
                     <div ref={setNode}>
                         <Banner {...props} />
                     </div>
-                </SlideIn>
+                </FadeIn>
             );
         }
     } catch (err) {

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -6,7 +6,7 @@ import {
     createViewEventFromTracking,
     isProfileUrl,
 } from '@sdc/shared/lib';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
     BannerContent,
     BannerProps,
@@ -91,7 +91,7 @@ const withBannerData = (
         },
         true,
     ) as HasBeenSeen;
-    const slideInRef = useRef<HTMLDivElement>(null);
+    // const slideInRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (hasBeenSeen && submitComponentEvent) {
@@ -280,7 +280,7 @@ const withBannerData = (
             return (
                 <SlideIn
                     canShow={canShow}
-                    bannerRefClientHeight={slideInRef.current && slideInRef.current.clientHeight}
+                    // bannerRefClientHeight={slideInRef.current && slideInRef.current.clientHeight}
                 >
                     <div ref={setNode}>
                         <Banner {...props} />

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -33,7 +33,7 @@ import { withParsedProps } from '../../shared/ModuleWrapper';
 import { HasBeenSeen, useHasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import { getReminderFields } from '@sdc/shared/dist/lib';
 import { useScrollDepth } from '../../../hooks/useScrollDepth';
-import FadeIn from './SlideIn';
+import FadeIn from './FadeIn';
 
 // A separate article count is rendered as a subheading
 const buildSubheading = (
@@ -277,9 +277,7 @@ const withBannerData = (
             };
 
             return (
-                <FadeIn
-                    canShow={canShow}
-                >
+                <FadeIn canShow={canShow}>
                     <div ref={setNode}>
                         <Banner {...props} />
                     </div>

--- a/packages/modules/src/modules/banners/common/FadeIn.tsx
+++ b/packages/modules/src/modules/banners/common/FadeIn.tsx
@@ -4,8 +4,7 @@ import { css } from '@emotion/react';
 const FadeIn = ({
     children,
     canShow,
-}:
-{
+}: {
     children: JSX.Element;
     canShow: boolean;
 }): JSX.Element => {

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -12,8 +12,6 @@ const SlideIn = ({
 
     canShow && setTimeout(() => setStartAnimation(true), 2000);
 
-    console.log('startAnimation: ', startAnimation);
-
     const slideInAnimation = css`
         transform: ${startAnimation ? 'translateY(0%)' : 'translateY(100%)'};
         transition-property: transform;

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+const SlideIn = ({
+    children,
+    startAnimation,
+    bannerRefClientHeight,
+}: {
+    children: JSX.Element;
+    startAnimation: boolean;
+    bannerRefClientHeight: number | null;
+}): JSX.Element => {
+    const slideInAnimation = css`
+        margin-bottom: ${startAnimation ? `-${bannerRefClientHeight}` : '0'}px;
+        opacity: ${startAnimation ? '1' : '0'};
+        transition-property: margin-bottom, opacity;
+        transition-duration: 2s;
+    `;
+
+    return <div css={slideInAnimation}>{children}</div>;
+};
+
+export default SlideIn;

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
-const FadeIn = ({
+const SlideIn = ({
     children,
     canShow,
 }: {
@@ -12,13 +12,16 @@ const FadeIn = ({
 
     canShow && setTimeout(() => setStartAnimation(true), 2000);
 
+    console.log('startAnimation: ', startAnimation);
+
     const slideInAnimation = css`
-        opacity: ${startAnimation ? '1' : '0'};
-        transition-property: opacity;
+        transform: ${startAnimation ? 'translateY(0px)' : 'translateY(1000px)'};
+        transition-property: transform;
         transition-duration: 2s;
     `;
 
     return <div css={slideInAnimation}>{children}</div>;
 };
 
-export default FadeIn;
+export default SlideIn;
+

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -14,7 +14,7 @@ const SlideIn = ({
         margin-bottom: ${startAnimation ? `-${bannerRefClientHeight}` : '0'}px;
         opacity: ${startAnimation ? '1' : '0'};
         transition-property: margin-bottom, opacity;
-        transition-duration: 2s;
+        transition-duration: 6s;
     `;
 
     return <div css={slideInAnimation}>{children}</div>;

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
-const SlideIn = ({
+const FadeIn = ({
     children,
     canShow,
-}: // bannerRefClientHeight,
+}:
 {
     children: JSX.Element;
     canShow: boolean;
-    // bannerRefClientHeight: number | null;
 }): JSX.Element => {
     const [startAnimation, setStartAnimation] = useState(false);
 
@@ -23,4 +22,4 @@ const SlideIn = ({
     return <div css={slideInAnimation}>{children}</div>;
 };
 
-export default SlideIn;
+export default FadeIn;

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -17,7 +17,7 @@ const SlideIn = ({
     const slideInAnimation = css`
         transform: ${startAnimation ? 'translateY(0px)' : 'translateY(1000px)'};
         transition-property: transform;
-        transition-duration: 2s;
+        transition-duration: 0.25s;
     `;
 
     return <div css={slideInAnimation}>{children}</div>;

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -17,7 +17,7 @@ const SlideIn = ({
     const slideInAnimation = css`
         transform: ${startAnimation ? 'translateY(0px)' : 'translateY(1000px)'};
         transition-property: transform;
-        transition-duration: 0.25s;
+        transition-duration: 0.75s;
     `;
 
     return <div css={slideInAnimation}>{children}</div>;

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -1,20 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
 const SlideIn = ({
     children,
-    startAnimation,
+    canShow,
     bannerRefClientHeight,
 }: {
     children: JSX.Element;
-    startAnimation: boolean;
+    canShow: boolean;
     bannerRefClientHeight: number | null;
 }): JSX.Element => {
+    const [startAnimation, setStartAnimation] = useState(false);
+
+    canShow && setTimeout(() => setStartAnimation(true) , 2000);
+
     const slideInAnimation = css`
         margin-bottom: ${startAnimation ? `-${bannerRefClientHeight}` : '0'}px;
-        opacity: ${startAnimation ? '1' : '0'};
-        transition-property: margin-bottom, opacity;
-        transition-duration: 6s;
+        transition-property: margin-bottom;
+        transition-duration: 2s;
     `;
 
     return <div css={slideInAnimation}>{children}</div>;

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -24,4 +24,3 @@ const SlideIn = ({
 };
 
 export default SlideIn;
-

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -12,7 +12,7 @@ const SlideIn = ({
 }): JSX.Element => {
     const [startAnimation, setStartAnimation] = useState(false);
 
-    canShow && setTimeout(() => setStartAnimation(true) , 2000);
+    canShow && setTimeout(() => setStartAnimation(true), 2000);
 
     const slideInAnimation = css`
         margin-bottom: ${startAnimation ? `-${bannerRefClientHeight}` : '0'}px;

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -4,19 +4,19 @@ import { css } from '@emotion/react';
 const SlideIn = ({
     children,
     canShow,
-    bannerRefClientHeight,
-}: {
+}: // bannerRefClientHeight,
+{
     children: JSX.Element;
     canShow: boolean;
-    bannerRefClientHeight: number | null;
+    // bannerRefClientHeight: number | null;
 }): JSX.Element => {
     const [startAnimation, setStartAnimation] = useState(false);
 
     canShow && setTimeout(() => setStartAnimation(true), 2000);
 
     const slideInAnimation = css`
-        margin-bottom: ${startAnimation ? `-${bannerRefClientHeight}` : '0'}px;
-        transition-property: margin-bottom;
+        opacity: ${startAnimation ? '1' : '0'};
+        transition-property: opacity;
         transition-duration: 2s;
     `;
 

--- a/packages/modules/src/modules/banners/common/SlideIn.tsx
+++ b/packages/modules/src/modules/banners/common/SlideIn.tsx
@@ -15,7 +15,7 @@ const SlideIn = ({
     console.log('startAnimation: ', startAnimation);
 
     const slideInAnimation = css`
-        transform: ${startAnimation ? 'translateY(0px)' : 'translateY(1000px)'};
+        transform: ${startAnimation ? 'translateY(0%)' : 'translateY(100%)'};
         transition-property: transform;
         transition-duration: 0.75s;
     `;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds a fade-in animation to the render delay banner branch

## How to test
- Deploy this branch to CODE
- On the web preview scroll to at least 25% down the page

## How can we measure success?
The banner fades in as expected, instead of appearing immediately

## Have we considered potential risks?
The current implementation has an unintended side effect on the "live preview" of banners in the RRCP. 
