### PR TITLE
DRAFT: add hardcoded article count copy AB tests

### DIFF
--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -27,6 +27,10 @@ import { logWarn } from '../utils/logging';
 import { SuperModeArticle } from '../lib/superMode';
 import { isMobile } from '../lib/deviceType';
 import { ValueProvider } from '../utils/valueReloader';
+import {
+    epicArticleCountCopyLessThanFifty,
+    epicArticleCountCopyMoreThanFifty,
+} from '../tests/epics/epicArticleCount';
 
 interface EpicDataResponse {
     data?: {
@@ -41,7 +45,10 @@ interface EpicDataResponse {
 }
 
 // Any hardcoded epic tests should go here. They will take priority over any tests from the epic tool.
-const hardcodedEpicTests: EpicTest[] = [];
+const hardcodedEpicTests: EpicTest[] = [
+    epicArticleCountCopyLessThanFifty,
+    epicArticleCountCopyMoreThanFifty,
+];
 
 export const buildEpicRouter = (
     channelSwitches: ValueProvider<ChannelSwitches>,

--- a/packages/server/src/tests/epics/epicArticleCount.ts
+++ b/packages/server/src/tests/epics/epicArticleCount.ts
@@ -1,0 +1,89 @@
+import { EpicTest } from '@sdc/shared/dist/types';
+
+const lessThanFiftyTest = '2024-01-22_article_count_copy_less_than_fifty';
+
+export const epicArticleCountCopyLessThanFifty: EpicTest = {
+    name: lessThanFiftyTest,
+    campaignId: lessThanFiftyTest,
+    hasArticleCountInCopy: true,
+    status: 'Live',
+    locations: ['GBPCountries', 'AUDCountries', 'EURCountries', 'UnitedStates', 'International'], // is this right? doesn't map exactly to the spec
+    audience: 1, // not sure
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: false, // not sure
+    userCohort: 'Everyone', // is this right? should supporters be excluded?
+    isLiveBlog: false,
+    hasCountryName: false,
+    highPriority: true, // not sure!
+    useLocalViewLog: false, // ?
+    articlesViewedSettings: {
+        minViews: 0,
+        maxViews: 50,
+        periodInWeeks: 52,
+    },
+
+    variants: [
+        {
+            name: 'control',
+            paragraphs: ['ToDo less than fifty control'],
+            separateArticleCount: {
+                type: 'above',
+                copy: 'You’ve read %%ARTICLE_COUNT%% articles in the last year',
+            },
+        },
+        {
+            name: 'variant',
+            paragraphs: ['ToDo less than fifty variant'],
+            separateArticleCount: {
+                type: 'above',
+                copy: 'You’ve chosen to read %%ARTICLE_COUNT%% articles in the last year',
+            },
+        },
+    ],
+};
+
+const moreThanFiftyTest = '2024-01-22_article_count_copy_more_than_fifty';
+
+export const epicArticleCountCopyMoreThanFifty: EpicTest = {
+    name: moreThanFiftyTest,
+    campaignId: moreThanFiftyTest,
+    hasArticleCountInCopy: true,
+    status: 'Live',
+    locations: ['GBPCountries', 'AUDCountries', 'EURCountries', 'UnitedStates', 'International'], // is this right? doesn't map exactly to the spec
+    audience: 1, // not sure
+    tagIds: [],
+    sections: [],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: false, // not sure
+    userCohort: 'Everyone', // is this right? should supporters be excluded?
+    isLiveBlog: false,
+    hasCountryName: false,
+    highPriority: true, // not sure!
+    useLocalViewLog: false, // ?
+    articlesViewedSettings: {
+        minViews: 50,
+        periodInWeeks: 52,
+    },
+    variants: [
+        {
+            name: 'control',
+            paragraphs: ['ToDo more than fifty control'],
+            separateArticleCount: {
+                type: 'above',
+                copy: 'Congratulations on being one of our top readers globally – you’ve read %%ARTICLE_COUNT%% articles in the last year',
+            },
+        },
+        {
+            name: 'variant',
+            paragraphs: ['ToDo more than fifty variant'],
+            separateArticleCount: {
+                type: 'above',
+                copy: 'Congratulations on being one of our top readers globally – you’ve chosen to read %%ARTICLE_COUNT%% articles in the last year',
+            },
+        },
+    ],
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
