### PR TITLE
Handle Apple Pay button click so it gets tracked in Ophan

### DIFF
--- a/packages/modules/src/modules/epics/ButtonApplePay.tsx
+++ b/packages/modules/src/modules/epics/ButtonApplePay.tsx
@@ -13,7 +13,7 @@ type Url = string;
 
 type Props = {
     onClickAction: Url;
-    submitComponentEvent?: (event: OphanComponentEvent) => void;
+    submitComponentEvent: (event: OphanComponentEvent) => void;
     children: React.ReactElement | string;
 };
 
@@ -45,15 +45,10 @@ const buttonStyles = (): SerializedStyles => css`
 export const ButtonApplePay: ReactComponent<Props> = (allProps: Props) => {
     const { onClickAction, submitComponentEvent, children, ...props } = allProps;
 
-    const onApplePayCtaClick = (e: React.MouseEvent<HTMLElement>) => {
-        e.preventDefault();
-
-        if (submitComponentEvent) {
-            submitComponentEvent(OPHAN_COMPONENT_EVENT_APPLEPAY_CTA);
-        }
-
-        window.open(onClickAction);
+    const onApplePayCtaClick = () => {
+       submitComponentEvent(OPHAN_COMPONENT_EVENT_APPLEPAY_CTA);
     };
+
     return (
         <ThemeProvider theme={buttonStyles}>
             <LinkButton

--- a/packages/modules/src/modules/epics/ButtonApplePay.tsx
+++ b/packages/modules/src/modules/epics/ButtonApplePay.tsx
@@ -45,10 +45,14 @@ const buttonStyles = (): SerializedStyles => css`
 export const ButtonApplePay: ReactComponent<Props> = (allProps: Props) => {
     const { onClickAction, submitComponentEvent, children, ...props } = allProps;
 
-    const onApplePayCtaClick = () => {
+    const onApplePayCtaClick = (e: React.MouseEvent<HTMLElement>) => {
+        e.preventDefault();
+
         if (submitComponentEvent) {
             submitComponentEvent(OPHAN_COMPONENT_EVENT_APPLEPAY_CTA);
         }
+
+        window.open(onClickAction);
     };
     return (
         <ThemeProvider theme={buttonStyles}>

--- a/packages/modules/src/modules/epics/ButtonApplePay.tsx
+++ b/packages/modules/src/modules/epics/ButtonApplePay.tsx
@@ -13,7 +13,7 @@ type Url = string;
 
 type Props = {
     onClickAction: Url;
-    submitComponentEvent: (event: OphanComponentEvent) => void;
+    submitComponentEvent?: (event: OphanComponentEvent) => void;
     children: React.ReactElement | string;
 };
 
@@ -46,7 +46,9 @@ export const ButtonApplePay: ReactComponent<Props> = (allProps: Props) => {
     const { onClickAction, submitComponentEvent, children, ...props } = allProps;
 
     const onApplePayCtaClick = () => {
-        submitComponentEvent(OPHAN_COMPONENT_EVENT_APPLEPAY_CTA);
+        if (submitComponentEvent) {
+            submitComponentEvent(OPHAN_COMPONENT_EVENT_APPLEPAY_CTA);
+        }
     };
 
     return (

--- a/packages/modules/src/modules/epics/ButtonApplePay.tsx
+++ b/packages/modules/src/modules/epics/ButtonApplePay.tsx
@@ -46,7 +46,7 @@ export const ButtonApplePay: ReactComponent<Props> = (allProps: Props) => {
     const { onClickAction, submitComponentEvent, children, ...props } = allProps;
 
     const onApplePayCtaClick = () => {
-       submitComponentEvent(OPHAN_COMPONENT_EVENT_APPLEPAY_CTA);
+        submitComponentEvent(OPHAN_COMPONENT_EVENT_APPLEPAY_CTA);
     };
 
     return (

--- a/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
@@ -300,6 +300,7 @@ export const ContributionsEpicButtons = ({
                                 amountsTestName={amountsTestName}
                                 amountsVariantName={amountsVariantName}
                                 countryCode={countryCode}
+                                submitComponentEvent={submitComponentEvent}
                             />
                             <SecondaryCtaButtonApplePay
                                 cta={getCta(cta)}

--- a/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
@@ -149,6 +149,7 @@ const PrimaryCtaButtonApplePay = ({
     amountsTestName,
     amountsVariantName,
     numArticles,
+    submitComponentEvent,
 }: {
     cta?: Cta;
     tracking: Tracking;
@@ -156,6 +157,7 @@ const PrimaryCtaButtonApplePay = ({
     amountsTestName?: string;
     amountsVariantName?: string;
     numArticles: number;
+    submitComponentEvent: (event: OphanComponentEvent) => void;
 }): JSX.Element | null => {
     if (!cta) {
         return null;
@@ -174,7 +176,12 @@ const PrimaryCtaButtonApplePay = ({
 
     return (
         <div css={buttonMarginStyles(true)}>
-            <ButtonApplePay onClickAction={urlWithRegionAndTracking}>{buttonText}</ButtonApplePay>
+            <ButtonApplePay
+                submitComponentEvent={submitComponentEvent}
+                onClickAction={urlWithRegionAndTracking}
+            >
+                {buttonText}
+            </ButtonApplePay>
         </div>
     );
 };

--- a/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
+++ b/packages/modules/src/modules/epics/ContributionsEpicButtons.tsx
@@ -157,7 +157,7 @@ const PrimaryCtaButtonApplePay = ({
     amountsTestName?: string;
     amountsVariantName?: string;
     numArticles: number;
-    submitComponentEvent: (event: OphanComponentEvent) => void;
+    submitComponentEvent?: (event: OphanComponentEvent) => void;
 }): JSX.Element | null => {
     if (!cta) {
         return null;


### PR DESCRIPTION
## What does this change?

We released the Apple Pay Epic AB test yesterday. I checked the component events in the Page View table in the Data Lake today and noted we have no click events on the Apple Pay button recorded. This is because `submitComponentEvent` wasn't passed to `ButtonApplePay`.