### PR TITLE
moved shared amounts types from epic to shared type definition file

### DIFF
--- a/packages/modules/src/hooks/useChoiceCards.ts
+++ b/packages/modules/src/hooks/useChoiceCards.ts
@@ -1,7 +1,10 @@
-import { ContributionFrequency, SelectedAmountsVariant } from '@sdc/shared/src/types/abTests/epic';
 import { useState, useEffect } from 'react';
 import { BannerTextContent } from '../modules/banners/common/types';
 import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib';
+import {
+    ContributionFrequency,
+    SelectedAmountsVariant,
+} from '@sdc/shared/src/types/abTests/shared';
 
 export interface ChoiceCardSelection {
     frequency: ContributionFrequency;

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -1,7 +1,11 @@
 import { CountryGroupId, ReminderFields } from '../../lib';
 import {
+    AmountsVariant,
     ArticlesViewedSettings,
+    ContributionAmounts,
+    ContributionFrequency,
     ControlProportionSettings,
+    SelectedAmountsVariant,
     Test,
     TestStatus,
     UserCohort,
@@ -65,8 +69,6 @@ export interface EpicVariant extends Variant {
     showSignInLink?: boolean;
 }
 
-export type ContributionFrequency = 'ONE_OFF' | 'MONTHLY' | 'ANNUAL';
-
 export const contributionTabFrequencies: ContributionFrequency[] = ['ONE_OFF', 'MONTHLY', 'ANNUAL'];
 
 interface ContributionTypeItem {
@@ -103,27 +105,6 @@ Region test:
     - users will be randomly segregated into an AB test and see the appropriate variant
     - analytics will use the `liveTestName` label
 */
-interface AmountValuesObject {
-    amounts: number[];
-    defaultAmount: number;
-    hideChooseYourAmount?: boolean;
-}
-
-export type AmountsCardData = {
-    [key in ContributionFrequency]: AmountValuesObject;
-};
-
-export interface AmountsVariant {
-    variantName: string;
-    defaultContributionType: ContributionFrequency;
-    displayContributionType: ContributionFrequency[];
-    amountsCardData: AmountsCardData;
-}
-
-export interface SelectedAmountsVariant extends AmountsVariant {
-    testName: string;
-}
-
 export type AmountsTestTargeting =
     | { targetingType: 'Region'; region: CountryGroupId }
     | { targetingType: 'Country'; countries: string[] };
@@ -140,6 +121,15 @@ export interface AmountsTest {
 }
 
 export type AmountsTests = AmountsTest[];
+
+export type ConfiguredRegionAmounts = {
+    control: ContributionAmounts;
+    test?: AmountsTest;
+};
+
+export type ChoiceCardAmounts = {
+    [key in CountryGroupId]: ConfiguredRegionAmounts;
+};
 
 export interface EpicTest extends Test<EpicVariant> {
     name: string;

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -64,3 +64,37 @@ export interface PurchaseInfoTest {
     userType: purchaseInfoUser[];
     product: purchaseInfoProduct[];
 }
+
+export interface AmountSelection {
+    amounts: number[];
+    defaultAmount: number;
+    hideChooseYourAmount?: boolean;
+}
+
+export type ContributionFrequency = 'ONE_OFF' | 'MONTHLY' | 'ANNUAL';
+
+export type ContributionAmounts = {
+    [key in ContributionFrequency]: AmountSelection;
+};
+
+interface AmountValuesObject {
+    amounts: number[];
+    defaultAmount: number;
+    hideChooseYourAmount?: boolean;
+}
+
+export type AmountsCardData = {
+    [key in ContributionFrequency]: AmountValuesObject;
+};
+
+export interface AmountsVariant {
+    variantName: string;
+    defaultContributionType: ContributionFrequency;
+    displayContributionType: ContributionFrequency[];
+    amountsCardData: AmountsCardData;
+}
+
+export interface SelectedAmountsVariant extends AmountsVariant {
+    testName: string;
+    amounts?: ContributionAmounts;
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
