### PR TITLE
Banner: remove padding to stop highlighted text overlapping

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerBody.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerBody.tsx
@@ -56,7 +56,6 @@ const getStyles = (settings: HighlightedTextSettings) => ({
         `
             : ''}
 
-        padding: 0.15rem 0.15rem;
         ${body.small({ fontWeight: 'bold', lineHeight: 'regular' })};
         ${from.desktop} {
             ${body.medium({ fontWeight: 'bold', lineHeight: 'regular' })};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove the padding to prevent highlighted text from overlapping previous lines and cutting off the text in designable banners. This was introduced in #1049 when changing the lineheight. 

I've tried to get it as close to possible to the [figma](https://www.figma.com/file/Awq5x4DJ6bIoXpmRiBDPHw/Banner-tooling-Templates?type=design&node-id=55-65120&mode=design&t=XZ1CtvE6t6m3RG7U-0).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Load banner: see gap between highlighted text, text from line above not cut off.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/4f87abf3-d38a-4bb1-9157-2471794a4dc5)

After
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/803b4c7a-0f71-4c28-9639-a641923fca2a)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
