### PR TITLE
add functions to calculate US thanksgiving and giving tuesday program…

### DIFF
--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -75,7 +75,7 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
 
 const newYearsEve = new Date('2023-12-31');
 const givingTuesdayReminderStart = (date: Date): Date => {
-    return new Date(date.getFullYear(), 10, 1); // November 1st (provisional auto start date, to be confirmed)
+    return new Date(date.getFullYear(), 9, 20); // October 20th (provisional auto start date, to be confirmed)
 };
 
 // Giving Tuesday is 'active' from November 1st until the day before Giving Tuesday

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -5,14 +5,24 @@ export interface ReminderFields {
     reminderOption?: string;
 }
 
-const thanksgivingUsa = (year: number = new Date().getFullYear()): Date => {
-    const novemberFirst = new Date(year, 10, 1).getDay();
+// Thanksgiving in the USA is always the fourth Thursday in November
+const thanksgivingUSA = (year: number): Date => {
+    // An integer representing the day of the week for November 1st (0 == Sunday, 1 == Monday, 2 == Tuesday, etc.)
+    const novemberFirstDay = new Date(year, 10, 1).getDay();
 
-    return new Date(year, 10, 22 + ((11 - novemberFirst) % 7));
+    // We calculate the offset between the first of November and the first Thursday in November using a modulus operation
+    const firstThursdayOffset = (11 - novemberFirstDay) % 7;
+
+    // The 22nd is the earliest possible date in November for Thanksgiving (USA). We add the offset to 22 to find the
+    // date of Thanksgiving for the given year
+    const thanksgivingDate = 22 + firstThursdayOffset;
+
+    return new Date(year, 10, thanksgivingDate);
 };
 
-const givingTuesday = (year: number = new Date().getFullYear()): Date => {
-    return new Date(year, 10, thanksgivingUsa(year).getDate() + 5);
+// Giving Tuesday is always the Tuesday following Thanksgiving, i.e. five days after Thanksgiving
+const givingTuesday = (year: number): Date => {
+    return new Date(year, 10, thanksgivingUSA(year).getDate() + 5);
 };
 
 const getReminderDate = (date: Date): Date => {
@@ -22,18 +32,22 @@ const getReminderDate = (date: Date): Date => {
     return date;
 };
 
-export const GIVING_TUESDAY_REMINDER_FIELDS: ReminderFields = {
-    reminderCta: 'Remind me on Giving Tuesday',
-    reminderPeriod: '2023-11-01',
-    reminderLabel: 'on Giving Tuesday',
-    reminderOption: 'giving-tuesday-2023',
+const givingTuesdayReminderFields = (year: number): ReminderFields => {
+    return {
+        reminderCta: 'Remind me on Giving Tuesday',
+        reminderPeriod: `${year}-11-01`,
+        reminderLabel: 'on Giving Tuesday',
+        reminderOption: `giving-tuesday-${year}`,
+    };
 };
 
-export const NEW_YEARS_EVE_REMINDER_FIELDS: ReminderFields = {
-    reminderCta: 'Remind me on New Years Eve',
-    reminderPeriod: '2023-12-01',
-    reminderLabel: 'on New Years Eve',
-    reminderOption: 'new-years-eve-2023',
+const newYearsEveReminderFields = (year: number): ReminderFields => {
+    return {
+        reminderCta: 'Remind me on New Years Eve',
+        reminderPeriod: `${year}-12-01`,
+        reminderLabel: 'on New Years Eve',
+        reminderOption: `new-years-eve-${year}`,
+    };
 };
 
 export const buildReminderFields = (today: Date = new Date()): ReminderFields => {
@@ -51,24 +65,29 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-const givingTuesdayIsActive = (date: Date): boolean => date < givingTuesday();
+const newYearsEve = new Date('2023-12-31');
+const givingTuesdayReminderStart = (date: Date): Date => {
+    return new Date(date.getFullYear(), 10, 1); // November 1st (provisional auto start date, to be confirmed)
+};
 
-const newYearsEveStart = new Date('2023-11-28');
-const newYearsEveCutOff = new Date('2023-12-30');
+// Giving Tuesday is 'active' from November 1st until the day before Giving Tuesday
+const givingTuesdayIsActive = (date: Date): boolean =>
+    date >= givingTuesdayReminderStart(date) && date < givingTuesday(date.getFullYear());
 
+// Giving Tuesday is 'active' from Giving Tuesday until the day before NYE
 const newYearsEveIsActive = (date: Date): boolean =>
-    date >= newYearsEveStart && date <= newYearsEveCutOff;
+    date >= givingTuesday(date.getFullYear()) && date < newYearsEve;
 
 export const getReminderFields = (
     countryCode?: string,
     date: Date = new Date(),
 ): ReminderFields => {
     if (countryCode === 'US' && givingTuesdayIsActive(date)) {
-        return GIVING_TUESDAY_REMINDER_FIELDS;
+        return givingTuesdayReminderFields(date.getFullYear());
     }
 
     if (countryCode === 'US' && newYearsEveIsActive(date)) {
-        return NEW_YEARS_EVE_REMINDER_FIELDS;
+        return newYearsEveReminderFields(date.getFullYear());
     }
 
     return buildReminderFields(date);

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -22,7 +22,12 @@ const thanksgivingUSA = (year: number): Date => {
 
 // Giving Tuesday is always the Tuesday following Thanksgiving, i.e. five days after Thanksgiving
 const givingTuesday = (year: number): Date => {
-    return new Date(year, 10, thanksgivingUSA(year).getDate() + 5);
+    const date = thanksgivingUSA(year);
+    // We cannot simply query the date of the month for Thanksgiving and add 5 to it, we need to allow for Giving Tuesday
+    // to be in the first week of December
+    date.setDate(date.getDate() + 5);
+
+    return date;
 };
 
 const getReminderDate = (date: Date): Date => {
@@ -33,9 +38,12 @@ const getReminderDate = (date: Date): Date => {
 };
 
 const givingTuesdayReminderFields = (year: number): ReminderFields => {
+    // Giving Tuesday can be in either November or December
+    // Months in JS run from 0-11, we want 01-12 for the reminderPeriod field
+    const givingTuesdayMonth = (givingTuesday(year).getMonth() + 1).toString().padStart(0, '2');
     return {
         reminderCta: 'Remind me on Giving Tuesday',
-        reminderPeriod: `${year}-11-01`,
+        reminderPeriod: `${year}-${givingTuesdayMonth}-01`,
         reminderLabel: 'on Giving Tuesday',
         reminderOption: `giving-tuesday-${year}`,
     };

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -78,7 +78,7 @@ const givingTuesdayReminderStart = (date: Date): Date => {
     return new Date(date.getFullYear(), 9, 20); // October 20th (provisional auto start date, to be confirmed)
 };
 
-// Giving Tuesday is 'active' from November 1st until the day before Giving Tuesday
+// Giving Tuesday is 'active' from October 20th until the day before Giving Tuesday
 const givingTuesdayIsActive = (date: Date): boolean =>
     date >= givingTuesdayReminderStart(date) && date < givingTuesday(date.getFullYear());
 

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -5,6 +5,16 @@ export interface ReminderFields {
     reminderOption?: string;
 }
 
+const thanksgiving = (year: number = new Date().getFullYear()): Date => {
+    const novemberFirst = new Date(year, 10, 1).getDay();
+
+    return new Date(year, 10, 22 + ((11 - novemberFirst) % 7));
+};
+
+const givingTuesday = (year: number = new Date().getFullYear()): Date => {
+    return new Date(year, 10, thanksgiving(year).getDate() + 5);
+};
+
 const getReminderDate = (date: Date): Date => {
     const monthsAhead = date.getDate() < 20 ? 1 : 2;
     date.setMonth(date.getMonth() + monthsAhead);
@@ -41,9 +51,7 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
     };
 };
 
-const givingTuesdayCutOff = new Date('2023-11-27');
-
-const givingTuesdayIsActive = (date: Date): boolean => date <= givingTuesdayCutOff;
+const givingTuesdayIsActive = (date: Date): boolean => date < givingTuesday();
 
 const newYearsEveStart = new Date('2023-11-28');
 const newYearsEveCutOff = new Date('2023-12-30');

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -74,7 +74,7 @@ const givingTuesdayReminderStart = (date: Date): Date => {
 const givingTuesdayIsActive = (date: Date): boolean =>
     date >= givingTuesdayReminderStart(date) && date < givingTuesday(date.getFullYear());
 
-// Giving Tuesday is 'active' from Giving Tuesday until the day before NYE
+// New Years Eve is 'active' from Giving Tuesday until the day before NYE
 const newYearsEveIsActive = (date: Date): boolean =>
     date >= givingTuesday(date.getFullYear()) && date < newYearsEve;
 

--- a/packages/shared/src/lib/reminderFields.ts
+++ b/packages/shared/src/lib/reminderFields.ts
@@ -5,14 +5,14 @@ export interface ReminderFields {
     reminderOption?: string;
 }
 
-const thanksgiving = (year: number = new Date().getFullYear()): Date => {
+const thanksgivingUsa = (year: number = new Date().getFullYear()): Date => {
     const novemberFirst = new Date(year, 10, 1).getDay();
 
     return new Date(year, 10, 22 + ((11 - novemberFirst) % 7));
 };
 
 const givingTuesday = (year: number = new Date().getFullYear()): Date => {
-    return new Date(year, 10, thanksgiving(year).getDate() + 5);
+    return new Date(year, 10, thanksgivingUsa(year).getDate() + 5);
 };
 
 const getReminderDate = (date: Date): Date => {


### PR DESCRIPTION
This is a small PR to add functions which calculate the date of Thanksgiving (US) and Giving Tuesday programmatically, ie. without the need to manually update and hard code these dates.

In summary:
- Giving Tuesday will either be in the last week of November, or the first week of December, depending on the year
- From October 20th until the day before Giving Tuesday readers in the US will see a 'Remind me on Giving Tuesday' reminder CTA
- From Giving Tuesday until the day before New Year's Eve readers in the US will see a 'Remind me on New Year's Eve' reminder CTA