### PR TITLE
RRCP Banner header and text box widths

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -384,6 +384,19 @@ const styles = {
             grid-column: 1 / span 1;
             grid-row: 1 / span 1;
             background: ${background};
+            width: 400px;
+        }
+
+        ${from.desktop} {
+            width:460px
+        }
+
+        ${from.leftCol} {
+            width: 620px;
+        }
+
+        ${from.wide} {
+            width: 700px;
         }
         ${templateSpacing.bannerHeader}
     `,
@@ -420,6 +433,18 @@ const styles = {
             grid-row-end: span ${isChoiceCardsContainer ? '1' : '2'};
             align-self: ${isChoiceCardsContainer ? 'start' : 'center'};
             margin-top: ${isChoiceCardsContainer ? '0' : `calc(${space[3]}px + 40px)`};
+            width: 400px;
+        }
+        ${from.desktop} {
+            width: 460px;
+        }
+
+        ${from.leftCol} {
+            width: 620px;
+        }
+
+        ${from.wide} {
+            width: 700px;
         }
     `,
     ctasContainer: css`

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -384,19 +384,19 @@ const styles = {
             grid-column: 1 / span 1;
             grid-row: 1 / span 1;
             background: ${background};
-            max-width: 400px;
+            width: 400px;
         }
 
         ${from.desktop} {
-            max-width: 460px;
+            width: 460px;
         }
 
         ${from.leftCol} {
-            max-width: 620px;
+            width: 620px;
         }
 
         ${from.wide} {
-            max-width: 700px;
+            width: 700px;
         }
         ${templateSpacing.bannerHeader}
     `,
@@ -418,19 +418,18 @@ const styles = {
         ${from.tablet} {
             grid-column: 1 / span 1;
             grid-row: 2 / span 2;
-            max-width: 400px;
+            width: 400px;
         }
-
         ${from.desktop} {
-            max-width: 460px;
+            width: 460px;
         }
 
         ${from.leftCol} {
-            max-width: 620px;
+            width: 620px;
         }
 
         ${from.wide} {
-            max-width: 700px;
+            width: 700px;
         }
     `,
     bannerVisualContainer: (background: string, isChoiceCardsContainer?: boolean) => css`

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -384,19 +384,19 @@ const styles = {
             grid-column: 1 / span 1;
             grid-row: 1 / span 1;
             background: ${background};
-            width: 400px;
+            max-width: 400px;
         }
 
         ${from.desktop} {
-            width:460px
+            max-width: 460px;
         }
 
         ${from.leftCol} {
-            width: 620px;
+            max-width: 620px;
         }
 
         ${from.wide} {
-            width: 700px;
+            max-width: 700px;
         }
         ${templateSpacing.bannerHeader}
     `,
@@ -418,6 +418,19 @@ const styles = {
         ${from.tablet} {
             grid-column: 1 / span 1;
             grid-row: 2 / span 2;
+            max-width: 400px;
+        }
+
+        ${from.desktop} {
+            max-width: 460px;
+        }
+
+        ${from.leftCol} {
+            max-width: 620px;
+        }
+
+        ${from.wide} {
+            max-width: 700px;
         }
     `,
     bannerVisualContainer: (background: string, isChoiceCardsContainer?: boolean) => css`
@@ -433,18 +446,6 @@ const styles = {
             grid-row-end: span ${isChoiceCardsContainer ? '1' : '2'};
             align-self: ${isChoiceCardsContainer ? 'start' : 'center'};
             margin-top: ${isChoiceCardsContainer ? '0' : `calc(${space[3]}px + 40px)`};
-            width: 400px;
-        }
-        ${from.desktop} {
-            width: 460px;
-        }
-
-        ${from.leftCol} {
-            width: 620px;
-        }
-
-        ${from.wide} {
-            width: 700px;
         }
     `,
     ctasContainer: css`


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Aligns the heading and body text width on the banners to match the style guide:

- Wide 700px
- LeftCol 620px
- Desktop 460px
- Tablet 400px

[Trello card](https://trello.com/c/ezNCdCnX/157-rrcp-banner-text-width-design-system-s)

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
**Wide**
**Header**
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/761a18f4-2c7d-48b8-a46c-ef1d4eb92e14)

**Body**
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/b20172cd-dd40-434e-a586-69b5d8594a27)

Alignment is unaffected:
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/af6e72e7-4ef7-4826-8df7-6b120a640d08)


**LeftCol**
**Header**
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/2941d3a6-4e99-4be4-973f-befd1f45c0b8)

**Body**
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/3850a158-3bb6-4179-9ef6-711ce0504676)

Alignment is unaffected:
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/8d4879c8-a49c-4dab-abae-3baeb019d4af)

**Desktop**
**Header**
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/5d537189-8f84-4337-aa26-f107df1a09d7)

**Body**
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/5521e775-1844-4dc6-9874-df25950f3366)

Alignment is unaffected:
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/6cb3207a-54ac-4733-a67c-13e5ae8565c3)

**Tablet**
**Header**
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/89a43c97-5b8c-4f34-8130-5e699798a66e)

**Body**
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/dac85885-bc86-452a-a30c-73d48c4c1498)

Alignment is unaffected:
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/81a87839-0163-4fb7-817c-a452822a327d)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
