### PR TITLE
Supporter Banner moment background and hover color changes

### DIFF
--- a/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
@@ -31,7 +31,7 @@ const SupporterMomentBanner = bannerWrapper(
                 textColour: 'white',
             },
             hover: {
-                backgroundColour: '#2D0427',
+                backgroundColour: '#55114C',
                 textColour: 'white',
             },
         },

--- a/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.tsx
+++ b/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.tsx
@@ -4,7 +4,7 @@ import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner'
 
 const SupporterMomentBanner = getMomentTemplateBanner({
     containerSettings: {
-        backgroundColour: '#F1F8FC',
+        backgroundColour: '#FDF1F8',
     },
     headerSettings: {
         showHeader: { text: true },
@@ -16,7 +16,7 @@ const SupporterMomentBanner = getMomentTemplateBanner({
             textColour: 'white',
         },
         hover: {
-            backgroundColour: '#2D0427',
+            backgroundColour: '#55114C',
             textColour: 'white',
         },
     },


### PR DESCRIPTION
## What does this change?

Colour change to background and hover as shown ->
![image](https://github.com/guardian/support-dotcom-components/assets/76729591/ccba5831-dce8-46d5-ba57-a9904cd6bdce)