### PR TITLE
Designable banner: more colours

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { brand, neutral, space, specialReport } from '@guardian/src-foundations';
+import { neutral, space, specialReport } from '@guardian/src-foundations';
 import { BannerEnrichedReminderCta, BannerRenderProps } from '../common/types';
 import { DesignableBannerHeader } from './components/DesignableBannerHeader';
 import { DesignableBannerArticleCount } from './components/DesignableBannerArticleCount';
@@ -42,54 +42,56 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
         return <></>;
     }
 
+    const { basic, primaryCta, secondaryCta, highlightedText, closeButton } = design.colours;
+
     const templateSettings: BannerTemplateSettings = {
         containerSettings: {
-            backgroundColour: hexColourToString(design.colours.basic.background),
-            textColor: hexColourToString(design.colours.basic.bodyText),
+            backgroundColour: hexColourToString(basic.background),
+            textColor: hexColourToString(basic.bodyText),
         },
         headerSettings: {
-            textColour: neutral[100],
+            textColour: hexColourToString(basic.headerText),
         },
         primaryCtaSettings: {
             default: {
-                backgroundColour: brand[500],
-                textColour: neutral[100],
+                backgroundColour: hexColourToString(primaryCta.default.background),
+                textColour: hexColourToString(primaryCta.default.text),
             },
             hover: {
-                backgroundColour: neutral[100],
-                textColour: brand[500],
+                backgroundColour: hexColourToString(primaryCta.hover.background),
+                textColour: hexColourToString(primaryCta.hover.text),
             },
         },
         secondaryCtaSettings: {
             default: {
-                backgroundColour: specialReport[100],
-                textColour: neutral[100],
-                border: `1px solid ${neutral[100]}`,
+                backgroundColour: hexColourToString(secondaryCta.default.background),
+                textColour: hexColourToString(secondaryCta.default.text),
+                border: `1px solid ${secondaryCta.default.border || neutral[100]}`,
             },
             hover: {
                 backgroundColour: neutral[100],
                 textColour: specialReport[100],
-                border: `1px solid ${specialReport[100]}`,
+                border: `1px solid ${secondaryCta.hover.border || specialReport[100]}`,
             },
         },
         closeButtonSettings: {
             default: {
-                backgroundColour: neutral[100],
-                textColour: specialReport[100],
+                backgroundColour: hexColourToString(closeButton.default.background),
+                textColour: hexColourToString(closeButton.default.text),
                 border: `1px solid ${specialReport[100]}`,
             },
             hover: {
-                backgroundColour: specialReport[100],
-                textColour: neutral[100],
+                backgroundColour: hexColourToString(closeButton.hover.background),
+                textColour: hexColourToString(closeButton.hover.text),
                 border: `1px solid ${neutral[100]}`,
             },
-            guardianRoundel: 'inverse',
+            guardianRoundel: 'inverse', // TODO - should this be configurable?
         },
         highlightedTextSettings: {
-            textColour: specialReport[100],
-            highlightColour: neutral[100],
+            textColour: hexColourToString(highlightedText.text),
+            highlightColour: hexColourToString(highlightedText.highlight),
         },
-        articleCountTextColour: neutral[100],
+        articleCountTextColour: hexColourToString(basic.articleCountText),
         imageSettings: {
             mainUrl: design.image.mobileUrl,
             mobileUrl: design.image.mobileUrl,

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -102,7 +102,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         : neutral[100]
                 }`,
             },
-            guardianRoundel: guardianRoundel || 'default',
+            guardianRoundel: guardianRoundel,
         },
         highlightedTextSettings: {
             textColour: hexColourToString(highlightedText.text),

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -42,7 +42,8 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
         return <></>;
     }
 
-    const { basic, primaryCta, secondaryCta, highlightedText, closeButton } = design.colours;
+    const { basic, primaryCta, secondaryCta, highlightedText, closeButton, guardianRoundel } =
+        design.colours;
 
     const templateSettings: BannerTemplateSettings = {
         containerSettings: {
@@ -66,26 +67,42 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
             default: {
                 backgroundColour: hexColourToString(secondaryCta.default.background),
                 textColour: hexColourToString(secondaryCta.default.text),
-                border: `1px solid ${secondaryCta.default.border || neutral[100]}`,
+                border: `1px solid ${
+                    secondaryCta.default.border
+                        ? hexColourToString(secondaryCta.default.border)
+                        : neutral[100]
+                }`,
             },
             hover: {
                 backgroundColour: neutral[100],
                 textColour: specialReport[100],
-                border: `1px solid ${secondaryCta.hover.border || specialReport[100]}`,
+                border: `1px solid ${
+                    secondaryCta.hover.border
+                        ? hexColourToString(secondaryCta.hover.border)
+                        : specialReport[100]
+                }`,
             },
         },
         closeButtonSettings: {
             default: {
                 backgroundColour: hexColourToString(closeButton.default.background),
                 textColour: hexColourToString(closeButton.default.text),
-                border: `1px solid ${specialReport[100]}`,
+                border: `1px solid ${
+                    closeButton.default.border
+                        ? hexColourToString(closeButton.default.border)
+                        : specialReport[100]
+                }`,
             },
             hover: {
                 backgroundColour: hexColourToString(closeButton.hover.background),
                 textColour: hexColourToString(closeButton.hover.text),
-                border: `1px solid ${neutral[100]}`,
+                border: `1px solid ${
+                    closeButton.hover.border
+                        ? hexColourToString(closeButton.hover.border)
+                        : neutral[100]
+                }`,
             },
-            guardianRoundel: 'inverse', // TODO - should this be configurable?
+            guardianRoundel: guardianRoundel || 'default',
         },
         highlightedTextSettings: {
             textColour: hexColourToString(highlightedText.text),

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -19,7 +19,7 @@ export function DesignableBannerCloseButton({
     settings,
     styleOverides,
 }: DesignableBannerCloseButtonProps): JSX.Element {
-    const { theme, guardianRoundel } = settings;
+    const { guardianRoundel } = settings;
 
     const getRoundel = () => {
         if (guardianRoundel) {
@@ -32,10 +32,6 @@ export function DesignableBannerCloseButton({
                     return <SvgRoundelDefault />;
             }
         }
-        if (theme && theme === 'brand') {
-            return <SvgRoundelBrand />;
-        }
-        return <SvgRoundelDefault />;
     };
 
     return (

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -22,15 +22,13 @@ export function DesignableBannerCloseButton({
     const { guardianRoundel } = settings;
 
     const getRoundel = () => {
-        if (guardianRoundel) {
-            switch (guardianRoundel) {
-                case 'brand':
-                    return <SvgRoundelBrand />;
-                case 'inverse':
-                    return <SvgRoundelInverse />;
-                default:
-                    return <SvgRoundelDefault />;
-            }
+        switch (guardianRoundel) {
+            case 'brand':
+                return <SvgRoundelBrand />;
+            case 'inverse':
+                return <SvgRoundelInverse />;
+            default:
+                return <SvgRoundelDefault />;
         }
     };
 

--- a/packages/modules/src/modules/banners/designableBanner/settings.ts
+++ b/packages/modules/src/modules/banners/designableBanner/settings.ts
@@ -1,4 +1,4 @@
-import { Image } from '@sdc/shared/dist/types';
+import { GuardianRoundel, Image } from '@sdc/shared/dist/types';
 import { ReactNode } from 'react';
 import { BannerId } from '../common/types';
 
@@ -14,15 +14,11 @@ export type CtaStateSettings = {
     border?: string;
 };
 
-type GuardianRoundel = 'default' | 'brand' | 'inverse';
-type GuardianTheme = 'default' | 'brand';
-
 export interface CtaSettings {
     default: CtaStateSettings;
     hover: CtaStateSettings;
     mobile?: CtaStateSettings;
     desktop?: CtaStateSettings;
-    theme?: GuardianTheme;
     guardianRoundel?: GuardianRoundel;
 }
 

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -1,7 +1,8 @@
 import { Meta } from '@storybook/react';
 import { props } from '../../utils/storybook';
-import { SecondaryCtaType } from '@sdc/shared/types';
+import { HexColour, SecondaryCtaType } from '@sdc/shared/types';
 import { DefaultTemplate } from './Default';
+import { ConfigurableDesign } from '@sdc/shared/dist/types';
 
 export default {
     title: 'Banners/Custom',
@@ -12,6 +13,72 @@ export default {
     },
     args: props,
 } as Meta;
+
+// Unsafe - do not use outside of storybook
+const hexColourFromString = (s: string): HexColour =>
+    ({
+        r: s[0] + s[1],
+        g: s[2] + s[3],
+        b: s[4] + s[5],
+        kind: 'hex',
+    }) as HexColour;
+
+const design: ConfigurableDesign = {
+    image: {
+        mobileUrl:
+            'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
+        tabletDesktopUrl:
+            'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
+        wideUrl:
+            'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
+        altText: 'Example alt text',
+    },
+    colours: {
+        basic: {
+            background: hexColourFromString('F1F8FC'),
+            bodyText: hexColourFromString('000000'),
+            headerText: hexColourFromString('000000'),
+            articleCountText: hexColourFromString('000000'),
+        },
+        highlightedText: {
+            text: hexColourFromString('000000'),
+            highlight: hexColourFromString('FFE500'),
+        },
+        primaryCta: {
+            default: {
+                text: hexColourFromString('FFFFFF'),
+                background: hexColourFromString('0077B6'),
+            },
+            hover: {
+                text: hexColourFromString('FFFFFF'),
+                background: hexColourFromString('004E7C'),
+            },
+        },
+        secondaryCta: {
+            default: {
+                text: hexColourFromString('004E7C'),
+                background: hexColourFromString('F1F8FC'),
+                border: hexColourFromString('FFFFFF'),
+            },
+            hover: {
+                text: hexColourFromString('004E7C'),
+                background: hexColourFromString('E5E5E5'),
+                border: hexColourFromString('222527'),
+            },
+        },
+        closeButton: {
+            default: {
+                text: hexColourFromString('052962'),
+                background: hexColourFromString('F1F8FC'),
+                border: hexColourFromString('052962'),
+            },
+            hover: {
+                text: hexColourFromString('052962'),
+                background: hexColourFromString('E5E5E5'),
+            },
+        },
+    },
+};
 
 export const Designable = DefaultTemplate.bind({});
 Designable.args = {
@@ -62,31 +129,5 @@ Designable.args = {
     },
     numArticles: 50,
     tickerSettings: undefined,
-    design: {
-        image: {
-            mobileUrl:
-                'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
-            tabletDesktopUrl:
-                'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
-            wideUrl:
-                'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
-            altText: 'Example alt text',
-        },
-        colours: {
-            basic: {
-                background: {
-                    r: '22',
-                    g: '25',
-                    b: '27',
-                    kind: 'hex',
-                },
-                bodyText: {
-                    r: 'FF',
-                    g: 'FF',
-                    b: 'FF',
-                    kind: 'hex',
-                },
-            },
-        },
-    },
+    design,
 };

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -14,14 +14,20 @@ export default {
     args: props,
 } as Meta;
 
-// Unsafe - do not use outside of storybook
-const hexColourFromString = (s: string): HexColour =>
-    ({
-        r: s[0] + s[1],
-        g: s[2] + s[3],
-        b: s[4] + s[5],
-        kind: 'hex',
-    }) as HexColour;
+const hexColourStringRegex = /^([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$/i;
+const stringToHexColour = (colourString: string): HexColour => {
+    if (hexColourStringRegex.test(colourString)) {
+        const matches = hexColourStringRegex.exec(colourString);
+        return {
+            r: (matches?.[1] as string).toUpperCase(),
+            g: (matches?.[2] as string).toUpperCase(),
+            b: (matches?.[3] as string).toUpperCase(),
+            kind: 'hex',
+        } as HexColour;
+    } else {
+        throw new Error('Invalid hex colour string!');
+    }
+};
 
 const design: ConfigurableDesign = {
     image: {
@@ -35,46 +41,46 @@ const design: ConfigurableDesign = {
     },
     colours: {
         basic: {
-            background: hexColourFromString('F1F8FC'),
-            bodyText: hexColourFromString('000000'),
-            headerText: hexColourFromString('000000'),
-            articleCountText: hexColourFromString('000000'),
+            background: stringToHexColour('F1F8FC'),
+            bodyText: stringToHexColour('000000'),
+            headerText: stringToHexColour('000000'),
+            articleCountText: stringToHexColour('000000'),
         },
         highlightedText: {
-            text: hexColourFromString('000000'),
-            highlight: hexColourFromString('FFE500'),
+            text: stringToHexColour('000000'),
+            highlight: stringToHexColour('FFE500'),
         },
         primaryCta: {
             default: {
-                text: hexColourFromString('FFFFFF'),
-                background: hexColourFromString('0077B6'),
+                text: stringToHexColour('FFFFFF'),
+                background: stringToHexColour('0077B6'),
             },
             hover: {
-                text: hexColourFromString('FFFFFF'),
-                background: hexColourFromString('004E7C'),
+                text: stringToHexColour('FFFFFF'),
+                background: stringToHexColour('004E7C'),
             },
         },
         secondaryCta: {
             default: {
-                text: hexColourFromString('004E7C'),
-                background: hexColourFromString('F1F8FC'),
-                border: hexColourFromString('004E7C'),
+                text: stringToHexColour('004E7C'),
+                background: stringToHexColour('F1F8FC'),
+                border: stringToHexColour('004E7C'),
             },
             hover: {
-                text: hexColourFromString('004E7C'),
-                background: hexColourFromString('E5E5E5'),
-                border: hexColourFromString('004E7C'),
+                text: stringToHexColour('004E7C'),
+                background: stringToHexColour('E5E5E5'),
+                border: stringToHexColour('004E7C'),
             },
         },
         closeButton: {
             default: {
-                text: hexColourFromString('052962'),
-                background: hexColourFromString('F1F8FC'),
-                border: hexColourFromString('052962'),
+                text: stringToHexColour('052962'),
+                background: stringToHexColour('F1F8FC'),
+                border: stringToHexColour('052962'),
             },
             hover: {
-                text: hexColourFromString('052962'),
-                background: hexColourFromString('E5E5E5'),
+                text: stringToHexColour('052962'),
+                background: stringToHexColour('E5E5E5'),
             },
         },
     },

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -83,6 +83,7 @@ const design: ConfigurableDesign = {
                 background: stringToHexColour('E5E5E5'),
             },
         },
+        guardianRoundel: 'inverse',
     },
 };
 

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -58,12 +58,12 @@ const design: ConfigurableDesign = {
             default: {
                 text: hexColourFromString('004E7C'),
                 background: hexColourFromString('F1F8FC'),
-                border: hexColourFromString('FFFFFF'),
+                border: hexColourFromString('004E7C'),
             },
             hover: {
                 text: hexColourFromString('004E7C'),
                 background: hexColourFromString('E5E5E5'),
-                border: hexColourFromString('222527'),
+                border: hexColourFromString('004E7C'),
             },
         },
         closeButton: {

--- a/packages/server/src/factories/bannerDesign.ts
+++ b/packages/server/src/factories/bannerDesign.ts
@@ -1,14 +1,20 @@
 import { BannerDesignFromTool, HexColour } from '@sdc/shared/types';
 import { Factory } from 'fishery';
 
-// Unsafe - do not use outside of factories
-const hexColourFromString = (s: string): HexColour =>
-    ({
-        r: s[0] + s[1],
-        g: s[2] + s[3],
-        b: s[4] + s[5],
-        kind: 'hex',
-    }) as HexColour;
+const hexColourStringRegex = /^([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$/i;
+const stringToHexColour = (colourString: string): HexColour => {
+    if (hexColourStringRegex.test(colourString)) {
+        const matches = hexColourStringRegex.exec(colourString);
+        return {
+            r: (matches?.[1] as string).toUpperCase(),
+            g: (matches?.[2] as string).toUpperCase(),
+            b: (matches?.[3] as string).toUpperCase(),
+            kind: 'hex',
+        } as HexColour;
+    } else {
+        throw new Error('Invalid hex colour string!');
+    }
+};
 
 export default Factory.define<BannerDesignFromTool>(() => ({
     name: 'EXAMPLE_DESIGN',
@@ -23,46 +29,46 @@ export default Factory.define<BannerDesignFromTool>(() => ({
     },
     colours: {
         basic: {
-            background: hexColourFromString('F1F8FC'),
-            bodyText: hexColourFromString('000000'),
-            headerText: hexColourFromString('000000'),
-            articleCountText: hexColourFromString('000000'),
+            background: stringToHexColour('F1F8FC'),
+            bodyText: stringToHexColour('000000'),
+            headerText: stringToHexColour('000000'),
+            articleCountText: stringToHexColour('000000'),
         },
         highlightedText: {
-            text: hexColourFromString('000000'),
-            highlight: hexColourFromString('FFE500'),
+            text: stringToHexColour('000000'),
+            highlight: stringToHexColour('FFE500'),
         },
         primaryCta: {
             default: {
-                text: hexColourFromString('FFFFFF'),
-                background: hexColourFromString('0077B6'),
+                text: stringToHexColour('FFFFFF'),
+                background: stringToHexColour('0077B6'),
             },
             hover: {
-                text: hexColourFromString('FFFFFF'),
-                background: hexColourFromString('004E7C'),
+                text: stringToHexColour('FFFFFF'),
+                background: stringToHexColour('004E7C'),
             },
         },
         secondaryCta: {
             default: {
-                text: hexColourFromString('004E7C'),
-                background: hexColourFromString('F1F8FC'),
-                border: hexColourFromString('FFFFFF'),
+                text: stringToHexColour('004E7C'),
+                background: stringToHexColour('F1F8FC'),
+                border: stringToHexColour('FFFFFF'),
             },
             hover: {
-                text: hexColourFromString('004E7C'),
-                background: hexColourFromString('E5E5E5'),
-                border: hexColourFromString('222527'),
+                text: stringToHexColour('004E7C'),
+                background: stringToHexColour('E5E5E5'),
+                border: stringToHexColour('222527'),
             },
         },
         closeButton: {
             default: {
-                text: hexColourFromString('052962'),
-                background: hexColourFromString('F1F8FC'),
-                border: hexColourFromString('052962'),
+                text: stringToHexColour('052962'),
+                background: stringToHexColour('F1F8FC'),
+                border: stringToHexColour('052962'),
             },
             hover: {
-                text: hexColourFromString('052962'),
-                background: hexColourFromString('E5E5E5'),
+                text: stringToHexColour('052962'),
+                background: stringToHexColour('E5E5E5'),
             },
         },
     },

--- a/packages/server/src/factories/bannerDesign.ts
+++ b/packages/server/src/factories/bannerDesign.ts
@@ -1,5 +1,14 @@
-import { BannerDesignFromTool } from '@sdc/shared/types';
+import { BannerDesignFromTool, HexColour } from '@sdc/shared/types';
 import { Factory } from 'fishery';
+
+// Unsafe - do not use outside of factories
+const hexColourFromString = (s: string): HexColour =>
+    ({
+        r: s[0] + s[1],
+        g: s[2] + s[3],
+        b: s[4] + s[5],
+        kind: 'hex',
+    }) as HexColour;
 
 export default Factory.define<BannerDesignFromTool>(() => ({
     name: 'EXAMPLE_DESIGN',
@@ -14,17 +23,46 @@ export default Factory.define<BannerDesignFromTool>(() => ({
     },
     colours: {
         basic: {
-            background: {
-                r: 'FF',
-                g: '00',
-                b: '00',
-                kind: 'hex',
+            background: hexColourFromString('F1F8FC'),
+            bodyText: hexColourFromString('000000'),
+            headerText: hexColourFromString('000000'),
+            articleCountText: hexColourFromString('000000'),
+        },
+        highlightedText: {
+            text: hexColourFromString('000000'),
+            highlight: hexColourFromString('FFE500'),
+        },
+        primaryCta: {
+            default: {
+                text: hexColourFromString('FFFFFF'),
+                background: hexColourFromString('0077B6'),
             },
-            bodyText: {
-                r: '00',
-                g: '00',
-                b: '00',
-                kind: 'hex',
+            hover: {
+                text: hexColourFromString('FFFFFF'),
+                background: hexColourFromString('004E7C'),
+            },
+        },
+        secondaryCta: {
+            default: {
+                text: hexColourFromString('004E7C'),
+                background: hexColourFromString('F1F8FC'),
+                border: hexColourFromString('FFFFFF'),
+            },
+            hover: {
+                text: hexColourFromString('004E7C'),
+                background: hexColourFromString('E5E5E5'),
+                border: hexColourFromString('222527'),
+            },
+        },
+        closeButton: {
+            default: {
+                text: hexColourFromString('052962'),
+                background: hexColourFromString('F1F8FC'),
+                border: hexColourFromString('052962'),
+            },
+            hover: {
+                text: hexColourFromString('052962'),
+                background: hexColourFromString('E5E5E5'),
             },
         },
     },

--- a/packages/server/src/factories/bannerDesign.ts
+++ b/packages/server/src/factories/bannerDesign.ts
@@ -71,5 +71,6 @@ export default Factory.define<BannerDesignFromTool>(() => ({
                 background: stringToHexColour('E5E5E5'),
             },
         },
+        guardianRoundel: 'inverse',
     },
 }));

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -62,6 +62,16 @@ export interface HexColour {
 
 export const hexColourToString = (h: HexColour): string => `#${h.r}${h.g}${h.b}`;
 
+interface CtaStateDesign {
+    text: HexColour;
+    background: HexColour;
+    border?: HexColour;
+}
+export interface CtaDesign {
+    default: CtaStateDesign;
+    hover: CtaStateDesign;
+}
+
 export interface ConfigurableDesign {
     image: {
         mobileUrl: string;
@@ -73,6 +83,15 @@ export interface ConfigurableDesign {
         basic: {
             background: HexColour;
             bodyText: HexColour;
+            headerText: HexColour;
+            articleCountText: HexColour;
         };
+        highlightedText: {
+            text: HexColour;
+            highlight: HexColour;
+        };
+        primaryCta: CtaDesign;
+        secondaryCta: CtaDesign;
+        closeButton: CtaDesign;
     };
 }

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -72,6 +72,8 @@ export interface CtaDesign {
     hover: CtaStateDesign;
 }
 
+export type GuardianRoundel = 'default' | 'brand' | 'inverse';
+
 export interface ConfigurableDesign {
     image: {
         mobileUrl: string;
@@ -93,5 +95,6 @@ export interface ConfigurableDesign {
         primaryCta: CtaDesign;
         secondaryCta: CtaDesign;
         closeButton: CtaDesign;
+        guardianRoundel?: GuardianRoundel;
     };
 }

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -95,6 +95,6 @@ export interface ConfigurableDesign {
         primaryCta: CtaDesign;
         secondaryCta: CtaDesign;
         closeButton: CtaDesign;
-        guardianRoundel?: GuardianRoundel;
+        guardianRoundel: GuardianRoundel;
     };
 }


### PR DESCRIPTION
Expands the `ConfigurableDesign` model to support more colours.
I've made all fields required as I'm not sure it makes sense to have defaults for these.

Current storybook -
![Screenshot 2023-10-04 at 08 38 25](https://github.com/guardian/support-dotcom-components/assets/1513454/b1da95aa-2ed1-4d09-9b17-2658c62ec56e)

Corresponding SAC PR: https://github.com/guardian/support-admin-console/pull/503
