### PR TITLE
RRCP: choice card width on Tablet

### DIFF
--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
@@ -54,6 +54,10 @@ const styles = {
             max-width: 716px;
         }
 
+        ${from.tablet} {
+            max-width: 280px;
+        }
+
         ${from.desktop} {
             min-height: 208px;
             max-width: 380px;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Sets the choice card width to 280px when on Tablet breakpoint
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
New choice card wdith
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/34979e9b-f832-47a0-8e3b-c90892923b42)

Showing that the change has not impacted the alignments on the banner
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/ed20ab4b-b874-42ae-ab93-ed7ae9c09b27)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
