### PR TITLE
Add responsive views to chromatic

### DIFF
--- a/packages/modules/.storybook/preview.tsx
+++ b/packages/modules/.storybook/preview.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { FocusStyleManager } from '@guardian/source-foundations';
 import { breakpoints } from '@guardian/source-foundations';
 import { StylesDecorator } from './StylesDecorator';
+import { Preview } from '@storybook/react';
 
 const isProd = process.env.NODE_ENV === 'production';
 
@@ -72,3 +73,24 @@ const FocusManagerDecorator = (storyFn) => {
 };
 
 export const decorators = [FocusManagerDecorator, StylesDecorator];
+
+const preview: Preview = {
+    parameters: {
+        chromatic: {
+            delay: 300,
+            modes: {
+                mobile: {
+                    viewport: 'mobile',
+                },
+                tablet: {
+                    viewport: 'tablet',
+                },
+                desktop: {
+                    viewport: 'desktop',
+                },
+            },
+        },
+    },
+};
+
+export default preview;

--- a/packages/modules/.storybook/preview.tsx
+++ b/packages/modules/.storybook/preview.tsx
@@ -55,15 +55,6 @@ const viewportEntries = Object.entries(breakpoints).map(([name, width]) => {
 });
 const viewports = Object.fromEntries(viewportEntries);
 
-export const parameters = {
-    options: {
-        isToolshown: !isProd,
-        isFullscreen: isProd,
-    },
-    viewport: { viewports },
-    layout: 'fullscreen',
-};
-
 const FocusManagerDecorator = (storyFn) => {
     useEffect(() => {
         FocusStyleManager.onlyShowFocusOnTabs();
@@ -90,6 +81,12 @@ const preview: Preview = {
                 },
             },
         },
+        options: {
+            isToolshown: !isProd,
+            isFullscreen: isProd,
+        },
+        viewport: { viewports },
+        layout: 'fullscreen',
     },
 };
 

--- a/packages/modules/src/modules/banners/contributions/ContributionsBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBanner.stories.tsx
@@ -7,11 +7,6 @@ import { BannerProps, SecondaryCtaType } from '@sdc/shared/types';
 export default {
     component: ContributionsBanner,
     title: 'Banners/Custom/Contributions',
-    parameters: {
-        chromatic: {
-            delay: 300,
-        },
-    },
     args: props,
 } as Meta;
 

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedOut.stories.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedOut.stories.tsx
@@ -22,11 +22,6 @@ const BannerDecorator = (Story: Story): JSX.Element => (
 export default {
     component: ContributionsBannerReminderSignedOut,
     title: 'Banners/Custom/Contributions/ReminderSignedOut',
-    parameters: {
-        chromatic: {
-            delay: 300,
-        },
-    },
     args: {
         reminderCta: {
             type: SecondaryCtaType.ContributionsReminder,

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerWithSignIn.stories.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerWithSignIn.stories.tsx
@@ -7,11 +7,6 @@ import { BannerProps } from '@sdc/shared/types';
 export default {
     component: ContributionsBannerWithSignIn,
     title: 'Banners/Custom/Contributions',
-    parameters: {
-        chromatic: {
-            delay: 300,
-        },
-    },
     args: props,
 } as Meta;
 

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -14,22 +14,7 @@ import { DefaultTemplate } from './Default';
 
 export default {
     title: 'Banners/Designable',
-    parameters: {
-        chromatic: {
-            delay: 300,
-            modes: {
-                mobile: {
-                    viewport: 'mobile',
-                },
-                tablet: {
-                    viewport: 'tablet',
-                },
-                desktop: {
-                    viewport: 'desktop',
-                },
-            },
-        },
-    },
+
     args: props,
 } as Meta;
 

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -17,6 +17,17 @@ export default {
     parameters: {
         chromatic: {
             delay: 300,
+            modes: {
+                mobile: {
+                    viewport: 'mobile',
+                },
+                tablet: {
+                    viewport: 'tablet',
+                },
+                desktop: {
+                    viewport: 'desktop',
+                },
+            },
         },
     },
     args: props,

--- a/packages/modules/src/modules/banners/environment/EnvironmentBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/environment/EnvironmentBanner.stories.tsx
@@ -7,11 +7,6 @@ import { BannerProps, SecondaryCtaType } from '@sdc/shared/types';
 export default {
     component: EnvironmentBanner,
     title: 'Banners/Retired',
-    parameters: {
-        chromatic: {
-            delay: 300,
-        },
-    },
     args: props,
 } as Meta;
 

--- a/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.stories.tsx
@@ -9,11 +9,6 @@ import { HeaderImage } from './components/headerImage';
 
 export default {
     title: 'Banners/Moment',
-    parameters: {
-        chromatic: {
-            delay: 300,
-        },
-    },
     args: props,
 } as Meta;
 

--- a/packages/modules/src/modules/banners/momentTemplate/stories/MomentTemplateBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/MomentTemplateBanner.stories.tsx
@@ -11,11 +11,6 @@ import { WithBackDropTemplate } from './WithBackDrop';
 
 export default {
     title: 'Banners/MomentTemplate',
-    parameters: {
-        chromatic: {
-            delay: 300,
-        },
-    },
     args: props,
 } as Meta;
 

--- a/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.stories.tsx
@@ -8,11 +8,6 @@ import { SignInPromptBannerUnvalidated as SignInPromptBanner } from './SignInPro
 export default {
     component: SignInPromptBanner,
     title: 'Banners/Retired',
-    parameters: {
-        chromatic: {
-            delay: 300,
-        },
-    },
 } as ComponentMeta<typeof SignInPromptBanner>;
 
 const Template: ComponentStory<typeof SignInPromptBanner> = (props) => (

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/worldPressFreedomDayBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/worldPressFreedomDayBanner.stories.tsx
@@ -12,11 +12,6 @@ import { WorldPressFreedomDayBannerUnValidated as WorldPressFreedomDayBanner } f
 export default {
     component: WorldPressFreedomDayBanner,
     title: 'Banners/Custom',
-    parameters: {
-        chromatic: {
-            delay: 300,
-        },
-    },
 } as Meta;
 
 const Template: Story<BannerProps> = (props: BannerProps) => (


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds responsive viewports to chromatic config

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
This is a QoL test to improve the usefulness of chromatic so the outcome should be that our chromatic snapshots include changes to mobile view. This PR will add a whole suite of them but future PRs will only flag changes. Check the chromatic link on this PR to see the added snapshots.
