### PR TITLE
Validate header test data from Dynamodb

### DIFF
--- a/packages/modules/src/modules/headers/HeaderWrapper.tsx
+++ b/packages/modules/src/modules/headers/HeaderWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { HeaderProps, Cta, headerSchema, OphanAction } from '@sdc/shared/types';
+import { HeaderProps, Cta, headerPropsSchema, OphanAction } from '@sdc/shared/types';
 import {
     addRegionIdAndTrackingParamsToSupportUrl,
     addTrackingParamsToProfileUrl,
@@ -145,7 +145,7 @@ export const headerWrapper = (
 };
 
 const validate = (props: unknown): props is HeaderProps => {
-    const result = headerSchema.safeParse(props);
+    const result = headerPropsSchema.safeParse(props);
     return result.success;
 };
 

--- a/packages/server/src/tests/headers/headerTests.ts
+++ b/packages/server/src/tests/headers/headerTests.ts
@@ -1,8 +1,9 @@
-import { HeaderTest } from '@sdc/shared/types';
+import { HeaderTestDB } from '@sdc/shared/types';
 import { getTests } from '../store';
 import { buildReloader, ValueReloader } from '../../utils/valueReloader';
+import { headerTestDBSchema } from '@sdc/shared/dist/types';
 
-const buildHeaderTestsReloader = (): Promise<ValueReloader<HeaderTest[]>> =>
-    buildReloader(() => getTests<HeaderTest>('Header'), 60);
+const buildHeaderTestsReloader = (): Promise<ValueReloader<HeaderTestDB[]>> =>
+    buildReloader(() => getTests<HeaderTestDB>('Header', headerTestDBSchema), 60);
 
 export { buildHeaderTestsReloader };

--- a/packages/shared/src/types/abTests/header.ts
+++ b/packages/shared/src/types/abTests/header.ts
@@ -1,22 +1,35 @@
-import { UserCohort, Test, Variant, TestStatus } from './shared';
-import { HeaderContent } from '../props';
-import { CountryGroupId } from '../../lib';
-import { PurchaseInfoTest } from '../abTests';
+import { testSchema, userCohortSchema, purchaseInfoTestSchema } from './shared';
+import { headerContentSchema } from '../props';
+import { countryGroupIdSchema } from '../../lib';
+import * as z from 'zod';
 
-export interface HeaderVariant extends Variant {
-    name: string;
-    content: HeaderContent;
-    mobileContent?: HeaderContent;
+/**
+ * Models and schemas for data from the database
+ */
+const headerVariantDBSchema = z.object({
+    name: z.string(),
+    content: headerContentSchema,
+    mobileContent: headerContentSchema.optional(),
+});
+export type HeaderVariantDB = z.infer<typeof headerVariantDBSchema>;
+
+export const headerTestDBSchema = testSchema.extend({
+    locations: z.array(countryGroupIdSchema),
+    userCohort: userCohortSchema,
+    purchaseInfo: purchaseInfoTestSchema.optional(),
+    variants: z.array(headerVariantDBSchema),
+});
+export type HeaderTestDB = z.infer<typeof headerTestDBSchema>;
+
+/**
+ * Models with additional properties determined by the server
+ */
+export interface HeaderVariant extends HeaderVariantDB {
     modulePathBuilder?: (version?: string) => string;
     moduleName?: string;
 }
 
-export interface HeaderTest extends Test<HeaderVariant> {
-    name: string;
-    status: TestStatus;
-    locations: CountryGroupId[];
-    userCohort: UserCohort;
-    purchaseInfo?: PurchaseInfoTest;
+export interface HeaderTest extends HeaderTestDB {
     variants: HeaderVariant[];
 }
 

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -1,6 +1,11 @@
 import * as z from 'zod';
 import { OphanComponentType, OphanProduct } from '../ophan';
-import { purchaseInfoProduct, purchaseInfoUser } from '../purchaseInfo';
+import {
+    purchaseInfoProduct,
+    purchaseInfoProductSchema,
+    purchaseInfoUser,
+    purchaseInfoUserSchema,
+} from '../purchaseInfo';
 
 const TestStatus = ['Live', 'Draft', 'Archived'] as const;
 export type TestStatus = (typeof TestStatus)[number];
@@ -101,6 +106,11 @@ export interface PurchaseInfoTest {
     userType: purchaseInfoUser[];
     product: purchaseInfoProduct[];
 }
+
+export const purchaseInfoTestSchema = z.object({
+    userType: z.array(purchaseInfoUserSchema),
+    product: z.array(purchaseInfoProductSchema),
+});
 
 export interface PageContextTargeting {
     tagIds: string[]; // tags must include one of these

--- a/packages/shared/src/types/props/header.ts
+++ b/packages/shared/src/types/props/header.ts
@@ -11,11 +11,12 @@ export interface HeaderContent {
     benefits?: string[];
 }
 
-const headerContentSchema = z.object({
+export const headerContentSchema = z.object({
     heading: z.string(),
     subheading: z.string(),
-    primaryCta: ctaSchema.nullish(),
-    secondaryCta: ctaSchema.nullish(),
+    primaryCta: ctaSchema.optional(),
+    secondaryCta: ctaSchema.optional(),
+    benefits: z.array(z.string()).optional(),
 });
 
 export interface HeaderProps extends EmotionJSX.IntrinsicAttributes {
@@ -27,11 +28,11 @@ export interface HeaderProps extends EmotionJSX.IntrinsicAttributes {
     numArticles?: number;
 }
 
-export const headerSchema = z.object({
+export const headerPropsSchema = z.object({
     content: headerContentSchema,
     tracking: trackingSchema,
-    mobileContent: headerContentSchema.nullish(),
-    countryCode: z.string().nullish(),
+    mobileContent: headerContentSchema.optional(),
+    countryCode: z.string().optional(),
     submitComponentEvent: z.any(),
-    numArticles: z.number().nullish(),
+    numArticles: z.number().optional(),
 });

--- a/packages/shared/src/types/purchaseInfo.ts
+++ b/packages/shared/src/types/purchaseInfo.ts
@@ -1,2 +1,9 @@
-export type purchaseInfoProduct = 'Contribution' | 'SupporterPlus' | 'GuardianWeekly' | 'Paper';
-export type purchaseInfoUser = 'new' | 'guest' | 'current';
+import * as z from 'zod';
+
+const purchaseInfoProduct = ['Contribution', 'SupporterPlus', 'GuardianWeekly', 'Paper'] as const;
+export type purchaseInfoProduct = (typeof purchaseInfoProduct)[number];
+export const purchaseInfoProductSchema = z.enum(purchaseInfoProduct);
+
+const purchaseInfoUser = ['new', 'guest', 'current'] as const;
+export type purchaseInfoUser = (typeof purchaseInfoUser)[number];
+export const purchaseInfoUserSchema = z.enum(purchaseInfoUser);


### PR DESCRIPTION
Follows [previous work](https://github.com/guardian/support-dotcom-components/pull/1058) on the epic AB test data.
Validates data from Dynamodb using zod, and migrates to inferring header types from the zod schemas to avoid duplication