### PR TITLE
Exclude draft banner designs

### DIFF
--- a/packages/server/src/tests/store.ts
+++ b/packages/server/src/tests/store.ts
@@ -48,6 +48,13 @@ export const getBannerDesigns = (): Promise<BannerDesignFromTool[]> => {
     return docClient
         .scan({
             TableName: `support-admin-console-banner-designs-${stage.toUpperCase()}`,
+            ExpressionAttributeValues: {
+                ':draft': 'Draft',
+            },
+            ExpressionAttributeNames: {
+                '#status': 'status', // Necessary because status is a reserved word in dynamodb
+            },
+            FilterExpression: '#status <> :draft',
         })
         .promise()
         .then(results => (results.Items || []) as BannerDesignFromTool[])


### PR DESCRIPTION
The RRCP prevents draft banner designs from being used in test variants.
SDC can safely ignore them