### PR TITLE
Disable scheduled banner deploys in US

### DIFF
--- a/packages/server/src/api/bannerRouter.ts
+++ b/packages/server/src/api/bannerRouter.ts
@@ -125,7 +125,7 @@ export const buildBannerRouter = (
             bannerTests.get(),
             bannerDeployTimes,
             enableHardcodedBannerTests,
-            enableScheduledBannerDeploys,
+            enableScheduledBannerDeploys && targeting.countryCode !== 'US', // disable scheduled deploys in the US
             params.force,
         );
 


### PR DESCRIPTION
Marketing want direct control of this.
This can be re-enabled in December