### PR TITLE
Fix Storybook issue caused by rendering based on scroll depth

### DIFF
--- a/packages/modules/src/hooks/useScrollDepth.ts
+++ b/packages/modules/src/hooks/useScrollDepth.ts
@@ -12,7 +12,10 @@ export function useScrollDepth(
     function onScroll() {
         const currentPosition = window.scrollY;
         const percentScroll = (currentPosition / pageHeight.current) * 100;
-        effect(percentScroll);
+
+        const normalisedPercentScroll = Number.isNaN(percentScroll) ? 0 : percentScroll;
+
+        effect(normalisedPercentScroll);
         throttleTimeout = null;
     }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This fixes an issue where the `useScrollDepth` hook was passing a scroll depth of `NaN` when banners were rendered in a Storybook iframe, causing the banner to never be rendered.
