### PR TITLE
Add 'undefined' test case and fix removeNullValues

### DIFF
--- a/packages/server/src/utils/removeNullValues.test.ts
+++ b/packages/server/src/utils/removeNullValues.test.ts
@@ -1,5 +1,13 @@
 import { removeNullValues } from './removeNullValues';
 const test = {
+    falsyObjects: {
+        undefinedField: undefined,
+        falseField: false,
+        nanField: NaN,
+        zeroField: 0,
+        negativeZeroField: -0,
+        emptyStringField: '',
+    },
     channel: 'Banner2',
     name: 'CHANNEL2',
     articlesViewedSettings: null,
@@ -45,6 +53,14 @@ const test = {
 };
 
 const testWithNoNulls = {
+    falsyObjects: {
+        undefinedField: undefined,
+        falseField: false,
+        nanField: NaN,
+        zeroField: 0,
+        negativeZeroField: -0,
+        emptyStringField: '',
+    },
     channel: 'Banner2',
     name: 'CHANNEL2',
     campaignName: 'NOT_IN_CAMPAIGN',
@@ -84,6 +100,6 @@ const testWithNoNulls = {
 describe('removeNullValues', () => {
     it('should remove all nulls from data', () => {
         const result = removeNullValues(test);
-        expect(result).toEqual(testWithNoNulls);
+        expect(result).toStrictEqual(testWithNoNulls);
     });
 });

--- a/packages/server/src/utils/removeNullValues.ts
+++ b/packages/server/src/utils/removeNullValues.ts
@@ -4,7 +4,7 @@
  */
 export function removeNullValues(obj: object): object {
     return Object.entries(obj)
-        .filter(([, v]) => v != null)
+        .filter(([, v]) => v !== null)
         .reduce((acc, [k, v]) => {
             if (Array.isArray(v)) {
                 return {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The `removeNullValues` was removing `undefined` properties because we used `!=` instead of `!==`. This PR fixes that and adds an undefined field into the test

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
