### PR TITLE
Full width CTA and move payment icons on mobile

### DIFF
--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
+import { from, space } from '@guardian/source-foundations';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
 import { ChoiceCardInteractive } from './ChoiceCardInteractive';
 import { ChoiceCardsSupportCta } from './ChoiceCardsSupportCta';
@@ -62,9 +62,32 @@ const styles = {
     ctaAndPaymentCardsContainer: css`
         display: flex;
         align-items: center;
+        flex-direction: column;
+        gap: ${space[4]}px;
+        margin-bottom: ${space[2]}px;
+
+        > span {
+            width: 100%;
+        }
+
+        ${from.tablet} {
+            flex-direction: row;
+            gap: 0;
+            margin-bottom: 0;
+
+            > span {
+                width: auto;
+            }
+        }
     `,
     paymentCardsSvgOverrides: css`
-        margin-top: -10px;
+        ${from.tablet} {
+            margin-top: -10px;
+        }
+    `,
+    ctaOverrides: css`
+        width: 100%;
+        justify-content: center;
     `,
 };
 
@@ -132,7 +155,10 @@ export const ChoiceCards: ReactComponent<ChoiceCardProps> = ({
                         numArticles={numArticles ?? 0}
                         selection={selection}
                         getCtaText={getCtaText}
-                        cssOverrides={cssCtaOverides}
+                        cssOverrides={css`
+                            ${cssCtaOverides}
+                            ${styles.ctaOverrides}
+                        `}
                         onCtaClick={onCtaClick}
                     />
                     <PaymentCards cssOverrides={styles.paymentCardsSvgOverrides} />

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
@@ -88,6 +88,10 @@ const styles = {
     ctaOverrides: css`
         width: 100%;
         justify-content: center;
+
+        ${from.tablet} {
+            width: auto;
+        }
     `,
 };
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Moves the payment icons below the CTA and makes the CTA full width on mobile

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Check Moment on storybook

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/support-dotcom-components/assets/99400613/5491bac5-8787-4191-99bd-9cc7c07391ed) | ![image](https://github.com/guardian/support-dotcom-components/assets/99400613/180e33fe-a416-43dd-8195-0ffd823ee8d1) |

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
This is a layout change and only moves non interactive elements so accessibility should be unaffected
