### PR TITLE
Update copy in environment moment header

### DIFF
--- a/packages/modules/src/modules/banners/environmentMoment/components/EnvironmentMomentBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/environmentMoment/components/EnvironmentMomentBannerHeader.tsx
@@ -134,10 +134,10 @@ export const EnvironmentMomentBannerHeader: React.FC = () => (
                         </div>
                     </Hide>
 
-                    <span>Cop27:</span>
+                    <span>Support impactful</span>
                 </div>
 
-                <span>no more hot air</span>
+                <span>climate journalism</span>
             </div>
         </div>
 


### PR DESCRIPTION
## What does this change?
This is a small copy update to the existing Environment Moment banner, changing the header to "Support impactful climate journalism" (with the line break after "impactful"), as requested by Marketing colleagues.

This PR does not alter the banner's existing layout, colour scheme or functionality in any way. Nor does it attempt to fix any existing issues with the banner's display on mobile/tablet devices.

![Screenshot 2023-08-02 at 09 16 05](https://github.com/guardian/support-dotcom-components/assets/5357530/f1037e12-12a4-4441-bd76-b3b80447f80b)
![Screenshot 2023-08-02 at 09 16 21](https://github.com/guardian/support-dotcom-components/assets/5357530/325524ee-8ed8-41c5-b1c7-b4a792e7a74a)
