### PR TITLE
US supreme Court 2023 moment banner

### DIFF
--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -31,6 +31,7 @@ export type BannerId =
     | 'us-eoy-banner-v3'
     | 'aus-eoy-banner'
     | 'ukraine-moment-banner'
+    | 'scotus-2023-moment-banner'
     | 'wpfd-banner';
 
 export interface BannerEnrichedCta {

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -178,9 +178,9 @@ export function getMomentTemplateBanner(
 }
 
 const styles = {
-    outerContainer: (background: string, copyColor: string = 'inherit') => css`
+    outerContainer: (background: string, textColor: string = 'inherit') => css`
         background: ${background};
-        color: ${copyColor};
+        color: ${textColor};
         max-height: 100vh;
         overflow: auto;
 

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -57,7 +57,12 @@ export function getMomentTemplateBanner(
         const showChoiceCards = !!(templateSettings.choiceCards && choiceCardAmounts?.amounts);
 
         return (
-            <div css={styles.outerContainer(templateSettings.containerSettings.backgroundColour)}>
+            <div
+                css={styles.outerContainer(
+                    templateSettings.containerSettings.backgroundColour,
+                    templateSettings.containerSettings.textColor,
+                )}
+            >
                 <Container cssOverrides={styles.containerOverrides(templateSettings.choiceCards)}>
                     <div css={styles.closeButtonContainer}>
                         <MomentTemplateBannerCloseButton
@@ -120,7 +125,6 @@ export function getMomentTemplateBanner(
                             <MomentTemplateBannerArticleCount
                                 numArticles={numArticles}
                                 settings={templateSettings}
-                                textColour={templateSettings.articleCountTextColour}
                             />
                         )}
 
@@ -174,8 +178,9 @@ export function getMomentTemplateBanner(
 }
 
 const styles = {
-    outerContainer: (background: string) => css`
+    outerContainer: (background: string, copyColor: string = 'inherit') => css`
         background: ${background};
+        color: ${copyColor};
         max-height: 100vh;
         overflow: auto;
 

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { neutral } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { headline } from '@guardian/src-foundations/typography';
 import { MomentTemplateArticleCountOptOut } from './MomentTemplateBannerArticleCountOptOut';
@@ -11,16 +10,14 @@ import { BannerTemplateSettings } from '../settings';
 interface MomentTemplateBannerArticleCountProps {
     numArticles: number;
     settings: BannerTemplateSettings;
-    textColour?: string;
 }
 
 export function MomentTemplateBannerArticleCount({
     numArticles,
     settings,
-    textColour = neutral[0],
 }: MomentTemplateBannerArticleCountProps): JSX.Element {
     return (
-        <div css={styles.container(textColour)}>
+        <div css={styles.container(settings.articleCountTextColour)}>
             You&apos;ve read{' '}
             <MomentTemplateArticleCountOptOut
                 numArticles={numArticles}
@@ -35,7 +32,7 @@ export function MomentTemplateBannerArticleCount({
 // ---- Styles ---- //
 
 const styles = {
-    container: (textColor: string) => css`
+    container: (textColor: string = 'inherit') => css`
         ${headline.xxxsmall({ fontWeight: 'bold' })}
         font-size: 15px;
         color: ${textColor};

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
@@ -80,7 +80,12 @@ const Overlay: React.FC<OverlayProps> = ({
     settings,
 }: OverlayProps) => {
     return (
-        <div css={overlayStyles.overlayContainer(settings.containerSettings.backgroundColour)}>
+        <div
+            css={overlayStyles.overlayContainer(
+                settings.containerSettings.backgroundColour,
+                settings.articleCountTextColour,
+            )}
+        >
             <div css={overlayStyles.overlayHeader}>
                 <div css={overlayStyles.overlayHeaderText}>
                     {hasOptedOut ? "You've opted out" : "What's this?"}
@@ -126,7 +131,7 @@ const Overlay: React.FC<OverlayProps> = ({
                 </div>
             )}
 
-            <div css={overlayStyles.overlayNote}>
+            <div css={overlayStyles.overlayNote(settings.articleCountTextColour)}>
                 {hasOptedOut ? (
                     <span>
                         If you have any questions, please{' '}
@@ -177,13 +182,13 @@ const styles = {
 };
 
 const overlayStyles = {
-    overlayContainer: (backgroundColour: string) => css`
+    overlayContainer: (backgroundColour: string, textColour: string = neutral[0]) => css`
         ${textSans.medium()}
         padding: ${space[2]}px;
         background-color: ${backgroundColour};
-        border: 1px solid ${neutral[0]};
+        border: 1px solid ${textColour};
         box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
-        color: ${neutral[0]};
+        color: ${textColour};
         `,
     overlayHeader: css`
         display: flex;
@@ -213,13 +218,13 @@ const overlayStyles = {
             }
         }
     `,
-    overlayNote: css`
+    overlayNote: (textColour: string = neutral[0]) => css`
         margin-top: ${space[2]}px;
         ${textSans.xsmall()}
         font-style: italic;
 
         a {
-            color: ${neutral[0]} !important;
+            color: ${textColour} !important;
             text-decoration: underline !important;
         }
     `,

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { neutral } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { body } from '@guardian/src-foundations/typography';
 import { createBannerBodyCopy } from '../../common/BannerText';
@@ -39,7 +38,6 @@ export function MomentTemplateBannerBody({
 const getStyles = (settings: HighlightedTextSettings) => ({
     container: css`
         ${body.small()}
-        color: ${neutral[0]};
         font-size: 15px;
         line-height: 135%;
 

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -4,7 +4,7 @@ import { SvgCross } from '@guardian/src-icons';
 import { Button } from '@guardian/src-button';
 import { buttonStyles } from '../styles/buttonStyles';
 import { CtaSettings } from '../settings';
-import { SvgRoundelBrand, SvgRoundelDefault } from '@guardian/src-brand';
+import { SvgRoundelBrand, SvgRoundelDefault, SvgRoundelInverse } from '@guardian/src-brand';
 import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
@@ -17,15 +17,27 @@ export function MomentTemplateBannerCloseButton({
     onCloseClick,
     settings,
 }: MomentTemplateBannerCloseButtonProps): JSX.Element {
+    const { theme, guardianRoundel } = settings;
+
+    const getRoundel = () => {
+        if (guardianRoundel) {
+            if (guardianRoundel === 'brand') {
+                return <SvgRoundelBrand />;
+            }
+            if (guardianRoundel === 'inverse') {
+                return <SvgRoundelInverse />;
+            }
+            return <SvgRoundelDefault />;
+        }
+        if (theme && theme === 'brand') {
+            return <SvgRoundelBrand />;
+        }
+        return <SvgRoundelDefault />;
+    };
+
     return (
         <div css={styles.container}>
-            <div css={styles.roundelContainer}>
-                {settings.theme === 'default' || !settings.theme ? (
-                    <SvgRoundelDefault />
-                ) : (
-                    <SvgRoundelBrand />
-                )}
-            </div>
+            <div css={styles.roundelContainer}>{getRoundel()}</div>
 
             <Button
                 onClick={onCloseClick}

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -21,13 +21,14 @@ export function MomentTemplateBannerCloseButton({
 
     const getRoundel = () => {
         if (guardianRoundel) {
-            if (guardianRoundel === 'brand') {
-                return <SvgRoundelBrand />;
+            switch (guardianRoundel) {
+                case 'brand':
+                    return <SvgRoundelBrand />;
+                case 'inverse':
+                    return <SvgRoundelInverse />;
+                default:
+                    return <SvgRoundelDefault />;
             }
-            if (guardianRoundel === 'inverse') {
-                return <SvgRoundelInverse />;
-            }
-            return <SvgRoundelDefault />;
         }
         if (theme && theme === 'brand') {
             return <SvgRoundelBrand />;

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -4,6 +4,7 @@ import { BannerId } from '../common/types';
 
 export type ContainerSettings = {
     backgroundColour: string;
+    textColor?: string;
     paddingTop?: string;
 };
 
@@ -13,12 +14,16 @@ export type CtaStateSettings = {
     border?: string;
 };
 
+type GuardianRoundel = 'default' | 'brand' | 'inverse';
+type GuardianTheme = 'default' | 'brand';
+
 export interface CtaSettings {
     default: CtaStateSettings;
     hover: CtaStateSettings;
     mobile?: CtaStateSettings;
     desktop?: CtaStateSettings;
-    theme?: 'default' | 'brand';
+    theme?: GuardianTheme;
+    guardianRoundel?: GuardianRoundel;
 }
 
 export interface HighlightedTextSettings {

--- a/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.stories.tsx
@@ -62,17 +62,17 @@ const Scotus2023MomentBanner = bannerWrapper(
         articleCountTextColour: neutral[100],
         imageSettings: {
             mainUrl:
-                'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
+                'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/752_639_3258_1303/1000.jpg?width=500&quality=75&s=f19e815a62c8550748d9514d39298683',
             mobileUrl:
-                'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
+                'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/752_639_3258_1303/1000.jpg?width=500&quality=75&s=f19e815a62c8550748d9514d39298683',
             tabletUrl:
-                'https://i.guim.co.uk/img/media/4f2ec5867b1a111b78927547f2fdceb0066695f9/0_0_1024_920/500.png?width=500&quality=75&s=ef15b7ff812d997251a68b59a1b4279c',
+                'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/1400_406_1772_1773/1000.jpg?width=500&quality=75&s=16e4aebfcbad771ee40c9b6f9fd99056',
             desktopUrl:
-                'https://i.guim.co.uk/img/media/8d9128c93a61155e0b84f0eb229edd57951ee3ff/0_0_1280_1168/500.png?width=500&quality=75&s=0d8ff342ffc3005186903969b22a4674',
+                'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/1400_406_1772_1773/1000.jpg?width=500&quality=75&s=16e4aebfcbad771ee40c9b6f9fd99056',
             leftColUrl:
-                'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
+                'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/1395_636_1953_1302/1953.jpg?width=900&quality=75&s=133c6e21b3a43c57f91fd16ecbe942ec',
             wideUrl:
-                'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
+                'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/1395_636_1953_1302/1953.jpg?width=900&quality=75&s=133c6e21b3a43c57f91fd16ecbe942ec',
             altText: 'APPROPRIATE ALT TEXT HERE',
         },
         bannerId: 'scotus-2023-moment-banner',

--- a/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.stories.tsx
@@ -73,7 +73,7 @@ const Scotus2023MomentBanner = bannerWrapper(
                 'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
             wideUrl:
                 'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
-            altText: 'Ukraine one year on',
+            altText: 'APPROPRIATE ALT TEXT HERE',
         },
         bannerId: 'scotus-2023-moment-banner',
     }),

--- a/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.stories.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { brand, neutral, specialReport } from '@guardian/src-foundations';
+import { BannerProps, SecondaryCtaType } from '@sdc/shared/dist/types';
+import { Meta, Story } from '@storybook/react';
+import { bannerWrapper } from '../common/BannerWrapper';
+import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
+import { props } from '../utils/storybook';
+
+export default {
+    title: 'Banners/MomentTemplate',
+    args: props,
+} as Meta;
+
+const Scotus2023MomentBanner = bannerWrapper(
+    getMomentTemplateBanner({
+        containerSettings: {
+            backgroundColour: specialReport[100],
+            textColor: neutral[100],
+        },
+        headerSettings: {
+            textColour: neutral[100],
+        },
+        primaryCtaSettings: {
+            default: {
+                backgroundColour: brand[500],
+                textColour: neutral[100],
+            },
+            hover: {
+                backgroundColour: neutral[100],
+                textColour: brand[500],
+            },
+        },
+        secondaryCtaSettings: {
+            default: {
+                backgroundColour: specialReport[100],
+                textColour: neutral[100],
+                border: `1px solid ${neutral[100]}`,
+            },
+            hover: {
+                backgroundColour: neutral[100],
+                textColour: specialReport[100],
+                border: `1px solid ${specialReport[100]}`,
+            },
+        },
+        closeButtonSettings: {
+            default: {
+                backgroundColour: neutral[100],
+                textColour: specialReport[100],
+                border: `1px solid ${specialReport[100]}`,
+            },
+            hover: {
+                backgroundColour: specialReport[100],
+                textColour: neutral[100],
+                border: `1px solid ${neutral[100]}`,
+            },
+            guardianRoundel: 'inverse',
+        },
+        highlightedTextSettings: {
+            textColour: specialReport[100],
+            highlightColour: neutral[100],
+        },
+        articleCountTextColour: neutral[100],
+        imageSettings: {
+            mainUrl:
+                'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
+            mobileUrl:
+                'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
+            tabletUrl:
+                'https://i.guim.co.uk/img/media/4f2ec5867b1a111b78927547f2fdceb0066695f9/0_0_1024_920/500.png?width=500&quality=75&s=ef15b7ff812d997251a68b59a1b4279c',
+            desktopUrl:
+                'https://i.guim.co.uk/img/media/8d9128c93a61155e0b84f0eb229edd57951ee3ff/0_0_1280_1168/500.png?width=500&quality=75&s=0d8ff342ffc3005186903969b22a4674',
+            leftColUrl:
+                'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
+            wideUrl:
+                'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
+            altText: 'Ukraine one year on',
+        },
+        bannerId: 'scotus-2023-moment-banner',
+    }),
+    'scotus-2023-moment-banner',
+);
+
+const Scotus2023MomentTemplate: Story<BannerProps> = (props: BannerProps) => (
+    <Scotus2023MomentBanner {...props} />
+);
+
+export const Scotus2023Moment = Scotus2023MomentTemplate.bind({});
+Scotus2023Moment.args = {
+    ...props,
+    content: {
+        heading: 'One year ago, they set women’s rights back by half a century',
+        messageText: `You've read %%ARTICLE_COUNT%% articles in the last year`,
+        paragraphs: [
+            'From abortion to guns to environmental protections, the US Supreme Court is increasingly out of step with the American people. In recent years, a far-right movement has helped seat justices who are redefining public life and undermining democracy. Independent journalism is critical to holding this institution to account.',
+        ],
+        highlightedText:
+            'Our journalism is free for everyone, but if you can support us, we need you. Give just once from %%CURRENCY_SYMBOL%%1, or power us every month with a little more. Thank you.',
+        cta: {
+            text: 'Support monthly',
+            baseUrl: 'https://support.theguardian.com/contribute/recurring',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Support once',
+                baseUrl: 'https://support.theguardian.com/contribute/one-off',
+            },
+        },
+    },
+    mobileContent: {
+        heading: "One year ago, they set women's rights back by half a century",
+        messageText: `You've read %%ARTICLE_COUNT%% articles in the last year`,
+        paragraphs: [
+            'From abortion to guns to environmental protections, the US Supreme Court is increasingly out of step with the American people. In recent years, a far-right movement has helped seat justices who are redefining public life and undermining democracy. Independent journalism is critical to holding this institution to account.',
+        ],
+        highlightedText:
+            'Our journalism is free for everyone, but if you can support us, we need you. Give just once from %%CURRENCY_SYMBOL%%1, or power us every month with a little more. Thank you.',
+        cta: {
+            text: 'Support monthly',
+            baseUrl: 'https://support.theguardian.com/contribute/recurring',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Support once',
+                baseUrl: 'https://support.theguardian.com/contribute/one-off',
+            },
+        },
+    },
+    numArticles: 50,
+    tickerSettings: undefined,
+};

--- a/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.tsx
+++ b/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.tsx
@@ -1,0 +1,74 @@
+import { brand, neutral, specialReport } from '@guardian/src-foundations';
+import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
+import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
+
+const Scotus2023MomentBanner = getMomentTemplateBanner({
+    containerSettings: {
+        backgroundColour: specialReport[100],
+        textColor: neutral[100],
+    },
+    headerSettings: {
+        textColour: neutral[100],
+    },
+    primaryCtaSettings: {
+        default: {
+            backgroundColour: brand[500],
+            textColour: neutral[100],
+        },
+        hover: {
+            backgroundColour: neutral[100],
+            textColour: brand[500],
+        },
+    },
+    secondaryCtaSettings: {
+        default: {
+            backgroundColour: specialReport[100],
+            textColour: neutral[100],
+            border: `1px solid ${neutral[100]}`,
+        },
+        hover: {
+            backgroundColour: neutral[100],
+            textColour: specialReport[100],
+            border: `1px solid ${specialReport[100]}`,
+        },
+    },
+    closeButtonSettings: {
+        default: {
+            backgroundColour: neutral[100],
+            textColour: specialReport[100],
+            border: `1px solid ${specialReport[100]}`,
+        },
+        hover: {
+            backgroundColour: specialReport[100],
+            textColour: neutral[100],
+            border: `1px solid ${neutral[100]}`,
+        },
+        guardianRoundel: 'inverse',
+    },
+    highlightedTextSettings: {
+        textColour: specialReport[100],
+        highlightColour: neutral[100],
+    },
+    articleCountTextColour: neutral[100],
+    imageSettings: {
+        mainUrl:
+            'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
+        mobileUrl:
+            'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
+        tabletUrl:
+            'https://i.guim.co.uk/img/media/4f2ec5867b1a111b78927547f2fdceb0066695f9/0_0_1024_920/500.png?width=500&quality=75&s=ef15b7ff812d997251a68b59a1b4279c',
+        desktopUrl:
+            'https://i.guim.co.uk/img/media/8d9128c93a61155e0b84f0eb229edd57951ee3ff/0_0_1280_1168/500.png?width=500&quality=75&s=0d8ff342ffc3005186903969b22a4674',
+        leftColUrl:
+            'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
+        wideUrl:
+            'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
+        altText: 'Ukraine one year on',
+    },
+    bannerId: 'scotus-2023-moment-banner',
+});
+
+const unvalidated = bannerWrapper(Scotus2023MomentBanner, 'scotus-2023-moment-banner');
+const validated = validatedBannerWrapper(Scotus2023MomentBanner, 'scotus-2023-moment-banner');
+
+export { validated as Scotus2023MomentBanner, unvalidated as Scotus2023MomentBannerUnvalidated };

--- a/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.tsx
+++ b/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.tsx
@@ -52,17 +52,17 @@ const Scotus2023MomentBanner = getMomentTemplateBanner({
     articleCountTextColour: neutral[100],
     imageSettings: {
         mainUrl:
-            'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
+            'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/752_639_3258_1303/1000.jpg?width=500&quality=75&s=f19e815a62c8550748d9514d39298683',
         mobileUrl:
-            'https://i.guim.co.uk/img/media/5f55f84fbb107ad1539659d8caec5eeab7398dbc/0_0_1500_608/500.png?width=500&quality=75&s=2173abfa5e53fb64660c6596a887e9ac',
+            'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/752_639_3258_1303/1000.jpg?width=500&quality=75&s=f19e815a62c8550748d9514d39298683',
         tabletUrl:
-            'https://i.guim.co.uk/img/media/4f2ec5867b1a111b78927547f2fdceb0066695f9/0_0_1024_920/500.png?width=500&quality=75&s=ef15b7ff812d997251a68b59a1b4279c',
+            'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/1400_406_1772_1773/1000.jpg?width=500&quality=75&s=16e4aebfcbad771ee40c9b6f9fd99056',
         desktopUrl:
-            'https://i.guim.co.uk/img/media/8d9128c93a61155e0b84f0eb229edd57951ee3ff/0_0_1280_1168/500.png?width=500&quality=75&s=0d8ff342ffc3005186903969b22a4674',
+            'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/1400_406_1772_1773/1000.jpg?width=500&quality=75&s=16e4aebfcbad771ee40c9b6f9fd99056',
         leftColUrl:
-            'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
+            'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/1395_636_1953_1302/1953.jpg?width=900&quality=75&s=133c6e21b3a43c57f91fd16ecbe942ec',
         wideUrl:
-            'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
+            'https://i.guim.co.uk/img/media/d9439edc81326f0546960316bd1c84acaf974366/1395_636_1953_1302/1953.jpg?width=900&quality=75&s=133c6e21b3a43c57f91fd16ecbe942ec',
         altText: 'APPROPRIATE ALT TEXT HERE',
     },
     bannerId: 'scotus-2023-moment-banner',

--- a/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.tsx
+++ b/packages/modules/src/modules/banners/usSupremeCourt2023/Scotus2023MomentBanner.tsx
@@ -63,7 +63,7 @@ const Scotus2023MomentBanner = getMomentTemplateBanner({
             'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
         wideUrl:
             'https://i.guim.co.uk/img/media/359d8cde335895144b85a52ce0fe6b93fa8e1514/0_0_882_584/882.png?width=882&height=584&quality=75&s=da90ac1806631a1cb7f3903af88b5819',
-        altText: 'Ukraine one year on',
+        altText: 'APPROPRIATE ALT TEXT HERE',
     },
     bannerId: 'scotus-2023-moment-banner',
 });

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -14,6 +14,7 @@ import {
     globalNewYearBanner,
     signInPromptBanner,
     ukraineMomentBanner,
+    scotus2023MomentBanner,
     ausAnniversaryBanner,
     wpfdBanner,
 } from '@sdc/shared/config';
@@ -51,6 +52,7 @@ export const BannerPaths: {
     [BannerTemplate.GuardianWeeklyBanner]: guardianWeekly.endpointPathBuilder,
     [BannerTemplate.SignInPromptBanner]: signInPromptBanner.endpointPathBuilder,
     [BannerTemplate.UkraineMomentBanner]: ukraineMomentBanner.endpointPathBuilder,
+    [BannerTemplate.Scotus2023MomentBanner]: scotus2023MomentBanner.endpointPathBuilder,
     [BannerTemplate.WorldPressFreedomDayBanner]: wpfdBanner.endpointPathBuilder,
 };
 

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -115,6 +115,11 @@ export const ukraineMomentBanner: ModuleInfo = getDefaultModuleInfo(
     'banners/ukraineMoment/UkraineMomentBanner',
 );
 
+export const scotus2023MomentBanner: ModuleInfo = getDefaultModuleInfo(
+    'scotus-2023-moment-banner',
+    'banners/usSupremeCourt2023/Scotus2023MomentBanner',
+);
+
 export const wpfdBanner: ModuleInfo = getDefaultModuleInfo(
     'wpfd-banner',
     'banners/worldPressFreedomDay/WorldPressFreedomDayBanner',
@@ -142,5 +147,6 @@ export const moduleInfos: ModuleInfo[] = [
     header,
     signInPromptHeader,
     ukraineMomentBanner,
+    scotus2023MomentBanner,
     wpfdBanner,
 ];

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -30,6 +30,7 @@ export enum BannerTemplate {
     GlobalNewYearBanner = 'GlobalNewYearBanner',
     SignInPromptBanner = 'SignInPromptBanner',
     UkraineMomentBanner = 'UkraineMomentBanner',
+    Scotus2023MomentBanner = 'Scotus2023MomentBanner',
     WorldPressFreedomDayBanner = 'WorldPressFreedomDayBanner',
 }
 


### PR DESCRIPTION
## What does this change?
We have an ask to create a new Template Banner for the upcoming US Supreme Court Moment. 

To complete the work, we will merge 2 PRs in the following repos:
+ https://github.com/guardian/support-dotcom-components/pull/907
+ https://github.com/guardian/support-admin-console/pull/455

## How to test
+ A Storybook story has been created for this template banner, which we can use to make sure it conforms with design (see Trello card for link to Figma file)
+ We will test the banner by deploying both PRs and creating a new banner test using the template and reviewing its presentation and functionality in both `live` and `web` views in RRCP

## How can we measure success?
Marketing have defined success criteria in their scoping document for this work

## Have we considered potential risks?
We judge the risk to be low for this work as we are building the template on top of moment template code. No changes to layout or design are required beyond color and image changes

## Images
[TODO - add screenshots of the new banner template]

## Accessibility
+ Make sure that the template banner's colors comply with accessibility contrast requirements (should already have been checked as part of the design process)