### PR TITLE
Add new designable banner fields

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -9,7 +9,7 @@ import { DesignableBannerCtas } from './components/DesignableBannerCtas';
 import { DesignableBannerCloseButton } from './components/DesignableBannerCloseButton';
 import { DesignableBannerVisual } from './components/DesignableBannerVisual';
 import { between, from, until } from '@guardian/src-foundations/mq';
-import { SecondaryCtaType } from '@sdc/shared/types';
+import { SecondaryCtaType, hexColourToString } from '@sdc/shared/types';
 import { DesignableBannerReminder } from './components/DesignableBannerReminder';
 import DesignableBannerTicker from './components/DesignableBannerTicker';
 import { templateSpacing } from './styles/templateStyles';
@@ -44,8 +44,8 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 
     const templateSettings: BannerTemplateSettings = {
         containerSettings: {
-            backgroundColour: specialReport[100],
-            textColor: neutral[100],
+            backgroundColour: hexColourToString(design.colours.basic.background),
+            textColor: hexColourToString(design.colours.basic.bodyText),
         },
         headerSettings: {
             textColour: neutral[100],

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -72,5 +72,19 @@ Designable.args = {
                 'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
             altText: 'Example alt text',
         },
+        colours: {
+            basic: {
+                background: {
+                    r: '22',
+                    g: '25',
+                    b: '27',
+                },
+                bodyText: {
+                    r: 'FF',
+                    g: 'FF',
+                    b: 'FF',
+                },
+            },
+        },
     },
 };

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -78,11 +78,13 @@ Designable.args = {
                     r: '22',
                     g: '25',
                     b: '27',
+                    kind: 'hex',
                 },
                 bodyText: {
                     r: 'FF',
                     g: 'FF',
                     b: 'FF',
+                    kind: 'hex',
                 },
             },
         },

--- a/packages/server/src/factories/bannerDesign.ts
+++ b/packages/server/src/factories/bannerDesign.ts
@@ -12,4 +12,18 @@ export default Factory.define<BannerDesignFromTool>(() => ({
             'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
         altText: 'Example alt text',
     },
+    colours: {
+        basic: {
+            background: {
+                r: 'FF',
+                g: '00',
+                b: '00',
+            },
+            bodyText: {
+                r: '00',
+                g: '00',
+                b: '00',
+            },
+        },
+    },
 }));

--- a/packages/server/src/factories/bannerDesign.ts
+++ b/packages/server/src/factories/bannerDesign.ts
@@ -18,11 +18,13 @@ export default Factory.define<BannerDesignFromTool>(() => ({
                 r: 'FF',
                 g: '00',
                 b: '00',
+                kind: 'hex',
             },
             bodyText: {
                 r: '00',
                 g: '00',
                 b: '00',
+                kind: 'hex',
             },
         },
     },

--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -13,6 +13,7 @@ import { OphanComponentEvent } from '../ophan';
 import * as z from 'zod';
 import { Prices } from '../prices';
 import { SelectedAmountsVariant } from '../abTests';
+import { ConfigurableDesign, configurableDesignSchema, hexColourToString } from './design';
 
 export const bannerChannelSchema = z.enum(['contributions', 'subscriptions', 'signIn']);
 
@@ -56,24 +57,6 @@ export interface BannerProps extends EmotionJSX.IntrinsicAttributes {
     design?: ConfigurableDesign;
 }
 
-export const configurableDesignSchema = z.object({
-    image: z.object({
-        mobileUrl: z.string(),
-        tabletDesktopUrl: z.string(),
-        wideUrl: z.string(),
-        altText: z.string(),
-    }),
-});
-
-export interface ConfigurableDesign {
-    image: {
-        mobileUrl: string;
-        tabletDesktopUrl: string;
-        wideUrl: string;
-        altText: string;
-    };
-}
-
 export const bannerSchema = z.object({
     tracking: trackingSchema,
     bannerChannel: bannerChannelSchema,
@@ -93,3 +76,5 @@ export const bannerSchema = z.object({
 export interface PuzzlesBannerProps extends Partial<BannerProps> {
     tracking: Tracking;
 }
+
+export { ConfigurableDesign, hexColourToString };

--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -76,5 +76,3 @@ export const bannerSchema = z.object({
 export interface PuzzlesBannerProps extends Partial<BannerProps> {
     tracking: Tracking;
 }
-
-export { ConfigurableDesign, hexColourToString };

--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -13,7 +13,7 @@ import { OphanComponentEvent } from '../ophan';
 import * as z from 'zod';
 import { Prices } from '../prices';
 import { SelectedAmountsVariant } from '../abTests';
-import { ConfigurableDesign, configurableDesignSchema, hexColourToString } from './design';
+import { ConfigurableDesign, configurableDesignSchema } from './design';
 
 export const bannerChannelSchema = z.enum(['contributions', 'subscriptions', 'signIn']);
 

--- a/packages/shared/src/types/props/design.test.ts
+++ b/packages/shared/src/types/props/design.test.ts
@@ -1,4 +1,4 @@
-import { hexColourSchema } from './design';
+import { HexColour, hexColourSchema, hexColourToString } from './design';
 
 describe('hexValueColourSchema', () => {
     it('successfully parses valid hex colours', () => {
@@ -30,5 +30,19 @@ describe('hexValueColourSchema', () => {
         const result = hexColourSchema.safeParse(badHexColour);
 
         expect(result.success).toBeFalsy();
+    });
+});
+
+describe('hexColourToString', () => {
+    it('returns a CSS colour string for a HexColour object', () => {
+        const hexColour: HexColour = {
+            r: 'FF',
+            g: '00',
+            b: '1F',
+        };
+
+        const cssString = hexColourToString(hexColour);
+
+        expect(cssString).toEqual('#FF001F');
     });
 });

--- a/packages/shared/src/types/props/design.test.ts
+++ b/packages/shared/src/types/props/design.test.ts
@@ -2,7 +2,7 @@ import { HexColour, hexColourSchema, hexColourToString } from './design';
 
 describe('hexValueColourSchema', () => {
     it('successfully parses valid hex colours', () => {
-        const goodHexColour = { r: 'AC', g: 'AA', b: 'AF' };
+        const goodHexColour = { r: 'AC', g: 'AA', b: 'AF', kind: 'hex' };
 
         const result = hexColourSchema.safeParse(goodHexColour);
 
@@ -14,6 +14,7 @@ describe('hexValueColourSchema', () => {
             r: 'AC',
             g: 'AA',
             b: 'ZZ',
+            kind: 'hex',
         };
 
         const result = hexColourSchema.safeParse(badHexColour);
@@ -25,6 +26,7 @@ describe('hexValueColourSchema', () => {
         const badHexColour = {
             r: 'AC',
             g: 'AA',
+            kind: 'hex',
         };
 
         const result = hexColourSchema.safeParse(badHexColour);
@@ -39,6 +41,7 @@ describe('hexColourToString', () => {
             r: 'FF',
             g: '00',
             b: '1F',
+            kind: 'hex',
         };
 
         const cssString = hexColourToString(hexColour);

--- a/packages/shared/src/types/props/design.test.ts
+++ b/packages/shared/src/types/props/design.test.ts
@@ -1,15 +1,34 @@
 import { hexColourSchema } from './design';
 
 describe('hexValueColourSchema', () => {
-    it('enforces that hex values are valid', () => {
-        const goodHexColour = {
-            r: 'AC',
-            g: 'AA',
-            b: '15',
-        };
+    it('successfully parses valid hex colours', () => {
+        const goodHexColour = { r: 'AC', g: 'AA', b: 'AF' };
 
         const result = hexColourSchema.safeParse(goodHexColour);
 
         expect(result.success).toBeTruthy();
+    });
+
+    it('does not successfully parse when the object contains a bad hex value', () => {
+        const badHexColour = {
+            r: 'AC',
+            g: 'AA',
+            b: 'ZZ',
+        };
+
+        const result = hexColourSchema.safeParse(badHexColour);
+
+        expect(result.success).toBeFalsy();
+    });
+
+    it('does not successfully parse when the object is missing a hex value', () => {
+        const badHexColour = {
+            r: 'AC',
+            g: 'AA',
+        };
+
+        const result = hexColourSchema.safeParse(badHexColour);
+
+        expect(result.success).toBeFalsy();
     });
 });

--- a/packages/shared/src/types/props/design.test.ts
+++ b/packages/shared/src/types/props/design.test.ts
@@ -1,0 +1,15 @@
+import { hexColourSchema } from './design';
+
+describe('hexValueColourSchema', () => {
+    it('enforces that hex values are valid', () => {
+        const goodHexColour = {
+            r: 'AC',
+            g: 'AA',
+            b: '15',
+        };
+
+        const result = hexColourSchema.safeParse(goodHexColour);
+
+        expect(result.success).toBeTruthy();
+    });
+});

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -3,10 +3,10 @@ import * as z from 'zod';
 const hexValueRegex = /^[0-9A-F]{2}$/;
 
 const hexValueSchema = z.string().refine(
-    val => {
+    (val) => {
         return hexValueRegex.test(val);
     },
-    val => {
+    (val) => {
         return { message: `"${val}" is not a valid hex value` };
     },
 );

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -15,6 +15,7 @@ export const hexColourSchema = z.object({
     r: hexValueSchema,
     g: hexValueSchema,
     b: hexValueSchema,
+    kind: z.literal('hex'),
 });
 
 export const configurableDesignSchema = z.object({
@@ -56,6 +57,7 @@ export interface HexColour {
     r: HexValue;
     g: HexValue;
     b: HexValue;
+    kind: 'hex';
 }
 
 export const hexColourToString = (h: HexColour): string => `#${h.r}${h.g}${h.b}`;

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -1,0 +1,76 @@
+import * as z from 'zod';
+
+const hexValueRegex = /^[0-9A-F]{2}$/;
+
+const hexValueSchema = z.string().refine(
+    val => {
+        return hexValueRegex.test(val);
+    },
+    val => {
+        return { message: `"${val}" is not a valid hex value` };
+    },
+);
+
+export const hexColourSchema = z.object({
+    r: hexValueSchema,
+    g: hexValueSchema,
+    b: hexValueSchema,
+});
+
+export const configurableDesignSchema = z.object({
+    image: z.object({
+        mobileUrl: z.string(),
+        tabletDesktopUrl: z.string(),
+        wideUrl: z.string(),
+        altText: z.string(),
+    }),
+    colours: z.object({
+        basic: z.object({
+            background: hexColourSchema,
+            bodyText: hexColourSchema,
+        }),
+    }),
+});
+
+type HexChar =
+    | '0'
+    | '1'
+    | '2'
+    | '3'
+    | '4'
+    | '5'
+    | '6'
+    | '7'
+    | '8'
+    | '9'
+    | 'A'
+    | 'B'
+    | 'C'
+    | 'D'
+    | 'E'
+    | 'F';
+
+type HexValue = `${HexChar}${HexChar}`;
+
+interface HexColour {
+    r: HexValue;
+    g: HexValue;
+    b: HexValue;
+}
+
+export const hexColourToString = (h: HexColour): string => `#${h.r}${h.g}${h.b}`;
+
+export interface ConfigurableDesign {
+    image: {
+        mobileUrl: string;
+        tabletDesktopUrl: string;
+        wideUrl: string;
+        altText: string;
+    };
+    colours: {
+        basic: {
+            background: HexColour;
+            bodyText: HexColour;
+        };
+    };
+}

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -52,7 +52,7 @@ type HexChar =
 
 type HexValue = `${HexChar}${HexChar}`;
 
-interface HexColour {
+export interface HexColour {
     r: HexValue;
     g: HexValue;
     b: HexValue;

--- a/packages/shared/src/types/props/index.ts
+++ b/packages/shared/src/types/props/index.ts
@@ -2,3 +2,4 @@ export * from './epic';
 export * from './banner';
 export * from './header';
 export * from './shared';
+export * from './design';


### PR DESCRIPTION
## What does this change?

This introduces two new colour properties to the design prop of the `DesignableBanner` component: the `background` and `bodyText` colours.

This change will need to go hand-in-hand with guardian/support-admin-console#499 where we add the UI to configure these new values in a banner design.

<img width="1512" alt="Screenshot 2023-10-02 at 13 01 42" src="https://github.com/guardian/support-dotcom-components/assets/379839/bb6c53c2-d69e-4f0a-8498-cab1a1421f0f">

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
