### PR TITLE
Fix banner choice cards validation

### DIFF
--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -27,19 +27,19 @@ const imageSchema = z.object({
 });
 
 const choiceCardsSchema = z.object({
-    buttonColour: z.optional(hexColourSchema),
-    buttonTextColour: z.optional(hexColourSchema),
-    buttonBorderColour: z.optional(hexColourSchema),
-    buttonSelectColour: z.optional(hexColourSchema),
-    buttonSelectTextColour: z.optional(hexColourSchema),
-    buttonSelectBorderColour: z.optional(hexColourSchema),
+    buttonColour: hexColourSchema.nullish(),
+    buttonTextColour: hexColourSchema.nullish(),
+    buttonBorderColour: hexColourSchema.nullish(),
+    buttonSelectColour: hexColourSchema.nullish(),
+    buttonSelectTextColour: hexColourSchema.nullish(),
+    buttonSelectBorderColour: hexColourSchema.nullish(),
     kind: z.literal('ChoiceCards'),
 });
 
 const visualSchema = z.discriminatedUnion('kind', [imageSchema, choiceCardsSchema]);
 
 export const configurableDesignSchema = z.object({
-    visual: z.optional(visualSchema),
+    visual: visualSchema.nullish(),
     colours: z.object({
         basic: z.object({
             background: hexColourSchema,


### PR DESCRIPTION
The designable banner choice cards have been broken by the validation that was recently added [here](https://github.com/guardian/support-dotcom-components/commit/9d892033f5a199a78945e354042acd935d26b741#diff-9bcf42ad88e2672cbf6fecd6f0d2e94330a4e274fa938424edea3f6705874c42L29).

Currently the validation doesn't accept `null` values for optional fields, but dynamodb represents these as nulls. The fix (as elsewhere in the codebase) is to use zod's `nullish`