### PR TITLE
Make banner close button sticky

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -317,7 +317,7 @@ const styles = {
     `,
     closeButtonOverrides: css`
         ${until.tablet} {
-            position: absolute;
+            position: fixed;
             top: ${space[3]}px;
             right: 0;
         }

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -318,7 +318,7 @@ const styles = {
     closeButtonOverrides: css`
         ${until.tablet} {
             position: fixed;
-            top: ${space[3]}px;
+            margin-top: ${space[3]}px;
             right: 0;
         }
         ${from.tablet} {

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -56,7 +56,6 @@ export function DesignableBannerCloseButton({
 const styles = {
     container: css`
         display: flex;
-        justify-content: end;
         position: fixed;
         right: 0;
         padding-right: 20px;

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -57,7 +57,9 @@ const styles = {
     container: css`
         display: flex;
         justify-content: end;
-        position: relative;
+        position: fixed;
+        right: 0;
+        padding-right: 20px;
         z-index: 100;
     `,
     roundelContainer: css`

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -230,7 +230,7 @@ const styles = {
     `,
     closeButtonOverrides: css`
         ${until.tablet} {
-            position: absolute;
+            position: fixed;
             top: ${space[3]}px;
             right: 0;
         }

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -231,7 +231,7 @@ const styles = {
     closeButtonOverrides: css`
         ${until.tablet} {
             position: fixed;
-            top: ${space[3]}px;
+            margin-top: ${space[3]}px;
             right: 0;
         }
         ${from.tablet} {

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -62,8 +62,9 @@ export function MomentTemplateBannerCloseButton({
 const styles = {
     container: css`
         display: flex;
-        justify-content: end;
-        position: relative;
+        position: fixed;
+        right: 0;
+        padding-right: 20px;
         z-index: 100;
     `,
     roundelContainer: css`


### PR DESCRIPTION
Banners are frequently too tall.

This makes the close button always in view for the DesignableBanner and MomentTemplateBanner.
Tabbing to the button still works

![Screenshot 2023-11-17 at 15 37 38](https://github.com/guardian/support-dotcom-components/assets/1513454/bf31144a-4768-4855-84c7-023d665301e9)
![Screenshot 2023-11-17 at 15 37 54](https://github.com/guardian/support-dotcom-components/assets/1513454/af14cfcb-2f57-4c0b-8ec1-eb75c71aa772)
