### PR TITLE
Europe local language Epic translation

### DIFF
--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -32,6 +32,7 @@ import { logWarn } from '../utils/logging';
 import { SuperModeArticle } from '../lib/superMode';
 import { isMobile } from '../lib/deviceType';
 import { ValueProvider } from '../utils/valueReloader';
+import { localLanguagesEpicTests } from '../tests/epics/hardCodedTests/localLanguageCopy';
 
 interface EpicDataResponse {
     data?: {
@@ -47,7 +48,7 @@ interface EpicDataResponse {
 }
 
 // Any hardcoded epic tests should go here. They will take priority over any tests from the epic tool.
-const hardcodedEpicTests: EpicTest[] = [];
+const hardcodedEpicTests: EpicTest[] = [...localLanguagesEpicTests];
 
 export const buildEpicRouter = (
     channelSwitches: ValueProvider<ChannelSwitches>,

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -17,6 +17,7 @@ import {
     withinMaxViews,
     deviceTypeMatchesFilter,
     correctSignedInStatusFilter,
+    matchesCountryCodes,
 } from './epicSelection';
 
 const testDefault: EpicTest = {
@@ -533,6 +534,68 @@ describe('matchesCountryGroups filter', () => {
         };
 
         const got = matchesCountryGroups.test(test, targeting);
+
+        expect(got).toBe(false);
+    });
+});
+
+describe('matchesCountryCodes filter', () => {
+    it('should pass if no location or country code location set in the test', () => {
+        const test = {
+            ...testDefault,
+            locations: [],
+            countryCodeLocations: [],
+        };
+
+        const got = matchesCountryCodes.test(test, targetingDefault);
+
+        expect(got).toBe(true);
+    });
+
+    it('should fail if location and country code location is set but user location unknown', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            locations: ['GBPCountries'],
+            countryCodeLocations: ['GB'],
+        };
+        const targeting = {
+            ...targetingDefault,
+            countryCode: undefined,
+        };
+
+        const got = matchesCountryCodes.test(test, targeting);
+
+        expect(got).toBe(false);
+    });
+
+    it('should pass if user in country group and country code location', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            locations: ['EURCountries'],
+            countryCodeLocations: ['PT'],
+        };
+        const targeting: EpicTargeting = {
+            ...targetingDefault,
+            countryCode: 'PT',
+        };
+
+        const got = matchesCountryCodes.test(test, targeting);
+
+        expect(got).toBe(true);
+    });
+
+    it('should fail if user in country group but not country code location', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            locations: ['EURCountries'],
+            countryCodeLocations: ['GB'],
+        };
+        const targeting: EpicTargeting = {
+            ...targetingDefault,
+            countryCode: 'PT',
+        };
+
+        const got = matchesCountryCodes.test(test, targeting);
 
         expect(got).toBe(false);
     });

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -17,7 +17,7 @@ import {
     withinMaxViews,
     deviceTypeMatchesFilter,
     correctSignedInStatusFilter,
-    matchesCountryCodes,
+    matchesCountryCodeLocations,
 } from './epicSelection';
 
 const testDefault: EpicTest = {
@@ -547,7 +547,7 @@ describe('matchesCountryCodes filter', () => {
             countryCodeLocations: [],
         };
 
-        const got = matchesCountryCodes.test(test, targetingDefault);
+        const got = matchesCountryCodeLocations.test(test, targetingDefault);
 
         expect(got).toBe(true);
     });
@@ -563,7 +563,7 @@ describe('matchesCountryCodes filter', () => {
             countryCode: undefined,
         };
 
-        const got = matchesCountryCodes.test(test, targeting);
+        const got = matchesCountryCodeLocations.test(test, targeting);
 
         expect(got).toBe(false);
     });
@@ -579,7 +579,7 @@ describe('matchesCountryCodes filter', () => {
             countryCode: 'PT',
         };
 
-        const got = matchesCountryCodes.test(test, targeting);
+        const got = matchesCountryCodeLocations.test(test, targeting);
 
         expect(got).toBe(true);
     });
@@ -595,7 +595,7 @@ describe('matchesCountryCodes filter', () => {
             countryCode: 'PT',
         };
 
-        const got = matchesCountryCodes.test(test, targeting);
+        const got = matchesCountryCodeLocations.test(test, targeting);
 
         expect(got).toBe(false);
     });

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -1,4 +1,9 @@
-import { countryCodeToCountryGroupId, getCountryName, inCountryGroups } from '@sdc/shared/lib';
+import {
+    countryCodeToCountryGroupId,
+    getCountryName,
+    inCountryCodeArray,
+    inCountryGroups,
+} from '@sdc/shared/lib';
 import {
     EpicTargeting,
     EpicTest,
@@ -132,6 +137,12 @@ export const matchesCountryGroups: Filter = {
     test: (test, targeting): boolean => inCountryGroups(targeting.countryCode, test.locations),
 };
 
+export const matchesCountryCodes: Filter = {
+    id: 'matchesCountryCodes',
+    test: (test, targeting): boolean =>
+        inCountryCodeArray(targeting.countryCode, test.countryCodeLocations),
+};
+
 export const withinMaxViews = (log: EpicViewLog, now: Date = new Date()): Filter => ({
     id: 'shouldThrottle',
     test: (test): boolean => {
@@ -242,6 +253,7 @@ export const findTestAndVariant = (
             excludeTags,
             hasCountryCode,
             matchesCountryGroups,
+            matchesCountryCodes,
             // For the super mode pass, we treat all tests as "always ask" so disable this filter
             ...(isSuperModePass ? [] : [withinMaxViews(targeting.epicViewLog || [])]),
             respectArticleCountOptOut,

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -1,7 +1,7 @@
 import {
     countryCodeToCountryGroupId,
     getCountryName,
-    inCountryCodeArray,
+    inCountryCodeLocations,
     inCountryGroups,
 } from '@sdc/shared/lib';
 import {
@@ -137,10 +137,10 @@ export const matchesCountryGroups: Filter = {
     test: (test, targeting): boolean => inCountryGroups(targeting.countryCode, test.locations),
 };
 
-export const matchesCountryCodes: Filter = {
-    id: 'matchesCountryCodes',
+export const matchesCountryCodeLocations: Filter = {
+    id: 'matchesCountryCodeLocations',
     test: (test, targeting): boolean =>
-        inCountryCodeArray(targeting.countryCode, test.countryCodeLocations),
+        inCountryCodeLocations(targeting.countryCode, test.countryCodeLocations),
 };
 
 export const withinMaxViews = (log: EpicViewLog, now: Date = new Date()): Filter => ({
@@ -253,7 +253,7 @@ export const findTestAndVariant = (
             excludeTags,
             hasCountryCode,
             matchesCountryGroups,
-            matchesCountryCodes,
+            matchesCountryCodeLocations,
             // For the super mode pass, we treat all tests as "always ask" so disable this filter
             ...(isSuperModePass ? [] : [withinMaxViews(targeting.epicViewLog || [])]),
             respectArticleCountOptOut,

--- a/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
+++ b/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
@@ -29,7 +29,7 @@ const localLanguagesEpicCopy = {
 // Epic Tests below & variant info to be finalised
 const getEpicVariant = (countryCode: keyof typeof localLanguagesEpicCopy) => {
     const variant: EpicVariant = {
-        name: 'variant',
+        name: 'CONTROL',
         heading: localLanguagesEpicCopy[countryCode].heading,
         paragraphs: localLanguagesEpicCopy[countryCode].paragraphs,
         highlightedText: localLanguagesEpicCopy[countryCode].highlightedText,
@@ -45,11 +45,11 @@ const getEpicVariant = (countryCode: keyof typeof localLanguagesEpicCopy) => {
 };
 
 const franceCopyTest: EpicTest = {
-    name: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_FRANCE',
+    name: 'LOCAL_LANGUAGE',
 
     // These are specific to hardcoded tests
     // expiry: '2023-09-01',
-    campaignId: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_FRANCE',
+    campaignId: '',
 
     hasArticleCountInCopy: true,
     status: 'Live',
@@ -74,11 +74,11 @@ const franceCopyTest: EpicTest = {
 };
 
 const germanCopyTest: EpicTest = {
-    name: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_GERMANY',
+    name: 'LOCAL_LANGUAGE',
 
     // These are specific to hardcoded tests
     // expiry: '2023-09-01',
-    campaignId: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_GERMANY',
+    campaignId: '',
 
     audience: 1,
     alwaysAsk: false,
@@ -99,11 +99,11 @@ const germanCopyTest: EpicTest = {
 };
 
 const netherlandsCopyTest: EpicTest = {
-    name: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_NETHERLANDS',
+    name: 'LOCAL_LANGUAGE',
 
     // These are specific to hardcoded tests
     // expiry: '2023-09-01',
-    campaignId: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_NETHERLANDS',
+    campaignId: '',
 
     audience: 1,
     alwaysAsk: false,

--- a/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
+++ b/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
@@ -1,21 +1,28 @@
 import { EpicTest, EpicVariant } from '@sdc/shared/dist/types';
 
 const localLanguagesEpicCopy = {
-    // Copy to be updated if this approach is taken forward
     FR: {
-        heading: 'Bonjour',
-        paragraphs: ['Bonjour', 'Bonjour', 'Bonjour '],
-        highlightedText: 'Bonjour',
+        heading: '… il existe une bonne raison de ne pas soutenir le Guardian.',
+        paragraphs: [
+            `Actuellement, beaucoup de lecteurs ne sont pas ou plus en mesure de payer pour accéder aux informations. C’est pour cela que nos contenus sont et resteront gratuits et ouverts à tous. Si tel est votre cas, vous pouvez continuer à lire nos articles librement, comme vous le faites à présent, depuis la France.`,
+            `Si au contraire, vous avez les moyens de contribuer financièrement, voici trois bonnes raisons de soutenir le Guardian dès aujourd’hui.`,
+            `1. Nous sommes une rédaction indépendante. Personne ne contrôle notre ligne éditoriale ; fait rare en Europe où la liberté des médias est souvent compromise par le poids des actionnaires et la corruption. `,
+            `2. Notre journalisme d'investigation met en lumière les dessous du pouvoir et dénonce l’injustice en Europe et dans le monde entier.`,
+            `3. Même sous l'ère du Brexit, nous restons plus européens que jamais. Nous venons de lancer notre nouvelle édition en ligne en anglais, dédiée à nos lecteurs en Europe, et donc à vous, en France. Cette année, nous avons investi dans notre journalisme européen, recruté de nouveaux correspondants sur le continent et publié plus de 10 000 articles sur les affaires européennes. Nous comptons désormais environ 180 000 de nos contributeurs en Europe.`,
+            `Afin que ce travail essentiel perdure dans les années à venir, nous avons besoin du soutien des lecteurs. Si vous le pouvez, `,
+        ],
+        highlightedText:
+            'une contribution de seulement 2 euros par mois peut dès aujourd’hui faire toute la différence. Merci.',
     },
     DE: {
         heading: 'Hallo Germany',
-        paragraphs: ['Hallo', 'Hallo', 'Hallo '],
-        highlightedText: 'Hallo',
+        paragraphs: ['Hallo1', 'Hallo2', 'Hallo3'],
+        highlightedText: 'Hallo Germany',
     },
     NL: {
         heading: 'Hallo Netherlands',
-        paragraphs: ['Hallo', 'Hallo', 'Hallo '],
-        highlightedText: 'Hallo',
+        paragraphs: ['Hallo1', 'Hallo2'],
+        highlightedText: 'Hallo Netherlands',
     },
 };
 

--- a/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
+++ b/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
@@ -1,0 +1,119 @@
+import { EpicTest, EpicVariant } from '@sdc/shared/dist/types';
+
+const localLanguagesEpicCopy = {
+    // Copy to be updated if this approach is taken forward
+    FR: {
+        heading: 'Bonjour',
+        paragraphs: ['Bonjour', 'Bonjour', 'Bonjour '],
+        highlightedText: 'Bonjour',
+    },
+    DE: {
+        heading: 'Hallo Germany',
+        paragraphs: ['Hallo', 'Hallo', 'Hallo '],
+        highlightedText: 'Hallo',
+    },
+    NL: {
+        heading: 'Hallo Netherlands',
+        paragraphs: ['Hallo', 'Hallo', 'Hallo '],
+        highlightedText: 'Hallo',
+    },
+};
+
+// Epic Tests below & variant info to be finalised
+const getEpicVariant = (countryCode: keyof typeof localLanguagesEpicCopy) => {
+    const variant: EpicVariant = {
+        name: 'variant',
+        heading: localLanguagesEpicCopy[countryCode].heading,
+        paragraphs: localLanguagesEpicCopy[countryCode].paragraphs,
+        highlightedText: localLanguagesEpicCopy[countryCode].highlightedText,
+        cta: {
+            text: 'Support the Guardian',
+            baseUrl: 'https://support.theguardian.com/contribute',
+        },
+        showChoiceCards: true,
+        separateArticleCount: { type: 'above' },
+    };
+
+    return variant;
+};
+
+const franceCopyTest: EpicTest = {
+    name: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_FRANCE',
+
+    // These are specific to hardcoded tests
+    // expiry: '2023-09-01',
+    campaignId: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_FRANCE',
+
+    hasArticleCountInCopy: true,
+    status: 'Live',
+    locations: ['EURCountries'],
+    countryCodeLocations: ['FR'],
+    audience: 1,
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: false,
+    hasCountryName: false,
+    highPriority: true,
+    isLiveBlog: false,
+    useLocalViewLog: true,
+    userCohort: 'AllNonSupporters',
+    variants: [getEpicVariant('FR')],
+    // articlesViewedSettings: {
+    //     minViews: ,
+    //     periodInWeeks: ,
+    // },
+};
+
+const germanCopyTest: EpicTest = {
+    name: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_GERMANY',
+
+    // These are specific to hardcoded tests
+    // expiry: '2023-09-01',
+    campaignId: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_GERMANY',
+
+    audience: 1,
+    alwaysAsk: false,
+    excludedSections: [],
+    excludedTagIds: [],
+    hasArticleCountInCopy: true,
+    hasCountryName: false,
+    highPriority: true,
+    isLiveBlog: false,
+    status: 'Live',
+    locations: ['EURCountries'],
+    countryCodeLocations: ['DE'],
+    sections: [],
+    tagIds: [],
+    useLocalViewLog: true,
+    userCohort: 'AllNonSupporters',
+    variants: [getEpicVariant('DE')],
+};
+
+const netherlandsCopyTest: EpicTest = {
+    name: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_NETHERLANDS',
+
+    // These are specific to hardcoded tests
+    // expiry: '2023-09-01',
+    campaignId: 'EPIC_LOCAL_LANGUAGE_SEPT_2023_NETHERLANDS',
+
+    audience: 1,
+    alwaysAsk: false,
+    excludedSections: [],
+    excludedTagIds: [],
+    hasArticleCountInCopy: true,
+    hasCountryName: false,
+    highPriority: true,
+    isLiveBlog: false,
+    status: 'Live',
+    locations: ['EURCountries'],
+    countryCodeLocations: ['NL'],
+    sections: [],
+    tagIds: [],
+    useLocalViewLog: true,
+    userCohort: 'AllNonSupporters',
+    variants: [getEpicVariant('NL')],
+};
+
+export const localLanguagesEpicTests = [franceCopyTest, germanCopyTest, netherlandsCopyTest];

--- a/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
+++ b/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
@@ -9,20 +9,36 @@ const localLanguagesEpicCopy = {
             `1. Nous sommes une rédaction indépendante. Personne ne contrôle notre ligne éditoriale ; fait rare en Europe où la liberté des médias est souvent compromise par le poids des actionnaires et la corruption. `,
             `2. Notre journalisme d'investigation met en lumière les dessous du pouvoir et dénonce l’injustice en Europe et dans le monde entier.`,
             `3. Même sous l'ère du Brexit, nous restons plus européens que jamais. Nous venons de lancer notre nouvelle édition en ligne en anglais, dédiée à nos lecteurs en Europe, et donc à vous, en France. Cette année, nous avons investi dans notre journalisme européen, recruté de nouveaux correspondants sur le continent et publié plus de 10 000 articles sur les affaires européennes. Nous comptons désormais environ 180 000 de nos contributeurs en Europe.`,
-            `Afin que ce travail essentiel perdure dans les années à venir, nous avons besoin du soutien des lecteurs. Si vous le pouvez, `,
+            `Afin que ce travail essentiel perdure dans les années à venir, nous avons besoin du soutien des lecteurs. `,
         ],
         highlightedText:
-            'une contribution de seulement 2 euros par mois peut dès aujourd’hui faire toute la différence. Merci.',
+            'Si vous le pouvez, une contribution de seulement €2 par mois peut dès aujourd’hui faire toute la différence. Merci.',
     },
     DE: {
-        heading: 'Hallo Germany',
-        paragraphs: ['Hallo1', 'Hallo2', 'Hallo3'],
-        highlightedText: 'Hallo Germany',
+        heading: '… es gibt einen guten Grund, den Guardian nicht zu unterstützen.',
+        paragraphs: [
+            `Nicht jeder kann es sich zur Zeit leisten, für Nachrichten zu bezahlen. Deshalb bieten wir unseren Journalismus jedem frei zugänglich an. Falls das auf Sie zutrifft, lesen Sie bitte kostenfrei weiter, wenn Sie heute aus Deutschland zu uns stoßen. `,
+            `Aber wenn Sie dazu in der Lage sind, dann gibt es drei gute Gründe, uns heute zu unterstützen.`,
+            `1. Wir sind absolut unabhängig und legen unsere eigene Agenda fest, eine zunehmende Seltenheit in einem Europa der nicht unabhängigen Medien.`,
+            `2. Unser furchtloser, investigativer Journalismus bietet eine wirksame Kontrolle in einer Zeit, in der die Reichen und Mächtigen in Europa und darüber hinaus immer mehr ihre Interessen durchsetzen.`,
+            `3. Seit dem Brexit sind wir mehr und nicht weniger europäisch geworden und haben jetzt eine neue Europa-Ausgabe herausgebracht. Wir haben eine Reihe neuer Korrespondenten auf dem Kontinent eingestellt, veröffentlichen jährlich 10.000 Artikel zu europäischen Themen und werden von rund 180.000 Unterstützern finanziert, die in Europa leben – vom Atlantik bis zum Schwarzen Meer, vom hohen Norden bis zum Mittelmeer, darunter viele in Deutschland.`,
+            `Helfen Sie mit, den Journalismus des Guardian auch in den kommenden Jahren zu unterstützen, sei es mit einem kleinen oder größeren Betrag. `,
+        ],
+        highlightedText:
+            'Wenn Sie können, unterstützen Sie uns bitte monatlich mit nur €2 oder mehr. Es dauert weniger als eine Minute, dies einzurichten und Sie können sicher sein, dass Sie jeden Monat einen großen Beitrag zur Unterstützung eines offenen, unabhängigen Journalismus leisten. Vielen Dank.',
     },
     NL: {
-        heading: 'Hallo Netherlands',
-        paragraphs: ['Hallo1', 'Hallo2'],
-        highlightedText: 'Hallo Netherlands',
+        heading: '… er is een goede reden om de Guardian niet te steunen.',
+        paragraphs: [
+            `Niet iedereen kan het zich veroorloven om voor nieuws te betalen. Daarom houden we onze nieuwssite open voor iedereen. Als jij dat wilt, blijf ons dan vooral gratis lezen vanuit Nederland.`,
+            `Maar als je ons wel kan steunen, dan zijn daar drie goede redenen voor.`,
+            `1. We zijn volstrekt onafhankelijk en bepalen onze eigen agenda en dat is steeds meer een uitzondering in Europa.`,
+            `2. Onze onverschrokken onderzoeksjournalistiek is een belangrijke factor in deze tijd waarin de elite met steeds meer wegkomt, in Europa en daarbuiten.`,
+            `3. Sinds Brexit zijn we meer, niet minder, Europees geworden en hebben nu zelfs een nieuwe Europese editie gelanceerd. We hebben een groot aantal nieuwe correspondenten in Europa en publiceren zo’n tienduizend artikelen per jaar over Europese zaken. We krijgen steun van ongeveer 180.000 supporters die in Europa wonen - van de Atlantische Oceaan tot de aan de Zwarte Zee, van de Noordpool tot aan de Middellandse Zee, waaronder ook velen uit Nederland.`,
+            `Help mee om de journalistiek van the Guardian de komende jaren te versterken, met welk bedrag dan ook. `,
+        ],
+        highlightedText:
+            'Als je kunt, steun ons dan maandelijks vanaf slechts €2. Het kost minder dan een minuut om het te regelen en je kunt er zeker van zijn dat je elke maand een grote impact hebt op eerlijke, onafhankelijke berichtgeving.',
     },
 };
 

--- a/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
+++ b/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
@@ -61,11 +61,11 @@ const getEpicVariant = (countryCode: keyof typeof localLanguagesEpicCopy) => {
 };
 
 const franceCopyTest: EpicTest = {
-    name: 'LOCAL-LANGUAGE',
+    name: 'LOCAL-LANGUAGE-FR',
 
     // These are specific to hardcoded tests
     // expiry: '2023-09-01',
-    campaignId: '',
+    campaignId: 'NOT_IN_CAMPAIGN',
 
     hasArticleCountInCopy: true,
     status: 'Live',
@@ -90,11 +90,11 @@ const franceCopyTest: EpicTest = {
 };
 
 const germanCopyTest: EpicTest = {
-    name: 'LOCAL-LANGUAGE',
+    name: 'LOCAL-LANGUAGE-DE',
 
     // These are specific to hardcoded tests
     // expiry: '2023-09-01',
-    campaignId: '',
+    campaignId: 'NOT_IN_CAMPAIGN',
 
     audience: 1,
     alwaysAsk: false,
@@ -115,11 +115,11 @@ const germanCopyTest: EpicTest = {
 };
 
 const netherlandsCopyTest: EpicTest = {
-    name: 'LOCAL-LANGUAGE',
+    name: 'LOCAL-LANGUAGE-NL',
 
     // These are specific to hardcoded tests
     // expiry: '2023-09-01',
-    campaignId: '',
+    campaignId: 'NOT_IN_CAMPAIGN',
 
     audience: 1,
     alwaysAsk: false,

--- a/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
+++ b/packages/server/src/tests/epics/hardCodedTests/localLanguageCopy.ts
@@ -45,7 +45,7 @@ const getEpicVariant = (countryCode: keyof typeof localLanguagesEpicCopy) => {
 };
 
 const franceCopyTest: EpicTest = {
-    name: 'LOCAL_LANGUAGE',
+    name: 'LOCAL-LANGUAGE',
 
     // These are specific to hardcoded tests
     // expiry: '2023-09-01',
@@ -74,7 +74,7 @@ const franceCopyTest: EpicTest = {
 };
 
 const germanCopyTest: EpicTest = {
-    name: 'LOCAL_LANGUAGE',
+    name: 'LOCAL-LANGUAGE',
 
     // These are specific to hardcoded tests
     // expiry: '2023-09-01',
@@ -99,7 +99,7 @@ const germanCopyTest: EpicTest = {
 };
 
 const netherlandsCopyTest: EpicTest = {
-    name: 'LOCAL_LANGUAGE',
+    name: 'LOCAL-LANGUAGE',
 
     // These are specific to hardcoded tests
     // expiry: '2023-09-01',

--- a/packages/server/src/tests/epics/hardCodedTests/usTopReaderCopy.ts
+++ b/packages/server/src/tests/epics/hardCodedTests/usTopReaderCopy.ts
@@ -6,8 +6,10 @@ const paragraphs: string[] = [
     'And we provide all this for free, for everyone to read. We do this because we believe in information equality. Greater numbers of people can keep track of the global events shaping our world, understand their impact on people and communities, and become inspired to take meaningful action. Millions can benefit from open access to quality, truthful news, regardless of their ability to pay for it.',
     'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
 ];
+
 const highlightedText =
     'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.';
+
 const cta: Cta = {
     text: 'Support the Guardian',
     baseUrl: 'https://support.theguardian.com/contribute',

--- a/packages/server/src/tests/epics/hardCodedTests/usTopReaderCopy.ts
+++ b/packages/server/src/tests/epics/hardCodedTests/usTopReaderCopy.ts
@@ -6,10 +6,8 @@ const paragraphs: string[] = [
     'And we provide all this for free, for everyone to read. We do this because we believe in information equality. Greater numbers of people can keep track of the global events shaping our world, understand their impact on people and communities, and become inspired to take meaningful action. Millions can benefit from open access to quality, truthful news, regardless of their ability to pay for it.',
     'If there were ever a time to join us, it is now. Every contribution, however big or small, powers our journalism and sustains our future.',
 ];
-
 const highlightedText =
     'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – it only takes a minute. Thank you.';
-
 const cta: Cta = {
     text: 'Support the Guardian',
     baseUrl: 'https://support.theguardian.com/contribute',

--- a/packages/shared/src/lib/geolocation.ts
+++ b/packages/shared/src/lib/geolocation.ts
@@ -537,6 +537,8 @@ const countryNames: CountryNameMap = {
     ZW: 'Zimbabwe',
 };
 
+export type CountryCodes = keyof typeof countryNames;
+
 const extendedCurrencySymbol = {
     GBPCountries: '£',
     UnitedStates: '$',
@@ -572,6 +574,28 @@ export const inCountryGroups = (
     }
 
     return countryGroups.includes(countryCodeToCountryGroupId(countryCode.toUpperCase()));
+};
+
+export const inCountryCodeArray = (
+    countryCode?: string,
+    countryCodeLocations?: CountryCodes[],
+): boolean => {
+    // Always True if no country codes set for the test
+    if (!countryCodeLocations) {
+        return true;
+    }
+
+    // Always True if no country codes set for the test
+    if (countryCodeLocations.length === 0) {
+        return true;
+    }
+
+    // Always False if user location unknown
+    if (!countryCode) {
+        return false;
+    }
+
+    return countryCodeLocations.includes(countryCode.toUpperCase());
 };
 
 const defaultCurrencySymbol = '£';

--- a/packages/shared/src/lib/geolocation.ts
+++ b/packages/shared/src/lib/geolocation.ts
@@ -576,7 +576,7 @@ export const inCountryGroups = (
     return countryGroups.includes(countryCodeToCountryGroupId(countryCode.toUpperCase()));
 };
 
-export const inCountryCodeArray = (
+export const inCountryCodeLocations = (
     countryCode?: string,
     countryCodeLocations?: CountryCodes[],
 ): boolean => {

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -1,4 +1,4 @@
-import { CountryGroupId, ReminderFields } from '../../lib';
+import { CountryCodes, CountryGroupId, ReminderFields } from '../../lib';
 import {
     ArticlesViewedSettings,
     ControlProportionSettings,
@@ -145,6 +145,7 @@ export interface EpicTest extends Test<EpicVariant> {
     name: string;
     status: TestStatus;
     locations: CountryGroupId[];
+    countryCodeLocations?: CountryCodes[];
     tagIds: string[];
     sections: string[]; // section IDs
     excludedTagIds: string[];


### PR DESCRIPTION
## What does this change?

Marketing would like to target users' in specific countries viewing the Epic, altering the Epic headline, paragraph and highlightedtext copy to be a message in 3 regional language. It will fallback to RRCP defaults in all other cases.

Countries to target:
- Germany
- France
- Netherlands

![image](https://github.com/guardian/support-dotcom-components/assets/76729591/d2183671-b850-4536-af41-b0599504c0e0)

On the '/epic' endpoint if the user is in the EUR test and in the subset of countries adjust response to return hardcoded copy. This way we don't have to edit the template. We include the reader's country code in the payload sent to /epic. We will need to know the Europe Moment Banner test / variant names to do this targeting, as we only want to do the swap for users' in the correct test.

Epic Test Name: LOCAL-LANGAUGE-FR, LOCAL-LANGAUGE-DE, LOCAL-LANGAUGE-NL
Epic Variant Name: CONTROL

| Country | Epic | 
|--------|--------|

## How to test (RRCP)
- Instructions to change GeoLocation here ->http://reader-revenue-bookmarklets.s3-website-eu-west-1.amazonaws.com/
- RRCP webpreview correct epic
- Change Geo-location

Country | Header

## How to test (PostMan /Curl)
- SDC - YARN SERVER START (will default to: 8082)
- URL Post (local server) : http://localhost:8082/epic?force=LOCAL-LANGUAGE:CONTROL
- {Body is JSON from inspect/banner content}
- Modify countryCode to DE,FR,NL to get predefined headers, all remaining use default header defined in RRCP.

[Trello] 
https://trello.com/c/tczGM1e7/1518-epic-for-europe-translate-for-european-countries-local-language