### PR TITLE
Avoid byline image cropping

### DIFF
--- a/packages/modules/src/modules/epics/BylineWithHeadshot.tsx
+++ b/packages/modules/src/modules/epics/BylineWithHeadshot.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { body } from '@guardian/src-foundations/typography';
 import { BylineWithImage } from '@sdc/shared/types';
 import type { ReactComponent } from '../../types';
+import { until } from '@guardian/src-foundations/mq';
 
 interface BylineWithHeadshotProps {
     bylineWithImage: BylineWithImage;
@@ -24,7 +25,9 @@ const bylineCopyContainer = css`
 `;
 
 const bylineImageContainer = css`
-    width: 30%;
+    ${until.tablet} {
+        max-width: 30%;
+    }
     height: 100%;
     position: absolute;
     top: 0;

--- a/packages/modules/src/modules/epics/BylineWithHeadshot.tsx
+++ b/packages/modules/src/modules/epics/BylineWithHeadshot.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/react';
 import { body } from '@guardian/src-foundations/typography';
 import { BylineWithImage } from '@sdc/shared/types';
 import type { ReactComponent } from '../../types';
-import { until } from '@guardian/src-foundations/mq';
 
 interface BylineWithHeadshotProps {
     bylineWithImage: BylineWithImage;
@@ -25,9 +24,7 @@ const bylineCopyContainer = css`
 `;
 
 const bylineImageContainer = css`
-    ${until.tablet} {
-        max-width: 30%;
-    }
+    max-width: 30%;
     height: 100%;
     position: absolute;
     top: 0;


### PR DESCRIPTION
Currently the byline image always gets cropped, even if you follow the guidance in the RRCP that it should be a square.
This is because we set the width to 30%.
It's necessary to limit the width at mobile, but we don't need to from tablet.

![mobile-small](https://github.com/guardian/support-dotcom-components/assets/1513454/3f71be60-e5e3-43af-92f2-30d521f8f483)
![mobile-medium](https://github.com/guardian/support-dotcom-components/assets/1513454/986f327e-d70f-4bd3-b6b9-a34dc83590a6)
![tablet](https://github.com/guardian/support-dotcom-components/assets/1513454/220b6bd2-052c-469c-b25f-7d5f4f1e4b43)
