### PR TITLE
Fix release with cwd

### DIFF
--- a/.github/workflows/dotcom-components.yml
+++ b/.github/workflows/dotcom-components.yml
@@ -96,7 +96,8 @@ jobs:
       - name: Release
         uses: changesets/action@v1
         with:
-          publish: yarn dotcom changeset publish
+          cwd: packages/dotcom
+          publish: yarn changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
currently the `Release` workflow job fails with:
`Error: There is no .changeset directory in this project`
This is because we're using yarn workspaces.
We can use [`cwd`](https://github.com/changesets/action/tree/main#inputs) to tell changeset to run it from the relevant yarn workspace