### PR TITLE
Add Giving Tuesday and New Years Eve reminders logic

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -187,7 +187,7 @@ const withBannerData =
 
                 return {
                     type: SecondaryCtaType.ContributionsReminder,
-                    reminderFields: getReminderFields(),
+                    reminderFields: getReminderFields(countryCode),
                 };
             };
 

--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -118,7 +118,8 @@ export const buildEpicRouter = (
 
         const tickerSettings =
             variant.tickerSettings && tickerData.addTickerDataToSettings(variant.tickerSettings);
-        const showReminderFields = variant.showReminderFields ?? getReminderFields();
+        const showReminderFields =
+            variant.showReminderFields ?? getReminderFields(targeting.countryCode);
 
         const contributionAmounts = choiceCardAmounts.get();
         const requiredCountry = targeting.countryCode ?? 'GB';

--- a/packages/shared/src/lib/reminderFields.test.ts
+++ b/packages/shared/src/lib/reminderFields.test.ts
@@ -1,4 +1,4 @@
-import { buildReminderFields } from './reminderFields';
+import { buildReminderFields, getReminderFields } from './reminderFields';
 
 describe('buildReminderFields', () => {
     it('should set date to the next calendar month if the current date is BEFORE the 20th', () => {
@@ -38,5 +38,38 @@ describe('buildReminderFields', () => {
         const actual = buildReminderFields(novemberTwentyFirst);
 
         expect(actual).toEqual(expected);
+    });
+});
+
+describe('getReminderFields', () => {
+    describe('when in the US, during the giving Tuesday period', () => {
+        it('should return Giving Tuesday reminder fields', () => {
+            const inTheGivingTuesdayPeriod = new Date('2023-11-15');
+
+            const actual = getReminderFields('US', inTheGivingTuesdayPeriod);
+
+            const expected = {
+                reminderCta: 'Remind me on Giving Tuesday',
+                reminderPeriod: '2023-11-01',
+                reminderLabel: 'on Giving Tuesday',
+                reminderOption: 'giving-tuesday-2023',
+            };
+            expect(actual).toEqual(expected);
+        });
+    });
+
+    describe('when outside the US, during the giving Tuesday period', () => {
+        it('should return standard reminder fields', () => {
+            const inTheGivingTuesdayPeriod = new Date('2023-11-15');
+
+            const actual = getReminderFields('AU', inTheGivingTuesdayPeriod);
+
+            const expected = {
+                reminderCta: `Remind me in December`,
+                reminderPeriod: `2023-12-01`,
+                reminderLabel: `December 2023`,
+            };
+            expect(actual).toEqual(expected);
+        });
     });
 });

--- a/packages/shared/src/lib/reminderFields.test.ts
+++ b/packages/shared/src/lib/reminderFields.test.ts
@@ -58,6 +58,22 @@ describe('getReminderFields', () => {
         });
     });
 
+    describe('when in the US, between Giving Tuesday and the day before New Years Eve', () => {
+        it('should return New Years Eve reminder fields', () => {
+            const inTheNewYearsEveReminderPeriod = new Date('2023-12-15');
+
+            const actual = getReminderFields('US', inTheNewYearsEveReminderPeriod);
+
+            const expected = {
+                reminderCta: 'Remind me on New Years Eve',
+                reminderPeriod: '2023-12-01',
+                reminderLabel: 'on New Years Eve',
+                reminderOption: 'new-years-eve-2023',
+            };
+            expect(actual).toEqual(expected);
+        });
+    });
+
     describe('when outside the US, during the giving Tuesday period', () => {
         it('should return standard reminder fields', () => {
             const inTheGivingTuesdayPeriod = new Date('2023-11-15');
@@ -68,6 +84,21 @@ describe('getReminderFields', () => {
                 reminderCta: `Remind me in December`,
                 reminderPeriod: `2023-12-01`,
                 reminderLabel: `December 2023`,
+            };
+            expect(actual).toEqual(expected);
+        });
+    });
+
+    describe('when outside the US, between Giving Tuesday and the day before New Years Eve', () => {
+        it('should return standard reminder fields', () => {
+            const inTheNewYearsEveReminderPeriod = new Date('2023-12-15');
+
+            const actual = getReminderFields('FR', inTheNewYearsEveReminderPeriod);
+
+            const expected = {
+                reminderCta: `Remind me in January`,
+                reminderPeriod: `2024-01-01`,
+                reminderLabel: `January 2024`,
             };
             expect(actual).toEqual(expected);
         });

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -34,11 +34,11 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-const givingTuesdayStart = new Date('2023-11-01'); // TODO: confirm this start date
-const givingTuesdayCutOff = new Date('2023-11-28');
+const givingTuesdayStart = new Date('2023-11-10');
+const givingTuesdayCutOff = new Date('2023-11-27');
 
 const givingTuesdayIsActive = (date: Date): boolean =>
-    date >= givingTuesdayStart && date < givingTuesdayCutOff;
+    date >= givingTuesdayStart && date <= givingTuesdayCutOff;
 
 export const getReminderFields = (
     countryCode?: string,

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -12,6 +12,13 @@ const getReminderDate = (date: Date): Date => {
     return date;
 };
 
+export const GIVING_TUESDAY_REMINDER_FIELDS: ReminderFields = {
+    reminderCta: 'Remind me on Giving Tuesday',
+    reminderPeriod: '2023-11-01',
+    reminderLabel: 'on Giving Tuesday',
+    reminderOption: 'giving-tuesday-2023', // TODO: this needs to be added somewhere? Braze?
+};
+
 export const buildReminderFields = (today: Date = new Date()): ReminderFields => {
     const reminderDate = getReminderDate(today);
 
@@ -27,7 +34,19 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-export const getReminderFields = (): ReminderFields => {
-    // Add campaign-specific reminders here, e.g. Giving Tuesday
-    return buildReminderFields();
+const givingTuesdayStart = new Date('2023-11-01'); // TODO: confirm this start date
+const givingTuesdayCutOff = new Date('2023-11-28');
+
+const givingTuesdayIsActive = (date: Date): boolean =>
+    date >= givingTuesdayStart && date < givingTuesdayCutOff;
+
+export const getReminderFields = (
+    countryCode?: string,
+    date: Date = new Date(),
+): ReminderFields => {
+    if (countryCode === 'US' && givingTuesdayIsActive(date)) {
+        return GIVING_TUESDAY_REMINDER_FIELDS;
+    }
+
+    return buildReminderFields(date);
 };

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -41,11 +41,9 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-const givingTuesdayStart = new Date('2023-11-10');
 const givingTuesdayCutOff = new Date('2023-11-27');
 
-const givingTuesdayIsActive = (date: Date): boolean =>
-    date >= givingTuesdayStart && date <= givingTuesdayCutOff;
+const givingTuesdayIsActive = (date: Date): boolean => date <= givingTuesdayCutOff;
 
 const newYearsEveStart = new Date('2023-11-28');
 const newYearsEveCutOff = new Date('2023-12-30');

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -16,7 +16,14 @@ export const GIVING_TUESDAY_REMINDER_FIELDS: ReminderFields = {
     reminderCta: 'Remind me on Giving Tuesday',
     reminderPeriod: '2023-11-01',
     reminderLabel: 'on Giving Tuesday',
-    reminderOption: 'giving-tuesday-2023', // TODO: this needs to be added somewhere? Braze?
+    reminderOption: 'giving-tuesday-2023',
+};
+
+export const NEW_YEARS_EVE_REMINDER_FIELDS: ReminderFields = {
+    reminderCta: 'Remind me on New Years Eve',
+    reminderPeriod: '2023-12-01',
+    reminderLabel: 'on New Years Eve',
+    reminderOption: 'new-years-eve-2023',
 };
 
 export const buildReminderFields = (today: Date = new Date()): ReminderFields => {
@@ -40,12 +47,22 @@ const givingTuesdayCutOff = new Date('2023-11-27');
 const givingTuesdayIsActive = (date: Date): boolean =>
     date >= givingTuesdayStart && date <= givingTuesdayCutOff;
 
+const newYearsEveStart = new Date('2023-11-28');
+const newYearsEveCutOff = new Date('2023-12-30');
+
+const newYearsEveIsActive = (date: Date): boolean =>
+    date >= newYearsEveStart && date <= newYearsEveCutOff;
+
 export const getReminderFields = (
     countryCode?: string,
     date: Date = new Date(),
 ): ReminderFields => {
     if (countryCode === 'US' && givingTuesdayIsActive(date)) {
         return GIVING_TUESDAY_REMINDER_FIELDS;
+    }
+
+    if (countryCode === 'US' && newYearsEveIsActive(date)) {
+        return NEW_YEARS_EVE_REMINDER_FIELDS;
     }
 
     return buildReminderFields(date);


### PR DESCRIPTION
## What does this change?

In the US we want to use different reminders logic in the epic for two distinct periods:

November 10th - November 27th inclusive: `Remind me on Giving Tuesday`
November 28th - December 30th inclusive: `Remind me on New Years Eve`

This PR adds logic to support this. Braze canvases/campaigns will need to be created to support the two new reminder option fields:

`giving-tuesday-2023`
`new-years-eve-2023`

I'll work with marketing to ensure this happens.

### Giving Tuesday preview

![Screen Recording 2023-10-24 at 10 54 46 mov](https://github.com/guardian/support-dotcom-components/assets/379839/d3d2b8a7-0507-42e3-8e45-376eceae35b0)

### New Years Eve preview

![Screen Recording 2023-10-24 at 10 55 22 mov](https://github.com/guardian/support-dotcom-components/assets/379839/a38aa01a-685f-44ef-a2c7-334d5a8db01b)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
