### PR TITLE
Backdrop enabled Moment banners

### DIFF
--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -168,8 +168,12 @@ export function getMomentTemplateBanner(
 }
 
 const styles = {
-    outerContainer: (backgroundColour: string, textColor: string = 'inherit', backgroundImage? : string) => css`
-        ${backgroundColour && `background-color: ${backgroundColour};`}
+    outerContainer: (
+        background: string,
+        textColor: string = 'inherit',
+        backgroundImage?: string,
+    ) => css`
+        background: ${background};
         ${backgroundImage && `background-image: url(${backgroundImage});`}
         color: ${textColor};
         max-height: 100vh;

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -20,6 +20,7 @@ import useChoiceCards from '../../../hooks/useChoiceCards';
 import { ChoiceCards } from '../choiceCardsButtonsBanner/components/ChoiceCards';
 import { buttonStyles } from './styles/buttonStyles';
 import { ReactComponent } from '../../../types';
+import { Image } from '@sdc/shared/dist/types';
 
 export function getMomentTemplateBanner(
     templateSettings: BannerTemplateSettings,
@@ -55,7 +56,7 @@ export function getMomentTemplateBanner(
                 css={styles.outerContainer(
                     templateSettings.containerSettings.backgroundColour,
                     templateSettings.containerSettings.textColor,
-                    templateSettings.containerSettings.backgroundImage,
+                    templateSettings.containerSettings.backgroundImages,
                 )}
             >
                 <div css={styles.containerOverrides}>
@@ -171,10 +172,10 @@ const styles = {
     outerContainer: (
         background: string,
         textColor: string = 'inherit',
-        backgroundImage?: string,
+        backgroundImages?: Image,
     ) => css`
         background: ${background};
-        ${backgroundImage && `background-image: url(${backgroundImage});`}
+        ${backgroundImages?.mainUrl && `background-image: url(${backgroundImages.mainUrl});`}
         color: ${textColor};
         max-height: 100vh;
         overflow: auto;
@@ -182,9 +183,28 @@ const styles = {
         * {
             box-sizing: border-box;
         }
+        ${until.tablet} {
+            ${backgroundImages?.mobileUrl &&
+            `background-image: url(${backgroundImages.mobileUrl});`}
+        }
         ${from.tablet} {
             border-top: 1px solid ${neutral[0]};
             padding: 0 ${space[5]}px;
+        }
+        ${between.tablet.and.desktop} {
+            ${backgroundImages?.tabletUrl &&
+            `background-image: url(${backgroundImages.tabletUrl});`}
+        }
+        ${between.desktop.and.leftCol} {
+            ${backgroundImages?.desktopUrl &&
+            `background-image: url(${backgroundImages.desktopUrl});`}
+        }
+        ${between.leftCol.and.wide} {
+            ${backgroundImages?.leftColUrl &&
+            `background-image: url(${backgroundImages.leftColUrl});`}
+        }
+        ${from.wide} {
+            ${backgroundImages?.wideUrl && `background-image: url(${backgroundImages.wideUrl});`}
         }
     `,
     containerOverrides: css`

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -55,6 +55,7 @@ export function getMomentTemplateBanner(
                 css={styles.outerContainer(
                     templateSettings.containerSettings.backgroundColour,
                     templateSettings.containerSettings.textColor,
+                    templateSettings.containerSettings.backgroundImage,
                 )}
             >
                 <div css={styles.containerOverrides}>
@@ -167,8 +168,9 @@ export function getMomentTemplateBanner(
 }
 
 const styles = {
-    outerContainer: (background: string, textColor: string = 'inherit') => css`
-        background: ${background};
+    outerContainer: (backgroundColour: string, textColor: string = 'inherit', backgroundImage? : string) => css`
+        ${backgroundColour && `background-color: ${backgroundColour};`}
+        ${backgroundImage && `background-image: url(${backgroundImage});`}
         color: ${textColor};
         max-height: 100vh;
         overflow: auto;
@@ -228,7 +230,6 @@ const styles = {
         ${from.tablet} {
             grid-column: 1 / span 1;
             grid-row: 1 / span 1;
-            background: ${background};
         }
         ${templateSpacing.bannerHeader}
     `,
@@ -242,7 +243,6 @@ const styles = {
     bannerVisualContainer: (background: string, isChoiceCardsContainer?: boolean) => css`
         display: ${isChoiceCardsContainer ? 'block' : 'none'};
         order: ${isChoiceCardsContainer ? '3' : '1'};
-        background: ${background};
         ${from.mobileMedium} {
             display: block;
         }

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
@@ -149,9 +149,11 @@ const styles = {
         display: flex;
         flex-wrap: wrap;
 
+        & a {
+            margin-bottom: ${space[2]}px;
+        }
         & a:not(:last-child) {
             margin-right: ${space[3]}px;
-            margin-bottom: ${space[2]}px;
         }
     `,
     paymentMethods: css`

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -4,6 +4,7 @@ import { BannerId } from '../common/types';
 
 export type ContainerSettings = {
     backgroundColour: string;
+    backgroundImage?: string;
     textColor?: string;
     paddingTop?: string;
 };

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -4,7 +4,7 @@ import { BannerId } from '../common/types';
 
 export type ContainerSettings = {
     backgroundColour: string;
-    backgroundImage?: string;
+    backgroundImages?: Image;
     textColor?: string;
     paddingTop?: string;
 };

--- a/packages/modules/src/modules/banners/momentTemplate/stories/MomentTemplateBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/MomentTemplateBanner.stories.tsx
@@ -7,6 +7,7 @@ import { BannerWithChoiceCardsTemplate } from './WithChoiceCards';
 import { DefaultTemplate } from './Default';
 import { BannerWithTickerTemplate } from './WithTicker';
 import { BannerWithChoiceCardsHeaderImageTemplate } from './WithChoiceCardsHeaderImage';
+import { WithBackDropTemplate } from './WithBackDrop';
 
 export default {
     title: 'Banners/MomentTemplate',
@@ -19,6 +20,57 @@ export default {
 } as Meta;
 
 export const Default = DefaultTemplate.bind({});
+Default.args = {
+    ...props,
+    content: {
+        heading: 'Show your support for reader-funded journalism',
+        messageText:
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations. We do not shy away. And we provide all this for free, for everyone.',
+        paragraphs: [
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations.',
+            'We do not shy away. And we provide all this for free, for everyone.',
+        ],
+        highlightedText:
+            'Show your support today from just %%CURRENCY_SYMBOL%%1, or sustain us long term with a little more. Thank you.',
+        cta: {
+            text: 'Support once',
+            baseUrl: 'https://support.theguardian.com/contribute/one-off',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Support monthly',
+                baseUrl: 'https://support.theguardian.com/contribute/recurring',
+            },
+        },
+    },
+    mobileContent: {
+        heading: 'Show your support for reader-funded journalism',
+        messageText:
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations. We do not shy away. And we provide all this for free, for everyone.',
+        paragraphs: [
+            'Fearless, investigative reporting shapes a fairer world. At the Guardian, our independence allows us to chase the truth wherever it takes us. We have no shareholders. No vested interests. Just the determination and passion to bring readers quality reporting, including groundbreaking investigations.',
+            'We do not shy away. And we provide all this for free, for everyone.',
+        ],
+        highlightedText:
+            'Show your support today from just %%CURRENCY_SYMBOL%%1, or sustain us long term with a little more. Thank you.',
+        cta: {
+            text: 'Support us',
+            baseUrl: 'https://support.theguardian.com/contribute/one-off',
+        },
+        secondaryCta: {
+            type: SecondaryCtaType.Custom,
+            cta: {
+                text: 'Learn more',
+                baseUrl: 'https://support.theguardian.com/contribute/recurring',
+            },
+        },
+    },
+    numArticles: 50,
+    tickerSettings: undefined,
+};
+
+export const WithBackDrop = WithBackDropTemplate.bind({});
 Default.args = {
     ...props,
     content: {

--- a/packages/modules/src/modules/banners/momentTemplate/stories/WithBackDrop.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/WithBackDrop.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { brand, neutral, brandAlt } from '@guardian/src-foundations';
+import { BannerProps } from '@sdc/shared/src/types';
+import { Story } from '@storybook/react';
+import { bannerWrapper } from '../../common/BannerWrapper';
+import { getMomentTemplateBanner } from '../MomentTemplateBanner';
+
+export const WithBackDropBanner = bannerWrapper(
+    getMomentTemplateBanner({
+        containerSettings: {
+            backgroundColour: '#F1F8FC',
+            backgroundImage:
+                'https://i.guim.co.uk/img/media/6b024b25e355d89385a87fe08a05cdf9d44f2db1/0_0_5000_5000/500.jpg?width=500&height=500&quality=75&s=8dc82adf770733853e5b180f965a313f',
+        },
+        headerSettings: {
+            showHeader: { text: true },
+            textColour: '#0077B6',
+        },
+        primaryCtaSettings: {
+            default: {
+                backgroundColour: '#0077B6',
+                textColour: 'white',
+            },
+            hover: {
+                backgroundColour: '#004E7C',
+                textColour: 'white',
+                border: '1px solid #004E7C',
+            },
+        },
+        secondaryCtaSettings: {
+            default: {
+                backgroundColour: '#F1F8FC',
+                textColour: '#004E7C',
+                border: '1px solid #004E7C',
+            },
+            hover: {
+                backgroundColour: '#E5E5E5',
+                textColour: '#004E7C',
+                border: '1px solid #004E7C',
+            },
+        },
+        closeButtonSettings: {
+            default: {
+                backgroundColour: '#F1F8FC',
+                textColour: brand[400],
+                border: `1px solid ${brand[400]}`,
+            },
+            hover: {
+                backgroundColour: '#E5E5E5',
+                textColour: brand[400],
+            },
+            theme: 'brand',
+        },
+        highlightedTextSettings: {
+            textColour: neutral[0],
+            highlightColour: brandAlt[400],
+        },
+        imageSettings: {
+            mainUrl:
+                'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
+            mobileUrl:
+                'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
+            tabletUrl:
+                'https://i.guim.co.uk/img/media/d1af2bcab927ca0ad247522105fe41a52a474d27/0_0_1080_1000/500.png?width=500&quality=75&s=af39fa30f36fce453eabaef3063a3180',
+            desktopUrl:
+                'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
+            wideUrl:
+                'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
+            altText: 'Guardian logo being held up by supporters of the Guardian',
+        },
+        bannerId: 'global-new-year-moment-banner',
+    }),
+    'global-new-year-moment-banner',
+);
+
+export const WithBackDropTemplate: Story<BannerProps> = (props: BannerProps) => (
+    <WithBackDropBanner {...props} />
+);

--- a/packages/modules/src/modules/banners/momentTemplate/stories/WithBackDrop.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/WithBackDrop.tsx
@@ -9,8 +9,13 @@ export const WithBackDropBanner = bannerWrapper(
     getMomentTemplateBanner({
         containerSettings: {
             backgroundColour: '#F1F8FC',
-            backgroundImage:
-                'https://i.guim.co.uk/img/media/6b024b25e355d89385a87fe08a05cdf9d44f2db1/0_0_5000_5000/500.jpg?width=500&height=500&quality=75&s=8dc82adf770733853e5b180f965a313f',
+            backgroundImages: {
+                mainUrl:
+                    'https://i.guim.co.uk/img/media/6b024b25e355d89385a87fe08a05cdf9d44f2db1/0_0_5000_5000/500.jpg?width=500&height=500&quality=75&s=8dc82adf770733853e5b180f965a313f',
+                wideUrl:
+                    'https://i.guim.co.uk/img/media/bcd3d16ac69232a046033cef0898abb85d593cdd/0_240_3500_2100/500.jpg?width=500&quality=100&s=b1adde7f66fa2741af911f5493ec2df7',
+                altText: 'Currency backdrop',
+            },
         },
         headerSettings: {
             showHeader: { text: true },


### PR DESCRIPTION
## What does this change?

- Image background colours removed
- Backdrop tiled image added to banner (image can be breakpoint dependent)
- Story 'MomentTemplate/With Backdrop' to demonstrate
- Bugfix: Single CTA (non-choice card) moment banners, bottom spacing corrected to card icons

## Why are we doing this change?

Moment template banner cleanup

![image](https://github.com/guardian/support-dotcom-components/assets/76729591/c0a36c0d-ef25-4754-9c64-f6f79db09f3e)

[Trello] https://trello.com/c/i5kQWfNy/1564-momenttemplate-banner-sub-components-background-change-backcolour-to-transparent
