### PR TITLE
Banner ticker design

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -42,8 +42,15 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
         return <></>;
     }
 
-    const { basic, primaryCta, secondaryCta, highlightedText, closeButton, guardianRoundel } =
-        design.colours;
+    const {
+        basic,
+        primaryCta,
+        secondaryCta,
+        highlightedText,
+        closeButton,
+        guardianRoundel,
+        ticker,
+    } = design.colours;
 
     const templateSettings: BannerTemplateSettings = {
         containerSettings: {
@@ -118,6 +125,12 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
             altText: design.image.altText,
         },
         bannerId: 'designable-banner',
+        tickerStylingSettings: {
+            textColour: hexColourToString(ticker.textColour),
+            filledProgressColour: hexColourToString(ticker.filledProgressColour),
+            progressBarBackgroundColour: hexColourToString(ticker.progressBarBackgroundColour),
+            goalMarkerColour: hexColourToString(ticker.goalMarkerColour),
+        },
     };
 
     const { isReminderActive, onReminderCtaClick, mobileReminderRef } =

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -126,10 +126,10 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
         },
         bannerId: 'designable-banner',
         tickerStylingSettings: {
-            textColour: hexColourToString(ticker.textColour),
-            filledProgressColour: hexColourToString(ticker.filledProgressColour),
-            progressBarBackgroundColour: hexColourToString(ticker.progressBarBackgroundColour),
-            goalMarkerColour: hexColourToString(ticker.goalMarkerColour),
+            textColour: hexColourToString(ticker.text),
+            filledProgressColour: hexColourToString(ticker.filledProgress),
+            progressBarBackgroundColour: hexColourToString(ticker.progressBarBackground),
+            goalMarkerColour: hexColourToString(ticker.goalMarker),
         },
     };
 

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/react';
 import { props } from '../../utils/storybook';
-import { HexColour, SecondaryCtaType } from '@sdc/shared/types';
+import { HexColour, SecondaryCtaType, TickerCountType, TickerEndType } from '@sdc/shared/types';
 import { DefaultTemplate } from './Default';
 import { ConfigurableDesign } from '@sdc/shared/dist/types';
 
@@ -84,6 +84,12 @@ const design: ConfigurableDesign = {
             },
         },
         guardianRoundel: 'inverse',
+        ticker: {
+            textColour: stringToHexColour('052962'),
+            filledProgressColour: stringToHexColour('052962'),
+            progressBarBackgroundColour: stringToHexColour('ffffff'),
+            goalMarkerColour: stringToHexColour('000000'),
+        },
     },
 };
 
@@ -135,6 +141,20 @@ Designable.args = {
         },
     },
     numArticles: 50,
-    tickerSettings: undefined,
+    tickerSettings: {
+        countType: TickerCountType.money,
+        endType: TickerEndType.hardstop,
+        currencySymbol: '',
+        copy: {
+            countLabel: 'contributions in May',
+            goalReachedPrimary: "We've met our goal - thank you!",
+            goalReachedSecondary: '',
+        },
+        tickerData: {
+            total: 4_000,
+            goal: 50_000,
+        },
+        name: 'AU_2022',
+    },
     design,
 };

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -85,10 +85,10 @@ const design: ConfigurableDesign = {
         },
         guardianRoundel: 'inverse',
         ticker: {
-            textColour: stringToHexColour('052962'),
-            filledProgressColour: stringToHexColour('052962'),
-            progressBarBackgroundColour: stringToHexColour('ffffff'),
-            goalMarkerColour: stringToHexColour('000000'),
+            text: stringToHexColour('052962'),
+            filledProgress: stringToHexColour('052962'),
+            progressBarBackground: stringToHexColour('ffffff'),
+            goalMarker: stringToHexColour('000000'),
         },
     },
 };

--- a/packages/server/src/factories/bannerDesign.ts
+++ b/packages/server/src/factories/bannerDesign.ts
@@ -73,10 +73,10 @@ export default Factory.define<BannerDesignFromTool>(() => ({
         },
         guardianRoundel: 'inverse',
         ticker: {
-            textColour: stringToHexColour('052962'),
-            filledProgressColour: stringToHexColour('052962'),
-            progressBarBackgroundColour: stringToHexColour('ffffff'),
-            goalMarkerColour: stringToHexColour('000000'),
+            text: stringToHexColour('052962'),
+            filledProgress: stringToHexColour('052962'),
+            progressBarBackground: stringToHexColour('ffffff'),
+            goalMarker: stringToHexColour('000000'),
         },
     },
 }));

--- a/packages/server/src/factories/bannerDesign.ts
+++ b/packages/server/src/factories/bannerDesign.ts
@@ -72,5 +72,11 @@ export default Factory.define<BannerDesignFromTool>(() => ({
             },
         },
         guardianRoundel: 'inverse',
+        ticker: {
+            textColour: stringToHexColour('052962'),
+            filledProgressColour: stringToHexColour('052962'),
+            progressBarBackgroundColour: stringToHexColour('ffffff'),
+            goalMarkerColour: stringToHexColour('000000'),
+        },
     },
 }));

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -74,6 +74,13 @@ export interface CtaDesign {
 
 export type GuardianRoundel = 'default' | 'brand' | 'inverse';
 
+interface TickerDesign {
+    textColour: HexColour;
+    filledProgressColour: HexColour;
+    progressBarBackgroundColour: HexColour;
+    goalMarkerColour: HexColour;
+}
+
 export interface ConfigurableDesign {
     image: {
         mobileUrl: string;
@@ -96,5 +103,6 @@ export interface ConfigurableDesign {
         secondaryCta: CtaDesign;
         closeButton: CtaDesign;
         guardianRoundel: GuardianRoundel;
+        ticker: TickerDesign;
     };
 }

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -75,10 +75,10 @@ export interface CtaDesign {
 export type GuardianRoundel = 'default' | 'brand' | 'inverse';
 
 interface TickerDesign {
-    textColour: HexColour;
-    filledProgressColour: HexColour;
-    progressBarBackgroundColour: HexColour;
-    goalMarkerColour: HexColour;
+    text: HexColour;
+    filledProgress: HexColour;
+    progressBarBackground: HexColour;
+    goalMarker: HexColour;
 }
 
 export interface ConfigurableDesign {


### PR DESCRIPTION
this enables the new banner design tool to configure the ticker colours

SAC PR - https://github.com/guardian/support-admin-console/pull/504

![Screenshot 2023-10-06 at 11 54 45](https://github.com/guardian/support-dotcom-components/assets/1513454/4341f153-0ca4-4e87-bddc-9d69b51209ca)
