### PR TITLE
Fix epic ctas view event

### DIFF
--- a/packages/modules/src/modules/epics/utils/ophan.ts
+++ b/packages/modules/src/modules/epics/utils/ophan.ts
@@ -32,7 +32,7 @@ export const OPHAN_COMPONENT_EVENT_CTAS_VIEW: OphanComponentEvent = {
         componentType: 'ACQUISITIONS_OTHER',
         id: OPHAN_COMPONENT_ID_CTAS_VIEW,
     },
-    action: 'CLICK',
+    action: 'VIEW',
 };
 
 export const OPHAN_COMPONENT_EVENT_APPLEPAY_VIEW: OphanComponentEvent = {


### PR DESCRIPTION
This event tracks when the ctas component of the epic comes into view. It incorrectly has action `CLICK`.
We get over 1m of these events per day so it's quite misleading