### PR TITLE
More exports to support migration of epic to DCR

### DIFF
--- a/packages/dotcom/.changeset/happy-garlics-sniff.md
+++ b/packages/dotcom/.changeset/happy-garlics-sniff.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+More exports to support migration of epic to DCR

--- a/packages/dotcom/src/index.ts
+++ b/packages/dotcom/src/index.ts
@@ -7,7 +7,11 @@ export {
 export * from '../../shared/src/lib/geolocation';
 export * from '../../shared/src/lib/viewLog';
 export * from '../../shared/src/lib/reminderFields';
-export { SecondaryCtaType, TickerCountType, TickerEndType } from '../../shared/src/types/props/shared';
+export {
+    SecondaryCtaType,
+    TickerCountType,
+    TickerEndType,
+} from '../../shared/src/types/props/shared';
 export { contributionTabFrequencies } from '../../shared/src/types/abTests/epic';
 export { epicPropsSchema } from '../../shared/src/types/props/epic';
 export * from './requests';

--- a/packages/dotcom/src/index.ts
+++ b/packages/dotcom/src/index.ts
@@ -7,5 +7,7 @@ export {
 export * from '../../shared/src/lib/geolocation';
 export * from '../../shared/src/lib/viewLog';
 export * from '../../shared/src/lib/reminderFields';
-export { SecondaryCtaType } from '../../shared/src/types/props/shared';
+export { SecondaryCtaType, TickerCountType, TickerEndType } from '../../shared/src/types/props/shared';
+export { contributionTabFrequencies } from '../../shared/src/types/abTests/epic';
+export { epicPropsSchema } from '../../shared/src/types/props/epic';
 export * from './requests';


### PR DESCRIPTION
I'm working on [migrating](https://github.com/guardian/dotcom-rendering/pull/9959) the epic component to DCR