### PR TITLE
Use the full ‘The Guardian’ logo at the bottom right and remove the roundel from the top right

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -352,7 +352,7 @@ const styles = {
             position: static;
             display: grid;
             grid-template-columns: 1.5fr 1fr;
-            grid-template-rows: auto 1fr 32px;
+            grid-template-rows: auto 1fr auto;
             column-gap: ${space[5]}px;
             position: relative;
             width: 100%;
@@ -443,7 +443,6 @@ const styles = {
         grid-column: 2 / span 1;
         grid-row: 3 / span 1;
         justify-self: end;
-        margin-right: ${space[5]}px;
         padding-top: ${space[3]}px;
     `,
 };

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -377,7 +377,7 @@ const styles = {
         ${until.tablet} {
             position: fixed;
             margin-top: ${space[3]}px;
-            padding-right: ${space[5]}px;
+            padding-right: 10px;
             right: 0;
         }
         ${from.tablet} {

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -371,6 +371,7 @@ const styles = {
         ${until.tablet} {
             position: fixed;
             margin-top: ${space[3]}px;
+            padding-right: ${space[5]}px;
             right: 0;
         }
         ${from.tablet} {

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -309,7 +309,13 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                     )}
                 </div>
                 <div css={styles.guardianLogoContainer}>
-                    <SvgGuardianLogo />
+                    <span
+                        css={css`
+                            fill: ${hexColourToString(basic.logo)};
+                        `}
+                    >
+                        <SvgGuardianLogo />
+                    </span>
                 </div>
             </div>
             {mainOrMobileContent.secondaryCta?.type === SecondaryCtaType.ContributionsReminder &&

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -28,6 +28,7 @@ import { buttonStyles } from './styles/buttonStyles';
 import { BannerTemplateSettings } from './settings';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import type { ReactComponent } from '../../../types';
+import { SvgGuardianLogo } from '@guardian/src-brand';
 
 const buildImageSettings = (
     design: BannerDesignImage | BannerDesignHeaderImage,
@@ -229,7 +230,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                     settings={templateSettings.closeButtonSettings}
                     styleOverides={styles.closeButtonOverrides}
                 />
-
                 <div css={getHeaderContainerCss()}>
                     <DesignableBannerHeader
                         heading={content.mainContent.heading}
@@ -237,7 +237,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         headerSettings={templateSettings.headerSettings}
                     />
                 </div>
-
                 <div css={styles.contentContainer}>
                     {separateArticleCount && Number(numArticles) > 5 && (
                         <DesignableBannerArticleCount
@@ -274,7 +273,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         </section>
                     )}
                 </div>
-
                 <div
                     css={styles.bannerVisualContainer(
                         templateSettings.containerSettings.backgroundColour,
@@ -309,6 +307,9 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                             onCtaClick={onCtaClick}
                         />
                     )}
+                </div>
+                <div css={styles.guardianLogoContainer}>
+                    <SvgGuardianLogo />
                 </div>
             </div>
             {mainOrMobileContent.secondaryCta?.type === SecondaryCtaType.ContributionsReminder &&
@@ -351,7 +352,7 @@ const styles = {
             position: static;
             display: grid;
             grid-template-columns: 1.5fr 1fr;
-            grid-template-rows: auto 1fr;
+            grid-template-rows: auto 1fr 32px;
             column-gap: ${space[5]}px;
             position: relative;
             width: 100%;
@@ -411,7 +412,7 @@ const styles = {
         order: 2;
         ${from.tablet} {
             grid-column: 1 / span 1;
-            grid-row: 2 / span 1;
+            grid-row: 2 / span 2;
         }
     `,
     bannerVisualContainer: (background: string, isChoiceCardsContainer?: boolean) => css`
@@ -432,6 +433,18 @@ const styles = {
     ctasContainer: css`
         display: flex;
         flex-direction: row;
+    `,
+    guardianLogoContainer: css`
+        display: none;
+        ${from.tablet} {
+            display: block;
+            width: 100px;
+        }
+        grid-column: 2 / span 1;
+        grid-row: 3 / span 1;
+        justify-self: end;
+        margin-right: ${space[5]}px;
+        padding-top: ${space[3]}px;
     `,
 };
 

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -4,9 +4,6 @@ import { SvgCross } from '@guardian/src-icons';
 import { Button } from '@guardian/src-button';
 import { buttonStyles } from '../styles/buttonStyles';
 import { CtaSettings } from '../settings';
-import { SvgRoundelBrand, SvgRoundelDefault, SvgRoundelInverse } from '@guardian/src-brand';
-import { from } from '@guardian/src-foundations/mq';
-import { space } from '@guardian/src-foundations';
 
 interface DesignableBannerCloseButtonProps {
     onCloseClick: () => void;
@@ -19,27 +16,12 @@ export function DesignableBannerCloseButton({
     settings,
     styleOverides,
 }: DesignableBannerCloseButtonProps): JSX.Element {
-    const { guardianRoundel } = settings;
-
-    const getRoundel = () => {
-        switch (guardianRoundel) {
-            case 'brand':
-                return <SvgRoundelBrand />;
-            case 'inverse':
-                return <SvgRoundelInverse />;
-            default:
-                return <SvgRoundelDefault />;
-        }
-    };
-
     return (
         <div
             css={css`
                 ${styles.container} ${styleOverides || ''}
             `}
         >
-            <div css={styles.roundelContainer}>{getRoundel()}</div>
-
             <Button
                 onClick={onCloseClick}
                 cssOverrides={buttonStyles(settings, styles.closeButtonOverrides)}
@@ -60,20 +42,6 @@ const styles = {
         right: 0;
         padding-right: 20px;
         z-index: 100;
-    `,
-    roundelContainer: css`
-        display: none;
-        height: 40px;
-
-        svg {
-            height: 40px;
-            width: 40px;
-        }
-
-        ${from.tablet} {
-            display: block;
-            margin-right: ${space[2]}px;
-        }
     `,
     closeButtonOverrides: css`
         height: 40px;

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -38,9 +38,7 @@ export function DesignableBannerCloseButton({
 const styles = {
     container: css`
         display: flex;
-        position: fixed;
-        right: 0;
-        padding-right: 20px;
+        justify-self: end;
         z-index: 100;
     `,
     closeButtonOverrides: css`

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -188,6 +188,7 @@ const design: ConfigurableDesign = {
             bodyText: stringToHexColour('000000'),
             headerText: stringToHexColour('000000'),
             articleCountText: stringToHexColour('000000'),
+            logo: stringToHexColour('000000'),
         },
         highlightedText: {
             text: stringToHexColour('000000'),
@@ -226,7 +227,7 @@ const design: ConfigurableDesign = {
                 background: stringToHexColour('E5E5E5'),
             },
         },
-        guardianRoundel: 'inverse',
+        guardianRoundel: 'default',
         ticker: {
             text: stringToHexColour('052962'),
             filledProgress: stringToHexColour('052962'),

--- a/packages/modules/src/modules/banners/designableBanner/styles/templateStyles.ts
+++ b/packages/modules/src/modules/banners/designableBanner/styles/templateStyles.ts
@@ -8,7 +8,7 @@ const templateSpacing = {
             margin-bottom: ${space[4]}px;
         }
         ${from.tablet} {
-            margin-bottom: ${space[6]}px;
+            margin-bottom: ${space[3]}px;
         }
     `,
     bannerHeader: css`

--- a/packages/server/src/factories/bannerDesign.ts
+++ b/packages/server/src/factories/bannerDesign.ts
@@ -34,6 +34,7 @@ export default Factory.define<BannerDesignFromTool>(() => ({
             bodyText: stringToHexColour('000000'),
             headerText: stringToHexColour('000000'),
             articleCountText: stringToHexColour('000000'),
+            logo: stringToHexColour('000000'),
         },
         highlightedText: {
             text: stringToHexColour('000000'),

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -128,6 +128,7 @@ export interface ConfigurableDesign {
             bodyText: HexColour;
             headerText: HexColour;
             articleCountText: HexColour;
+            logo: HexColour;
         };
         highlightedText: {
             text: HexColour;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Use the full ‘The Guardian’ logo at the bottom right and remove the roundel from the top right, in order to have the RRCP match our design style guide.

Also position the close button within the grid, after discussion with designers.

The logo only shows from 740px (tablet) onwards.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- Create a designable banner
- See Guardian logo in bottom right

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Wide
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/bc98362d-bb39-4e3a-9d1f-7e45fdc90b17)

Tablet
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/b35ca269-2971-42c5-9d53-35cf874c911a)

Mobile (unchanged)
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/13971428-6be3-443e-bd0f-23e173b7e60c)


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
