### PR TITLE
Moment Choice Card Banner CTA pulled from RRCP

### DIFF
--- a/packages/modules/src/hooks/useChoiceCards.ts
+++ b/packages/modules/src/hooks/useChoiceCards.ts
@@ -11,13 +11,11 @@ export interface ChoiceCardSelection {
 const useChoiceCards = (
     choiceCardAmounts: SelectedAmountsVariant | undefined,
     countryCode: string | undefined,
+    content: BannerTextContent,
 ): {
     choiceCardSelection: ChoiceCardSelection | undefined;
     setChoiceCardSelection: (choiceCardSelection: ChoiceCardSelection) => void;
-    getCtaText: (
-        contentType: 'mainContent' | 'mobileContent',
-        content?: BannerTextContent,
-    ) => string;
+    getCtaText: (contentType: 'mainContent' | 'mobileContent') => string;
     currencySymbol: string;
 } => {
     const [choiceCardSelection, setChoiceCardSelection] = useState<
@@ -37,13 +35,10 @@ const useChoiceCards = (
         }
     }, [choiceCardAmounts]);
 
-    const getCtaText = (
-        contentType: 'mainContent' | 'mobileContent',
-        content?: BannerTextContent,
-    ): string => {
+    const getCtaText = (contentType: 'mainContent' | 'mobileContent'): string => {
         const primaryCtaText = content?.[contentType]?.primaryCta?.ctaText;
 
-        return primaryCtaText ? primaryCtaText : 'Continue';
+        return primaryCtaText ? primaryCtaText : 'Contribute';
     };
 
     const currencySymbol = getLocalCurrencySymbol(countryCode);

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -111,7 +111,7 @@ const DesignableBanner: React.FC<BannerRenderProps> = ({
         setChoiceCardSelection,
         getCtaText,
         currencySymbol,
-    } = useChoiceCards(choiceCardAmounts, countryCode);
+    } = useChoiceCards(choiceCardAmounts, countryCode, content);
     const showChoiceCards = !!(templateSettings.choiceCards && choiceCardAmounts?.amountsCardData);
 
     return (

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -48,7 +48,8 @@ export function getMomentTemplateBanner(
             setChoiceCardSelection,
             getCtaText,
             currencySymbol,
-        } = useChoiceCards(choiceCardAmounts, countryCode);
+        } = useChoiceCards(choiceCardAmounts, countryCode, content);
+
         const showChoiceCards = !!(
             templateSettings.choiceCards && choiceCardAmounts?.amountsCardData
         );

--- a/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/supporterMoment/SupporterMomentBanner.stories.tsx
@@ -87,7 +87,7 @@ SupporterMoment.args = {
         highlightedText:
             'Nullam dictum felis eu pede mollis pretium. Integeir tincidunt. Thank you.',
         cta: {
-            text: 'Contribute',
+            text: 'Continue',
             baseUrl: 'https://support.theguardian.com/contribute/one-off',
         },
     },
@@ -101,7 +101,7 @@ SupporterMoment.args = {
         highlightedText:
             'Nullam dictum felis eu pede mollis pretium. Integeir tincidunt. Thank you.',
         cta: {
-            text: 'Contribute',
+            text: 'Continue',
             baseUrl: 'https://support.theguardian.com/contribute/one-off',
         },
     },


### PR DESCRIPTION
## What does this change?

Moment Choice Card banners (Europe Local Language and Supporter) pull RRCP CTA settings through to banner.
![image](https://github.com/guardian/support-dotcom-components/assets/76729591/e8570cee-66dd-48cb-8a02-904bf03137f4)

Note: This is a wider fix supercedes the fix described in this PR -> 
https://github.com/guardian/support-dotcom-components/pull/964

## Images

| Before | After | 
|--------|--------|
|<img width="1026" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/76729591/0b645d92-539e-4466-8187-14917386db58">|<img width="1026" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/76729591/bafea35f-8e4a-4c34-b78e-8400592692f7">|
|<img width="1026" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/76729591/f170183a-23b9-4cf1-9df8-44e4f340b7ff">|<img width="1026" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/76729591/962f7a04-289a-4104-94f5-032e20117213">|