### PR TITLE
Add missing epic fields

### DIFF
--- a/packages/dotcom/.changeset/chilled-cobras-dream.md
+++ b/packages/dotcom/.changeset/chilled-cobras-dream.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+Add missing epic fields

--- a/packages/modules/.storybook/preview.tsx
+++ b/packages/modules/.storybook/preview.tsx
@@ -68,7 +68,7 @@ export const decorators = [FocusManagerDecorator, StylesDecorator];
 const preview: Preview = {
     parameters: {
         chromatic: {
-            delay: 300,
+            delay: 1000,
             modes: {
                 mobile: {
                     viewport: 'mobile',

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -17,6 +17,8 @@ export type ArticleCountType =
     | 'for52Weeks' // The user's total article view count, which currently goes back as far as 52 weeks
     | 'forTargetedWeeks'; // The user's article view count for the configured periodInWeeks/tag
 
+const articleCountTypeSchema = z.enum(['for52Weeks', 'forTargetedWeeks']);
+
 export type ArticleCounts = {
     [type in ArticleCountType]: number;
 };
@@ -52,6 +54,7 @@ const maxViewsSchema = z.object({
 const separateArticleCountSchema = z.object({
     type: z.literal('above'),
     copy: z.string().optional(),
+    countType: articleCountTypeSchema.optional(), // defaults to `for52Weeks`
 });
 
 const reminderFieldsSchema = z.object({
@@ -86,6 +89,10 @@ const selectedAmountsVariantSchema = z.object({
     }),
 });
 
+const newsletterSignupSchema = z.object({
+    url: z.string(),
+});
+
 export const variantSchema = z.object({
     name: z.string(),
     heading: z.string().optional(),
@@ -94,6 +101,7 @@ export const variantSchema = z.object({
     tickerSettings: tickerSettingsSchema.optional(),
     cta: ctaSchema.optional(),
     secondaryCta: secondaryCtaSchema.optional(),
+    newsletterSignup: newsletterSignupSchema.optional(),
     footer: z.string().optional(),
     image: imageSchema.optional(),
     showReminderFields: reminderFieldsSchema.optional(),


### PR DESCRIPTION
These were accidentally dropped by [this PR](https://github.com/guardian/support-dotcom-components/pull/1058).
It didn't become a problem until updating the npm dependency in dotcom-rendering and running `tsc`.