### PR TITLE
Add r.thegulocal.com to allowed origins

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -31,7 +31,11 @@ const buildApp = async (): Promise<Express> => {
     app.use(express.json({ limit: '50mb' }));
     app.use(compression());
 
-    const dotcomDevOrigins = ['http://localhost:3030', 'http://localhost:9000'];
+    const dotcomDevOrigins = [
+        'https://r.thegulocal.com',
+        'http://localhost:3030',
+        'http://localhost:9000',
+    ];
     const corsOrigin = () => {
         switch (process.env.stage) {
             case 'PROD':

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -32,6 +32,7 @@ const buildApp = async (): Promise<Express> => {
     app.use(compression());
 
     const dotcomDevOrigins = [
+        // see: https://github.com/guardian/dotcom-rendering/blob/f05969110b0ab9af18041bbe537f93f98d28ad8f/dotcom-rendering/scripts/nginx/setup.sh#L11
         'https://r.thegulocal.com',
         'http://localhost:3030',
         'http://localhost:9000',


### PR DESCRIPTION
We use `https://r.thegulocal.com` when running DCR locally. This change is necessary to avoid CORS errors when making requests to SDC