### PR TITLE
Validate amp epic data

### DIFF
--- a/packages/server/src/tests/amp/ampEpicModels.ts
+++ b/packages/server/src/tests/amp/ampEpicModels.ts
@@ -1,7 +1,12 @@
 import { ContributionFrequency } from '@sdc/shared/types';
 import { AMPTicker } from './ampTicker';
 import * as z from 'zod';
-import {contributionFrequencySchema, ctaSchema, testSchema, tickerSettingsSchema} from '@sdc/shared/dist/types';
+import {
+    contributionFrequencySchema,
+    ctaSchema,
+    testSchema,
+    tickerSettingsSchema,
+} from '@sdc/shared/dist/types';
 import { countryGroupIdSchema } from '@sdc/shared/dist/lib';
 
 /**
@@ -46,4 +51,4 @@ export const ampEpicTestSchema = testSchema.extend({
     variants: z.array(ampEpicTestVariantSchema),
 });
 
-export const AmpEpicTest = z.infer<typeof ampEpicTestSchema>;
+export type AmpEpicTest = z.infer<typeof ampEpicTestSchema>;

--- a/packages/server/src/tests/amp/ampEpicModels.ts
+++ b/packages/server/src/tests/amp/ampEpicModels.ts
@@ -1,6 +1,8 @@
-import { CountryGroupId } from '@sdc/shared/lib';
-import { Cta, TickerSettings, ContributionFrequency, TestStatus } from '@sdc/shared/types';
+import { ContributionFrequency } from '@sdc/shared/types';
 import { AMPTicker } from './ampTicker';
+import * as z from 'zod';
+import {contributionFrequencySchema, ctaSchema, testSchema, tickerSettingsSchema} from '@sdc/shared/dist/types';
+import { countryGroupIdSchema } from '@sdc/shared/dist/lib';
 
 /**
  * Models for the data returned to AMP
@@ -27,22 +29,21 @@ export interface AMPEpic {
 /**
  * Models for the data published by the epic tool
  */
-export interface AmpEpicTestVariant {
-    name: string;
-    heading?: string;
-    paragraphs: string[];
-    highlightedText?: string;
-    cta?: Cta;
-    tickerSettings?: TickerSettings;
-    showChoiceCards?: boolean;
-    defaultChoiceCardFrequency?: ContributionFrequency;
-}
+const ampEpicTestVariantSchema = z.object({
+    name: z.string(),
+    heading: z.string().optional(),
+    paragraphs: z.array(z.string()),
+    highlightedText: z.string().optional(),
+    cta: ctaSchema.optional(),
+    tickerSettings: tickerSettingsSchema.optional(),
+    showChoiceCards: z.boolean().optional(),
+    defaultChoiceCardFrequency: contributionFrequencySchema.optional(),
+});
 
-export interface AmpEpicTest {
-    name: string;
-    priority: number;
-    nickname?: string;
-    status: TestStatus;
-    locations: CountryGroupId[];
-    variants: AmpEpicTestVariant[];
-}
+export const ampEpicTestSchema = testSchema.extend({
+    nickname: z.string().optional(),
+    locations: z.array(countryGroupIdSchema),
+    variants: z.array(ampEpicTestVariantSchema),
+});
+
+export const AmpEpicTest = z.infer<typeof ampEpicTestSchema>;

--- a/packages/server/src/tests/amp/ampEpicTests.ts
+++ b/packages/server/src/tests/amp/ampEpicTests.ts
@@ -1,6 +1,6 @@
 import { getTests } from '../store';
-import { AmpEpicTest } from './ampEpicModels';
+import { AmpEpicTest, ampEpicTestSchema } from './ampEpicModels';
 import { buildReloader, ValueReloader } from '../../utils/valueReloader';
 
 export const buildAmpEpicTestsReloader = (): Promise<ValueReloader<AmpEpicTest[]>> =>
-    buildReloader(() => getTests<AmpEpicTest>('EpicAMP'), 60);
+    buildReloader(() => getTests<AmpEpicTest>('EpicAMP', ampEpicTestSchema), 60);

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -63,7 +63,7 @@ const reminderFieldsSchema = z.object({
     reminderPeriod: z.string(),
 });
 
-const contributionFrequencySchema = z.enum(['ONE_OFF', 'MONTHLY', 'ANNUAL']);
+export const contributionFrequencySchema = z.enum(['ONE_OFF', 'MONTHLY', 'ANNUAL']);
 
 const selectedAmountsVariantSchema = z.object({
     testName: z.string(),


### PR DESCRIPTION
Continues the work to validate AB test data from Dynamodb.

The AMP epic situation is a bit different because there's no client side use of the models. DCR has the [AMP component](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/components/Epic.amp.tsx#L348).
But it's still good to validate the data from dynamo and infer the types from the schema.

Tested in CODE by viewing the epic on an AMP article, e.g. https://amp.code.dev-theguardian.com/football/2024/jan/04/wayne-rooney-needed-time-patience-lacking-in-football-birmingham
I also tested geolocation targeting still works by copying the request to SDC and using postman to set the `X-GU-GeoIP-Country-Code` header to `US`.