### PR TITLE
move Epic Sign-In to bottom

### DIFF
--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -296,7 +296,6 @@ WithChoiceCardsAndSignInLink.args = {
             },
         },
     },
-    countryCode: 'AU',
 };
 
 export const WithSignInLink = Template.bind({});

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -260,6 +260,15 @@ WithSignInLink.args = {
     },
 };
 
+export const WithSignInLinkAUS = Template.bind({});
+WithSignInLinkAUS.args = {
+    variant: {
+        ...props.variant,
+        showSignInLink: true,
+    },
+    countryCode: 'AU',
+};
+
 export const WithReminderAndSignInLink = Template.bind({});
 WithReminderAndSignInLink.args = {
     variant: {

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -252,21 +252,44 @@ WithChoiceCards.args = {
     },
 };
 
+export const WithChoiceCardsSignInLinkAUS = Template.bind({});
+WithChoiceCardsSignInLinkAUS.args = {
+    variant: {
+        ...props.variant,
+        name: 'V1_SIGN_IN',
+        showSignInLink: true,
+        showChoiceCards: true,
+        choiceCardAmounts: {
+            testName: 'Storybook_test',
+            variantName: 'Control',
+            amounts: {
+                ONE_OFF: {
+                    amounts: [5, 10, 15, 20],
+                    defaultAmount: 5,
+                    hideChooseYourAmount: false,
+                },
+                MONTHLY: {
+                    amounts: [6, 12, 18, 24],
+                    defaultAmount: 12,
+                    hideChooseYourAmount: true,
+                },
+                ANNUAL: {
+                    amounts: [50, 100, 150, 200],
+                    defaultAmount: 100,
+                    hideChooseYourAmount: true,
+                },
+            },
+        },
+    },
+    countryCode: 'AU',
+};
+
 export const WithSignInLink = Template.bind({});
 WithSignInLink.args = {
     variant: {
         ...props.variant,
         showSignInLink: true,
     },
-};
-
-export const WithSignInLinkAUS = Template.bind({});
-WithSignInLinkAUS.args = {
-    variant: {
-        ...props.variant,
-        showSignInLink: true,
-    },
-    countryCode: 'AU',
 };
 
 export const WithReminderAndSignInLink = Template.bind({});

--- a/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.stories.tsx
@@ -132,8 +132,8 @@ WithReminder.args = {
     stage: 'DEV',
 };
 
-export const WithPrefilledReminder = Template.bind({});
-WithPrefilledReminder.args = {
+export const WithReminderPrefilled = Template.bind({});
+WithReminderPrefilled.args = {
     fetchEmail: () => {
         return new Promise(resolve => {
             setTimeout(() => {
@@ -143,6 +143,22 @@ WithPrefilledReminder.args = {
     },
     variant: {
         ...props.variant,
+        secondaryCta: {
+            type: SecondaryCtaType.ContributionsReminder,
+        },
+        showReminderFields: {
+            reminderCta: 'Remind me in May',
+            reminderPeriod: '2020-05-01',
+            reminderLabel: 'May',
+        },
+    },
+};
+
+export const WithReminderAndSignInLink = Template.bind({});
+WithReminderAndSignInLink.args = {
+    variant: {
+        ...props.variant,
+        showSignInLink: true,
         secondaryCta: {
             type: SecondaryCtaType.ContributionsReminder,
         },
@@ -251,9 +267,8 @@ WithChoiceCards.args = {
         },
     },
 };
-
-export const WithChoiceCardsSignInLinkAUS = Template.bind({});
-WithChoiceCardsSignInLinkAUS.args = {
+export const WithChoiceCardsAndSignInLink = Template.bind({});
+WithChoiceCardsAndSignInLink.args = {
     variant: {
         ...props.variant,
         name: 'V1_SIGN_IN',
@@ -289,22 +304,6 @@ WithSignInLink.args = {
     variant: {
         ...props.variant,
         showSignInLink: true,
-    },
-};
-
-export const WithReminderAndSignInLink = Template.bind({});
-WithReminderAndSignInLink.args = {
-    variant: {
-        ...props.variant,
-        showSignInLink: true,
-        secondaryCta: {
-            type: SecondaryCtaType.ContributionsReminder,
-        },
-        showReminderFields: {
-            reminderCta: 'Remind me in May',
-            reminderPeriod: '2020-05-01',
-            reminderLabel: 'May',
-        },
     },
 };
 

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -11,7 +11,6 @@ import {
     createViewEventFromTracking,
     logEpicView,
     createInsertEventFromTracking,
-    countryCodeToCountryGroupId,
 } from '@sdc/shared/lib';
 import { ContributionFrequency, EpicProps, epicPropsSchema, Stage } from '@sdc/shared/types';
 import { BylineWithHeadshot } from './BylineWithHeadshot';

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -405,8 +405,6 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 <BylineWithHeadshot bylineWithImage={variant.bylineWithImage} />
             )}
 
-            {variant.showSignInLink && <ContributionsEpicSignInCta />}
-
             {choiceCardAmounts && (
                 <ContributionsEpicChoiceCards
                     setSelectionsCallback={setChoiceCardSelection}
@@ -436,6 +434,8 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                     choiceCardSelection={choiceCardSelection}
                 />
             )}
+
+            {variant.showSignInLink && <ContributionsEpicSignInCta />}
         </section>
     );
 };

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -353,7 +353,9 @@ const ContributionsEpic: React.FC<EpicProps> = ({
         variant.separateArticleCount?.type === 'above' && hasConsentForArticleCount
     );
 
-    const regionCode = countryCodeToCountryGroupId(countryCode);
+    const region = countryCodeToCountryGroupId(countryCode);
+    const displaySignInBottom =
+        region === 'AUDCountries' && variant.choiceCardAmounts && variant.name === 'V1_SIGN_IN';
 
     return (
         <section ref={setNode} css={wrapperStyles}>
@@ -408,9 +410,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 <BylineWithHeadshot bylineWithImage={variant.bylineWithImage} />
             )}
 
-            {variant.showSignInLink && regionCode !== 'AUDCountries' && (
-                <ContributionsEpicSignInCta />
-            )}
+            {variant.showSignInLink && !displaySignInBottom && <ContributionsEpicSignInCta />}
 
             {choiceCardAmounts && (
                 <ContributionsEpicChoiceCards
@@ -442,9 +442,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 />
             )}
 
-            {variant.showSignInLink && regionCode === 'AUDCountries' && (
-                <ContributionsEpicSignInCta />
-            )}
+            {variant.showSignInLink && displaySignInBottom && <ContributionsEpicSignInCta />}
         </section>
     );
 };

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -11,6 +11,7 @@ import {
     createViewEventFromTracking,
     logEpicView,
     createInsertEventFromTracking,
+    countryCodeToCountryGroupId,
 } from '@sdc/shared/lib';
 import { ContributionFrequency, EpicProps, epicPropsSchema, Stage } from '@sdc/shared/types';
 import { BylineWithHeadshot } from './BylineWithHeadshot';
@@ -352,6 +353,8 @@ const ContributionsEpic: React.FC<EpicProps> = ({
         variant.separateArticleCount?.type === 'above' && hasConsentForArticleCount
     );
 
+    const regionCode = countryCodeToCountryGroupId(countryCode);
+
     return (
         <section ref={setNode} css={wrapperStyles}>
             {showAboveArticleCount && (
@@ -405,6 +408,10 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 <BylineWithHeadshot bylineWithImage={variant.bylineWithImage} />
             )}
 
+            {variant.showSignInLink && regionCode !== 'AUDCountries' && (
+                <ContributionsEpicSignInCta />
+            )}
+
             {choiceCardAmounts && (
                 <ContributionsEpicChoiceCards
                     setSelectionsCallback={setChoiceCardSelection}
@@ -435,7 +442,9 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 />
             )}
 
-            {variant.showSignInLink && <ContributionsEpicSignInCta />}
+            {variant.showSignInLink && regionCode === 'AUDCountries' && (
+                <ContributionsEpicSignInCta />
+            )}
         </section>
     );
 };

--- a/packages/modules/src/modules/epics/ContributionsEpic.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpic.tsx
@@ -353,10 +353,6 @@ const ContributionsEpic: React.FC<EpicProps> = ({
         variant.separateArticleCount?.type === 'above' && hasConsentForArticleCount
     );
 
-    const region = countryCodeToCountryGroupId(countryCode);
-    const displaySignInBottom =
-        region === 'AUDCountries' && variant.choiceCardAmounts && variant.name === 'V1_SIGN_IN';
-
     return (
         <section ref={setNode} css={wrapperStyles}>
             {showAboveArticleCount && (
@@ -410,8 +406,6 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 <BylineWithHeadshot bylineWithImage={variant.bylineWithImage} />
             )}
 
-            {variant.showSignInLink && !displaySignInBottom && <ContributionsEpicSignInCta />}
-
             {choiceCardAmounts && (
                 <ContributionsEpicChoiceCards
                     setSelectionsCallback={setChoiceCardSelection}
@@ -442,7 +436,7 @@ const ContributionsEpic: React.FC<EpicProps> = ({
                 />
             )}
 
-            {variant.showSignInLink && displaySignInBottom && <ContributionsEpicSignInCta />}
+            {variant.showSignInLink && <ContributionsEpicSignInCta />}
         </section>
     );
 };


### PR DESCRIPTION
## What does this change?

Move the sign in prompt to be below all of the payment CTA’s on the epic. We feel the journey seems disjointed as is: going from support → sign in → support again.

## How to test

DRR are running a test launching this sign in feature in AUS only (as shown in attachment), and ASAP. However, conversions and personalisation feel like to give the sign in prompt the best chance in this test (without harming the conversion rate) we would like to move the position of the sign in CTA.

## Awaiting Confirmation
- Affects all Epic's with SignIn link enabled.

## Images 
[Existing] ->
<img width="836" alt="Screenshot_2023-08-04_at_15 29 59" src="https://github.com/guardian/support-dotcom-components/assets/76729591/b77cec8e-22bd-4b14-856f-b501c26a1f5f">
[New Variant] ->
![Screenshot 2023-08-10 at 09 48 48](https://github.com/guardian/support-dotcom-components/assets/76729591/a5594a3a-7322-4808-b825-2787ff133295)
