### PR TITLE
Single to One-time frequency card for MomentChoiceCard Banner and Epic

### DIFF
--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardFrequencyTabs.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardFrequencyTabs.tsx
@@ -78,7 +78,7 @@ export const ChoiceCardFrequencyTabs = ({
     const tabList = tabFrequencies.map((tabFrequency) => ({
         frequency: tabFrequency,
         id: `banner-${tabFrequency}`,
-        labelText: tabFrequency === 'ONE_OFF' ? 'Single' : getRecurringLabelText(tabFrequency),
+        labelText: tabFrequency === 'ONE_OFF' ? 'One-time' : getRecurringLabelText(tabFrequency),
         selected: selection.frequency === tabFrequency,
     }));
 

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCards.tsx
@@ -111,7 +111,7 @@ const styles = {
 
 const contributionType: ContributionType = {
     ONE_OFF: {
-        label: 'Single',
+        label: 'One-time',
         suffix: '',
     },
     MONTHLY: {

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/ChoiceCards.tsx
@@ -108,7 +108,7 @@ const styles = {
 
 const contributionType: ContributionType = {
     ONE_OFF: {
-        label: 'Single',
+        label: 'One-time',
         suffix: '',
     },
     MONTHLY: {

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/FrequencyTabs.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/FrequencyTabs.tsx
@@ -53,7 +53,8 @@ export const FrequencyTabs = ({
         return tabFrequencies.map((tabFrequency) => ({
             frequency: tabFrequency,
             id: `banner-${tabFrequency}`,
-            labelText: tabFrequency === 'ONE_OFF' ? 'Single' : getRecurringLabelText(tabFrequency),
+            labelText:
+                tabFrequency === 'ONE_OFF' ? 'One-time' : getRecurringLabelText(tabFrequency),
             selected: selection.frequency === tabFrequency,
         }));
     };

--- a/packages/modules/src/modules/shared/helpers/choiceCards.ts
+++ b/packages/modules/src/modules/shared/helpers/choiceCards.ts
@@ -8,7 +8,7 @@ export interface ChoiceCardSelection {
 
 export const contributionType: ContributionType = {
     ONE_OFF: {
-        label: 'Single',
+        label: 'One-time',
         suffix: '',
     },
     MONTHLY: {


### PR DESCRIPTION
## What does this change?

Following UXR, We would like to test changing the word “single” on the checkout to “One-time”. This would not be a test, this would be global.

[**Trello Card**](https://trello.com/c/c3cMVhhj/1625-changing-single-to-one-time-on-banner-epic-choice-cards-support-dotcom-components)

|Type|Before|After|
|--------|--------|--------|
|TemplateBanner|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/0deb1f26-896d-41f9-80d8-c717429f2f5d)|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/ec29e984-f0c4-4869-a716-c0fb92041d84)|
|WorldPressFreedomDay|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/c7576139-0d06-40a7-bcf9-0ea95f249539)|![image](https://github.com/guardian/support-dotcom-components/assets/76729591/c0b3365e-0863-476c-910a-99810015a141)|

## Accessibility
-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
