### PR TITLE
Speed up rollup module build process

### DIFF
--- a/packages/modules/rollup.config.js
+++ b/packages/modules/rollup.config.js
@@ -15,6 +15,22 @@ const globals = {
     react: 'guardian.automat.react',
 };
 
+const commonPlugins = [
+    resolveNode(),
+    commonjs(),
+    json(),
+    typescript(),
+    babel({
+        extensions: ['.ts', '.tsx', '.js', '.jsx', '.es6', '.es', '.mjs'],
+        babelHelpers: 'bundled',
+    }),
+
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    terser({ compress: { global_defs: { 'process.env.NODE_ENV': 'production' } } }),
+    externalGlobals(globals),
+    filesize(),
+];
+
 const config = args => {
     const modules = args.moduleName
         ? [moduleInfos.find(i => i.name === args.moduleName)]
@@ -33,20 +49,7 @@ const config = args => {
             external: id => Object.keys(globals).some(key => key == id),
 
             plugins: [
-                resolveNode(),
-                commonjs(),
-                json(),
-                typescript(),
-                babel({
-                    extensions: ['.ts', '.tsx', '.js', '.jsx', '.es6', '.es', '.mjs'],
-                    babelHelpers: 'bundled',
-                }),
-
-                // eslint-disable-next-line @typescript-eslint/camelcase
-                terser({ compress: { global_defs: { 'process.env.NODE_ENV': 'production' } } }),
-                externalGlobals(globals),
-                filesize(),
-
+                ...commonPlugins,
                 // Note, visualizer is useful for *relative* sizes, but reports
                 // pre-minification.
                 visualizer({


### PR DESCRIPTION
## What does this change?

Extracting out common config in the rollup configuration seems to have a good effect. On my local machine:

Before:

```
✨  Done in 264.07s.
NODE_ENV=production NODE_OPTIONS="--max-old-space-size=16384" yarn modules   312.63s user 130.41s system 167% cpu 4:24.19 total
```

After:
```
✨  Done in 69.38s.
NODE_ENV=production NODE_OPTIONS="--max-old-space-size=16384" yarn modules   125.94s user 17.37s system 206% cpu 1:09.49 total
```

The speedup is also seen in GHA:

Before:

![Screenshot 2023-09-13 at 14 22 07](https://github.com/guardian/support-dotcom-components/assets/379839/f5fb5bc7-92d1-4a88-a5f8-7ce3c006227b)

After:

![Screenshot 2023-09-13 at 14 22 38](https://github.com/guardian/support-dotcom-components/assets/379839/8836acf1-19b8-4717-85fc-19e6fb987caf)

I've tested this in CODE and have seen banners and epics render as expected. I also diffed the output of the build process before and after this change and confirmed it was identical.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
