### PR TITLE
Improve context targeting logic

### DIFF
--- a/packages/server/src/lib/targeting.test.ts
+++ b/packages/server/src/lib/targeting.test.ts
@@ -207,6 +207,24 @@ describe('pageContextMatches', () => {
         expect(result).toBe(false);
     });
 
+    // Required tags *and* sections
+    it('returns true if page has required tag or required section', () => {
+        const result = pageContextMatches(pageContext, {
+            ...pageContextTargeting,
+            tagIds: ['politics/politics'],
+            sectionIds: ['environment'],
+        });
+        expect(result).toBe(true);
+    });
+    it('returns false if page does not have required tag or required section', () => {
+        const result = pageContextMatches(pageContext, {
+            ...pageContextTargeting,
+            tagIds: ['environment/environment'],
+            sectionIds: ['environment'],
+        });
+        expect(result).toBe(false);
+    });
+
     // Excluded tags
     it('returns false if page has excluded tag', () => {
         const result = pageContextMatches(pageContext, {
@@ -221,6 +239,17 @@ describe('pageContextMatches', () => {
             excludedTagIds: ['environment/environment'],
         });
         expect(result).toBe(true);
+    });
+    it('returns false if page has required tag but also excluded tag', () => {
+        const result = pageContextMatches(
+            { ...pageContext, tagIds: ['politics/politics', 'environment/environment'] },
+            {
+                ...pageContextTargeting,
+                tagIds: ['politics/politics'],
+                excludedTagIds: ['environment/environment'],
+            },
+        );
+        expect(result).toBe(false);
     });
 
     // Excluded sections

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -124,8 +124,10 @@ export const pageContextMatches = (
 ): boolean => {
     const { tagIds, sectionIds, excludedTagIds, excludedSectionIds } = testTargeting;
 
+    const noTargeting = tagIds.length === 0 && sectionIds.length === 0;
+    
     const inclusionsMatch: boolean =
-        (tagIds.length === 0 && sectionIds.length === 0) || // no targeting
+        noTargeting ||
         pageHasATag(tagIds, pageContext.tagIds) ||
         pageHasASection(sectionIds, pageContext.sectionId);
 

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -124,11 +124,15 @@ export const pageContextMatches = (
 ): boolean => {
     const { tagIds, sectionIds, excludedTagIds, excludedSectionIds } = testTargeting;
 
-    return (
-        (tagIds.length === 0 || pageHasATag(tagIds, pageContext.tagIds)) &&
-        (sectionIds.length === 0 || pageHasASection(sectionIds, pageContext.sectionId)) &&
-        (excludedTagIds.length === 0 || !pageHasATag(excludedTagIds, pageContext.tagIds)) &&
-        (excludedSectionIds.length === 0 ||
-            !pageHasASection(excludedSectionIds, pageContext.sectionId))
-    );
+    const inclusionsMatch: boolean =
+        (tagIds.length === 0 && sectionIds.length === 0) || // no targeting
+        pageHasATag(tagIds, pageContext.tagIds) ||
+        pageHasASection(sectionIds, pageContext.sectionId);
+
+    const exclusionsMatch: boolean =
+        (excludedTagIds.length > 0 && pageHasATag(excludedTagIds, pageContext.tagIds)) ||
+        (excludedSectionIds.length > 0 &&
+            pageHasASection(excludedSectionIds, pageContext.sectionId));
+
+    return inclusionsMatch && !exclusionsMatch;
 };

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -125,7 +125,7 @@ export const pageContextMatches = (
     const { tagIds, sectionIds, excludedTagIds, excludedSectionIds } = testTargeting;
 
     const noTargeting = tagIds.length === 0 && sectionIds.length === 0;
-    
+
     const inclusionsMatch: boolean =
         noTargeting ||
         pageHasATag(tagIds, pageContext.tagIds) ||


### PR DESCRIPTION
Currently if a test has required tagIds and required sectionIds set, then these expressions are AND'ed, i.e. a page must have both a matching tag and a matching section.
This isn't the desired behaviour.

With this PR, the logic becomes:
`(target tags match OR target sections match) AND NOT (excluded tags match OR excluded sections match)`