### PR TITLE
[RB] - publish storybook to github pages

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,7 +2,7 @@ name: Chromatic
 on:
   push:
 jobs:
-  upload-storybook:
+  update-chromatic:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,27 @@
+name: Build and Deploy Storybook
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/modules/src/**/*.tsx?' # Trigger the action when files matching this pattern change
+jobs:
+  build-and-deploy-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          cache: yarn
+      - name: Install and Build 🔧
+        run: |
+          yarn
+          yarn modules build-storybook
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: packages/modules/storybook-static # The folder that the build-storybook script generates files
+          clean: true


### PR DESCRIPTION
## What does this change?

This pr should publish storybook to github pages on the following url (https://guardian.github.io/support-dotcom-components/) via github action on push of the `main` branch. It is also currently configured to look for changes to `.ts` or `.tsx` file changes recursively in the packages/modules/src/ directory. 📖 

#### To get this to work you also need to update the 'pages' setting in this repo, select the 'gh-pages' branch and the root directory.

## NOTE:
This pr may not be necessary as we have a perm link to the main branch build via chromatic : https://main--5fb7a8c515dcfc0021275379.chromatic.com

It appears the only benefit to this approach would be a slightly nicer url.