### PR TITLE
Add color options to designable banner choice card

### DIFF
--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
@@ -13,12 +13,15 @@ import { ChoiceCardSettings } from './ChoiceCards';
 import type { ReactComponent } from '../../../../types';
 
 const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: number) => {
-    const buttonColour = design?.buttonColour ?? 'transparent';
-    const buttonTextColour = design?.buttonTextColour ?? '#767676';
-    const buttonBorderColour = design?.buttonBorderColour ?? '#999999';
-    const buttonSelectColour = design?.buttonSelectColour ?? '#E3F6FF';
-    const buttonSelectTextColour = design?.buttonSelectTextColour ?? '#062962';
-    const buttonSelectBorderColour = design?.buttonSelectBorderColour ?? '#017ABC';
+    const {
+        buttonColour,
+        buttonTextColour,
+        buttonBorderColour,
+        buttonSelectColour,
+        buttonSelectTextColour,
+        buttonSelectBorderColour,
+    } = design || {};
+
     return {
         hideChoiceCardGroupLegend: css`
             label {
@@ -75,23 +78,27 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
             }
 
             & + label {
-                color: ${buttonTextColour};
-                background-color: ${buttonColour};
-                box-shadow: inset 0 0 0 2px ${buttonBorderColour};
+                ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
+                ${buttonColour ? `background-color: ${buttonColour};` : ''}
+                ${buttonBorderColour ? `box-shadow: inset 0 0 0 2px ${buttonBorderColour};` : ''}
             }
 
             &:hover + label {
-                color: ${buttonTextColour};
-                background-color: ${buttonColour};
-                box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};
+                ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
+                ${buttonColour ? `background-color: ${buttonColour};` : ''}
+                ${buttonBorderColour
+                    ? `box-shadow: inset 0 0 0 2px ${buttonSelectBorderColour};`
+                    : ''}
             }
 
             &:checked + label {
-                background-color: ${buttonSelectColour};
-                box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};
+                ${buttonColour ? `background-color: ${buttonSelectColour};` : ''}
+                ${buttonBorderColour
+                    ? `box-shadow: inset 0 0 0 2px ${buttonSelectBorderColour};`
+                    : ''}
             }
             &:checked + label > * {
-                color: ${buttonSelectTextColour};
+                ${buttonTextColour ? `color: ${buttonSelectTextColour};` : ''}
             }
         `,
         bannerAmountsGroupOverrides: css`
@@ -142,23 +149,27 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
             }
 
             & + label {
-                color: ${buttonTextColour};
-                background-color: ${buttonColour};
-                box-shadow: inset 0 0 0 2px ${buttonBorderColour};
+                ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
+                ${buttonColour ? `background-color: ${buttonColour};` : ''}
+                ${buttonBorderColour ? `box-shadow: inset 0 0 0 2px ${buttonBorderColour};` : ''}
             }
 
             &:hover + label {
-                color: ${buttonTextColour};
-                background-color: ${buttonColour};
-                box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};
+                ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
+                ${buttonColour ? `background-color: ${buttonColour};` : ''}
+                ${buttonBorderColour
+                    ? `box-shadow: inset 0 0 0 2px ${buttonSelectBorderColour};`
+                    : ''}
             }
 
             &:checked + label {
-                background-color: ${buttonSelectColour};
-                box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};
+                ${buttonColour ? `background-color: ${buttonSelectColour};` : ''}
+                ${buttonBorderColour
+                    ? `box-shadow: inset 0 0 0 2px ${buttonSelectBorderColour};`
+                    : ''}
             }
             &:checked + label > * {
-                color: ${buttonSelectTextColour};
+                ${buttonTextColour ? `color: ${buttonSelectTextColour};` : ''}
             }
         `,
     };

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
@@ -71,36 +71,6 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
                 margin-right: 0 !important;
             }
         `,
-        frequencyButtonOverride: css`
-            border-radius: ${space[3]}px;
-            ${until.mobileMedium} {
-                font-size: 10px;
-            }
-
-            & + label {
-                ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
-                ${buttonColour ? `background-color: ${buttonColour};` : ''}
-                ${buttonBorderColour ? `box-shadow: inset 0 0 0 2px ${buttonBorderColour};` : ''}
-            }
-
-            &:hover + label {
-                ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
-                ${buttonColour ? `background-color: ${buttonColour};` : ''}
-                ${buttonSelectBorderColour
-                    ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
-                    : ''}
-            }
-
-            &:checked + label {
-                ${buttonSelectColour ? `background-color: ${buttonSelectColour};` : ''}
-                ${buttonSelectBorderColour
-                    ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
-                    : ''}
-            }
-            &:checked + label > * {
-                ${buttonSelectTextColour ? `color: ${buttonSelectTextColour};` : ''}
-            }
-        `,
         bannerAmountsGroupOverrides: css`
             > div:first-of-type {
                 display: block !important;
@@ -142,34 +112,32 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
             }}
         `,
 
-        amountsButtonOverride: css`
+        buttonOverride: css`
             border-radius: ${space[3]}px;
             ${until.mobileMedium} {
                 font-size: 10px;
             }
 
             & + label {
-                ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
-                ${buttonColour ? `background-color: ${buttonColour};` : ''}
-                ${buttonBorderColour ? `box-shadow: inset 0 0 0 2px ${buttonBorderColour};` : ''}
+                ${buttonTextColour && `color: ${buttonTextColour};`}
+                ${buttonColour && `background-color: ${buttonColour};`}
+                ${buttonBorderColour && `box-shadow: inset 0 0 0 2px ${buttonBorderColour};`}
             }
 
             &:hover + label {
-                ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
-                ${buttonColour ? `background-color: ${buttonColour};` : ''}
-                ${buttonSelectBorderColour
-                    ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
-                    : ''}
+                ${buttonTextColour && `color: ${buttonTextColour};`}
+                ${buttonColour && `background-color: ${buttonColour};`}
+                ${buttonSelectBorderColour &&
+                `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`}
             }
 
             &:checked + label {
-                ${buttonSelectColour ? `background-color: ${buttonSelectColour};` : ''}
-                ${buttonSelectBorderColour
-                    ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
-                    : ''}
+                ${buttonSelectColour && `background-color: ${buttonSelectColour};`}
+                ${buttonSelectBorderColour &&
+                `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`}
             }
             &:checked + label > * {
-                ${buttonSelectTextColour ? `color: ${buttonSelectTextColour};` : ''}
+                ${buttonSelectTextColour && `color: ${buttonSelectTextColour};`}
             }
         `,
     };
@@ -250,7 +218,7 @@ export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> =
                     id={`contributions-banner-${amount}`}
                     checked={selection.amount === amount}
                     onChange={() => updateAmount(amount)}
-                    cssOverrides={style.amountsButtonOverride}
+                    cssOverrides={style.buttonOverride}
                 />
             );
         }
@@ -270,7 +238,7 @@ export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> =
                         label="Other"
                         id="contributions-banner-third"
                         checked={true}
-                        cssOverrides={style.amountsButtonOverride}
+                        cssOverrides={style.buttonOverride}
                     />
                 </div>
             );
@@ -294,7 +262,7 @@ export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> =
                             id="contributions-banner-other"
                             checked={selection.amount === 'other'}
                             onChange={() => updateAmount('other')}
-                            cssOverrides={style.amountsButtonOverride}
+                            cssOverrides={style.buttonOverride}
                         />
                     </div>
                 )}
@@ -312,7 +280,7 @@ export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> =
                 id={`contributions-banner-${frequency}`}
                 checked={selection.frequency === frequency}
                 onChange={() => updateFrequency(frequency)}
-                cssOverrides={style.frequencyButtonOverride}
+                cssOverrides={style.buttonOverride}
             />
         );
     };

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
@@ -86,19 +86,19 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
             &:hover + label {
                 ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
                 ${buttonColour ? `background-color: ${buttonColour};` : ''}
-                ${buttonBorderColour
+                ${buttonSelectBorderColour
                     ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
                     : ''}
             }
 
             &:checked + label {
-                ${buttonColour ? `background-color: ${buttonSelectColour};` : ''}
-                ${buttonBorderColour
+                ${buttonSelectColour ? `background-color: ${buttonSelectColour};` : ''}
+                ${buttonSelectBorderColour
                     ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
                     : ''}
             }
             &:checked + label > * {
-                ${buttonTextColour ? `color: ${buttonSelectTextColour};` : ''}
+                ${buttonSelectTextColour ? `color: ${buttonSelectTextColour};` : ''}
             }
         `,
         bannerAmountsGroupOverrides: css`
@@ -157,19 +157,19 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
             &:hover + label {
                 ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
                 ${buttonColour ? `background-color: ${buttonColour};` : ''}
-                ${buttonBorderColour
+                ${buttonSelectBorderColour
                     ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
                     : ''}
             }
 
             &:checked + label {
-                ${buttonColour ? `background-color: ${buttonSelectColour};` : ''}
-                ${buttonBorderColour
+                ${buttonSelectColour ? `background-color: ${buttonSelectColour};` : ''}
+                ${buttonSelectBorderColour
                     ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
                     : ''}
             }
             &:checked + label > * {
-                ${buttonTextColour ? `color: ${buttonSelectTextColour};` : ''}
+                ${buttonSelectTextColour ? `color: ${buttonSelectTextColour};` : ''}
             }
         `,
     };

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
@@ -87,14 +87,14 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
                 ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
                 ${buttonColour ? `background-color: ${buttonColour};` : ''}
                 ${buttonBorderColour
-                    ? `box-shadow: inset 0 0 0 2px ${buttonSelectBorderColour};`
+                    ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
                     : ''}
             }
 
             &:checked + label {
                 ${buttonColour ? `background-color: ${buttonSelectColour};` : ''}
                 ${buttonBorderColour
-                    ? `box-shadow: inset 0 0 0 2px ${buttonSelectBorderColour};`
+                    ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
                     : ''}
             }
             &:checked + label > * {
@@ -158,14 +158,14 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
                 ${buttonTextColour ? `color: ${buttonTextColour};` : ''}
                 ${buttonColour ? `background-color: ${buttonColour};` : ''}
                 ${buttonBorderColour
-                    ? `box-shadow: inset 0 0 0 2px ${buttonSelectBorderColour};`
+                    ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
                     : ''}
             }
 
             &:checked + label {
                 ${buttonColour ? `background-color: ${buttonSelectColour};` : ''}
                 ${buttonBorderColour
-                    ? `box-shadow: inset 0 0 0 2px ${buttonSelectBorderColour};`
+                    ? `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`
                     : ''}
             }
             &:checked + label > * {

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
@@ -14,7 +14,11 @@ import type { ReactComponent } from '../../../../types';
 
 const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: number) => {
     const buttonColour = design?.buttonColour ?? 'transparent';
-
+    const buttonTextColour = design?.buttonTextColour ?? '#767676';
+    const buttonBorderColour = design?.buttonBorderColour ?? '#999999';
+    const buttonSelectColour = design?.buttonSelectColour ?? '#E3F6FF';
+    const buttonSelectTextColour = design?.buttonSelectTextColour ?? '#062962';
+    const buttonSelectBorderColour = design?.buttonSelectBorderColour ?? '#017ABC';
     return {
         hideChoiceCardGroupLegend: css`
             label {
@@ -53,7 +57,6 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
                 margin-right: ${space[2]}px !important;
                 margin-bottom: ${space[3]}px !important;
                 min-width: 0;
-                background-color: ${buttonColour};
             }
 
             > label > div {
@@ -63,6 +66,32 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
 
             > label:last-of-type {
                 margin-right: 0 !important;
+            }
+        `,
+        frequencyButtonOverride: css`
+            border-radius: ${space[3]}px;
+            ${until.mobileMedium} {
+                font-size: 10px;
+            }
+
+            & + label {
+                color: ${buttonTextColour};
+                background-color: ${buttonColour};
+                box-shadow: inset 0 0 0 2px ${buttonBorderColour};
+            }
+
+            &:hover + label {
+                color: ${buttonTextColour};
+                background-color: ${buttonColour};
+                box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};
+            }
+
+            &:checked + label {
+                background-color: ${buttonSelectColour};
+                box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};
+            }
+            &:checked + label > * {
+                color: ${buttonSelectTextColour};
             }
         `,
         bannerAmountsGroupOverrides: css`
@@ -81,7 +110,6 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
 
             > label {
                 margin: 0 !important;
-                background-color: ${buttonColour};
             }
 
             > label:first-of-type {
@@ -102,10 +130,6 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
         amountsOrOtherButton: css`
             margin-bottom: ${space[1]}px;
 
-            > label {
-                background-color: ${buttonColour};
-            }
-
             ${from.mobileLandscape} { 
                 margin-bottom: ${space[3]}px;
             }}
@@ -115,6 +139,26 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
             border-radius: ${space[3]}px;
             ${until.mobileMedium} {
                 font-size: 10px;
+            }
+
+            & + label {
+                color: ${buttonTextColour};
+                background-color: ${buttonColour};
+                box-shadow: inset 0 0 0 2px ${buttonBorderColour};
+            }
+
+            &:hover + label {
+                color: ${buttonTextColour};
+                background-color: ${buttonColour};
+                box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};
+            }
+
+            &:checked + label {
+                background-color: ${buttonSelectColour};
+                box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};
+            }
+            &:checked + label > * {
+                color: ${buttonSelectTextColour};
             }
         `,
     };
@@ -257,6 +301,7 @@ export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> =
                 id={`contributions-banner-${frequency}`}
                 checked={selection.frequency === frequency}
                 onChange={() => updateFrequency(frequency)}
+                cssOverrides={style.frequencyButtonOverride}
             />
         );
     };

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
@@ -12,6 +12,11 @@ import { ChoiceCardSelection } from '../../../shared/helpers/choiceCards';
 
 export interface ChoiceCardSettings {
     buttonColour?: string;
+    buttonTextColour?: string;
+    buttonBorderColour?: string;
+    buttonSelectColour?: string;
+    buttonSelectTextColour?: string;
+    buttonSelectBorderColour?: string;
 }
 
 interface ChoiceCardProps {

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -56,9 +56,29 @@ const buildHeaderImageSettings = (design: ConfigurableDesign): Image | undefined
 
 const buildChoiceCardSettings = (design: ConfigurableDesign): ChoiceCardSettings | undefined => {
     if (design.visual?.kind === 'ChoiceCards') {
-        const { buttonColour } = design.visual;
+        const {
+            buttonColour,
+            buttonTextColour,
+            buttonBorderColour,
+            buttonSelectColour,
+            buttonSelectTextColour,
+            buttonSelectBorderColour,
+        } = design.visual;
         return {
             buttonColour: buttonColour ? hexColourToString(buttonColour) : undefined,
+            buttonTextColour: buttonTextColour ? hexColourToString(buttonTextColour) : undefined,
+            buttonBorderColour: buttonBorderColour
+                ? hexColourToString(buttonBorderColour)
+                : undefined,
+            buttonSelectColour: buttonSelectColour
+                ? hexColourToString(buttonSelectColour)
+                : undefined,
+            buttonSelectTextColour: buttonSelectTextColour
+                ? hexColourToString(buttonSelectTextColour)
+                : undefined,
+            buttonSelectBorderColour: buttonSelectBorderColour
+                ? hexColourToString(buttonSelectBorderColour)
+                : undefined,
         };
     }
     return undefined;

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -260,7 +260,7 @@ DesignTwoRegularAmounts.args = {
         ...design,
         visual: {
             kind: 'ChoiceCards',
-            // buttonColour: stringToHexColour('E5E5E5'),
+            buttonColour: stringToHexColour('E5E5E5'),
         },
     },
     choiceCardAmounts: regularChoiceCardAmounts,
@@ -277,7 +277,6 @@ DesignTwoEdgeCaseAmounts.args = {
         ...design,
         visual: {
             kind: 'ChoiceCards',
-            // buttonColour: stringToHexColour('E5E5E5'),
             buttonColour: stringToHexColour('883333'),
             buttonTextColour: stringToHexColour('FFFFFF'),
             buttonBorderColour: stringToHexColour('8888FF'),
@@ -301,7 +300,7 @@ DesignThreeHeaderImageOnly.args = {
         headerImage,
         visual: {
             kind: 'ChoiceCards',
-            // buttonColour: stringToHexColour('E5E5E5'),
+            buttonColour: stringToHexColour('E5E5E5'),
         },
         colours: {
             ...design.colours,
@@ -326,7 +325,7 @@ DesignFourHeaderImageAndCopy.args = {
         headerImage,
         visual: {
             kind: 'ChoiceCards',
-            // buttonColour: stringToHexColour('E5E5E5'),
+            buttonColour: stringToHexColour('E5E5E5'),
         },
         colours: {
             ...design.colours,

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -260,7 +260,7 @@ DesignTwoRegularAmounts.args = {
         ...design,
         visual: {
             kind: 'ChoiceCards',
-            buttonColour: stringToHexColour('E5E5E5'),
+            // buttonColour: stringToHexColour('E5E5E5'),
         },
     },
     choiceCardAmounts: regularChoiceCardAmounts,
@@ -277,7 +277,13 @@ DesignTwoEdgeCaseAmounts.args = {
         ...design,
         visual: {
             kind: 'ChoiceCards',
-            buttonColour: stringToHexColour('E5E5E5'),
+            // buttonColour: stringToHexColour('E5E5E5'),
+            buttonColour: stringToHexColour('883333'),
+            buttonTextColour: stringToHexColour('FFFFFF'),
+            buttonBorderColour: stringToHexColour('8888FF'),
+            buttonSelectColour: stringToHexColour('338833'),
+            buttonSelectTextColour: stringToHexColour('FFFF88'),
+            buttonSelectBorderColour: stringToHexColour('88FF88'),
         },
     },
     choiceCardAmounts: edgeCaseChoiceCardAmounts,
@@ -295,7 +301,7 @@ DesignThreeHeaderImageOnly.args = {
         headerImage,
         visual: {
             kind: 'ChoiceCards',
-            buttonColour: stringToHexColour('E5E5E5'),
+            // buttonColour: stringToHexColour('E5E5E5'),
         },
         colours: {
             ...design.colours,
@@ -320,7 +326,7 @@ DesignFourHeaderImageAndCopy.args = {
         headerImage,
         visual: {
             kind: 'ChoiceCards',
-            buttonColour: stringToHexColour('E5E5E5'),
+            // buttonColour: stringToHexColour('E5E5E5'),
         },
         colours: {
             ...design.colours,

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -28,6 +28,11 @@ const imageSchema = z.object({
 
 const choiceCardsSchema = z.object({
     buttonColour: z.optional(hexColourSchema),
+    buttonTextColour: z.optional(hexColourSchema),
+    buttonBorderColour: z.optional(hexColourSchema),
+    buttonSelectColour: z.optional(hexColourSchema),
+    buttonSelectTextColour: z.optional(hexColourSchema),
+    buttonSelectBorderColour: z.optional(hexColourSchema),
     kind: z.literal('ChoiceCards'),
 });
 
@@ -106,6 +111,11 @@ export interface BannerDesignImage extends BannerDesignHeaderImage {
 interface ChoiceCardsDesign {
     kind: 'ChoiceCards';
     buttonColour?: HexColour;
+    buttonTextColour?: HexColour;
+    buttonBorderColour?: HexColour;
+    buttonSelectColour?: HexColour;
+    buttonSelectTextColour?: HexColour;
+    buttonSelectBorderColour?: HexColour;
 }
 type Visual = BannerDesignImage | ChoiceCardsDesign;
 


### PR DESCRIPTION
## What does this change?
Currently the designable banner tool only allows the choice card button background color to be set. This PR extends that functionality to allow choice card button background, text and border colors to be set via the tool.

See related PR in SAC: https://github.com/guardian/support-admin-console/pull/541

## How to test
In SDC Storybook, and in RRCP CODE site (when both this PR and the accompanying SAC PR have been deployed to CODE).

## Images

**Using default colors** - no colors have been set for the amounts card design
![Screenshot 2023-12-20 at 11 41 33](https://github.com/guardian/support-dotcom-components/assets/5357530/3bbea424-d83e-4c8c-8aeb-ac3815b3a2fe)

**Using tool-defined colors**
![Screenshot 2023-12-20 at 11 41 50](https://github.com/guardian/support-dotcom-components/assets/5357530/40e8571b-636e-4b77-a9c2-dbf5292091f4)

