### PR TITLE
Hide payment icons not support cta

### DIFF
--- a/packages/modules/src/modules/banners/contributions/ContributionsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBanner.stories.tsx
@@ -28,3 +28,14 @@ WithReminder.args = {
         },
     },
 };
+
+export const WithNonSupportUrl = Template.bind({});
+WithNonSupportUrl.args = {
+    content: {
+        ...content,
+        cta: {
+            baseUrl: 'theguardian.com',
+            text: 'Continue to the Guardian',
+        },
+    },
+};

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCtas.tsx
@@ -8,6 +8,7 @@ import { PaymentCards } from '../../common/PaymentCards';
 import { buttonStyles } from '../styles/buttonStyles';
 import { CtaSettings } from '../settings';
 import { from } from '@guardian/src-foundations/mq';
+import { isSupportUrl } from '@sdc/shared/src/lib';
 
 interface DesignableBannerCtasProps {
     mainOrMobileContent: BannerRenderedContent;
@@ -27,6 +28,7 @@ export function DesignableBannerCtas({
     secondaryCtaSettings,
 }: DesignableBannerCtasProps): JSX.Element {
     const { primaryCta, secondaryCta } = mainOrMobileContent;
+    const hasSupportCta = primaryCta ? isSupportUrl(primaryCta.ctaUrl) : false;
 
     return (
         <div>
@@ -66,7 +68,7 @@ export function DesignableBannerCtas({
                 )}
             </div>
 
-            <div>{primaryCta && <PaymentCards />}</div>
+            <div>{primaryCta && hasSupportCta && <PaymentCards />}</div>
         </div>
     );
 }

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCtas.tsx
@@ -8,7 +8,7 @@ import { PaymentCards } from '../../common/PaymentCards';
 import { buttonStyles } from '../styles/buttonStyles';
 import { CtaSettings } from '../settings';
 import { from } from '@guardian/src-foundations/mq';
-import { isSupportUrl } from '@sdc/shared/src/lib';
+import { isSupportUrl } from '@sdc/shared/dist/lib';
 
 interface DesignableBannerCtasProps {
     mainOrMobileContent: BannerRenderedContent;

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -350,3 +350,21 @@ NoChoiceCardOrImage.args = {
     },
     tickerSettings: undefined,
 };
+
+export const WithNonSupportUrl = DefaultTemplate.bind({});
+WithNonSupportUrl.args = {
+    ...props,
+    content: {
+        ...contentWithHeading,
+        cta: {
+            baseUrl: 'theguardian.com',
+            text: 'Continue to the Guardian',
+        },
+    },
+    numArticles: 50,
+    design: {
+        ...design,
+        visual: undefined,
+    },
+    tickerSettings: undefined,
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Checks the baseUrl of the primary CTA in designable banners - if url is not to the support site we do not show the payment icons.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test



<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/a7fb5e93-b8f1-45ef-aec9-f942a9b5ab54)

After
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/52fb705f-032a-4043-b889-070b47e2a3d2)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
