### PR TITLE
Moment Template Banner align choice cards (only) top with article count/body top

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCards.tsx
@@ -54,12 +54,13 @@ const styles = {
         }
 
         ${from.tablet} {
-            margin: ${verticalPosAdjust}px 0 ${space[5]}px;
+            margin: ${verticalPosAdjust ?? 108}px 0 ${space[5]}px;
         }
 
         ${from.desktop} {
             min-height: 208px;
             max-width: 380px;
+            margin-top: ${verticalPosAdjust ?? 120}px;
         }
     `,
     bannerFrequenciesGroupOverrides: css`

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCards.tsx
@@ -31,10 +31,11 @@ interface ChoiceCardProps {
     numArticles?: number;
     content?: BannerTextContent;
     cssCtaOverides?: SerializedStyles;
+    verticalPosAdjust?: number;
 }
 
 const styles = {
-    container: css`
+    container: (verticalPosAdjust?: number) => css`
         // This position: relative is necessary to stop it jumping to the top of the page when a button is clicked
         position: relative;
         margin: ${space[3]}px 0 ${space[5]}px;
@@ -53,13 +54,12 @@ const styles = {
         }
 
         ${from.tablet} {
-            margin: 108px 0 ${space[5]}px;
+            margin: ${verticalPosAdjust}px 0 ${space[5]}px;
         }
 
         ${from.desktop} {
             min-height: 208px;
             max-width: 380px;
-            margin-top: 120px;
         }
     `,
     bannerFrequenciesGroupOverrides: css`
@@ -139,6 +139,7 @@ export const ChoiceCards: React.FC<ChoiceCardProps> = ({
     numArticles,
     getCtaText,
     cssCtaOverides,
+    verticalPosAdjust,
 }: ChoiceCardProps) => {
     if (!selection || !amounts) {
         return <></>;
@@ -166,7 +167,7 @@ export const ChoiceCards: React.FC<ChoiceCardProps> = ({
     }, [hasBeenSeen, submitComponentEvent]);
 
     return (
-        <div ref={setNode} css={styles.container}>
+        <div ref={setNode} css={styles.container(verticalPosAdjust)}>
             <ChoiceCardGroup
                 name="contribution-frequency"
                 columns={3}

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { neutral, space } from '@guardian/src-foundations';
 import { Container } from '@guardian/src-layout';
@@ -30,6 +30,11 @@ export function getMomentTemplateBanner(
     const hasBannerAndHeaderVisuals =
         !!templateSettings.imageSettings && !!templateSettings.headerSettings?.image;
 
+    function getHeightHeader(id: string) {
+        const element = document.getElementById(id);
+        return (element?.offsetHeight || 0) + space[6];
+    }
+
     function MomentTemplateBanner({
         content,
         onCloseClick,
@@ -44,6 +49,19 @@ export function getMomentTemplateBanner(
         submitComponentEvent,
         tracking,
     }: BannerRenderProps): JSX.Element {
+        const [heightHeader, setHeightHeader] = useState<number>(
+            getHeightHeader('headerContainer'),
+        );
+
+        useEffect(() => {
+            handleRefresh();
+            window.addEventListener('resize', handleRefresh);
+        }, []);
+
+        function handleRefresh() {
+            setHeightHeader(getHeightHeader('headerContainer'));
+        }
+
         const { isReminderActive, onReminderCtaClick, mobileReminderRef } = useReminder(
             reminderTracking,
         );
@@ -103,6 +121,7 @@ export function getMomentTemplateBanner(
                                     numArticles={numArticles}
                                     content={content}
                                     getCtaText={getCtaText}
+                                    verticalPosAdjust={heightHeader}
                                 />
                             )}
                         </div>
@@ -116,6 +135,7 @@ export function getMomentTemplateBanner(
                                     SecondaryCtaType.ContributionsReminder,
                                 templateSettings.choiceCards,
                             )}
+                            id="headerContainer"
                         >
                             <MomentTemplateBannerHeader
                                 heading={content.mainContent.heading}
@@ -131,7 +151,7 @@ export function getMomentTemplateBanner(
                             />
                         )}
 
-                        <div css={styles.bodyContainer}>
+                        <div css={styles.bodyContainer} id="bodyContainer">
                             <MomentTemplateBannerBody
                                 mainContent={content.mainContent}
                                 mobileContent={content.mobileContent}
@@ -266,8 +286,6 @@ const styles = {
         display: block; // choice cards visible below mobileMedium
 
         ${from.tablet} {
-            display: flex;
-            align-items: center;
             width: 350px;
         }
     `

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -49,17 +49,14 @@ export function getMomentTemplateBanner(
         submitComponentEvent,
         tracking,
     }: BannerRenderProps): JSX.Element {
-        const [heightHeader, setHeightHeader] = useState<number>(
-            getHeightHeader('headerContainer'),
-        );
-
+        const [headerHeight, setHeaderHeight] = useState<number>();
         useEffect(() => {
-            handleRefresh();
-            window.addEventListener('resize', handleRefresh);
+            handleResize();
+            window.addEventListener('resize', handleResize);
         }, []);
 
-        function handleRefresh() {
-            setHeightHeader(getHeightHeader('headerContainer'));
+        function handleResize() {
+            setHeaderHeight(getHeightHeader('headerContainer'));
         }
 
         const { isReminderActive, onReminderCtaClick, mobileReminderRef } = useReminder(
@@ -121,7 +118,7 @@ export function getMomentTemplateBanner(
                                     numArticles={numArticles}
                                     content={content}
                                     getCtaText={getCtaText}
-                                    verticalPosAdjust={heightHeader}
+                                    verticalPosAdjust={headerHeight}
                                 />
                             )}
                         </div>

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -151,7 +151,7 @@ export function getMomentTemplateBanner(
                             />
                         )}
 
-                        <div css={styles.bodyContainer} id="bodyContainer">
+                        <div css={styles.bodyContainer}>
                             <MomentTemplateBannerBody
                                 mainContent={content.mainContent}
                                 mobileContent={content.mobileContent}

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -51,13 +51,13 @@ export function getMomentTemplateBanner(
     }: BannerRenderProps): JSX.Element {
         const [headerHeight, setHeaderHeight] = useState<number>();
         useEffect(() => {
-            handleResize();
+            function handleResize() {
+                setHeaderHeight(getHeightHeader('headerContainer'));
+            }
             window.addEventListener('resize', handleResize);
+            handleResize();
+            return () => window.removeEventListener('resize', handleResize);
         }, []);
-
-        function handleResize() {
-            setHeaderHeight(getHeightHeader('headerContainer'));
-        }
 
         const { isReminderActive, onReminderCtaClick, mobileReminderRef } = useReminder(
             reminderTracking,


### PR DESCRIPTION
## What does this change?

Update our new Moment Templates w/ Choice Cards so the top of the choice cards component is vertically aligned to the top of the article count copy, to it’s left, and if there is no article count copy it should be vertically aligned to the top of the main banner copy, also to it’s left. Currently we vertically centre this component.

before
![image](https://github.com/guardian/support-dotcom-components/assets/76729591/8936c1cc-d7f0-446b-b722-22b92ef13752)

after (with article count)
![image](https://github.com/guardian/support-dotcom-components/assets/76729591/6ba818d6-efba-4c0b-96a1-226b0c97026b)

## Accessibility test checklist
 - [x] [Tested with screen reader](https://webaim.org/articles/voiceover/)