### PR TITLE
Choice cards banner below mobile medium close button stop overflowing header

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/choiceCardsButtonsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/choiceCardsButtonsBannerStyles.ts
@@ -78,6 +78,7 @@ export const heading = (headingColor: string): SerializedStyles => css`
 
     ${from.mobileMedium} {
         font-size: 24px;
+        margin-right: 0px;
         max-width: calc(100% - ${height.ctaSmall * 2 + space[2]}px);
     }
 

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/choiceCardsButtonsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/choiceCardsButtonsBannerStyles.ts
@@ -73,7 +73,7 @@ export const choiceCardVerticalAlignment = css`
 export const heading = (headingColor: string): SerializedStyles => css`
     ${headline.xxsmall({ fontWeight: 'bold' })};
     font-size: 22px;
-    margin: 0 0 ${space[4]}px;
+    margin: 0 ${space[12]}px ${space[4]}px 0;
     color: ${headingColor};
 
     ${from.mobileMedium} {


### PR DESCRIPTION
## What does this change?

At small Mobile breakpoints and below the close button overflows across the banner header. This occurs on the original Choice Cards banner only (Moment version is fine). 

Font has already been reduced from 24px to 22px below MobileMedium.

## Images
![image](https://github.com/guardian/support-dotcom-components/assets/76729591/b153ecc4-8dd2-46d8-9b09-74ce4a6b7ee8)


[Trello]
https://trello.com/c/y0l6bigp/1538-bespoke-choice-card-banner-mobile-breakpoint-close-button-overlays-header
