### PR TITLE
Europe and Supporter Moment Banner CTA correction

### DIFF
--- a/packages/modules/src/hooks/useChoiceCards.ts
+++ b/packages/modules/src/hooks/useChoiceCards.ts
@@ -43,7 +43,7 @@ const useChoiceCards = (
     ): string => {
         const primaryCtaText = content?.[contentType]?.primaryCta?.ctaText;
 
-        return primaryCtaText ? primaryCtaText : 'Contribute';
+        return primaryCtaText ? primaryCtaText : 'Continue';
     };
 
     const currencySymbol = getLocalCurrencySymbol(countryCode);

--- a/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.stories.tsx
@@ -89,7 +89,7 @@ EuropeMomentLocalLanguage.args = {
         highlightedText:
             'Nullam dictum felis eu pede mollis pretium. Integeir tincidunt. Thank you.',
         cta: {
-            text: 'Contribute',
+            text: 'Continue',
             baseUrl: 'https://support.theguardian.com/contribute/one-off',
         },
     },
@@ -103,7 +103,7 @@ EuropeMomentLocalLanguage.args = {
         highlightedText:
             'Nullam dictum felis eu pede mollis pretium. Integeir tincidunt. Thank you.',
         cta: {
-            text: 'Contribute',
+            text: 'Continue',
             baseUrl: 'https://support.theguardian.com/contribute/one-off',
         },
     },


### PR DESCRIPTION
## What does this change?

Fallback changed from 'Contribute' to 'Continue' for Moment Choice Card banners (Europe Local Lnaguage and Supporter).

A separate PR will be created to ensure RRCP CTA setting are passed through to this banner type (Moment Choice Cards).

## Images

| Before | After | 
|--------|--------|
|<img width="1026" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/76729591/0b645d92-539e-4466-8187-14917386db58">|<img width="1026" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/76729591/bafea35f-8e4a-4c34-b78e-8400592692f7">|
|<img width="1026" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/76729591/f170183a-23b9-4cf1-9df8-44e4f340b7ff">|<img width="1026" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/76729591/962f7a04-289a-4104-94f5-032e20117213">|




