### PR TITLE
Revert "Suppress banners on the new Europe edition front"

### DIFF
--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -168,12 +168,6 @@ export const selectBannerTest = (
         return null;
     }
 
-    // Temporary code to suppress showing banners on the new Europe edition front
-    // To be removed as soon as Marketing colleagues give us the go-ahead
-    if (pageTracking?.referrerUrl === 'https://www.theguardian.com/europe') {
-        return null;
-    }
-
     for (const test of tests) {
         const deploySchedule = enableScheduledDeploys
             ? targetingTest?.deploySchedule ?? defaultDeploySchedule


### PR DESCRIPTION
Reverts guardian/support-dotcom-components#962

The requirement to suppress banners on the new Front was always temporary. This PR will revert the changes once the requirement completes