### PR TITLE
Supporter Banner moment

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/SupportCta.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/SupportCta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/dist/lib';
 import { Tracking } from '@sdc/shared/dist/types';
-import { brandAlt, neutral, space } from '@guardian/src-foundations';
+import { space } from '@guardian/src-foundations';
 import { css, SerializedStyles } from '@emotion/react';
 import { Hide } from '@guardian/src-layout';
 import { Button } from './Button';
@@ -9,12 +9,6 @@ import { ChoiceCardSelection } from '../ChoiceCardsButtonsBanner';
 
 const buttonOverrides = css`
     margin-right: ${space[3]}px;
-    background: ${brandAlt[400]};
-    color: ${neutral[0]} !important;
-
-    &:hover {
-        background-color: ${brandAlt[200]};
-    }
 `;
 
 export const SupportCta = ({

--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -22,6 +22,7 @@ export type BannerId =
     | 'choice-cards-banner-yellow'
     | 'choice-cards-buttons-banner-blue'
     | 'choice-cards-buttons-banner-yellow'
+    | 'supporter-moment-banner'
     | 'global-new-year-banner'
     | 'election-au-moment-banner'
     | 'sign-in-prompt-banner'

--- a/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.stories.tsx
@@ -26,12 +26,12 @@ const EuropeMomentLocalLanguageBanner = bannerWrapper(
         },
         primaryCtaSettings: {
             default: {
-                backgroundColour: brand[400],
-                textColour: 'white',
+                backgroundColour: brandAlt[400],
+                textColour: 'black',
             },
             hover: {
                 backgroundColour: brandAlt[200],
-                textColour: brand[400],
+                textColour: 'black',
             },
         },
         secondaryCtaSettings: {

--- a/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.stories.tsx
@@ -105,7 +105,7 @@ EuropeMomentLocalLanguage.args = {
         },
     },
     choiceCardAmounts: {
-        testName: 'Storybook_europeLocalLanguage',
+        testName: 'Storybook_test',
         variantName: 'CONTROL',
         defaultContributionType: 'MONTHLY',
         displayContributionType: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],

--- a/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.tsx
+++ b/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.tsx
@@ -11,12 +11,12 @@ const EuropeMomentLocalLanguageBanner = getMomentTemplateBanner({
     },
     primaryCtaSettings: {
         default: {
-            backgroundColour: brand[400],
-            textColour: 'white',
+            backgroundColour: brandAlt[400],
+            textColour: 'black',
         },
         hover: {
             backgroundColour: brandAlt[200],
-            textColour: brand[400],
+            textColour: 'black',
         },
     },
     secondaryCtaSettings: {

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -18,6 +18,7 @@ import useReminder from '../../../hooks/useReminder';
 import useMediaQuery from '../../../hooks/useMediaQuery';
 import useChoiceCards from '../../../hooks/useChoiceCards';
 import { ChoiceCards } from '../choiceCardsButtonsBanner/components/ChoiceCards';
+import { buttonStyles } from './styles/buttonStyles';
 
 export function getMomentTemplateBanner(
     templateSettings: BannerTemplateSettings,
@@ -144,6 +145,7 @@ export function getMomentTemplateBanner(
                                 numArticles={numArticles}
                                 content={content}
                                 getCtaText={getCtaText}
+                                cssCtaOverides={buttonStyles(templateSettings.primaryCtaSettings)}
                             />
                         )}
                     </div>
@@ -258,5 +260,12 @@ const styles = {
     ctasContainer: css`
         display: flex;
         flex-direction: row;
+    `,
+    ctaPrimaryColors: (backColor: string, textColor: string, hoverColor: string) => css`
+        background: ${backColor};
+        color: ${textColor} !important;
+        &:hover {
+            background-color: ${hoverColor};
+        }
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -261,11 +261,4 @@ const styles = {
         display: flex;
         flex-direction: row;
     `,
-    ctaPrimaryColors: (backColor: string, textColor: string, hoverColor: string) => css`
-        background: ${backColor};
-        color: ${textColor} !important;
-        &:hover {
-            background-color: ${hoverColor};
-        }
-    `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/stories/WithChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/WithChoiceCards.tsx
@@ -15,13 +15,12 @@ export const BannerWithChoiceCards = bannerWrapper(
         },
         primaryCtaSettings: {
             default: {
-                backgroundColour: '#0077B6',
-                textColour: 'white',
+                backgroundColour: brandAlt[400],
+                textColour: 'black',
             },
             hover: {
-                backgroundColour: '#004E7C',
-                textColour: 'white',
-                border: '1px solid #004E7C',
+                backgroundColour: brandAlt[200],
+                textColour: 'black',
             },
         },
         secondaryCtaSettings: {

--- a/packages/modules/src/modules/banners/momentTemplate/stories/WithChoiceCardsHeaderImage.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/WithChoiceCardsHeaderImage.tsx
@@ -17,13 +17,12 @@ export const BannerWithChoiceCardsHeaderImage = bannerWrapper(
         },
         primaryCtaSettings: {
             default: {
-                backgroundColour: '#0077B6',
-                textColour: 'white',
+                backgroundColour: brandAlt[400],
+                textColour: 'black',
             },
             hover: {
-                backgroundColour: '#004E7C',
-                textColour: 'white',
-                border: '1px solid #004E7C',
+                backgroundColour: brandAlt[200],
+                textColour: 'black',
             },
         },
         secondaryCtaSettings: {

--- a/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
@@ -30,7 +30,7 @@ const SupporterMomentBanner = bannerWrapper(
                 textColour: 'white',
             },
             hover: {
-                backgroundColour: '#721765',
+                backgroundColour: '#2D0427',
                 textColour: 'white',
             },
         },

--- a/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
@@ -106,8 +106,10 @@ SupporterMoment.args = {
     },
     choiceCardAmounts: {
         testName: 'Storybook_europeLocalLanguage',
-        variantName: 'Control',
-        amounts: {
+        variantName: 'CONTROL',
+        defaultContributionType: 'MONTHLY',
+        displayContributionType: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],
+        amountsCardData: {
             ONE_OFF: {
                 amounts: [5, 10, 15, 20],
                 defaultAmount: 5,

--- a/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { brand, culture } from '@guardian/src-foundations';
+import { bannerWrapper } from '../common/BannerWrapper';
+import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
+import { BannerProps } from '@sdc/shared/src/types';
+import { Meta, Story } from '@storybook/react';
+import { props } from '../utils/storybook';
+
+export default {
+    title: 'Banners/MomentTemplate',
+    parameters: {
+        chromatic: {
+            delay: 300,
+        },
+    },
+    args: props,
+} as Meta;
+
+const SupporterMomentBanner = bannerWrapper(
+    getMomentTemplateBanner({
+        containerSettings: {
+            backgroundColour: '#FDF1F8',
+        },
+        headerSettings: {
+            textColour: '#721765',
+        },
+        primaryCtaSettings: {
+            default: {
+                backgroundColour: '#721765',
+                textColour: 'white',
+            },
+            hover: {
+                backgroundColour: '#721765',
+                textColour: 'white',
+            },
+        },
+        secondaryCtaSettings: {
+            default: {
+                backgroundColour: culture[800],
+                textColour: brand[400],
+                border: '1px solid #052962',
+            },
+            hover: {
+                backgroundColour: '#E5E5E5',
+                textColour: brand[400],
+                border: '1px solid #052962',
+            },
+            theme: 'brand',
+        },
+        closeButtonSettings: {
+            default: {
+                backgroundColour: '#FDF1F8',
+                textColour: brand[400],
+                border: `1px solid ${brand[400]}`,
+            },
+            hover: {
+                backgroundColour: '#FDF1F8',
+                textColour: brand[400],
+            },
+            theme: 'brand',
+        },
+        highlightedTextSettings: {
+            textColour: 'white',
+            highlightColour: '#721765',
+        },
+        choiceCards: true,
+        bannerId: 'supporter-moment-banner',
+    }),
+    'supporter-moment-banner',
+);
+
+const SupporterMomentTemplate: Story<BannerProps> = (props: BannerProps) => (
+    <SupporterMomentBanner {...props} />
+);
+
+export const SupporterMoment = SupporterMomentTemplate.bind({});
+SupporterMoment.args = {
+    ...props,
+    content: {
+        heading: 'The only pocket we’re in is yours',
+        messageText:
+            'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, semi. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo.',
+        paragraphs: [
+            'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, semi. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. ',
+        ],
+        highlightedText:
+            'Nullam dictum felis eu pede mollis pretium. Integeir tincidunt. Thank you.',
+        cta: {
+            text: 'Contribute',
+            baseUrl: 'https://support.theguardian.com/contribute/one-off',
+        },
+    },
+    mobileContent: {
+        heading: 'The only pocket we’re in is yours',
+        messageText:
+            'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, semi. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo.',
+        paragraphs: [
+            'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, semi. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. ',
+        ],
+        highlightedText:
+            'Nullam dictum felis eu pede mollis pretium. Integeir tincidunt. Thank you.',
+        cta: {
+            text: 'Contribute',
+            baseUrl: 'https://support.theguardian.com/contribute/one-off',
+        },
+    },
+    choiceCardAmounts: {
+        testName: 'Storybook_europeLocalLanguage',
+        variantName: 'Control',
+        amounts: {
+            ONE_OFF: {
+                amounts: [5, 10, 15, 20],
+                defaultAmount: 5,
+                hideChooseYourAmount: false,
+            },
+            MONTHLY: {
+                amounts: [3, 6, 10],
+                defaultAmount: 10,
+                hideChooseYourAmount: true,
+            },
+            ANNUAL: {
+                amounts: [100],
+                defaultAmount: 100,
+                hideChooseYourAmount: true,
+            },
+        },
+    },
+    numArticles: 50,
+    tickerSettings: undefined,
+};

--- a/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
@@ -105,7 +105,7 @@ SupporterMoment.args = {
         },
     },
     choiceCardAmounts: {
-        testName: 'Storybook_europeLocalLanguage',
+        testName: 'Storybook_test',
         variantName: 'CONTROL',
         defaultContributionType: 'MONTHLY',
         displayContributionType: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],

--- a/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.tsx
@@ -15,7 +15,7 @@ const SupporterMomentBanner = getMomentTemplateBanner({
             textColour: 'white',
         },
         hover: {
-            backgroundColour: '#721765',
+            backgroundColour: '#2D0427',
             textColour: 'white',
         },
     },

--- a/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.tsx
@@ -1,0 +1,58 @@
+import { brand, culture } from '@guardian/src-foundations';
+import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
+import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
+
+const SupporterMomentBanner = getMomentTemplateBanner({
+    containerSettings: {
+        backgroundColour: '#F1F8FC',
+    },
+    headerSettings: {
+        textColour: '#721765',
+    },
+    primaryCtaSettings: {
+        default: {
+            backgroundColour: '#721765',
+            textColour: 'white',
+        },
+        hover: {
+            backgroundColour: '#721765',
+            textColour: 'white',
+        },
+    },
+    secondaryCtaSettings: {
+        default: {
+            backgroundColour: culture[800],
+            textColour: brand[400],
+            border: '1px solid #052962',
+        },
+        hover: {
+            backgroundColour: '#E5E5E5',
+            textColour: brand[400],
+            border: '1px solid #052962',
+        },
+        theme: 'brand',
+    },
+    closeButtonSettings: {
+        default: {
+            backgroundColour: '#F1F8FC',
+            textColour: brand[400],
+            border: `1px solid ${brand[400]}`,
+        },
+        hover: {
+            backgroundColour: '#F1F8FC',
+            textColour: brand[400],
+        },
+        theme: 'brand',
+    },
+    highlightedTextSettings: {
+        textColour: 'white',
+        highlightColour: '#721765',
+    },
+    choiceCards: true,
+    bannerId: 'supporter-moment-banner',
+});
+
+const unvalidated = bannerWrapper(SupporterMomentBanner, 'supporter-moment-banner');
+const validated = validatedBannerWrapper(SupporterMomentBanner, 'supporter-moment-banner');
+
+export { validated as SupporterMomentBanner, unvalidated as SupporterMomentBannerUnValidated };

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -17,6 +17,7 @@ import {
     scotus2023MomentBanner,
     ausAnniversaryBanner,
     wpfdBanner,
+    supporterMomentBanner,
 } from '@sdc/shared/config';
 import {
     BannerChannel,
@@ -49,6 +50,7 @@ export const BannerPaths: {
     [BannerTemplate.ChoiceCardsButtonsBannerBlue]: choiceCardsButtonsBannerBlue.endpointPathBuilder,
     [BannerTemplate.ChoiceCardsButtonsBannerYellow]:
         choiceCardsButtonsBannerYellow.endpointPathBuilder,
+    [BannerTemplate.SupporterMomentBanner]: supporterMomentBanner.endpointPathBuilder,
     [BannerTemplate.GuardianWeeklyBanner]: guardianWeekly.endpointPathBuilder,
     [BannerTemplate.SignInPromptBanner]: signInPromptBanner.endpointPathBuilder,
     [BannerTemplate.UkraineMomentBanner]: ukraineMomentBanner.endpointPathBuilder,

--- a/packages/shared/src/config/modules.ts
+++ b/packages/shared/src/config/modules.ts
@@ -88,6 +88,11 @@ export const choiceCardsButtonsBannerYellow: ModuleInfo = getDefaultModuleInfo(
     'banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBannerYellow',
 );
 
+export const supporterMomentBanner: ModuleInfo = getDefaultModuleInfo(
+    'supporter-moment-banner',
+    'banners/supporterMoment/SupporterMomentBanner',
+);
+
 export const guardianWeekly: ModuleInfo = getDefaultModuleInfo(
     'guardian-weekly-banner',
     'banners/guardianWeekly/GuardianWeeklyBanner',
@@ -141,6 +146,7 @@ export const moduleInfos: ModuleInfo[] = [
     choiceCardsBannerYellow,
     choiceCardsButtonsBannerBlue,
     choiceCardsButtonsBannerYellow,
+    supporterMomentBanner,
     guardianWeekly,
     puzzlesBanner,
     signInPromptBanner,

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -26,6 +26,7 @@ export enum BannerTemplate {
     ChoiceCardsBannerYellow = 'ChoiceCardsBannerYellow',
     ChoiceCardsButtonsBannerBlue = 'ChoiceCardsButtonsBannerBlue',
     ChoiceCardsButtonsBannerYellow = 'ChoiceCardsButtonsBannerYellow',
+    SupporterMomentBanner = 'SupporterMomentBanner',
     GuardianWeeklyBanner = 'GuardianWeeklyBanner',
     GlobalNewYearBanner = 'GlobalNewYearBanner',
     SignInPromptBanner = 'SignInPromptBanner',


### PR DESCRIPTION
## What does this change?

Marketing would like a matching separate moment choice card banner with header text (template3) for all regions EXCEPT Europe which has its own local language banner. 
Modify primaryCTA colour BannerTemplate settings to change the CTA button colour (currently it cannot be changed from yellow).

![image](https://github.com/guardian/support-dotcom-components/assets/76729591/3d1dcf37-c37a-47e5-9611-9a13687eba68)

[Support-Admin-Console Supporter Moment Banner PR] https://github.com/guardian/support-admin-console/pull/484

[Trello] https://trello.com/c/jRwJkWGV/1516-supporter-moment-choicecard-banner-create
