### PR TITLE
Suppress banners on the new Europe edition front

### DIFF
--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -168,6 +168,12 @@ export const selectBannerTest = (
         return null;
     }
 
+    // Temporary code to suppress showing banners on the new Europe edition front
+    // To be removed as soon as Marketing colleagues give us the go-ahead
+    if (pageTracking?.referrerUrl === 'https://www.theguardian.com/europe') {
+        return null;
+    }
+
     for (const test of tests) {
         const deploySchedule = enableScheduledDeploys
             ? targetingTest?.deploySchedule ?? defaultDeploySchedule


### PR DESCRIPTION
## What does this change?
Marketing have requested a temporary halt on showing Banner messages on the new Europe edition front.

## How to test
- Once the new Europe edition launches, attempt to force a banner to display on the front. No banner should display
- Then go to an article and repeat - a banner should display
- As a sanity check, check on a different edition front - again, a banner should display
