### PR TITLE
Guardian Weekly Banner SVG's hidden (over European Interactive Map)

### DIFF
--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -16,6 +16,7 @@ import {
     logoContainer,
     paragraph,
     siteMessage,
+    svgDisplayNoneImportantBleedReproduce,
 } from './guardianWeeklyBannerStyles';
 import { ResponsiveImage } from '../../shared/ResponsiveImage';
 import { BannerText } from '../common/BannerText';
@@ -91,79 +92,81 @@ const GuardianWeeklyBanner: ReactComponent<BannerRenderProps> = ({
 }) => {
     return (
         <section css={banner} data-target={bannerId}>
-            <Container>
-                <Columns>
-                    <Column width={1} cssOverrides={iconAndClosePosition}>
-                        <Inline space={1}>
-                            <div css={logoContainer}>
-                                <SvgRoundelDefault />
-                            </div>
-                            <CloseButton onClick={onCloseClick} />
-                        </Inline>
-                    </Column>
-                </Columns>
-                <Columns collapseBelow="tablet">
-                    <Column width={1 / 2} cssOverrides={copyColumn}>
-                        <BannerText
-                            styles={{
-                                desktop: {
-                                    heading,
-                                    copy: paragraph,
-                                },
-                            }}
-                            content={content}
-                        />
-                        <BannerContentRenderer
-                            content={content}
-                            render={({ renderContent }) => {
-                                const { primaryCta, secondaryCta } = renderContent;
-                                return (
-                                    <Inline space={3}>
-                                        <ThemeProvider theme={buttonReaderRevenue}>
-                                            <LinkButton
-                                                href={primaryCta?.ctaUrl}
-                                                data-link-name={ctaComponentId}
-                                                icon={<SvgArrowRightStraight />}
-                                                iconSide="right"
-                                                onClick={onCtaClick}
-                                                tabIndex={0}
+            <div css={svgDisplayNoneImportantBleedReproduce}>
+                <Container>
+                    <Columns>
+                        <Column width={1} cssOverrides={iconAndClosePosition}>
+                            <Inline space={1}>
+                                <div css={logoContainer}>
+                                    <SvgRoundelDefault />
+                                </div>
+                                <CloseButton onClick={onCloseClick} />
+                            </Inline>
+                        </Column>
+                    </Columns>
+                    <Columns collapseBelow="tablet">
+                        <Column width={1 / 2} cssOverrides={copyColumn}>
+                            <BannerText
+                                styles={{
+                                    desktop: {
+                                        heading,
+                                        copy: paragraph,
+                                    },
+                                }}
+                                content={content}
+                            />
+                            <BannerContentRenderer
+                                content={content}
+                                render={({ renderContent }) => {
+                                    const { primaryCta, secondaryCta } = renderContent;
+                                    return (
+                                        <Inline space={3}>
+                                            <ThemeProvider theme={buttonReaderRevenue}>
+                                                <LinkButton
+                                                    href={primaryCta?.ctaUrl}
+                                                    data-link-name={ctaComponentId}
+                                                    icon={<SvgArrowRightStraight />}
+                                                    iconSide="right"
+                                                    onClick={onCtaClick}
+                                                    tabIndex={0}
+                                                >
+                                                    {primaryCta?.ctaText || defaultCta}
+                                                </LinkButton>
+                                            </ThemeProvider>
+                                            <Button
+                                                priority="subdued"
+                                                data-link-name={notNowComponentId}
+                                                onClick={onNotNowClick}
                                             >
-                                                {primaryCta?.ctaText || defaultCta}
-                                            </LinkButton>
-                                        </ThemeProvider>
-                                        <Button
-                                            priority="subdued"
-                                            data-link-name={notNowComponentId}
-                                            onClick={onNotNowClick}
-                                        >
-                                            {(secondaryCta?.type === SecondaryCtaType.Custom &&
-                                                secondaryCta.cta.ctaText) ||
-                                                defaultSecondaryCta}
-                                        </Button>
-                                    </Inline>
-                                );
-                            }}
-                        />
-                        <div css={siteMessage}>
-                            Already a subscriber?{' '}
-                            <Link
-                                data-link-name={signInComponentId}
-                                onClick={onSignInClick}
-                                href={signInUrl}
-                                subdued
-                            >
-                                Sign in
-                            </Link>{' '}
-                            to not see this again
-                        </div>
-                    </Column>
-                    <Column width={1 / 2} cssOverrides={imageColumn}>
-                        <div css={imageContainer}>
-                            <ResponsiveImage images={images} baseImage={baseImg} />
-                        </div>
-                    </Column>
-                </Columns>
-            </Container>
+                                                {(secondaryCta?.type === SecondaryCtaType.Custom &&
+                                                    secondaryCta.cta.ctaText) ||
+                                                    defaultSecondaryCta}
+                                            </Button>
+                                        </Inline>
+                                    );
+                                }}
+                            />
+                            <div css={siteMessage}>
+                                Already a subscriber?{' '}
+                                <Link
+                                    data-link-name={signInComponentId}
+                                    onClick={onSignInClick}
+                                    href={signInUrl}
+                                    subdued
+                                >
+                                    Sign in
+                                </Link>{' '}
+                                to not see this again
+                            </div>
+                        </Column>
+                        <Column width={1 / 2} cssOverrides={imageColumn}>
+                            <div css={imageContainer}>
+                                <ResponsiveImage images={images} baseImage={baseImg} />
+                            </div>
+                        </Column>
+                    </Columns>
+                </Container>
+            </div>
         </section>
     );
 };

--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -6,6 +6,8 @@ import { Link } from '@guardian/src-link';
 import { SvgRoundelDefault } from '@guardian/src-brand';
 import { SvgArrowRightStraight, SvgCross } from '@guardian/src-icons';
 import {
+    SvgDisplay,
+    svgDisplayNoneImportantBleedReproduce,
     banner,
     closeButtonStyles,
     copyColumn,
@@ -16,7 +18,6 @@ import {
     logoContainer,
     paragraph,
     siteMessage,
-    svgDisplayNoneImportantBleedReproduce,
 } from './guardianWeeklyBannerStyles';
 import { ResponsiveImage } from '../../shared/ResponsiveImage';
 import { BannerText } from '../common/BannerText';
@@ -71,7 +72,7 @@ type ButtonPropTypes = {
 
 const CloseButton = (props: ButtonPropTypes): ReactElement => (
     <Button
-        css={closeButtonStyles}
+        cssOverrides={[closeButtonStyles, SvgDisplay]}
         data-link-name={closeComponentId}
         onClick={props.onClick}
         icon={<SvgCross />}
@@ -97,7 +98,7 @@ const GuardianWeeklyBanner: ReactComponent<BannerRenderProps> = ({
                     <Columns>
                         <Column width={1} cssOverrides={iconAndClosePosition}>
                             <Inline space={1}>
-                                <div css={logoContainer}>
+                                <div css={[logoContainer, SvgDisplay]}>
                                     <SvgRoundelDefault />
                                 </div>
                                 <CloseButton onClick={onCloseClick} />
@@ -124,6 +125,7 @@ const GuardianWeeklyBanner: ReactComponent<BannerRenderProps> = ({
                                             <ThemeProvider theme={buttonReaderRevenue}>
                                                 <LinkButton
                                                     href={primaryCta?.ctaUrl}
+                                                    cssOverrides={SvgDisplay}
                                                     data-link-name={ctaComponentId}
                                                     icon={<SvgArrowRightStraight />}
                                                     iconSide="right"

--- a/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
+++ b/packages/modules/src/modules/banners/guardianWeekly/GuardianWeeklyBanner.tsx
@@ -7,7 +7,6 @@ import { SvgRoundelDefault } from '@guardian/src-brand';
 import { SvgArrowRightStraight, SvgCross } from '@guardian/src-icons';
 import {
     SvgDisplay,
-    svgDisplayNoneImportantBleedReproduce,
     banner,
     closeButtonStyles,
     copyColumn,
@@ -93,82 +92,80 @@ const GuardianWeeklyBanner: ReactComponent<BannerRenderProps> = ({
 }) => {
     return (
         <section css={banner} data-target={bannerId}>
-            <div css={svgDisplayNoneImportantBleedReproduce}>
-                <Container>
-                    <Columns>
-                        <Column width={1} cssOverrides={iconAndClosePosition}>
-                            <Inline space={1}>
-                                <div css={[logoContainer, SvgDisplay]}>
-                                    <SvgRoundelDefault />
-                                </div>
-                                <CloseButton onClick={onCloseClick} />
-                            </Inline>
-                        </Column>
-                    </Columns>
-                    <Columns collapseBelow="tablet">
-                        <Column width={1 / 2} cssOverrides={copyColumn}>
-                            <BannerText
-                                styles={{
-                                    desktop: {
-                                        heading,
-                                        copy: paragraph,
-                                    },
-                                }}
-                                content={content}
-                            />
-                            <BannerContentRenderer
-                                content={content}
-                                render={({ renderContent }) => {
-                                    const { primaryCta, secondaryCta } = renderContent;
-                                    return (
-                                        <Inline space={3}>
-                                            <ThemeProvider theme={buttonReaderRevenue}>
-                                                <LinkButton
-                                                    href={primaryCta?.ctaUrl}
-                                                    cssOverrides={SvgDisplay}
-                                                    data-link-name={ctaComponentId}
-                                                    icon={<SvgArrowRightStraight />}
-                                                    iconSide="right"
-                                                    onClick={onCtaClick}
-                                                    tabIndex={0}
-                                                >
-                                                    {primaryCta?.ctaText || defaultCta}
-                                                </LinkButton>
-                                            </ThemeProvider>
-                                            <Button
-                                                priority="subdued"
-                                                data-link-name={notNowComponentId}
-                                                onClick={onNotNowClick}
+            <Container>
+                <Columns>
+                    <Column width={1} cssOverrides={iconAndClosePosition}>
+                        <Inline space={1}>
+                            <div css={[logoContainer, SvgDisplay]}>
+                                <SvgRoundelDefault />
+                            </div>
+                            <CloseButton onClick={onCloseClick} />
+                        </Inline>
+                    </Column>
+                </Columns>
+                <Columns collapseBelow="tablet">
+                    <Column width={1 / 2} cssOverrides={copyColumn}>
+                        <BannerText
+                            styles={{
+                                desktop: {
+                                    heading,
+                                    copy: paragraph,
+                                },
+                            }}
+                            content={content}
+                        />
+                        <BannerContentRenderer
+                            content={content}
+                            render={({ renderContent }) => {
+                                const { primaryCta, secondaryCta } = renderContent;
+                                return (
+                                    <Inline space={3}>
+                                        <ThemeProvider theme={buttonReaderRevenue}>
+                                            <LinkButton
+                                                href={primaryCta?.ctaUrl}
+                                                cssOverrides={SvgDisplay}
+                                                data-link-name={ctaComponentId}
+                                                icon={<SvgArrowRightStraight />}
+                                                iconSide="right"
+                                                onClick={onCtaClick}
+                                                tabIndex={0}
                                             >
-                                                {(secondaryCta?.type === SecondaryCtaType.Custom &&
-                                                    secondaryCta.cta.ctaText) ||
-                                                    defaultSecondaryCta}
-                                            </Button>
-                                        </Inline>
-                                    );
-                                }}
-                            />
-                            <div css={siteMessage}>
-                                Already a subscriber?{' '}
-                                <Link
-                                    data-link-name={signInComponentId}
-                                    onClick={onSignInClick}
-                                    href={signInUrl}
-                                    subdued
-                                >
-                                    Sign in
-                                </Link>{' '}
-                                to not see this again
-                            </div>
-                        </Column>
-                        <Column width={1 / 2} cssOverrides={imageColumn}>
-                            <div css={imageContainer}>
-                                <ResponsiveImage images={images} baseImage={baseImg} />
-                            </div>
-                        </Column>
-                    </Columns>
-                </Container>
-            </div>
+                                                {primaryCta?.ctaText || defaultCta}
+                                            </LinkButton>
+                                        </ThemeProvider>
+                                        <Button
+                                            priority="subdued"
+                                            data-link-name={notNowComponentId}
+                                            onClick={onNotNowClick}
+                                        >
+                                            {(secondaryCta?.type === SecondaryCtaType.Custom &&
+                                                secondaryCta.cta.ctaText) ||
+                                                defaultSecondaryCta}
+                                        </Button>
+                                    </Inline>
+                                );
+                            }}
+                        />
+                        <div css={siteMessage}>
+                            Already a subscriber?{' '}
+                            <Link
+                                data-link-name={signInComponentId}
+                                onClick={onSignInClick}
+                                href={signInUrl}
+                                subdued
+                            >
+                                Sign in
+                            </Link>{' '}
+                            to not see this again
+                        </div>
+                    </Column>
+                    <Column width={1 / 2} cssOverrides={imageColumn}>
+                        <div css={imageContainer}>
+                            <ResponsiveImage images={images} baseImage={baseImg} />
+                        </div>
+                    </Column>
+                </Columns>
+            </Container>
         </section>
     );
 };

--- a/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -128,3 +128,9 @@ export const logoContainer = css`
         margin-left: ${space[3]}px;
     }
 `;
+
+export const svgDisplayNoneImportantBleedReproduce = css`
+    svg {
+        display: none !important;
+    }
+`;

--- a/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -129,6 +129,13 @@ export const logoContainer = css`
     }
 `;
 
+// Guards against a 'DIV SECTION DIV SVG display: none!important' coming from Europe Pollution Divide area map
+export const SvgDisplay = css`
+    svg {
+        display: block !important;
+    }
+`;
+
 export const svgDisplayNoneImportantBleedReproduce = css`
     svg {
         display: none !important;

--- a/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
+++ b/packages/modules/src/modules/banners/guardianWeekly/guardianWeeklyBannerStyles.ts
@@ -135,9 +135,3 @@ export const SvgDisplay = css`
         display: block !important;
     }
 `;
-
-export const svgDisplayNoneImportantBleedReproduce = css`
-    svg {
-        display: none !important;
-    }
-`;


### PR DESCRIPTION
## What does this change?

Banner Centre cross of close button, Guardian log and primary CTA arrow SVG's hidden when in front of European Pollution Interactive Map. Affects 'Guardian Weekly'.

![image](https://github.com/guardian/support-dotcom-components/assets/76729591/0211a389-114a-4d60-b345-f0c38eb50acb)

##  Background

Style are bleeding from the interactive map into our banners (offending style highlighted in red). The style appear to be looking through the page for a 'DIV SECTION DIV SVG' then disabling the display (display:none). This appears to affect our SVG's in banners.

A longer term fix in the interactive map has been requested (Anna Leach / Antonio Voce)

CSS: 'DIV SECTION DIV SVG'  ->
| Applied | Removed |
|--------|--------|
|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/39af0bf0-8885-41df-b547-6cd8caf76acf)|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/91c37358-6b63-4226-8503-653101e4092c)|

## How to test

Test harness place around banner code -> 
`<div css={svgDisplayNoneImportantBleedReproduce}>...</div>`
`export const svgDisplayNoneImportantBleedReproduce = css  svg {display: none !important;};`

[Trello] : https://trello.com/c/Ifqmsxsg/1568-banner-close-guardian-weekly-close-cta-centre-hidden
