### PR TITLE
Europe local language Banner moment, mobile copy failing to display

### DIFF
--- a/packages/server/src/api/bannerRouter.ts
+++ b/packages/server/src/api/bannerRouter.ts
@@ -141,7 +141,10 @@ export const buildBannerRouter = (
                 isSupporter: !targeting.showSupportMessaging,
                 countryCode: targeting.countryCode,
                 content: bannerContent,
-                mobileContent: bannerMobileContent,
+                mobileContent:
+                    variant.mobileBannerContent === null
+                        ? variant.mobileBannerContent
+                        : bannerMobileContent,
                 numArticles: getArticleViewCountForWeeks(
                     targeting.weeklyArticleHistory,
                     test.articlesViewedSettings?.periodInWeeks,


### PR DESCRIPTION
## What does this change?

Marketing would like to target users' in specific countries viewing the banner, altering the Banner headline copy to be a message in the Country’s regional language.

Countries to target:
Germany,
France,  `Faites partie de notre aventure européenne !`
Netherlands,
Sweden,
Spain,
Italy, `Prendi parte alla nostra nuova avventura europea!`
{_Awaiting header text_}

On the '/banner' endpoint if the user is in the EUR test and in the subset of countries adjust response to return hardcoded copy. This way we don't have to edit the template. We include the reader's country code in the payload sent to /banner. We will need to know the Europe Moment Banner test / variant names to do this targeting, as we only want to do the swap for users' in the correct test.

Banner Name : Europe Moment Local Language 2023
{_Awaiting Banner Test Name, Variant Name text: currently LOCAL_LANGAUGE / CONTROL_} 
Style: Template 3, Header Text With Choice Cards {shown below}
{_Awaiting Final Banner Design_}
![image](https://github.com/guardian/support-dotcom-components/assets/76729591/386bb2f0-a1cf-43d8-974b-c541601aa469)


## How to test (PostMan /Curl)

URL Post (local server) : http://localhost:8082/banner?force=LOCAL-LANGUAGE:CONTROL
URL Post (CODE server) : https://contributions.code.dev-guardianapis.com/banner?force=LOCAL-LANGUAGE:CONTROL
Body (JSON) : `{"tracking":{"ophanPageId":"llqsj5ewjhdutovyvaz1","platformId":"GUARDIAN_WEB","clientName":"dcr","referrerUrl":"https://m.code.dev-theguardian.com/world/2020/may/08/commemorating-ve-day-during-coronavirus-lockdown-somehow-the-quiet-made-it-louder"},"targeting":{"alreadyVisitedCount":262,"shouldHideReaderRevenue":false,"isPaidContent":false,"showSupportMessaging":false,"engagementBannerLastClosedAt":"2023-08-25T15:08:55.083Z","subscriptionBannerLastClosedAt":"2023-03-20T14:19:01.025Z","signInBannerLastClosedAt":null,"mvtId":0,"countryCode":"DE","weeklyArticleHistory":[{"week":19590,"count":1,"tags":{"world/coronavirus-outbreak":1,"politics/politics":1}},{"week":19583,"count":1,"tags":{"world/coronavirus-outbreak":1,"politics/politics":1}},{"week":19555,"count":1,"tags":{"world/coronavirus-outbreak":1,"politics/politics":1}},{"week":19548,"count":1,"tags":{"world/coronavirus-outbreak":1,"politics/politics":1}},{"week":19534,"count":1,"tags":{"world/coronavirus-outbreak":1,"politics/politics":1}},{"week":19520,"count":1,"tags":{"world/coronavirus-outbreak":1,"politics/politics":1}},{"week":19513,"count":1,"tags":{"world/coronavirus-outbreak":1,"politics/politics":1}},{"week":19478,"count":1,"tags":{"world/coronavirus-outbreak":1,"politics/politics":1}},{"week":19471,"count":1,"tags":{"world/coronavirus-outbreak":1,"politics/politics":1}},{"week":19464,"count":1,"tags":{"world/coronavirus-outbreak":1,"politics/politics":1}},{"week":19443,"count":1,"tags":{"world/coronavirus-outbreak":1,"politics/politics":1}},{"week":19436,"count":2,"tags":{"world/coronavirus-outbreak":1,"politics/politics":2}},{"week":19429,"count":2,"tags":{"world/world":1,"world/coronavirus-outbreak":1,"politics/politics":1}}],"articleCountToday":15,"hasOptedOutOfArticleCount":false,"modulesVersion":"v3","sectionId":"world","tagIds":["world/ve-day","uk/uk","uk/monarchy","world/coronavirus-outbreak","world/secondworldwar","politics/politics","campaign/callout/callout-coronavirus","type/article","tone/comment","profile/jonathanfreedland","publication/theguardian","theguardian/mainsection","theguardian/mainsection/topstories","tracking/commissioningdesk/uk-opinion"],"contentType":"Article","isSignedIn":false,"lastOneOffContributionDate":"2023-06-30"}}`

Modify countryCode to DE,FR,IT,NL,SE,SP to get predefined headers, all reamaing use default header defined in RRCP.
VPN may allow Geo-location swap.

[Support-Admin-Console Local Language Banner PR] https://github.com/guardian/support-admin-console/pull/480

[Trello] https://trello.com/c/OUXtdFcx/1497-europe-moment-banner-headline-in-local-language

