### PR TITLE
Update DigitalPack to SupporterPlus PurchaseInfo

### DIFF
--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -368,7 +368,7 @@ describe('selectBannerTest', () => {
             {
                 ...baseTest,
                 name: 'banner-existing-subscriber',
-                purchaseInfo: { product: ['DigitalPack'], userType: ['current'] },
+                purchaseInfo: { product: ['SupporterPlus'], userType: ['current'] },
             },
         ];
 
@@ -401,7 +401,7 @@ describe('selectBannerTest', () => {
         it('It should return a test matching a subscription from an existing user', async () => {
             const result = await runSelection({
                 ...baseTargeting,
-                purchaseInfo: { product: 'DigitalPack', userType: 'current' },
+                purchaseInfo: { product: 'SupporterPlus', userType: 'current' },
             });
 
             expect(result?.test.name).toEqual('banner-existing-subscriber');

--- a/packages/server/src/tests/banners/signInPromptTests.ts
+++ b/packages/server/src/tests/banners/signInPromptTests.ts
@@ -41,15 +41,15 @@ const dismissAction = {
 
 const baseBenefits = ['Fewer interruptions', 'Newsletters and comments'];
 const normalBenefits = [...baseBenefits, 'Manage your account'];
-const digiSubBenefits = ['Ad free', ...baseBenefits];
+const supporterPlusBenefits = ['Ad free', ...baseBenefits];
 const paragraphs = [subheading, ...normalBenefits];
-const digiSubParagraphs = [subheading, ...digiSubBenefits];
+const supporterPlusParagraphs = [subheading, ...supporterPlusBenefits];
 
 const signInPromptNewUserDigitalSubscriberTest: BannerTest = {
     ...baseSignInPromptTest,
     name: 'banner-sign-in-prompt-new-user-digital-subscriber',
     purchaseInfo: {
-        product: ['DigitalPack'],
+        product: ['SupporterPlus'],
         userType: ['new', 'guest'],
     },
     variants: [
@@ -57,7 +57,7 @@ const signInPromptNewUserDigitalSubscriberTest: BannerTest = {
             ...baseSignInPromptVariant,
             bannerContent: {
                 heading: subscriberHeading,
-                paragraphs: digiSubParagraphs,
+                paragraphs: supporterPlusParagraphs,
                 cta: registerCTA,
                 secondaryCta: dismissAction,
             },
@@ -109,7 +109,7 @@ const signInPromptExistingUserDigitalSubscriberTest: BannerTest = {
     ...baseSignInPromptTest,
     name: 'banner-sign-in-prompt-existing-user-digital-subscriber',
     purchaseInfo: {
-        product: ['DigitalPack'],
+        product: ['SupporterPlus'],
         userType: ['current'],
     },
     variants: [
@@ -117,7 +117,7 @@ const signInPromptExistingUserDigitalSubscriberTest: BannerTest = {
             ...baseSignInPromptVariant,
             bannerContent: {
                 heading: subscriberHeading,
-                paragraphs: digiSubParagraphs,
+                paragraphs: supporterPlusParagraphs,
                 cta: signInCTA,
                 secondaryCta: dismissAction,
             },

--- a/packages/server/src/tests/headers/headerSelection.test.ts
+++ b/packages/server/src/tests/headers/headerSelection.test.ts
@@ -151,7 +151,7 @@ const header_existing_subscriber: HeaderTest = {
         'International',
     ],
     purchaseInfo: {
-        product: ['DigitalPack'],
+        product: ['SupporterPlus'],
         userType: ['current'],
     },
     variants: [
@@ -386,7 +386,7 @@ describe('selectBestTest', () => {
             modulesVersion: 'v3',
             mvtId: 900263,
             purchaseInfo: {
-                product: 'DigitalPack',
+                product: 'SupporterPlus',
                 userType: 'current',
             },
             isSignedIn: false,

--- a/packages/server/src/tests/headers/headerSelection.ts
+++ b/packages/server/src/tests/headers/headerSelection.ts
@@ -144,13 +144,13 @@ const registerCTA = {
 const baseBenefits = ['Fewer interruptions', 'Newsletters and comments'];
 // Why are benefits repeated below? The header animation ends statically on last benefit so it should be the "strongest"
 const normalBenefits = [...baseBenefits, 'Manage your account', 'Fewer interruptions'];
-const digiSubBenefits = ['Ad free', ...baseBenefits, 'Ad free'];
+const supporterPlusBenefits = ['Ad free', ...baseBenefits, 'Ad free'];
 
 const signInPromptNewUserDigitalSubscriberTest: HeaderTest = {
     name: 'header-sign-in-prompt-new-user-digital-subscriber',
     ...baseSignInPromptTest,
     purchaseInfo: {
-        product: ['DigitalPack'],
+        product: ['SupporterPlus'],
         userType: ['new', 'guest'],
     },
     variants: [
@@ -159,7 +159,7 @@ const signInPromptNewUserDigitalSubscriberTest: HeaderTest = {
             content: {
                 ...subscriberContent,
                 primaryCta: registerCTA,
-                benefits: digiSubBenefits,
+                benefits: supporterPlusBenefits,
             },
         },
     ],
@@ -207,7 +207,7 @@ const signInPromptExistingUserDigitalSubscriberTest: HeaderTest = {
     name: 'header-sign-in-prompt-existing-user-digital-subscriber',
     ...baseSignInPromptTest,
     purchaseInfo: {
-        product: ['DigitalPack'],
+        product: ['SupporterPlus'],
         userType: ['current'],
     },
     variants: [
@@ -216,7 +216,7 @@ const signInPromptExistingUserDigitalSubscriberTest: HeaderTest = {
             content: {
                 ...subscriberContent,
                 primaryCta: signInCTA,
-                benefits: digiSubBenefits,
+                benefits: supporterPlusBenefits,
             },
         },
     ],

--- a/packages/shared/src/types/purchaseInfo.ts
+++ b/packages/shared/src/types/purchaseInfo.ts
@@ -1,2 +1,2 @@
-export type purchaseInfoProduct = 'Contribution' | 'DigitalPack' | 'GuardianWeekly' | 'Paper';
+export type purchaseInfoProduct = 'Contribution' | 'SupporterPlus' | 'GuardianWeekly' | 'Paper';
 export type purchaseInfoUser = 'new' | 'guest' | 'current';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Updates the Sign In Prompt Header and Banner to perssonlise for the new SupporterPlus product that replaced the DigitalPack

## How to test

Tested in Code
- [x] Correct Banner is shown with SupporterPlus GU_CO_COMPLETE cookie is set
- [x] Correct Header is shown with SupporterPlus GU_CO_COMPLETE cookie is set

<img width="1085" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/32312712/7895d2ca-fe22-4214-879d-e175c833a49f">



## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
