### PR TITLE
Improve banner content logic

### DIFF
--- a/packages/server/src/api/bannerRouter.ts
+++ b/packages/server/src/api/bannerRouter.ts
@@ -64,15 +64,14 @@ const addLocalLanguageContent = (
     const { bannerContent, mobileBannerContent } = variant;
 
     if (moduleName === 'EuropeMomentLocalLanguageBanner') {
-        const localLanguage = countryCodeToLocalLanguageBannerHeader(
-            test.name,
-            variant.name,
-            country,
-            { bannerHeader: variant.bannerContent?.heading },
-        );
-
         const replaceHeading = (content?: BannerContent): BannerContent | undefined => {
             if (content?.heading) {
+                const localLanguage = countryCodeToLocalLanguageBannerHeader(
+                    test.name,
+                    variant.name,
+                    country,
+                    { bannerHeader: content.heading },
+                );
                 return {
                     ...content,
                     heading: localLanguage?.bannerHeader,


### PR DESCRIPTION
recently a [change to this code](https://github.com/guardian/support-dotcom-components/commit/8198d09cc7c1eae9a9cf788aebbb5c30186fcd9f#diff-fef75acb8a32b2c4c5efd89fc20b6844f30ffbf95b508e757707b953386ac983R146) caused an issue with banners with no `mobileContent` defined. Specifically, it affected the default hardcoded test, which we've [now removed](https://github.com/guardian/support-dotcom-components/pull/985).
We get away with it for (all?) RRCP tests because the tool sets `mobileContent` explicitly to `null` in dynamodb (rather than being undefined).
This PR tries to make the logic it a bit more robust to avoid this happening again.

Tested in CODE -

French:
![Screenshot 2023-10-12 at 15 34 41](https://github.com/guardian/support-dotcom-components/assets/1513454/ae48f5d8-1b5d-4db2-adf3-0e642f437e4b)
![Screenshot 2023-10-12 at 15 34 30](https://github.com/guardian/support-dotcom-components/assets/1513454/51dd1387-641e-4cda-8ce8-ce19a08531ee)

English:
![Screenshot 2023-10-12 at 15 35 07](https://github.com/guardian/support-dotcom-components/assets/1513454/77d47e70-9312-456e-b100-d1a4af13e729)
![Screenshot 2023-10-12 at 15 35 20](https://github.com/guardian/support-dotcom-components/assets/1513454/0d8a8bb8-e007-424a-98c8-6a070fe6be39)
