### PR TITLE
Browser font re-sizing supported for Moment Template And Design Banners

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
@@ -33,13 +33,12 @@ export function DesignableBannerArticleCount({
 
 const styles = {
     container: (textColor: string = 'inherit') => css`
-        ${headline.xxxsmall({ fontWeight: 'bold' })}
-        font-size: 15px;
-        color: ${textColor};
         margin: 0;
-
+        color: ${textColor};
+        ${headline.xxxsmall({ fontWeight: 'bold' })};
+        font-size: 94%;
         ${from.desktop} {
-            font-size: 17px;
+            font-size: ${(100 / 94) * 100}%;
         }
     `,
 };

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
@@ -36,9 +36,9 @@ const styles = {
         margin: 0;
         color: ${textColor};
         ${headline.xxxsmall({ fontWeight: 'bold' })};
-        font-size: 94%; /* headline reduced to 15px whilst allowing browser to font resize */
+        font-size: ${15 / 16}rem; /* root element 16px, headline 15px, allows browser font resize */
         ${from.desktop} {
-            font-size: ${(100 / 94) * 100}%; /* headline scaled back to 17px/xxxsmall */
+            font-size: ${17 / 16}rem; /* root element 16px, headline.xxxsmall 17px */
         }
     `,
 };

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
@@ -36,9 +36,9 @@ const styles = {
         margin: 0;
         color: ${textColor};
         ${headline.xxxsmall({ fontWeight: 'bold' })};
-        font-size: 94%;
+        font-size: 94%; /* headline reduced to 15px whilst allowing browser to font resize */
         ${from.desktop} {
-            font-size: ${(100 / 94) * 100}%;
+            font-size: ${(100 / 94) * 100}%; /* headline scaled back to 17px/xxxsmall */
         }
     `,
 };

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCountOptOut.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCountOptOut.tsx
@@ -195,12 +195,11 @@ const overlayStyles = {
         justify-content: space-between;
     `,
     overlayHeaderText: css`
-        font-size: 17px;
-        font-weight: bold;
+        ${textSans.medium({ fontWeight: 'bold' })};
     `,
     overlayBody: css`
         margin-top: ${space[1]}px;
-        font-size: 15px;
+        ${textSans.small()};
     `,
     overlayCtaContainer: css`
         margin-top: ${space[3]}px;

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerBody.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerBody.tsx
@@ -37,17 +37,12 @@ export function DesignableBannerBody({
 
 const getStyles = (settings: HighlightedTextSettings) => ({
     container: css`
-        line-height: 135%;
-        ${from.wide} {
-            line-height: 150%;
-        }
         p {
             margin: 0 0 0.5em 0;
         }
-
         ${body.small({ lineHeight: 'loose' })};
         ${from.desktop} {
-            ${body.medium({ lineHeight: 'loose' })};
+            ${body.medium({ lineHeight: 'regular' })};
         }
     `,
     highlightedText: css`

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerBody.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerBody.tsx
@@ -37,24 +37,17 @@ export function DesignableBannerBody({
 
 const getStyles = (settings: HighlightedTextSettings) => ({
     container: css`
-        ${body.small()}
-        font-size: 15px;
         line-height: 135%;
-
-        ${from.desktop} {
-            font-size: 17px;
-        }
-
         ${from.wide} {
             line-height: 150%;
         }
-
         p {
             margin: 0 0 0.5em 0;
         }
 
-        strong {
-            font-weight: bold;
+        ${body.small({ lineHeight: 'loose' })};
+        ${from.desktop} {
+            ${body.medium({ lineHeight: 'loose' })};
         }
     `,
     highlightedText: css`
@@ -71,10 +64,8 @@ const getStyles = (settings: HighlightedTextSettings) => ({
 
         padding: 0.15rem 0.15rem;
         ${body.small({ fontWeight: 'bold', lineHeight: 'loose' })};
-        font-size: 15px;
-
         ${from.desktop} {
-            font-size: 17px;
+            ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
         }
     `,
 });

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerHeader.tsx
@@ -42,9 +42,8 @@ const styles = {
         h2 {
             margin: 0;
             color: ${headerSettings?.textColour ?? neutral[0]};
-            line-height: 115%;
 
-            ${headline.xsmall({ fontWeight: 'bold' })}
+            ${headline.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })}
             ${from.tablet} {
                 ${headline.small({ fontWeight: 'bold' })}
             }

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerHeader.tsx
@@ -40,18 +40,16 @@ const styles = {
     `,
     header: (headerSettings: HeaderSettings | undefined) => css`
         h2 {
-            ${headline.xsmall({ fontWeight: 'bold' })}
             margin: 0;
             color: ${headerSettings?.textColour ?? neutral[0]};
-            font-size: 24px;
             line-height: 115%;
 
+            ${headline.xsmall({ fontWeight: 'bold' })}
             ${from.tablet} {
-                font-size: 28px;
+                ${headline.small({ fontWeight: 'bold' })}
             }
-
             ${from.desktop} {
-                font-size: 34px;
+                ${headline.medium({ fontWeight: 'bold' })}
             }
         }
     `,

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
@@ -38,7 +38,7 @@ const styles = {
         ${headline.xxxsmall({ fontWeight: 'bold' })};
         font-size: 94%;
         ${from.desktop} {
-            ${headline.xxxsmall({ fontWeight: 'bold' })}
+            font-size: ${(100 / 94) * 100}%;
         }
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
@@ -33,13 +33,12 @@ export function MomentTemplateBannerArticleCount({
 
 const styles = {
     container: (textColor: string = 'inherit') => css`
-        ${headline.xxxsmall({ fontWeight: 'bold' })}
-        font-size: 15px;
-        color: ${textColor};
         margin: 0;
-
+        color: ${textColor};
+        ${headline.xxxsmall({ fontWeight: 'bold' })};
+        font-size: 94%;
         ${from.desktop} {
-            font-size: 17px;
+            ${headline.xxxsmall({ fontWeight: 'bold' })}
         }
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
@@ -36,9 +36,9 @@ const styles = {
         margin: 0;
         color: ${textColor};
         ${headline.xxxsmall({ fontWeight: 'bold' })};
-        font-size: 94%; /* headline reduced to 15px whilst allowing browser to font resize */
+        font-size: ${15 / 16}rem; /* root element 16px, headline 15px, allows browser font resize */
         ${from.desktop} {
-            font-size: ${(100 / 94) * 100}%; /* headline scaled back to 17px/xxxsmall */
+            font-size: ${17 / 16}rem; /* root element 16px, headline.xxxsmall 17px */
         }
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
@@ -36,9 +36,9 @@ const styles = {
         margin: 0;
         color: ${textColor};
         ${headline.xxxsmall({ fontWeight: 'bold' })};
-        font-size: 94%;
+        font-size: 94%; /* headline reduced to 15px whilst allowing browser to font resize */
         ${from.desktop} {
-            font-size: ${(100 / 94) * 100}%;
+            font-size: ${(100 / 94) * 100}%; /* headline scaled back to 17px/xxxsmall */
         }
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
@@ -195,12 +195,11 @@ const overlayStyles = {
         justify-content: space-between;
     `,
     overlayHeaderText: css`
-        font-size: 17px;
-        font-weight: bold;
+        ${textSans.medium({ fontWeight: 'bold' })};
     `,
     overlayBody: css`
         margin-top: ${space[1]}px;
-        font-size: 15px;
+        ${textSans.small()};
     `,
     overlayCtaContainer: css`
         margin-top: ${space[3]}px;

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -46,12 +46,12 @@ const getStyles = (settings: HighlightedTextSettings) => ({
         }
 
         ${body.small({ lineHeight: 'loose' })};
-        ${until.tablet} {
+        ${until.desktop} {
             strong {
                 font-weight: 800;
             }
         }
-        ${from.tablet} {
+        ${from.desktop} {
             ${body.medium({ lineHeight: 'loose' })};
             strong {
                 ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
@@ -72,10 +72,10 @@ const getStyles = (settings: HighlightedTextSettings) => ({
 
         padding: 0.15rem 0.15rem;
         ${body.small({ fontWeight: 'bold', lineHeight: 'loose' })};
-        ${until.tablet} {
+        ${until.desktop} {
             font-weight: 800;
         }
-        ${from.tablet} {
+        ${from.desktop} {
             ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
         }
     `,

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, until } from '@guardian/src-foundations/mq';
+import { from } from '@guardian/src-foundations/mq';
 import { body } from '@guardian/src-foundations/typography';
 import { createBannerBodyCopy } from '../../common/BannerText';
 import { HighlightedTextSettings } from '../settings';
@@ -46,16 +46,8 @@ const getStyles = (settings: HighlightedTextSettings) => ({
         }
 
         ${body.small({ lineHeight: 'loose' })};
-        ${until.desktop} {
-            strong {
-                font-weight: 800;
-            }
-        }
         ${from.desktop} {
             ${body.medium({ lineHeight: 'loose' })};
-            strong {
-                ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
-            }
         }
     `,
     highlightedText: css`
@@ -72,9 +64,6 @@ const getStyles = (settings: HighlightedTextSettings) => ({
 
         padding: 0.15rem 0.15rem;
         ${body.small({ fontWeight: 'bold', lineHeight: 'loose' })};
-        ${until.desktop} {
-            font-weight: 800;
-        }
         ${from.desktop} {
             ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
         }

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -37,17 +37,12 @@ export function MomentTemplateBannerBody({
 
 const getStyles = (settings: HighlightedTextSettings) => ({
     container: css`
-        line-height: 135%;
-        ${from.wide} {
-            line-height: 150%;
-        }
         p {
             margin: 0 0 0.5em 0;
         }
-
         ${body.small({ lineHeight: 'loose' })};
         ${from.desktop} {
-            ${body.medium({ lineHeight: 'loose' })};
+            ${body.medium({ lineHeight: 'regular' })};
         }
     `,
     highlightedText: css`

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 import { body } from '@guardian/src-foundations/typography';
 import { createBannerBodyCopy } from '../../common/BannerText';
 import { HighlightedTextSettings } from '../settings';
@@ -23,7 +23,7 @@ export function MomentTemplateBannerBody({
     const isTabletOrAbove = useMediaQuery(from.tablet);
 
     return (
-        <div css={styles.container}>
+        <div css={[styles.commonFontSizing, styles.container]}>
             {isTabletOrAbove
                 ? createBannerBodyCopy(mainContent.paragraphs, mainContent.highlightedText, styles)
                 : createBannerBodyCopy(
@@ -36,25 +36,27 @@ export function MomentTemplateBannerBody({
 }
 
 const getStyles = (settings: HighlightedTextSettings) => ({
-    container: css`
-        ${body.small()}
-        font-size: 15px;
-        line-height: 135%;
-
-        ${from.desktop} {
-            font-size: 17px;
+    commonFontSizing: css`
+        ${body.small({ lineHeight: 'loose' })};
+        ${until.tablet} {
+            strong {
+                font-weight: 800;
+            }
         }
-
+        ${from.tablet} {
+            ${body.medium({ lineHeight: 'loose' })};
+            strong {
+                ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
+            }
+        }
+    `,
+    container: css`
+        line-height: 135%;
         ${from.wide} {
             line-height: 150%;
         }
-
         p {
             margin: 0 0 0.5em 0;
-        }
-
-        strong {
-            font-weight: bold;
         }
     `,
     highlightedText: css`

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -23,7 +23,7 @@ export function MomentTemplateBannerBody({
     const isTabletOrAbove = useMediaQuery(from.tablet);
 
     return (
-        <div css={[styles.commonFontSizing, styles.container]}>
+        <div css={styles.container}>
             {isTabletOrAbove
                 ? createBannerBodyCopy(mainContent.paragraphs, mainContent.highlightedText, styles)
                 : createBannerBodyCopy(
@@ -36,7 +36,15 @@ export function MomentTemplateBannerBody({
 }
 
 const getStyles = (settings: HighlightedTextSettings) => ({
-    commonFontSizing: css`
+    container: css`
+        line-height: 135%;
+        ${from.wide} {
+            line-height: 150%;
+        }
+        p {
+            margin: 0 0 0.5em 0;
+        }
+
         ${body.small({ lineHeight: 'loose' })};
         ${until.tablet} {
             strong {
@@ -48,15 +56,6 @@ const getStyles = (settings: HighlightedTextSettings) => ({
             strong {
                 ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
             }
-        }
-    `,
-    container: css`
-        line-height: 135%;
-        ${from.wide} {
-            line-height: 150%;
-        }
-        p {
-            margin: 0 0 0.5em 0;
         }
     `,
     highlightedText: css`
@@ -73,10 +72,11 @@ const getStyles = (settings: HighlightedTextSettings) => ({
 
         padding: 0.15rem 0.15rem;
         ${body.small({ fontWeight: 'bold', lineHeight: 'loose' })};
-        font-size: 15px;
-
-        ${from.desktop} {
-            font-size: 17px;
+        ${until.tablet} {
+            font-weight: 800;
+        }
+        ${from.tablet} {
+            ${body.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
         }
     `,
 });

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
@@ -32,18 +32,16 @@ const styles = {
     `,
     header: (headerSettings: HeaderSettings | undefined) => css`
         h2 {
-            ${headline.xsmall({ fontWeight: 'bold' })}
             margin: 0;
             color: ${headerSettings?.textColour ?? neutral[0]};
-            font-size: 24px;
             line-height: 115%;
 
+            ${headline.xsmall({ fontWeight: 'bold' })}
             ${from.tablet} {
-                font-size: 28px;
+                ${headline.small({ fontWeight: 'bold' })}
             }
-
             ${from.desktop} {
-                font-size: 34px;
+                ${headline.medium({ fontWeight: 'bold' })}
             }
         }
     `,

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
@@ -34,9 +34,8 @@ const styles = {
         h2 {
             margin: 0;
             color: ${headerSettings?.textColour ?? neutral[0]};
-            line-height: 115%;
 
-            ${headline.xsmall({ fontWeight: 'bold' })}
+            ${headline.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })}
             ${from.tablet} {
                 ${headline.small({ fontWeight: 'bold' })}
             }


### PR DESCRIPTION
## What does this change?

Moment Template Banner Accessibility - browser-level font enlarging not affecting banner header and copy.
This change will apply to all Moment Template based banners.


[**Trello Card**](https://trello.com/c/2UxqCzRM/1634-moment-template-banner-browser-level-font-enlarging-not-affecting-banner-header-and-copy)

## How to test

You can adjust Chrome's font settings from medium to very large here (chrome://settings/appearance) ->
![image](https://github.com/guardian/support-dotcom-components/assets/76729591/337c9e8c-f364-4b5a-85ec-93a8ef871116)

## How can we measure success?

|Banner|Font Size|Mobile|Desktop|
|--------|--------|--------|--------|
|ChoiceCardsMoment|Medium|<img width="375" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/76729591/2ad3bc97-884c-4400-8400-71cf1aeb02da">|<img width="978" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/76729591/1aa3e876-e4cc-40a8-b85c-56fe79ca9a92">|
|ChoiceCardsMoment|VeryLarge|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/8fe6b514-8edc-4512-96a1-8e162920f74e)|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/1cd1c3b7-8d22-4f58-9c37-7cf9782ba6e6)|
|Designable|Medium|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/706c9c2d-a88f-4527-a867-981a28b6ea7e)|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/724ccea1-582e-4c86-a779-5c2b48e4bda7)|
|Designable|VeryLarge|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/a79f9e24-1b74-4e74-a09c-862559635616)|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/960dd184-7eb3-42d8-b498-6c4d02b42709)|

## Have we considered potential risks?

- Will enlarge banner font height hide header & close button on devices with <680px height? (Separate [**Trello Card**](https://trello.com/c/572Xho5z/412-moment-template-banner-close-button-hidden))
- Regardless, accessibility requires the font to be resized appropriately.
- ChoiceCard 3xfrequency buttons have limited space, monthly can overflow at mobile breakpoint, judged minor.

## Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
