### PR TITLE
Fix media eventListener on old safari

### DIFF
--- a/packages/modules/src/hooks/useMediaQuery.ts
+++ b/packages/modules/src/hooks/useMediaQuery.ts
@@ -16,21 +16,20 @@ const useMediaQuery = (breakpoint: string): boolean => {
             setMatches(media.matches);
         }
 
-        try {
-            // Chrome & Firefox
+        if (media.addEventListener) {
             media.addEventListener('change', handleChange);
-        } catch (e1) {
-            try {
-                // Safari - addEventListener supported from v14
-                media.addListener(handleChange);
-            } catch (e2) {
-                console.error(e2);
-            }
+        } else if (media.addListener) {
+            // Safari - addEventListener supported from v14
+            media.addListener(handleChange);
         }
 
         return () => {
-            media.removeEventListener('change', handleChange);
-            media.removeListener(handleChange);
+            if (media.removeEventListener) {
+                media.removeEventListener('change', handleChange);
+            } else if (media.removeListener) {
+                // Safari - removeEventListener supported from v14
+                media.removeListener(handleChange);
+            }
         };
     }, [matches, query]);
 


### PR DESCRIPTION
On iOS 13 devices the DesignableBanner and MomentTemplateBanner components have a bug in the close button.

When a user clicks close, the banner is not immediately removed. On subsequent pageviews (e.g. refreshing the page) the banner is no longer displayed. This is because the localstorage item for recording when the banner was closed _is_ set.

The error in the console is:
`Unhandled Promise Rejection: TypeError: o.removeEventListener is not a function. (In 'o.removeEventListener("change",r)', 'o.removeEventListener' is undefined)`

The issue is the use of the `removeEventListener`, which is not available on old browsers.
There is already similar logic for handling `addEventListener`, and I've refactored this slightly at the same time.