### PR TITLE
Small fix to enforce amounts card tab order

### DIFF
--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
@@ -145,6 +145,8 @@ export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> =
 
     const { displayContributionType, amountsCardData } = amountsTest;
 
+    const contributionTypeTabOrder: ContributionFrequency[] = ['ONE_OFF', 'MONTHLY', 'ANNUAL'];
+
     if (!amountsCardData) {
         return <></>;
     }
@@ -271,7 +273,11 @@ export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> =
                 ]}
             >
                 <div css={style.frequencyContainer}>
-                    {displayContributionType.map((f) => generateChoiceCardFrequencyTab(f))}
+                    {contributionTypeTabOrder.map((f) =>
+                        displayContributionType.includes(f)
+                            ? generateChoiceCardFrequencyTab(f)
+                            : null,
+                    )}
                 </div>
             </ChoiceCardGroup>
             <ChoiceCardGroup


### PR DESCRIPTION
## What does this change?
RRCP live view of banner and epic tests with an amounts card show the card's tabs in reverse order (with "annual" to the left). When displayed on the main Guardian site the tabs appear in the correct order.

Reason for this discrepancy is because the ChoiceCard component (defined in SDC) processes the `displayContributionType` array without checking that the array's elements are in the correct order. This PR fixes this vulnerability.
 
## How to test
Review in Storybook, and in CODE environment for SDC and SAC repos to check the update fixes the live preview functionality

## Screenshots

__Live preview in RRCP__
![Screenshot 2023-11-14 at 12 04 53](https://github.com/guardian/support-dotcom-components/assets/5357530/a6da5dfc-f273-450f-b87b-8366e062abb7)

__Expected tab order__ (Annual tab always on the right)
![Screenshot 2023-11-14 at 12 02 33](https://github.com/guardian/support-dotcom-components/assets/5357530/d2af8377-c647-4912-9f09-3e5f27aebc17)
