### PR TITLE
[RB PD] Moment template banner css grid refactor

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBanner.tsx
@@ -19,7 +19,7 @@ import {
     paragraph,
     columnMarginOverrides,
     ctaOverridesBlue,
-    eol_choiceCardverticlaAlignment,
+    choiceCardVerticalAlignment,
 } from './choiceCardsButtonsBannerStyles';
 import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib';
 import { ChoiceCards } from './components/ChoiceCards';
@@ -155,7 +155,7 @@ export const ChoiceCardsButtonsBanner = ({
                         cssOverrides={[
                             choiceCardsColumn,
                             columnMarginOverrides,
-                            eol_choiceCardverticlaAlignment,
+                            choiceCardVerticalAlignment,
                         ]}
                     >
                         {choiceCardAmounts && (

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBanner.tsx
@@ -19,6 +19,7 @@ import {
     paragraph,
     columnMarginOverrides,
     ctaOverridesBlue,
+    eol_choiceCardverticlaAlignment,
 } from './choiceCardsButtonsBannerStyles';
 import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib';
 import { ChoiceCards } from './components/ChoiceCards';
@@ -149,7 +150,14 @@ export const ChoiceCardsButtonsBanner = ({
                             articleCount={showArticleCount ? articleCount : undefined}
                         />
                     </Column>
-                    <Column width={1 / 2} cssOverrides={[choiceCardsColumn, columnMarginOverrides]}>
+                    <Column
+                        width={1 / 2}
+                        cssOverrides={[
+                            choiceCardsColumn,
+                            columnMarginOverrides,
+                            eol_choiceCardverticlaAlignment,
+                        ]}
+                    >
                         {choiceCardAmounts && (
                             <ChoiceCards
                                 setSelectionsCallback={setChoiceCardSelection}

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/choiceCardsButtonsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/choiceCardsButtonsBannerStyles.ts
@@ -60,7 +60,7 @@ export const columnMarginOverrides = css`
     }
 `;
 
-export const eol_choiceCardverticlaAlignment = css`
+export const choiceCardVerticalAlignment = css`
     ${from.tablet} {
         justify-content: flex-start;
         margin-top: 6.6rem;

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/choiceCardsButtonsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/choiceCardsButtonsBannerStyles.ts
@@ -60,6 +60,16 @@ export const columnMarginOverrides = css`
     }
 `;
 
+export const eol_choiceCardverticlaAlignment = css`
+    ${from.tablet} {
+        justify-content: flex-start;
+        margin-top: 6.6rem;
+    }
+    ${from.desktop} {
+        margin-top: 7.6rem;
+    }
+`;
+
 export const heading = (headingColor: string): SerializedStyles => css`
     ${headline.xxsmall({ fontWeight: 'bold' })};
     font-size: 22px;

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardFrequencyTabs.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardFrequencyTabs.tsx
@@ -19,6 +19,11 @@ const container = css`
         min-width: 0;
     }
 
+    > label > div {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
     > label:last-of-type {
         margin-right: 0 !important;
     }

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCards.tsx
@@ -3,7 +3,6 @@ import { ChoiceCardGroup } from '@guardian/src-choice-card';
 import { css, SerializedStyles } from '@emotion/react';
 import { from } from '@guardian/src-foundations/mq';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
-import { space } from '@guardian/src-foundations';
 import { ChoiceCardAmountButtons } from './ChoiceCardAmountButtons';
 import { ChoiceCardFrequencyTabs, ContributionType } from './ChoiceCardFrequencyTabs';
 import { SupportCta } from './SupportCta';
@@ -37,7 +36,6 @@ const styles = {
     container: css`
         // This position: relative is necessary to stop it jumping to the top of the page when a button is clicked
         position: relative;
-        margin: ${space[3]}px 0 ${space[5]}px;
         max-width: 296px;
 
         ${from.mobile} {
@@ -52,21 +50,16 @@ const styles = {
             max-width: 716px;
         }
 
-        ${from.tablet} {
-            margin: 108px 0 ${space[5]}px;
-        }
-
         ${from.desktop} {
             min-height: 208px;
             max-width: 380px;
-            margin-top: 120px;
         }
     `,
     bannerFrequenciesGroupOverrides: css`
         display: grid;
 
         ${from.tablet} {
-            grid-template-columns: repeat(3, minmax(100px, 200px));
+            grid-template-columns: repeat(3, minmax(93px, 200px));
         }
 
         > div:first-of-type {

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import { neutral, space } from '@guardian/src-foundations';
-import { Container } from '@guardian/src-layout';
 import { BannerEnrichedReminderCta, BannerRenderProps } from '../common/types';
 import { MomentTemplateBannerHeader } from './components/MomentTemplateBannerHeader';
 import { MomentTemplateBannerArticleCount } from './components/MomentTemplateBannerArticleCount';
@@ -10,7 +9,7 @@ import { MomentTemplateBannerCtas } from './components/MomentTemplateBannerCtas'
 import { MomentTemplateBannerCloseButton } from './components/MomentTemplateBannerCloseButton';
 import { MomentTemplateBannerVisual } from './components/MomentTemplateBannerVisual';
 import { BannerTemplateSettings } from './settings';
-import { from } from '@guardian/src-foundations/mq';
+import { between, from, until } from '@guardian/src-foundations/mq';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { MomentTemplateBannerReminder } from './components/MomentTemplateBannerReminder';
 import MomentTemplateBannerTicker from './components/MomentTemplateBannerTicker';
@@ -23,13 +22,6 @@ import { ChoiceCards } from '../choiceCardsButtonsBanner/components/ChoiceCards'
 export function getMomentTemplateBanner(
     templateSettings: BannerTemplateSettings,
 ): React.FC<BannerRenderProps> {
-    const hasVisual =
-        templateSettings.imageSettings ||
-        templateSettings.alternativeVisual ||
-        templateSettings.choiceCards;
-    const hasBannerAndHeaderVisuals =
-        !!templateSettings.imageSettings && !!templateSettings.headerSettings?.image;
-
     function MomentTemplateBanner({
         content,
         onCloseClick,
@@ -65,73 +57,35 @@ export function getMomentTemplateBanner(
                     templateSettings.containerSettings.textColor,
                 )}
             >
-                <Container cssOverrides={styles.containerOverrides(templateSettings.choiceCards)}>
-                    <div css={styles.closeButtonContainer}>
-                        <MomentTemplateBannerCloseButton
-                            onCloseClick={onCloseClick}
-                            settings={templateSettings.closeButtonSettings}
+                <div css={styles.containerOverrides}>
+                    <MomentTemplateBannerCloseButton
+                        onCloseClick={onCloseClick}
+                        settings={templateSettings.closeButtonSettings}
+                        styleOverides={styles.closeButtonOverrides}
+                    />
+
+                    <div
+                        css={styles.headerContainer(
+                            templateSettings.containerSettings.backgroundColour,
+                            !!templateSettings.imageSettings,
+                        )}
+                    >
+                        <MomentTemplateBannerHeader
+                            heading={content.mainContent.heading}
+                            mobileHeading={content.mobileContent.heading}
+                            headerSettings={templateSettings.headerSettings}
                         />
                     </div>
 
-                    {hasVisual && (
-                        <div
-                            css={styles.bannerVisualContainer(
-                                templateSettings.containerSettings.backgroundColour,
-                                hasBannerAndHeaderVisuals,
-                                templateSettings.choiceCards,
-                            )}
-                        >
-                            {templateSettings.imageSettings && (
-                                <MomentTemplateBannerVisual
-                                    settings={templateSettings.imageSettings}
-                                    bannerId={templateSettings.bannerId}
-                                />
-                            )}
-                            {templateSettings.alternativeVisual}
-                            {showChoiceCards && (
-                                <ChoiceCards
-                                    setSelectionsCallback={setChoiceCardSelection}
-                                    selection={choiceCardSelection}
-                                    submitComponentEvent={submitComponentEvent}
-                                    currencySymbol={currencySymbol}
-                                    componentId={'choice-cards-buttons-banner-blue'}
-                                    amounts={choiceCardAmounts.amounts}
-                                    amountsTestName={choiceCardAmounts?.testName}
-                                    amountsVariantName={choiceCardAmounts?.variantName}
-                                    countryCode={countryCode}
-                                    bannerTracking={tracking}
-                                    numArticles={numArticles}
-                                    content={content}
-                                    getCtaText={getCtaText}
-                                />
-                            )}
-                        </div>
-                    )}
-
                     <div css={styles.contentContainer}>
-                        <div
-                            css={styles.headerContainer(
-                                templateSettings.containerSettings.backgroundColour,
-                                content.mobileContent.secondaryCta?.type ===
-                                    SecondaryCtaType.ContributionsReminder,
-                                templateSettings.choiceCards,
-                            )}
-                        >
-                            <MomentTemplateBannerHeader
-                                heading={content.mainContent.heading}
-                                mobileHeading={content.mobileContent.heading}
-                                headerSettings={templateSettings.headerSettings}
-                            />
-                        </div>
-
-                        {separateArticleCount && numArticles !== undefined && numArticles > 5 && (
+                        {separateArticleCount && Number(numArticles) > 5 && (
                             <MomentTemplateBannerArticleCount
-                                numArticles={numArticles}
+                                numArticles={numArticles as number}
                                 settings={templateSettings}
                             />
                         )}
 
-                        <div css={styles.bodyContainer}>
+                        <div css={templateSpacing.bannerBodyCopy}>
                             <MomentTemplateBannerBody
                                 mainContent={content.mainContent}
                                 mobileContent={content.mobileContent}
@@ -159,8 +113,39 @@ export function getMomentTemplateBanner(
                             </section>
                         )}
                     </div>
-                </Container>
 
+                    <div
+                        css={styles.bannerVisualContainer(
+                            templateSettings.containerSettings.backgroundColour,
+                            templateSettings.choiceCards,
+                        )}
+                    >
+                        {templateSettings.imageSettings && (
+                            <MomentTemplateBannerVisual
+                                settings={templateSettings.imageSettings}
+                                bannerId={templateSettings.bannerId}
+                            />
+                        )}
+                        {templateSettings.alternativeVisual}
+                        {showChoiceCards && (
+                            <ChoiceCards
+                                setSelectionsCallback={setChoiceCardSelection}
+                                selection={choiceCardSelection}
+                                submitComponentEvent={submitComponentEvent}
+                                currencySymbol={currencySymbol}
+                                componentId={'choice-cards-buttons-banner-blue'}
+                                amounts={choiceCardAmounts.amounts}
+                                amountsTestName={choiceCardAmounts?.testName}
+                                amountsVariantName={choiceCardAmounts?.variantName}
+                                countryCode={countryCode}
+                                bannerTracking={tracking}
+                                numArticles={numArticles}
+                                content={content}
+                                getCtaText={getCtaText}
+                            />
+                        )}
+                    </div>
+                </div>
                 {mainOrMobileContent.secondaryCta?.type ===
                     SecondaryCtaType.ContributionsReminder &&
                     isReminderActive && (
@@ -186,146 +171,90 @@ const styles = {
         color: ${textColor};
         max-height: 100vh;
         overflow: auto;
-
+        padding: 0 10px;
         * {
             box-sizing: border-box;
         }
-
         ${from.tablet} {
             border-top: 1px solid ${neutral[0]};
+            padding: 0 ${space[5]}px;
         }
     `,
-    containerOverrides: (isChoiceCardsContainer?: boolean) => css`
+    containerOverrides: css`
+        display: flex;
+        flex-direction: column;
+        position: relative;
         ${from.tablet} {
+            position: static;
+            display: grid;
+            grid-template-columns: 1.5fr 1fr;
+            grid-template-rows: auto 1fr;
+            column-gap: ${space[5]}px;
             position: relative;
             width: 100%;
             max-width: 1300px;
             margin: 0 auto;
         }
-
-        & > div {
-            display: flex;
-            flex-direction: column;
-
-            ${isChoiceCardsContainer
-                ? 'flex-direction: column-reverse;'
-                : 'flex-direction: column;'}
-
-            ${from.tablet} {
-                flex-direction: row-reverse;
-            }
-        }
-
-        ${templateSpacing.bannerContainer};
-    `,
-    bannerVisualContainer: (
-        background: string,
-        hasBannerAndHeaderVisuals: boolean,
-        isChoiceCardsContainer?: boolean,
-    ) => css`
-        display: none;
-
-        ${from.mobileMedium} {
-            ${hasBannerAndHeaderVisuals
-                ? ``
-                : `
-            display: block;
-
-            // Mobile Sticky Header Styles
-            background: ${background};
-            position: sticky;
-            top: 0px;
-            z-index: 100;
-            `}
-        }
-
-        ${from.tablet} {
-            display: block;
-
-            // Mobile Sticky Header Styles
-            background: ${background};
-            top: 0px;
-            width: 238px;
-            margin-left: ${space[3]}px;
-            position: relative;
-            z-index: 100;
-        }
-
         ${from.desktop} {
-            width: 320px;
-            margin-left: ${space[5]}px;
-        }
-
-        ${from.leftCol} {
-            width: 370px;
-            margin-left: ${space[9]}px;
-        }
-
-        ${isChoiceCardsContainer
-            ? `
-        display: block; // choice cards visible below mobileMedium
-
-        ${from.tablet} {
-            display: flex;
-            align-items: center;
-            width: 350px;
-        }
-    `
-            : `
-                pointer-events: none;
-        `}
-    `,
-    contentContainer: css`
-        ${from.tablet} {
-            width: 450px;
-        }
-        ${from.desktop} {
-            width: 600px;
-        }
-        ${from.leftCol} {
-            width: 700px;
+            column-gap: 60px;
         }
         ${from.wide} {
-            width: 860px;
+            column-gap: 100px;
+        }
+        ${templateSpacing.bannerContainer};
+    `,
+    closeButtonOverrides: css`
+        ${until.tablet} {
+            position: absolute;
+            top: ${space[3]}px;
+            right: 0;
+        }
+        ${from.tablet} {
+            margin-top: ${space[3]}px;
+            grid-column: 2 / span 1;
+            grid-row: 1 / span 1;
         }
     `,
-    headerContainer: (background: string, hasReminderCta: boolean, choiceCards?: boolean) => css`
-        ${templateSpacing.bannerHeader}
-        max-width: calc(100% - 46px); // 46px approx close button size
-
+    headerContainer: (background: string, bannerHasImage: boolean) => css`
+        order: 1;
+        ${until.tablet} {
+            max-width: calc(100% - 40px - ${space[3]}px);
+        }
+        ${between.mobileMedium.and.tablet} {
+            order: ${bannerHasImage ? '2' : '1'};
+            max-width: ${bannerHasImage ? '100%' : 'calc(100% - 40px - ${space[3]}px)'};
+        }
         ${from.tablet} {
-            // Mobile Sticky Header Styles
+            grid-column: 1 / span 1;
+            grid-row: 1 / span 1;
             background: ${background};
-            position: sticky;
-            top: ${choiceCards ? '0px' : '140px'}; // 140px for banner visual
-            z-index: 100;
-            ${hasReminderCta
-                ? `
-                    border-bottom: 1px solid ${neutral[0]};
-                    padding-bottom: ${space[2]}px;
-                `
-                : ''}
         }
-
+        ${templateSpacing.bannerHeader}
+    `,
+    contentContainer: css`
+        order: 2;
         ${from.tablet} {
-            max-width: initial;
-            position: relative;
-            top: initial;
-            z-index: initial;
-            padding-bottom: 0px;
-            border-bottom: initial;
+            grid-column: 1 / span 1;
+            grid-row: 2 / span 1;
         }
     `,
-    bodyContainer: css`
-        ${templateSpacing.bannerBodyCopy}
+    bannerVisualContainer: (background: string, isChoiceCardsContainer?: boolean) => css`
+        display: ${isChoiceCardsContainer ? 'block' : 'none'};
+        order: ${isChoiceCardsContainer ? '3' : '1'};
+        background: ${background};
+        ${from.mobileMedium} {
+            display: block;
+        }
+        ${from.tablet} {
+            grid-column: 2 / span 1;
+            grid-row-start: ${isChoiceCardsContainer ? '2' : '1'};
+            grid-row-end: span ${isChoiceCardsContainer ? '1' : '2'};
+            align-self: ${isChoiceCardsContainer ? 'start' : 'center'};
+            margin-top: ${isChoiceCardsContainer ? '0' : `calc(${space[3]}px + 40px)`};
+        }
     `,
     ctasContainer: css`
         display: flex;
         flex-direction: row;
-    `,
-    closeButtonContainer: css`
-        ${templateSpacing.bannerCloseButton}
-        z-index: 101;
-        position: absolute;
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
@@ -38,12 +38,8 @@ const styles = {
         color: ${textColor};
         margin: 0;
 
-        ${from.tablet} {
-            font-size: 17px;
-        }
-
         ${from.desktop} {
-            font-size: 20px;
+            font-size: 17px;
         }
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import { SvgCross } from '@guardian/src-icons';
 import { Button } from '@guardian/src-button';
 import { buttonStyles } from '../styles/buttonStyles';
@@ -11,11 +11,13 @@ import { space } from '@guardian/src-foundations';
 interface MomentTemplateBannerCloseButtonProps {
     onCloseClick: () => void;
     settings: CtaSettings;
+    styleOverides?: SerializedStyles;
 }
 
 export function MomentTemplateBannerCloseButton({
     onCloseClick,
     settings,
+    styleOverides,
 }: MomentTemplateBannerCloseButtonProps): JSX.Element {
     const { theme, guardianRoundel } = settings;
 
@@ -37,7 +39,11 @@ export function MomentTemplateBannerCloseButton({
     };
 
     return (
-        <div css={styles.container}>
+        <div
+            css={css`
+                ${styles.container} ${styleOverides || ''}
+            `}
+        >
             <div css={styles.roundelContainer}>{getRoundel()}</div>
 
             <Button


### PR DESCRIPTION
## What does this change?
This pr is a refactor of the moment template banner layout. It now uses flex for breakpoints up to tablet and then grid for anything greater.

Alignment issues with the choice cards have been fixed

Before            |  After
:-------------------------:|:-------------------------:
![](https://github.com/guardian/support-dotcom-components/assets/2510683/733ef3a0-65f5-471c-b1c1-d59cdfb33740)  |  ![](https://github.com/guardian/support-dotcom-components/assets/2510683/4557dfd3-6d12-4689-bd42-cbf2474b6ec2)

The article count font size has been changed to match the body copy:

<img width="1433" alt="Screenshot 2023-08-02 at 11 39 59" src="https://github.com/guardian/support-dotcom-components/assets/2510683/27d309a9-2217-4ee7-b6c8-5a6d223bf4c3">

