### PR TITLE
Use the full ‘The Guardian’ logo at the bottom right and remove the roundel from the top right

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -28,6 +28,7 @@ import { buttonStyles } from './styles/buttonStyles';
 import { BannerTemplateSettings } from './settings';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import type { ReactComponent } from '../../../types';
+import { SvgGuardianLogo } from '@guardian/src-brand';
 
 const buildImageSettings = (
     design: BannerDesignImage | BannerDesignHeaderImage,
@@ -229,7 +230,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                     settings={templateSettings.closeButtonSettings}
                     styleOverides={styles.closeButtonOverrides}
                 />
-
                 <div css={getHeaderContainerCss()}>
                     <DesignableBannerHeader
                         heading={content.mainContent.heading}
@@ -237,7 +237,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         headerSettings={templateSettings.headerSettings}
                     />
                 </div>
-
                 <div css={styles.contentContainer}>
                     {separateArticleCount && Number(numArticles) > 5 && (
                         <DesignableBannerArticleCount
@@ -274,7 +273,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         </section>
                     )}
                 </div>
-
                 <div
                     css={styles.bannerVisualContainer(
                         templateSettings.containerSettings.backgroundColour,
@@ -309,6 +307,21 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                             onCtaClick={onCtaClick}
                         />
                     )}
+                </div>
+                <div
+                    css={css`
+                        display: none;
+                        position: fixed;
+                        right: 0;
+                        margin-right: ${space[5]}px;
+                        align-self: end;
+                        ${from.tablet} {
+                            display: block;
+                            width: 100px;
+                        }
+                    `}
+                >
+                    <SvgGuardianLogo />
                 </div>
             </div>
             {mainOrMobileContent.secondaryCta?.type === SecondaryCtaType.ContributionsReminder &&

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -29,7 +29,6 @@ import { BannerTemplateSettings } from './settings';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import type { ReactComponent } from '../../../types';
 import { SvgGuardianLogo } from '@guardian/src-brand';
-import { Hide } from '@guardian/src-layout';
 
 const buildImageSettings = (
     design: BannerDesignImage | BannerDesignHeaderImage,
@@ -309,11 +308,9 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         />
                     )}
                 </div>
-                <Hide below="tablet">
-                    <div css={styles.guardianLogoContainer}>
-                        <SvgGuardianLogo />
-                    </div>
-                </Hide>
+                <div css={styles.guardianLogoContainer}>
+                    <SvgGuardianLogo />
+                </div>
             </div>
             {mainOrMobileContent.secondaryCta?.type === SecondaryCtaType.ContributionsReminder &&
                 isReminderActive && (
@@ -438,7 +435,11 @@ const styles = {
         flex-direction: row;
     `,
     guardianLogoContainer: css`
-        width: 100px;
+        display: none;
+        ${from.tablet} {
+            display: block;
+            width: 100px;
+        }
         grid-column: 2 / span 1;
         grid-row: 3 / span 1;
         position: fixed;

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -445,6 +445,7 @@ const styles = {
         position: fixed;
         right: 0;
         margin-right: ${space[5]}px;
+        padding-top: ${space[3]}px;
     `,
 };
 

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -352,7 +352,7 @@ const styles = {
             position: static;
             display: grid;
             grid-template-columns: 1.5fr 1fr;
-            grid-template-rows: auto 1fr auto;
+            grid-template-rows: auto 1fr 32px;
             column-gap: ${space[5]}px;
             position: relative;
             width: 100%;
@@ -442,7 +442,9 @@ const styles = {
         }
         grid-column: 2 / span 1;
         grid-row: 3 / span 1;
-        justify-self: end;
+        position: fixed;
+        right: 0;
+        margin-right: ${space[5]}px;
     `,
 };
 

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -442,8 +442,7 @@ const styles = {
         }
         grid-column: 2 / span 1;
         grid-row: 3 / span 1;
-        position: fixed;
-        right: 0;
+        justify-self: end;
         margin-right: ${space[5]}px;
         padding-top: ${space[3]}px;
     `,

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -308,19 +308,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         />
                     )}
                 </div>
-                <div
-                    css={css`
-                        display: none;
-                        position: fixed;
-                        right: 0;
-                        margin-right: ${space[5]}px;
-                        align-self: end;
-                        ${from.tablet} {
-                            display: block;
-                            width: 100px;
-                        }
-                    `}
-                >
+                <div css={styles.guardianLogoContainer}>
                     <SvgGuardianLogo />
                 </div>
             </div>
@@ -364,7 +352,7 @@ const styles = {
             position: static;
             display: grid;
             grid-template-columns: 1.5fr 1fr;
-            grid-template-rows: auto 1fr;
+            grid-template-rows: auto 1fr auto;
             column-gap: ${space[5]}px;
             position: relative;
             width: 100%;
@@ -445,6 +433,16 @@ const styles = {
     ctasContainer: css`
         display: flex;
         flex-direction: row;
+    `,
+    guardianLogoContainer: css`
+        display: none;
+        ${from.tablet} {
+            display: block;
+            width: 100px;
+        }
+        grid-column: 2 / span 1;
+        grid-row: 3 / span 1;
+        justify-self: end;
     `,
 };
 

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -412,7 +412,7 @@ const styles = {
         order: 2;
         ${from.tablet} {
             grid-column: 1 / span 1;
-            grid-row: 2 / span 1;
+            grid-row: 2 / span 2;
         }
     `,
     bannerVisualContainer: (background: string, isChoiceCardsContainer?: boolean) => css`

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -29,6 +29,7 @@ import { BannerTemplateSettings } from './settings';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import type { ReactComponent } from '../../../types';
 import { SvgGuardianLogo } from '@guardian/src-brand';
+import { Hide } from '@guardian/src-layout';
 
 const buildImageSettings = (
     design: BannerDesignImage | BannerDesignHeaderImage,
@@ -308,9 +309,11 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         />
                     )}
                 </div>
-                <div css={styles.guardianLogoContainer}>
-                    <SvgGuardianLogo />
-                </div>
+                <Hide below="tablet">
+                    <div css={styles.guardianLogoContainer}>
+                        <SvgGuardianLogo />
+                    </div>
+                </Hide>
             </div>
             {mainOrMobileContent.secondaryCta?.type === SecondaryCtaType.ContributionsReminder &&
                 isReminderActive && (
@@ -435,11 +438,7 @@ const styles = {
         flex-direction: row;
     `,
     guardianLogoContainer: css`
-        display: none;
-        ${from.tablet} {
-            display: block;
-            width: 100px;
-        }
+        width: 100px;
         grid-column: 2 / span 1;
         grid-row: 3 / span 1;
         position: fixed;

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -4,9 +4,6 @@ import { SvgCross } from '@guardian/src-icons';
 import { Button } from '@guardian/src-button';
 import { buttonStyles } from '../styles/buttonStyles';
 import { CtaSettings } from '../settings';
-import { SvgRoundelBrand, SvgRoundelDefault, SvgRoundelInverse } from '@guardian/src-brand';
-import { from } from '@guardian/src-foundations/mq';
-import { space } from '@guardian/src-foundations';
 
 interface DesignableBannerCloseButtonProps {
     onCloseClick: () => void;
@@ -19,27 +16,12 @@ export function DesignableBannerCloseButton({
     settings,
     styleOverides,
 }: DesignableBannerCloseButtonProps): JSX.Element {
-    const { guardianRoundel } = settings;
-
-    const getRoundel = () => {
-        switch (guardianRoundel) {
-            case 'brand':
-                return <SvgRoundelBrand />;
-            case 'inverse':
-                return <SvgRoundelInverse />;
-            default:
-                return <SvgRoundelDefault />;
-        }
-    };
-
     return (
         <div
             css={css`
                 ${styles.container} ${styleOverides || ''}
             `}
         >
-            <div css={styles.roundelContainer}>{getRoundel()}</div>
-
             <Button
                 onClick={onCloseClick}
                 cssOverrides={buttonStyles(settings, styles.closeButtonOverrides)}
@@ -60,20 +42,6 @@ const styles = {
         right: 0;
         padding-right: 20px;
         z-index: 100;
-    `,
-    roundelContainer: css`
-        display: none;
-        height: 40px;
-
-        svg {
-            height: 40px;
-            width: 40px;
-        }
-
-        ${from.tablet} {
-            display: block;
-            margin-right: ${space[2]}px;
-        }
     `,
     closeButtonOverrides: css`
         height: 40px;

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -22,7 +22,6 @@ import { buttonStyles } from './styles/buttonStyles';
 import { ReactComponent } from '../../../types';
 import { Image } from '@sdc/shared/dist/types';
 import { SvgGuardianLogo } from '@guardian/src-brand';
-import { Hide } from '@guardian/src-layout';
 
 export function getMomentTemplateBanner(
     templateSettings: BannerTemplateSettings,
@@ -149,11 +148,9 @@ export function getMomentTemplateBanner(
                             />
                         )}
                     </div>
-                    <Hide below="tablet">
-                        <div css={styles.guardianLogoContainer}>
-                            <SvgGuardianLogo />
-                        </div>
-                    </Hide>
+                    <div css={styles.guardianLogoContainer}>
+                        <SvgGuardianLogo />
+                    </div>
                 </div>
                 {mainOrMobileContent.secondaryCta?.type ===
                     SecondaryCtaType.ContributionsReminder &&
@@ -289,7 +286,11 @@ const styles = {
         flex-direction: row;
     `,
     guardianLogoContainer: css`
-        width: 100px;
+        display: none;
+        ${from.tablet} {
+            display: block;
+            width: 100px;
+        }
         grid-column: 2 / span 1;
         grid-row: 3 / span 1;
         position: fixed;

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -21,6 +21,7 @@ import { ChoiceCards } from '../common/choiceCard/ChoiceCards';
 import { buttonStyles } from './styles/buttonStyles';
 import { ReactComponent } from '../../../types';
 import { Image } from '@sdc/shared/dist/types';
+import { SvgGuardianLogo } from '@guardian/src-brand';
 
 export function getMomentTemplateBanner(
     templateSettings: BannerTemplateSettings,
@@ -147,6 +148,9 @@ export function getMomentTemplateBanner(
                             />
                         )}
                     </div>
+                    <div css={styles.guardianLogoContainer}>
+                        <SvgGuardianLogo />
+                    </div>
                 </div>
                 {mainOrMobileContent.secondaryCta?.type ===
                     SecondaryCtaType.ContributionsReminder &&
@@ -214,7 +218,7 @@ const styles = {
             position: static;
             display: grid;
             grid-template-columns: 1.5fr 1fr;
-            grid-template-rows: auto 1fr;
+            grid-template-rows: auto 1fr 32px;
             column-gap: ${space[5]}px;
             position: relative;
             width: 100%;
@@ -280,5 +284,18 @@ const styles = {
     ctasContainer: css`
         display: flex;
         flex-direction: row;
+    `,
+    guardianLogoContainer: css`
+        display: none;
+        ${from.tablet} {
+            display: block;
+            width: 100px;
+        }
+        grid-column: 2 / span 1;
+        grid-row: 3 / span 1;
+        position: fixed;
+        right: 0;
+        margin-right: ${space[5]}px;
+        padding-top: ${space[3]}px;
     `,
 };

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -22,6 +22,7 @@ import { buttonStyles } from './styles/buttonStyles';
 import { ReactComponent } from '../../../types';
 import { Image } from '@sdc/shared/dist/types';
 import { SvgGuardianLogo } from '@guardian/src-brand';
+import { Hide } from '@guardian/src-layout';
 
 export function getMomentTemplateBanner(
     templateSettings: BannerTemplateSettings,
@@ -148,9 +149,11 @@ export function getMomentTemplateBanner(
                             />
                         )}
                     </div>
-                    <div css={styles.guardianLogoContainer}>
-                        <SvgGuardianLogo />
-                    </div>
+                    <Hide below="tablet">
+                        <div css={styles.guardianLogoContainer}>
+                            <SvgGuardianLogo />
+                        </div>
+                    </Hide>
                 </div>
                 {mainOrMobileContent.secondaryCta?.type ===
                     SecondaryCtaType.ContributionsReminder &&
@@ -286,11 +289,7 @@ const styles = {
         flex-direction: row;
     `,
     guardianLogoContainer: css`
-        display: none;
-        ${from.tablet} {
-            display: block;
-            width: 100px;
-        }
+        width: 100px;
         grid-column: 2 / span 1;
         grid-row: 3 / span 1;
         position: fixed;

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -4,9 +4,6 @@ import { SvgCross } from '@guardian/src-icons';
 import { Button } from '@guardian/src-button';
 import { buttonStyles } from '../styles/buttonStyles';
 import { CtaSettings } from '../settings';
-import { SvgRoundelBrand, SvgRoundelDefault, SvgRoundelInverse } from '@guardian/src-brand';
-import { from } from '@guardian/src-foundations/mq';
-import { space } from '@guardian/src-foundations';
 
 interface MomentTemplateBannerCloseButtonProps {
     onCloseClick: () => void;
@@ -19,33 +16,12 @@ export function MomentTemplateBannerCloseButton({
     settings,
     styleOverides,
 }: MomentTemplateBannerCloseButtonProps): JSX.Element {
-    const { theme, guardianRoundel } = settings;
-
-    const getRoundel = () => {
-        if (guardianRoundel) {
-            switch (guardianRoundel) {
-                case 'brand':
-                    return <SvgRoundelBrand />;
-                case 'inverse':
-                    return <SvgRoundelInverse />;
-                default:
-                    return <SvgRoundelDefault />;
-            }
-        }
-        if (theme && theme === 'brand') {
-            return <SvgRoundelBrand />;
-        }
-        return <SvgRoundelDefault />;
-    };
-
     return (
         <div
             css={css`
                 ${styles.container} ${styleOverides || ''}
             `}
         >
-            <div css={styles.roundelContainer}>{getRoundel()}</div>
-
             <Button
                 onClick={onCloseClick}
                 cssOverrides={buttonStyles(settings, styles.closeButtonOverrides)}
@@ -66,20 +42,6 @@ const styles = {
         right: 0;
         padding-right: 20px;
         z-index: 100;
-    `,
-    roundelContainer: css`
-        display: none;
-        height: 40px;
-
-        svg {
-            height: 40px;
-            width: 40px;
-        }
-
-        ${from.tablet} {
-            display: block;
-            margin-right: ${space[2]}px;
-        }
     `,
     closeButtonOverrides: css`
         height: 40px;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Use the full ‘The Guardian’ logo at the bottom right and remove the roundel from the top right, in order to have the RRCP match our design style guide.

Logo only shows from 740px (tablet) onwards.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- Create a designable banner
- See Guardian logo in bottom right

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Designable banner: one image
Wide
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/19775f74-181f-4654-ab9e-fbfea77e1e70)
Tablet
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/4fd70e09-b06d-4346-9c94-b36e4f4e94e5)
Mobile
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/bd050306-ffd5-492e-8797-0917a47c3d7e)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
