### PR TITLE
Mock the date in Chromatic tests

### DIFF
--- a/packages/modules/.storybook/preview.js
+++ b/packages/modules/.storybook/preview.js
@@ -2,8 +2,14 @@ import React, { useEffect } from 'react';
 import { FocusStyleManager } from '@guardian/src-foundations/utils';
 import { breakpoints } from '@guardian/src-foundations';
 import { StylesDecorator } from './StylesDecorator';
+import isChromatic from 'chromatic/isChromatic';
+import MockDate from 'mockdate';
 
 const isProd = process.env.NODE_ENV === 'production';
+
+if (isChromatic()){
+    MockDate.set('1 Jan 2024');
+}
 
 const viewportMeta = {
     mobile: {

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -53,6 +53,7 @@
     "@types/react-dom": "18.0.11",
     "babel-loader": "^9.1.3",
     "chromatic": "^5.10.2",
+    "mockdate": "3.0.5",
     "nodemon": "^2.0.4",
     "react-docgen-typescript-loader": "^3.6.0",
     "rollup": "^2.10.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11456,6 +11456,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mockdate@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 moment@^2.18.1:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Mocks the date to a set date so this doesn't happen: 

![image](https://github.com/guardian/support-dotcom-components/assets/114918544/a1558e04-1ae5-4f29-b267-ac1e86c56351)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
