### PR TITLE
Add an alarm for banner design loading failures

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -8,6 +8,7 @@ Object {
       "GuStringParameter",
       "GuAlarm",
       "GuAlarm",
+      "GuAlarm",
       "GuDistributionBucketParameter",
       "GuGetS3ObjectsPolicy",
       "GuGetS3ObjectsPolicy",
@@ -855,6 +856,40 @@ chown -R dotcom-components:support /var/log/dotcom-components
         "ToPort": 3030,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBannerDesignsAlarmE829BAEA": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":reader-revenue-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Error fetching banner designs from Dynamodb",
+        "AlarmName": "support-dotcom-components: Banner Designs loading error - TEST",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "banner-designs-load-error",
+        "Namespace": "support-dotcom-components-TEST",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "ParameterStoreReadDotcomcomponents7A7C8BD4": Object {
       "Properties": Object {

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -83,6 +83,24 @@ export class DotcomComponents extends GuStack {
 			treatMissingData: TreatMissingData.NOT_BREACHING,
 		});
 
+		new GuAlarm(this, 'LoadBannerDesignsAlarm', {
+			app: appName,
+			alarmName: `support-${appName}: Banner Designs loading error - ${this.stage}`,
+			alarmDescription: 'Error fetching banner designs from Dynamodb',
+			snsTopicName,
+			metric: new Metric({
+				metricName: 'banner-designs-load-error',
+				namespace,
+				period: Duration.minutes(60),
+				statistic: 'sum',
+			}),
+			threshold: 1,
+			evaluationPeriods: 1,
+			comparisonOperator:
+				ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+			treatMissingData: TreatMissingData.NOT_BREACHING,
+		});
+
 		const userData = `#!/bin/bash
 
 groupadd support

--- a/packages/server/src/tests/banners/channelBannerTests.test.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.test.ts
@@ -1,7 +1,6 @@
 import { getDesignForVariant } from './channelBannerTests';
 import { factories } from '../../factories/';
-import { BannerTemplate } from '@sdc/shared/src/types';
-import { BannerDesignFromTool } from '@sdc/shared/dist/types';
+import { BannerDesignFromTool, BannerTemplate } from '@sdc/shared/src/types';
 
 describe('getDesignForVariant', () => {
     it('returns undefined if the variant specifies a template', () => {

--- a/packages/server/src/tests/store.ts
+++ b/packages/server/src/tests/store.ts
@@ -22,7 +22,7 @@ export const getTests = <T>(channel: ChannelTypes): Promise<T[]> =>
         .catch(error => {
             logError(`Error reading tests from Dynamo: ${error.message}`);
             putMetric('channel-tests-error');
-            return [];
+            return error;
         });
 
 function queryChannel(channel: ChannelTypes, stage: string) {

--- a/packages/server/src/tests/store.ts
+++ b/packages/server/src/tests/store.ts
@@ -50,5 +50,10 @@ export const getBannerDesigns = (): Promise<BannerDesignFromTool[]> => {
             TableName: `support-admin-console-banner-designs-${stage.toUpperCase()}`,
         })
         .promise()
-        .then(results => (results.Items || []) as BannerDesignFromTool[]);
+        .then(results => (results.Items || []) as BannerDesignFromTool[])
+        .catch(error => {
+            logError(`Error reading banner designs from Dynamo: ${error.message}`);
+            putMetric('banner-designs-load-error');
+            return error;
+        });
 };

--- a/packages/server/src/utils/cloudwatch.ts
+++ b/packages/server/src/utils/cloudwatch.ts
@@ -7,7 +7,7 @@ const cloudwatch = new AWS.CloudWatch({ region: 'eu-west-1' });
 const stage = isProd ? 'PROD' : 'CODE';
 const namespace = `support-dotcom-components-${stage}`;
 
-type Metric = 'super-mode-error' | 'channel-tests-error';
+type Metric = 'super-mode-error' | 'channel-tests-error' | 'banner-designs-load-error';
 
 // Sends a single metric to cloudwatch.
 // Avoid doing this per-request, to avoid high costs. This should instead be called from within a cacheAsync


### PR DESCRIPTION
## What does this change?

To be consistent with other Dynamo loading, add an alarm for banner design loading failures.

I've also made a change to the existing test loading so that instead of swallowing Dynamo errors and returning an empty array we now re-throw the error which results in a failed Promise being returned. This means if we already have previously successfully loaded test data we'll continue to use it (rather than wiping out existing test data with the empty array). If the failure is on the initial load the deployment will fail which I think is fine (gives visibility to the error).

## How to test

Deploy to CODE.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
