### PR TITLE
Remove roundel from banner design

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -105,15 +105,8 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
         return <></>;
     }
 
-    const {
-        basic,
-        primaryCta,
-        secondaryCta,
-        highlightedText,
-        closeButton,
-        guardianRoundel,
-        ticker,
-    } = design.colours;
+    const { basic, primaryCta, secondaryCta, highlightedText, closeButton, ticker } =
+        design.colours;
 
     const imageSettings = buildMainImageSettings(design);
     const choiceCardSettings = buildChoiceCardSettings(design);
@@ -176,7 +169,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         : neutral[100]
                 }`,
             },
-            guardianRoundel: guardianRoundel,
         },
         highlightedTextSettings: {
             textColour: hexColourToString(highlightedText.text),

--- a/packages/modules/src/modules/banners/designableBanner/settings.ts
+++ b/packages/modules/src/modules/banners/designableBanner/settings.ts
@@ -1,4 +1,4 @@
-import { GuardianRoundel, Image } from '@sdc/shared/dist/types';
+import { Image } from '@sdc/shared/dist/types';
 import { ReactNode } from 'react';
 import { BannerId } from '../common/types';
 import { ChoiceCardSettings } from '../common/choiceCard/ChoiceCards';
@@ -20,7 +20,6 @@ export interface CtaSettings {
     hover: CtaStateSettings;
     mobile?: CtaStateSettings;
     desktop?: CtaStateSettings;
-    guardianRoundel?: GuardianRoundel;
 }
 
 export interface HighlightedTextSettings {

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -227,7 +227,6 @@ const design: ConfigurableDesign = {
                 background: stringToHexColour('E5E5E5'),
             },
         },
-        guardianRoundel: 'default',
         ticker: {
             text: stringToHexColour('052962'),
             filledProgress: stringToHexColour('052962'),

--- a/packages/server/src/factories/bannerDesign.ts
+++ b/packages/server/src/factories/bannerDesign.ts
@@ -73,7 +73,6 @@ export default Factory.define<BannerDesignFromTool>(() => ({
                 background: stringToHexColour('E5E5E5'),
             },
         },
-        guardianRoundel: 'inverse',
         ticker: {
             text: stringToHexColour('052962'),
             filledProgress: stringToHexColour('052962'),

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -88,8 +88,6 @@ export interface CtaDesign {
     hover: CtaStateDesign;
 }
 
-export type GuardianRoundel = 'default' | 'brand' | 'inverse';
-
 interface TickerDesign {
     text: HexColour;
     filledProgress: HexColour;
@@ -137,7 +135,6 @@ export interface ConfigurableDesign {
         primaryCta: CtaDesign;
         secondaryCta: CtaDesign;
         closeButton: CtaDesign;
-        guardianRoundel: GuardianRoundel;
         ticker: TickerDesign;
     };
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove roundel settings and property from banner design - following up on #1044 where it is no longer used in designable banners

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
