### PR TITLE
Fix release - make packages private

### DIFF
--- a/packages/dotcom/.changeset/config.json
+++ b/packages/dotcom/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["@sdc/modules","@sdc/server","@sdc/shared"]

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sdc/modules",
-  "version": "1.0.0",
+  "private": true,
   "license": "MIT",
   "scripts": {
     "prebuild": "tsc --build",

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@sdc/modules",
+  "version": "1.0.0",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sdc/server",
-    "version": "1.0.0",
+    "private": true,
     "license": "MIT",
     "main": "dist/server.js",
     "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@sdc/server",
+    "version": "1.0.0",
     "private": true,
     "license": "MIT",
     "main": "dist/server.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sdc/shared",
   "version": "1.0.0",
+  "private": true,
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
It has been trying to publish the other packages, even though they are listed as excluded in the changeset config file.

This PR makes the other packages private.
Running `yarn changeset publish` locally looks more promising:
<img width="619" alt="Screenshot 2023-11-30 at 10 00 07" src="https://github.com/guardian/support-dotcom-components/assets/1513454/d749e97f-df55-4374-8ea9-7b755dde92f3">


Even though there are no changesets, it was trying to publish a first version because the other packages are not on npm.