### PR TITLE
Use correct componentType for epic clicks

### DIFF
--- a/packages/modules/src/modules/epics/utils/ophan.ts
+++ b/packages/modules/src/modules/epics/utils/ophan.ts
@@ -61,7 +61,7 @@ export const OPHAN_COMPONENT_EVENT_APPLEPAY_CTA: OphanComponentEvent = {
 
 export const OPHAN_COMPONENT_EVENT_PRIMARY_CTA: OphanComponentEvent = {
     component: {
-        componentType: 'ACQUISITIONS_OTHER',
+        componentType: 'ACQUISITIONS_EPIC',
         id: OPHAN_COMPONENT_ID_PRIMARY_CTA,
     },
     action: 'CLICK',


### PR DESCRIPTION
It's useful to be able to track clicks of the primary CTA on our channels (epic/banner/header links).

This has [just been reintroduced](https://github.com/guardian/support-dotcom-components/pull/1027) for the banner.

For the epic, the primary CTA clicks are being tracked against the `ACQUISITIONS_OTHER` componentType, but it's better to use `ACQUISITIONS_EPIC`.

This will help with a grafana dashboard + alerts that we're building.

![Screenshot 2024-01-03 at 14 44 32](https://github.com/guardian/support-dotcom-components/assets/1513454/8826f25f-e1b3-415e-bdbb-b2488092daca)
