### PR TITLE
Europe local language Epic translation V2

### DIFF
--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -20,6 +20,7 @@ import {
     buildCampaignCode,
     getReminderFields,
     countryCodeToCountryGroupId,
+    countryCodeToLocalLanguageEpic,
 } from '@sdc/shared/dist/lib';
 import { getArticleViewCounts } from '../lib/history';
 import {
@@ -129,8 +130,22 @@ export const buildEpicRouter = (
             targetingMvtId,
         );
 
+        const localLanguage = countryCodeToLocalLanguageEpic(
+            test.name,
+            variant.name,
+            requiredCountry,
+            {
+                heading: variant.heading,
+                paragraphs: variant.paragraphs,
+                highlightedText: variant.highlightedText,
+            },
+        );
+
         const propsVariant = {
             ...variant,
+            heading: localLanguage?.heading ?? variant.heading,
+            paragraphs: localLanguage?.paragraphs ?? variant.paragraphs,
+            highlightedText: localLanguage?.highlightedText ?? variant.highlightedText,
             tickerSettings,
             showReminderFields,
             choiceCardAmounts: variantAmounts,

--- a/packages/shared/src/lib/localLanguage.test.ts
+++ b/packages/shared/src/lib/localLanguage.test.ts
@@ -1,4 +1,7 @@
-import { countryCodeToLocalLanguageBannerHeader } from './localLanguage';
+import {
+    countryCodeToLocalLanguageBannerHeader,
+    countryCodeToLocalLanguageEpic,
+} from './localLanguage';
 
 describe('getCountryCodeToLocalLanguage', () => {
     const countries = [
@@ -141,6 +144,269 @@ describe('getCountryCodeToLocalLanguage', () => {
                         inputVariant,
                         inputCountryCode,
                         inputDefaultLocalLanguage,
+                    ),
+                ).toEqual(output);
+            });
+        },
+    );
+});
+
+describe('countryCodeToLocalLanguageEpic', () => {
+    const countriesEpic = [
+        {
+            inputCountryCode: 'FR',
+            inputTestName: 'LOCAL-LANGUAGE',
+            inputVariant: 'CONTROL',
+            inputDefaultEpic: { heading: '', paragraphs: [''], highlightedText: '' },
+            output: {
+                heading: '… il existe une bonne raison de ne pas soutenir le Guardian.',
+                paragraphs: [
+                    `Actuellement, beaucoup de lecteurs ne sont pas ou plus en mesure de payer pour accéder aux informations. C’est pour cela que nos contenus sont et resteront gratuits et ouverts à tous. Si tel est votre cas, vous pouvez continuer à lire nos articles librement, comme vous le faites à présent, depuis la France.`,
+                    `Si au contraire, vous avez les moyens de contribuer financièrement, voici trois bonnes raisons de soutenir le Guardian dès aujourd’hui.`,
+                    `1. Nous sommes une rédaction indépendante. Personne ne contrôle notre ligne éditoriale ; fait rare en Europe où la liberté des médias est souvent compromise par le poids des actionnaires et la corruption.`,
+                    `2. Notre journalisme d'investigation met en lumière les dessous du pouvoir et dénonce l’injustice en Europe et dans le monde entier.`,
+                    `3. Même sous l'ère du Brexit, nous restons plus européens que jamais. Nous venons de lancer notre nouvelle édition en ligne en anglais, dédiée à nos lecteurs en Europe, et donc à vous, en France. Cette année, nous avons investi dans notre journalisme européen, recruté de nouveaux correspondants sur le continent et publié plusieurs milliers d'articles sur les affaires européennes. Nous comptons désormais environ 180 000 de nos contributeurs en Europe.`,
+                    `Afin que ce travail essentiel perdure dans les années à venir, nous avons besoin du soutien des lecteurs. `,
+                ],
+                highlightedText:
+                    'Si vous le pouvez, une contribution de seulement €2 par mois peut dès aujourd’hui faire toute la différence. Merci.',
+            },
+        },
+        {
+            inputCountryCode: 'DE',
+            inputTestName: 'LOCAL-LANGUAGE',
+            inputVariant: 'CONTROL',
+            inputDefaultEpic: { heading: '', paragraphs: [''], highlightedText: '' },
+            output: {
+                heading: '… es gibt einen guten Grund, den Guardian nicht zu unterstützen.',
+                paragraphs: [
+                    `Nicht jeder kann es sich zur Zeit leisten, für Nachrichten zu bezahlen. Deshalb bieten wir unseren Journalismus jedem frei zugänglich an. Falls das auf Sie zutrifft, lesen Sie bitte kostenfrei weiter, wenn Sie heute aus Deutschland zu uns stoßen.`,
+                    `Aber wenn Sie dazu in der Lage sind, dann gibt es drei gute Gründe, uns heute zu unterstützen.`,
+                    `1. Wir sind absolut unabhängig und legen unsere eigene Agenda fest, eine zunehmende Seltenheit in einem Europa der nicht unabhängigen Medien.`,
+                    `2. Unser furchtloser, investigativer Journalismus bietet eine wirksame Kontrolle in einer Zeit, in der die Reichen und Mächtigen in Europa und darüber hinaus immer mehr ihre Interessen durchsetzen.`,
+                    `3. Seit dem Brexit sind wir mehr und nicht weniger europäisch geworden und haben jetzt eine neue Europa-Ausgabe herausgebracht. Wir haben eine Reihe neuer Korrespondenten auf dem europäischen Festland eingestellt, veröffentlichen jährlich tausende von Artikeln zu europäischen Themen und werden von rund 180.000 Unterstützern finanziert, die in Europa leben – vom Atlantik bis zum Schwarzen Meer, vom hohen Norden bis zum Mittelmeer, darunter viele in Deutschland.`,
+                    `Helfen Sie mit, den Journalismus des Guardian auch in den kommenden Jahren zu unterstützen, sei es mit einem kleinen oder größeren Betrag. `,
+                ],
+                highlightedText:
+                    'Wenn möglich, unterstützen Sie uns bitte monatlich mit einem Beitrag von €2 oder mehr. Es dauert weniger als eine Minute, dies einzurichten und Sie können sicher sein, dass Sie jeden Monat einen großen Beitrag zur Unterstützung eines offenen, unabhängigen Journalismus leisten. Vielen Dank.',
+            },
+        },
+        {
+            inputCountryCode: 'NL',
+            inputTestName: 'LOCAL-LANGUAGE',
+            inputVariant: 'CONTROL',
+            inputDefaultEpic: { heading: '', paragraphs: [''], highlightedText: '' },
+            output: {
+                heading: '… er is een goede reden om de Guardian niet te steunen.',
+                paragraphs: [
+                    `Niet iedereen kan het zich veroorloven om voor nieuws te betalen. Daarom houden we onze nieuwssite open voor iedereen. Als jij dat wilt, blijf ons dan vooral gratis lezen vanuit Nederland.`,
+                    `Maar als je ons wel kan steunen, dan zijn daar drie goede redenen voor. `,
+                    `1. We zijn volstrekt onafhankelijk en bepalen onze eigen agenda en dat is steeds meer een uitzondering in Europa.`,
+                    `2. Onze onverschrokken onderzoeksjournalistiek is een belangrijke factor in deze tijd waarin de elite met steeds meer wegkomt, in Europa en daarbuiten.`,
+                    `3. Sinds Brexit zijn we meer, niet minder, Europees geworden en hebben nu zelfs een nieuwe Europese editie gelanceerd. We hebben een groot aantal nieuwe correspondenten in Europa en publiceren duizenden artikelen per jaar over Europese zaken. We krijgen steun van ongeveer 180.000 supporters die in Europa wonen – van de Atlantische Oceaan tot aan de Zwarte Zee, van de Noordpool tot aan de Middellandse Zee, waaronder ook velen uit Nederland.`,
+                    `Help mee om de journalistiek van de Guardian de komende jaren te versterken, met welk bedrag dan ook. `,
+                ],
+                highlightedText:
+                    'Als je kunt, steun ons dan maandelijks vanaf slechts €2. Het kost minder dan een minuut om het te regelen en je kunt er zeker van zijn dat je elke maand een grote impact hebt op eerlijke, onafhankelijke berichtgeving.',
+            },
+        },
+        {
+            inputCountryCode: 'NL',
+            inputTestName: 'LOCAL-LANGUAGE1',
+            inputVariant: 'CONTROL',
+            inputDefaultEpic: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+            output: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+        },
+        {
+            inputCountryCode: 'NL',
+            inputTestName: 'LOCAL-LANGUAGE',
+            inputVariant: 'CONTROL1',
+            inputDefaultEpic: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+            output: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+        },
+        {
+            inputCountryCode: 'NL',
+            inputTestName: '',
+            inputVariant: '',
+            inputDefaultEpic: { heading: '', paragraphs: [''], highlightedText: '' },
+            output: { heading: '', paragraphs: [''], highlightedText: '' },
+        },
+        {
+            inputCountryCode: 'IT',
+            inputTestName: 'LOCAL-LANGUAGE',
+            inputVariant: 'CONTROL',
+            inputDefaultEpic: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+            output: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+        },
+        {
+            inputCountryCode: 'SE',
+            inputTestName: 'LOCAL-LANGUAGE',
+            inputVariant: 'CONTROL',
+            inputDefaultEpic: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+            output: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+        },
+        {
+            inputCountryCode: 'SP',
+            inputTestName: 'LOCAL-LANGUAGE',
+            inputVariant: 'CONTROL',
+            inputDefaultEpic: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+            output: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+        },
+        {
+            inputCountryCode: 'GB',
+            inputTestName: 'LOCAL-LANGUAGE',
+            inputVariant: 'CONTROL',
+            inputDefaultEpic: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+            output: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+        },
+        {
+            inputCountryCode: 'GB',
+            inputTestName: '',
+            inputVariant: '',
+            inputDefaultEpic: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+            output: {
+                heading: 'default',
+                paragraphs: ['default'],
+                highlightedText: 'default',
+            },
+        },
+        {
+            inputCountryCode: 'US',
+            inputTestName: 'LOCAL-LANGUAGE',
+            inputVariant: 'CONTROL',
+            inputDefaultEpic: {
+                heading: 'EpicHeaderTest',
+                paragraphs: ['1', '2', '3', '4', '5'],
+                highlightedText: `Highlight (US)`,
+            },
+            output: {
+                heading: 'EpicHeaderTest',
+                paragraphs: ['1', '2', '3', '4', '5'],
+                highlightedText: `Highlight (US)`,
+            },
+        },
+        {
+            inputCountryCode: '',
+            inputTestName: 'LOCAL-LANGUAGE',
+            inputVariant: 'CONTROL',
+            inputDefaultEpic: {
+                heading: 'EpicHeaderTest',
+                paragraphs: ['1', '2', '3', '4', '5'],
+                highlightedText: `Highlight`,
+            },
+            output: {
+                heading: 'EpicHeaderTest',
+                paragraphs: ['1', '2', '3', '4', '5'],
+                highlightedText: `Highlight`,
+            },
+        },
+        {
+            inputCountryCode: '',
+            inputTestName: '',
+            inputVariant: '',
+            inputDefaultEpic: { heading: '', paragraphs: [''], highlightedText: '' },
+            output: { heading: '', paragraphs: [''], highlightedText: '' },
+        },
+        {
+            inputCountryCode: '',
+            inputTestName: '',
+            inputVariant: '',
+            inputDefaultEpic: {
+                heading: 'EpicHeaderTest',
+                paragraphs: ['1', '2', '3', '4', '5'],
+                highlightedText: `Highlight`,
+            },
+            output: {
+                heading: 'EpicHeaderTest',
+                paragraphs: ['1', '2', '3', '4', '5'],
+                highlightedText: `Highlight`,
+            },
+        },
+        {
+            inputCountryCode: '',
+            inputTestName: '',
+            inputVariant: '',
+            inputDefaultEpic: {
+                heading: undefined,
+                paragraphs: undefined,
+                highlightedText: undefined,
+            },
+            output: {
+                heading: undefined,
+                paragraphs: undefined,
+                highlightedText: undefined,
+            },
+        },
+        {
+            inputCountryCode: '',
+            inputTestName: '',
+            inputVariant: '',
+            inputDefaultEpic: undefined,
+            output: undefined,
+        },
+    ];
+
+    countriesEpic.forEach(
+        ({ inputTestName, inputVariant, inputCountryCode, inputDefaultEpic, output }) => {
+            it(`returns ${output}, given ${inputCountryCode}`, () => {
+                expect(
+                    countryCodeToLocalLanguageEpic(
+                        inputTestName,
+                        inputVariant,
+                        inputCountryCode,
+                        inputDefaultEpic,
                     ),
                 ).toEqual(output);
             });

--- a/packages/shared/src/lib/localLanguage.test.ts
+++ b/packages/shared/src/lib/localLanguage.test.ts
@@ -159,13 +159,13 @@ describe('countryCodeToLocalLanguageEpic', () => {
             inputVariant: 'CONTROL',
             inputDefaultEpic: { heading: '', paragraphs: [''], highlightedText: '' },
             output: {
-                heading: '… il existe une bonne raison de ne pas soutenir le Guardian.',
+                heading: '… il existe une bonne raison de <em>ne pas</em> soutenir le Guardian.',
                 paragraphs: [
-                    `Actuellement, beaucoup de lecteurs ne sont pas ou plus en mesure de payer pour accéder aux informations. C’est pour cela que nos contenus sont et resteront gratuits et ouverts à tous. Si tel est votre cas, vous pouvez continuer à lire nos articles librement, comme vous le faites à présent, depuis la France.`,
-                    `Si au contraire, vous avez les moyens de contribuer financièrement, voici trois bonnes raisons de soutenir le Guardian dès aujourd’hui.`,
-                    `1. Nous sommes une rédaction indépendante. Personne ne contrôle notre ligne éditoriale ; fait rare en Europe où la liberté des médias est souvent compromise par le poids des actionnaires et la corruption.`,
-                    `2. Notre journalisme d'investigation met en lumière les dessous du pouvoir et dénonce l’injustice en Europe et dans le monde entier.`,
-                    `3. Même sous l'ère du Brexit, nous restons plus européens que jamais. Nous venons de lancer notre nouvelle édition en ligne en anglais, dédiée à nos lecteurs en Europe, et donc à vous, en France. Cette année, nous avons investi dans notre journalisme européen, recruté de nouveaux correspondants sur le continent et publié plusieurs milliers d'articles sur les affaires européennes. Nous comptons désormais environ 180 000 de nos contributeurs en Europe.`,
+                    `Actuellement, beaucoup de lecteurs ne sont pas ou plus en mesure de payer pour accéder aux informations. C’est pour cela que nos contenus sont et resteront gratuits et ouverts à tous. Si tel est votre cas, vous pouvez continuer à lire nos articles librement, comme vous le faites à présent, depuis <strong>la France.</strong>`,
+                    `Si au contraire, vous avez les moyens de contribuer financièrement, voici <strong>trois</strong> bonnes raisons de soutenir le Guardian dès aujourd’hui.`,
+                    `<strong>1.</strong> Nous sommes une rédaction indépendante. Personne ne contrôle notre ligne éditoriale ; fait rare en Europe où la liberté des médias est souvent compromise par le poids des actionnaires et la corruption.`,
+                    `<strong>2.</strong> Notre journalisme d'investigation met en lumière les dessous du pouvoir et dénonce l’injustice en Europe et dans le monde entier.`,
+                    `<strong>3.</strong> Même sous l'ère du Brexit, nous restons plus européens que jamais. Nous venons de lancer notre nouvelle édition en ligne en anglais, dédiée à nos lecteurs en Europe, et donc à vous, en France. Cette année, nous avons investi dans notre journalisme européen, recruté de nouveaux correspondants sur le continent et publié plusieurs milliers d'articles sur les affaires européennes. Nous comptons désormais environ 180 000 de nos contributeurs en Europe.`,
                     `Afin que ce travail essentiel perdure dans les années à venir, nous avons besoin du soutien des lecteurs. `,
                 ],
                 highlightedText:
@@ -178,13 +178,14 @@ describe('countryCodeToLocalLanguageEpic', () => {
             inputVariant: 'CONTROL',
             inputDefaultEpic: { heading: '', paragraphs: [''], highlightedText: '' },
             output: {
-                heading: '… es gibt einen guten Grund, den Guardian nicht zu unterstützen.',
+                heading:
+                    '… es gibt einen guten Grund, den Guardian <em>nicht</em> zu unterstützen.',
                 paragraphs: [
-                    `Nicht jeder kann es sich zur Zeit leisten, für Nachrichten zu bezahlen. Deshalb bieten wir unseren Journalismus jedem frei zugänglich an. Falls das auf Sie zutrifft, lesen Sie bitte kostenfrei weiter, wenn Sie heute aus Deutschland zu uns stoßen.`,
-                    `Aber wenn Sie dazu in der Lage sind, dann gibt es drei gute Gründe, uns heute zu unterstützen.`,
-                    `1. Wir sind absolut unabhängig und legen unsere eigene Agenda fest, eine zunehmende Seltenheit in einem Europa der nicht unabhängigen Medien.`,
-                    `2. Unser furchtloser, investigativer Journalismus bietet eine wirksame Kontrolle in einer Zeit, in der die Reichen und Mächtigen in Europa und darüber hinaus immer mehr ihre Interessen durchsetzen.`,
-                    `3. Seit dem Brexit sind wir mehr und nicht weniger europäisch geworden und haben jetzt eine neue Europa-Ausgabe herausgebracht. Wir haben eine Reihe neuer Korrespondenten auf dem europäischen Festland eingestellt, veröffentlichen jährlich tausende von Artikeln zu europäischen Themen und werden von rund 180.000 Unterstützern finanziert, die in Europa leben – vom Atlantik bis zum Schwarzen Meer, vom hohen Norden bis zum Mittelmeer, darunter viele in Deutschland.`,
+                    `Nicht jeder kann es sich zur Zeit leisten, für Nachrichten zu bezahlen. Deshalb bieten wir unseren Journalismus jedem frei zugänglich an. Falls das auf Sie zutrifft, lesen Sie bitte kostenfrei weiter, wenn Sie heute aus <strong>Deutschland</strong> zu uns stoßen.`,
+                    `Aber wenn Sie dazu in der Lage sind, dann gibt es <strong>drei</strong> gute Gründe, uns heute zu unterstützen.`,
+                    `<strong>1.</strong> Wir sind absolut unabhängig und legen unsere eigene Agenda fest, eine zunehmende Seltenheit in einem Europa der nicht unabhängigen Medien.`,
+                    `<strong>2.</strong> Unser furchtloser, investigativer Journalismus bietet eine wirksame Kontrolle in einer Zeit, in der die Reichen und Mächtigen in Europa und darüber hinaus immer mehr ihre Interessen durchsetzen.`,
+                    `<strong>3.</strong> Seit dem Brexit sind wir mehr und nicht weniger europäisch geworden und haben jetzt eine neue Europa-Ausgabe herausgebracht. Wir haben eine Reihe neuer Korrespondenten auf dem europäischen Festland eingestellt, veröffentlichen jährlich tausende von Artikeln zu europäischen Themen und werden von rund 180.000 Unterstützern finanziert, die in Europa leben – vom Atlantik bis zum Schwarzen Meer, vom hohen Norden bis zum Mittelmeer, darunter viele in Deutschland.`,
                     `Helfen Sie mit, den Journalismus des Guardian auch in den kommenden Jahren zu unterstützen, sei es mit einem kleinen oder größeren Betrag. `,
                 ],
                 highlightedText:
@@ -197,13 +198,13 @@ describe('countryCodeToLocalLanguageEpic', () => {
             inputVariant: 'CONTROL',
             inputDefaultEpic: { heading: '', paragraphs: [''], highlightedText: '' },
             output: {
-                heading: '… er is een goede reden om de Guardian niet te steunen.',
+                heading: '… er is een goede reden om de Guardian <em>niet</em> te steunen.',
                 paragraphs: [
-                    `Niet iedereen kan het zich veroorloven om voor nieuws te betalen. Daarom houden we onze nieuwssite open voor iedereen. Als jij dat wilt, blijf ons dan vooral gratis lezen vanuit Nederland.`,
-                    `Maar als je ons wel kan steunen, dan zijn daar drie goede redenen voor. `,
-                    `1. We zijn volstrekt onafhankelijk en bepalen onze eigen agenda en dat is steeds meer een uitzondering in Europa.`,
-                    `2. Onze onverschrokken onderzoeksjournalistiek is een belangrijke factor in deze tijd waarin de elite met steeds meer wegkomt, in Europa en daarbuiten.`,
-                    `3. Sinds Brexit zijn we meer, niet minder, Europees geworden en hebben nu zelfs een nieuwe Europese editie gelanceerd. We hebben een groot aantal nieuwe correspondenten in Europa en publiceren duizenden artikelen per jaar over Europese zaken. We krijgen steun van ongeveer 180.000 supporters die in Europa wonen – van de Atlantische Oceaan tot aan de Zwarte Zee, van de Noordpool tot aan de Middellandse Zee, waaronder ook velen uit Nederland.`,
+                    `Niet iedereen kan het zich veroorloven om voor nieuws te betalen. Daarom houden we onze nieuwssite open voor iedereen. Als jij dat wilt, blijf ons dan vooral gratis lezen vanuit <strong>Nederland.</strong>`,
+                    `Maar als je ons wel kan steunen, dan zijn daar <strong>drie</strong> goede redenen voor. `,
+                    `<strong>1.</strong> We zijn volstrekt onafhankelijk en bepalen onze eigen agenda en dat is steeds meer een uitzondering in Europa.`,
+                    `<strong>2.</strong> Onze onverschrokken onderzoeksjournalistiek is een belangrijke factor in deze tijd waarin de elite met steeds meer wegkomt, in Europa en daarbuiten.`,
+                    `<strong>3.</strong> Sinds Brexit zijn we meer, niet minder, Europees geworden en hebben nu zelfs een nieuwe Europese editie gelanceerd. We hebben een groot aantal nieuwe correspondenten in Europa en publiceren duizenden artikelen per jaar over Europese zaken. We krijgen steun van ongeveer 180.000 supporters die in Europa wonen – van de Atlantische Oceaan tot aan de Zwarte Zee, van de Noordpool tot aan de Middellandse Zee, waaronder ook velen uit Nederland.`,
                     `Help mee om de journalistiek van de Guardian de komende jaren te versterken, met welk bedrag dan ook. `,
                 ],
                 highlightedText:

--- a/packages/shared/src/lib/localLanguage.ts
+++ b/packages/shared/src/lib/localLanguage.ts
@@ -1,6 +1,11 @@
 type LocalLanguageBannerHeader = {
     bannerHeader?: string;
 };
+type LocalLanguageEpic = {
+    heading?: string;
+    paragraphs?: string[];
+    highlightedText?: string;
+};
 
 const localLanguageBannerHeaders: Record<string, LocalLanguageBannerHeader> = {
     FR: {
@@ -22,6 +27,47 @@ const localLanguageBannerHeaders: Record<string, LocalLanguageBannerHeader> = {
         bannerHeader: 'Fomentar el periodismo europeo independiente',
     },
 };
+const localLanguageEpic = {
+    FR: {
+        heading: '… il existe une bonne raison de ne pas soutenir le Guardian.',
+        paragraphs: [
+            `Actuellement, beaucoup de lecteurs ne sont pas ou plus en mesure de payer pour accéder aux informations. C’est pour cela que nos contenus sont et resteront gratuits et ouverts à tous. Si tel est votre cas, vous pouvez continuer à lire nos articles librement, comme vous le faites à présent, depuis la France.`,
+            `Si au contraire, vous avez les moyens de contribuer financièrement, voici trois bonnes raisons de soutenir le Guardian dès aujourd’hui.`,
+            `1. Nous sommes une rédaction indépendante. Personne ne contrôle notre ligne éditoriale ; fait rare en Europe où la liberté des médias est souvent compromise par le poids des actionnaires et la corruption.`,
+            `2. Notre journalisme d'investigation met en lumière les dessous du pouvoir et dénonce l’injustice en Europe et dans le monde entier.`,
+            `3. Même sous l'ère du Brexit, nous restons plus européens que jamais. Nous venons de lancer notre nouvelle édition en ligne en anglais, dédiée à nos lecteurs en Europe, et donc à vous, en France. Cette année, nous avons investi dans notre journalisme européen, recruté de nouveaux correspondants sur le continent et publié plusieurs milliers d'articles sur les affaires européennes. Nous comptons désormais environ 180 000 de nos contributeurs en Europe.`,
+            `Afin que ce travail essentiel perdure dans les années à venir, nous avons besoin du soutien des lecteurs. `,
+        ],
+        highlightedText:
+            'Si vous le pouvez, une contribution de seulement €2 par mois peut dès aujourd’hui faire toute la différence. Merci.',
+    },
+    DE: {
+        heading: '… es gibt einen guten Grund, den Guardian nicht zu unterstützen.',
+        paragraphs: [
+            `Nicht jeder kann es sich zur Zeit leisten, für Nachrichten zu bezahlen. Deshalb bieten wir unseren Journalismus jedem frei zugänglich an. Falls das auf Sie zutrifft, lesen Sie bitte kostenfrei weiter, wenn Sie heute aus Deutschland zu uns stoßen.`,
+            `Aber wenn Sie dazu in der Lage sind, dann gibt es drei gute Gründe, uns heute zu unterstützen.`,
+            `1. Wir sind absolut unabhängig und legen unsere eigene Agenda fest, eine zunehmende Seltenheit in einem Europa der nicht unabhängigen Medien.`,
+            `2. Unser furchtloser, investigativer Journalismus bietet eine wirksame Kontrolle in einer Zeit, in der die Reichen und Mächtigen in Europa und darüber hinaus immer mehr ihre Interessen durchsetzen.`,
+            `3. Seit dem Brexit sind wir mehr und nicht weniger europäisch geworden und haben jetzt eine neue Europa-Ausgabe herausgebracht. Wir haben eine Reihe neuer Korrespondenten auf dem europäischen Festland eingestellt, veröffentlichen jährlich tausende von Artikeln zu europäischen Themen und werden von rund 180.000 Unterstützern finanziert, die in Europa leben – vom Atlantik bis zum Schwarzen Meer, vom hohen Norden bis zum Mittelmeer, darunter viele in Deutschland.`,
+            `Helfen Sie mit, den Journalismus des Guardian auch in den kommenden Jahren zu unterstützen, sei es mit einem kleinen oder größeren Betrag. `,
+        ],
+        highlightedText:
+            'Wenn möglich, unterstützen Sie uns bitte monatlich mit einem Beitrag von €2 oder mehr. Es dauert weniger als eine Minute, dies einzurichten und Sie können sicher sein, dass Sie jeden Monat einen großen Beitrag zur Unterstützung eines offenen, unabhängigen Journalismus leisten. Vielen Dank.',
+    },
+    NL: {
+        heading: '… er is een goede reden om de Guardian niet te steunen.',
+        paragraphs: [
+            `Niet iedereen kan het zich veroorloven om voor nieuws te betalen. Daarom houden we onze nieuwssite open voor iedereen. Als jij dat wilt, blijf ons dan vooral gratis lezen vanuit Nederland.`,
+            `Maar als je ons wel kan steunen, dan zijn daar drie goede redenen voor. `,
+            `1. We zijn volstrekt onafhankelijk en bepalen onze eigen agenda en dat is steeds meer een uitzondering in Europa.`,
+            `2. Onze onverschrokken onderzoeksjournalistiek is een belangrijke factor in deze tijd waarin de elite met steeds meer wegkomt, in Europa en daarbuiten.`,
+            `3. Sinds Brexit zijn we meer, niet minder, Europees geworden en hebben nu zelfs een nieuwe Europese editie gelanceerd. We hebben een groot aantal nieuwe correspondenten in Europa en publiceren duizenden artikelen per jaar over Europese zaken. We krijgen steun van ongeveer 180.000 supporters die in Europa wonen – van de Atlantische Oceaan tot aan de Zwarte Zee, van de Noordpool tot aan de Middellandse Zee, waaronder ook velen uit Nederland.`,
+            `Help mee om de journalistiek van de Guardian de komende jaren te versterken, met welk bedrag dan ook. `,
+        ],
+        highlightedText:
+            'Als je kunt, steun ons dan maandelijks vanaf slechts €2. Het kost minder dan een minuut om het te regelen en je kunt er zeker van zijn dat je elke maand een grote impact hebt op eerlijke, onafhankelijke berichtgeving.',
+    },
+};
 
 export const countryCodeToLocalLanguageBannerHeader = (
     testName: string,
@@ -37,4 +83,20 @@ export const countryCodeToLocalLanguageBannerHeader = (
         return localLanguageBannerHeaders[countryCode];
     }
     return defaultBannerHeader;
+};
+
+export const countryCodeToLocalLanguageEpic = (
+    testName: string,
+    variantName: string,
+    countryCode: string,
+    defaultEpic: LocalLanguageEpic,
+): LocalLanguageEpic => {
+    if (
+        testName === 'LOCAL-LANGUAGE' &&
+        variantName === 'CONTROL' &&
+        localLanguageEpic[countryCode]
+    ) {
+        return localLanguageEpic[countryCode];
+    }
+    return defaultEpic;
 };

--- a/packages/shared/src/lib/localLanguage.ts
+++ b/packages/shared/src/lib/localLanguage.ts
@@ -29,39 +29,39 @@ const localLanguageBannerHeaders: Record<string, LocalLanguageBannerHeader> = {
 };
 const localLanguageEpic = {
     FR: {
-        heading: '… il existe une bonne raison de ne pas soutenir le Guardian.',
+        heading: '… il existe une bonne raison de <em>ne pas</em> soutenir le Guardian.',
         paragraphs: [
-            `Actuellement, beaucoup de lecteurs ne sont pas ou plus en mesure de payer pour accéder aux informations. C’est pour cela que nos contenus sont et resteront gratuits et ouverts à tous. Si tel est votre cas, vous pouvez continuer à lire nos articles librement, comme vous le faites à présent, depuis la France.`,
-            `Si au contraire, vous avez les moyens de contribuer financièrement, voici trois bonnes raisons de soutenir le Guardian dès aujourd’hui.`,
-            `1. Nous sommes une rédaction indépendante. Personne ne contrôle notre ligne éditoriale ; fait rare en Europe où la liberté des médias est souvent compromise par le poids des actionnaires et la corruption.`,
-            `2. Notre journalisme d'investigation met en lumière les dessous du pouvoir et dénonce l’injustice en Europe et dans le monde entier.`,
-            `3. Même sous l'ère du Brexit, nous restons plus européens que jamais. Nous venons de lancer notre nouvelle édition en ligne en anglais, dédiée à nos lecteurs en Europe, et donc à vous, en France. Cette année, nous avons investi dans notre journalisme européen, recruté de nouveaux correspondants sur le continent et publié plusieurs milliers d'articles sur les affaires européennes. Nous comptons désormais environ 180 000 de nos contributeurs en Europe.`,
+            `Actuellement, beaucoup de lecteurs ne sont pas ou plus en mesure de payer pour accéder aux informations. C’est pour cela que nos contenus sont et resteront gratuits et ouverts à tous. Si tel est votre cas, vous pouvez continuer à lire nos articles librement, comme vous le faites à présent, depuis <strong>la France.</strong>`,
+            `Si au contraire, vous avez les moyens de contribuer financièrement, voici <strong>trois</strong> bonnes raisons de soutenir le Guardian dès aujourd’hui.`,
+            `<strong>1.</strong> Nous sommes une rédaction indépendante. Personne ne contrôle notre ligne éditoriale ; fait rare en Europe où la liberté des médias est souvent compromise par le poids des actionnaires et la corruption.`,
+            `<strong>2.</strong> Notre journalisme d'investigation met en lumière les dessous du pouvoir et dénonce l’injustice en Europe et dans le monde entier.`,
+            `<strong>3.</strong> Même sous l'ère du Brexit, nous restons plus européens que jamais. Nous venons de lancer notre nouvelle édition en ligne en anglais, dédiée à nos lecteurs en Europe, et donc à vous, en France. Cette année, nous avons investi dans notre journalisme européen, recruté de nouveaux correspondants sur le continent et publié plusieurs milliers d'articles sur les affaires européennes. Nous comptons désormais environ 180 000 de nos contributeurs en Europe.`,
             `Afin que ce travail essentiel perdure dans les années à venir, nous avons besoin du soutien des lecteurs. `,
         ],
         highlightedText:
             'Si vous le pouvez, une contribution de seulement €2 par mois peut dès aujourd’hui faire toute la différence. Merci.',
     },
     DE: {
-        heading: '… es gibt einen guten Grund, den Guardian nicht zu unterstützen.',
+        heading: '… es gibt einen guten Grund, den Guardian <em>nicht</em> zu unterstützen.',
         paragraphs: [
-            `Nicht jeder kann es sich zur Zeit leisten, für Nachrichten zu bezahlen. Deshalb bieten wir unseren Journalismus jedem frei zugänglich an. Falls das auf Sie zutrifft, lesen Sie bitte kostenfrei weiter, wenn Sie heute aus Deutschland zu uns stoßen.`,
-            `Aber wenn Sie dazu in der Lage sind, dann gibt es drei gute Gründe, uns heute zu unterstützen.`,
-            `1. Wir sind absolut unabhängig und legen unsere eigene Agenda fest, eine zunehmende Seltenheit in einem Europa der nicht unabhängigen Medien.`,
-            `2. Unser furchtloser, investigativer Journalismus bietet eine wirksame Kontrolle in einer Zeit, in der die Reichen und Mächtigen in Europa und darüber hinaus immer mehr ihre Interessen durchsetzen.`,
-            `3. Seit dem Brexit sind wir mehr und nicht weniger europäisch geworden und haben jetzt eine neue Europa-Ausgabe herausgebracht. Wir haben eine Reihe neuer Korrespondenten auf dem europäischen Festland eingestellt, veröffentlichen jährlich tausende von Artikeln zu europäischen Themen und werden von rund 180.000 Unterstützern finanziert, die in Europa leben – vom Atlantik bis zum Schwarzen Meer, vom hohen Norden bis zum Mittelmeer, darunter viele in Deutschland.`,
+            `Nicht jeder kann es sich zur Zeit leisten, für Nachrichten zu bezahlen. Deshalb bieten wir unseren Journalismus jedem frei zugänglich an. Falls das auf Sie zutrifft, lesen Sie bitte kostenfrei weiter, wenn Sie heute aus <strong>Deutschland</strong> zu uns stoßen.`,
+            `Aber wenn Sie dazu in der Lage sind, dann gibt es <strong>drei</strong> gute Gründe, uns heute zu unterstützen.`,
+            `<strong>1.</strong> Wir sind absolut unabhängig und legen unsere eigene Agenda fest, eine zunehmende Seltenheit in einem Europa der nicht unabhängigen Medien.`,
+            `<strong>2.</strong> Unser furchtloser, investigativer Journalismus bietet eine wirksame Kontrolle in einer Zeit, in der die Reichen und Mächtigen in Europa und darüber hinaus immer mehr ihre Interessen durchsetzen.`,
+            `<strong>3.</strong> Seit dem Brexit sind wir mehr und nicht weniger europäisch geworden und haben jetzt eine neue Europa-Ausgabe herausgebracht. Wir haben eine Reihe neuer Korrespondenten auf dem europäischen Festland eingestellt, veröffentlichen jährlich tausende von Artikeln zu europäischen Themen und werden von rund 180.000 Unterstützern finanziert, die in Europa leben – vom Atlantik bis zum Schwarzen Meer, vom hohen Norden bis zum Mittelmeer, darunter viele in Deutschland.`,
             `Helfen Sie mit, den Journalismus des Guardian auch in den kommenden Jahren zu unterstützen, sei es mit einem kleinen oder größeren Betrag. `,
         ],
         highlightedText:
             'Wenn möglich, unterstützen Sie uns bitte monatlich mit einem Beitrag von €2 oder mehr. Es dauert weniger als eine Minute, dies einzurichten und Sie können sicher sein, dass Sie jeden Monat einen großen Beitrag zur Unterstützung eines offenen, unabhängigen Journalismus leisten. Vielen Dank.',
     },
     NL: {
-        heading: '… er is een goede reden om de Guardian niet te steunen.',
+        heading: '… er is een goede reden om de Guardian <em>niet</em> te steunen.',
         paragraphs: [
-            `Niet iedereen kan het zich veroorloven om voor nieuws te betalen. Daarom houden we onze nieuwssite open voor iedereen. Als jij dat wilt, blijf ons dan vooral gratis lezen vanuit Nederland.`,
-            `Maar als je ons wel kan steunen, dan zijn daar drie goede redenen voor. `,
-            `1. We zijn volstrekt onafhankelijk en bepalen onze eigen agenda en dat is steeds meer een uitzondering in Europa.`,
-            `2. Onze onverschrokken onderzoeksjournalistiek is een belangrijke factor in deze tijd waarin de elite met steeds meer wegkomt, in Europa en daarbuiten.`,
-            `3. Sinds Brexit zijn we meer, niet minder, Europees geworden en hebben nu zelfs een nieuwe Europese editie gelanceerd. We hebben een groot aantal nieuwe correspondenten in Europa en publiceren duizenden artikelen per jaar over Europese zaken. We krijgen steun van ongeveer 180.000 supporters die in Europa wonen – van de Atlantische Oceaan tot aan de Zwarte Zee, van de Noordpool tot aan de Middellandse Zee, waaronder ook velen uit Nederland.`,
+            `Niet iedereen kan het zich veroorloven om voor nieuws te betalen. Daarom houden we onze nieuwssite open voor iedereen. Als jij dat wilt, blijf ons dan vooral gratis lezen vanuit <strong>Nederland.</strong>`,
+            `Maar als je ons wel kan steunen, dan zijn daar <strong>drie</strong> goede redenen voor. `,
+            `<strong>1.</strong> We zijn volstrekt onafhankelijk en bepalen onze eigen agenda en dat is steeds meer een uitzondering in Europa.`,
+            `<strong>2.</strong> Onze onverschrokken onderzoeksjournalistiek is een belangrijke factor in deze tijd waarin de elite met steeds meer wegkomt, in Europa en daarbuiten.`,
+            `<strong>3.</strong> Sinds Brexit zijn we meer, niet minder, Europees geworden en hebben nu zelfs een nieuwe Europese editie gelanceerd. We hebben een groot aantal nieuwe correspondenten in Europa en publiceren duizenden artikelen per jaar over Europese zaken. We krijgen steun van ongeveer 180.000 supporters die in Europa wonen – van de Atlantische Oceaan tot aan de Zwarte Zee, van de Noordpool tot aan de Middellandse Zee, waaronder ook velen uit Nederland.`,
             `Help mee om de journalistiek van de Guardian de komende jaren te versterken, met welk bedrag dan ook. `,
         ],
         highlightedText:


### PR DESCRIPTION
## What does this change?

Marketing would like to target users' in specific countries viewing the Epic, altering the Epic headline, paragraph and highlightedtext copy to be a message in 3 regional language. It will fallback to RRCP defaults in all other cases.

Countries to target:
- Germany
- France
- Netherlands

On the '/epic' endpoint if the user is in the EUR test and in the subset of countries adjust response to return hardcoded copy. This way we don't have to edit the template. We include the reader's country code in the payload sent to /epic. We will need to know the Europe Moment Banner test / variant names to do this targeting, as we only want to do the swap for users' in the correct test.

Epic Test Name: LOCAL-LANGAUGE
Epic Variant Name: CONTROL

| Country | Epic | 
|--------|--------|
|Default|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/0fac65b3-ab50-466d-bc35-f81ae58f0b3e)|
|FR|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/2588eeb5-b5cd-45b8-9ba4-159996a77a19)|
|DE|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/cb655399-bd4a-480d-a68e-67ff371a5941)|
|NL|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/f09f2e32-b95a-4fb0-b682-932d1e8dc2e7)|

## How to test (RRCP)
- Instructions to change GeoLocation here ->http://reader-revenue-bookmarklets.s3-website-eu-west-1.amazonaws.com/
- RRCP webpreview correct epic
- Change Geo-location

Country | Header

## How to test (PostMan /Curl)
- SDC - YARN SERVER START (will default to: 8082)
- URL Post (local server) : http://localhost:8082/epic?force=LOCAL-LANGUAGE:CONTROL
- {Body is JSON from inspect/banner content}
- Modify countryCode to DE,FR,NL to get predefined headers, all remaining use default header defined in RRCP.

[Trello] 
https://trello.com/c/tczGM1e7/1518-epic-for-europe-translate-for-european-countries-local-language