### PR TITLE
AB Test Validation - Naming Consistency and make schema mandatory

### DIFF
--- a/packages/server/src/tests/epics/epicTests.ts
+++ b/packages/server/src/tests/epics/epicTests.ts
@@ -1,5 +1,5 @@
 import { containsArticleCountPlaceholder } from '@sdc/shared/lib';
-import { EpicTestDB, EpicTest, epicTestDBSchema, EpicVariant } from '@sdc/shared/types';
+import { EpicTestFromTool, EpicTest, epicTestFromToolSchema, EpicVariant } from '@sdc/shared/types';
 import { ChannelTypes, getTests } from '../store';
 import { buildReloader, ValueReloader } from '../../utils/valueReloader';
 
@@ -13,8 +13,8 @@ export const variantHasArticleCountCopy = (variant: EpicVariant): boolean => {
 };
 
 const fetchConfiguredEpicTests = (channel: ChannelTypes) => (): Promise<EpicTest[]> => {
-    return getTests<EpicTestDB>(channel, epicTestDBSchema).then((tests) => {
-        return tests.map((test: EpicTestDB) => {
+    return getTests<EpicTestFromTool>(channel, epicTestFromToolSchema).then((tests) => {
+        return tests.map((test: EpicTestFromTool) => {
             const hasArticleCountInCopy = test.variants.some(variantHasArticleCountCopy);
 
             return {

--- a/packages/server/src/tests/headers/headerTests.ts
+++ b/packages/server/src/tests/headers/headerTests.ts
@@ -1,9 +1,9 @@
-import { HeaderTestDB } from '@sdc/shared/types';
+import { HeaderTestFromTool } from '@sdc/shared/types';
 import { getTests } from '../store';
 import { buildReloader, ValueReloader } from '../../utils/valueReloader';
-import { headerTestDBSchema } from '@sdc/shared/dist/types';
+import { headerTestFromToolSchema } from '@sdc/shared/dist/types';
 
-const buildHeaderTestsReloader = (): Promise<ValueReloader<HeaderTestDB[]>> =>
-    buildReloader(() => getTests<HeaderTestDB>('Header', headerTestDBSchema), 60);
+const buildHeaderTestsReloader = (): Promise<ValueReloader<HeaderTestFromTool[]>> =>
+    buildReloader(() => getTests<HeaderTestFromTool>('Header', headerTestFromToolSchema), 60);
 
 export { buildHeaderTestsReloader };

--- a/packages/server/src/tests/store.ts
+++ b/packages/server/src/tests/store.ts
@@ -21,17 +21,13 @@ export type ChannelTypes =
 
 export const getTests = <T extends { priority: number }>(
     channel: ChannelTypes,
-    schema?: ZodSchema<T>,
+    schema: ZodSchema<T>,
 ): Promise<T[]> =>
     queryChannel(channel, stage)
         .then((tests) =>
             (tests.Items ?? [])
                 .map((test) => {
                     const testWithNullValuesRemoved = removeNullValues(test);
-
-                    if (!schema) {
-                        return testWithNullValuesRemoved as T;
-                    }
 
                     const parseResult = schema.safeParse(testWithNullValuesRemoved);
 

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -96,10 +96,10 @@ export interface AmountsTest {
 export type AmountsTests = AmountsTest[];
 
 // for validation from DynamoDB
-export type EpicTestDB = z.infer<typeof epicTestDBSchema>;
+export type EpicTestFromTool = z.infer<typeof epicTestFromToolSchema>;
 
 // with additional properties determined by the server
-export interface EpicTest extends EpicTestDB {
+export interface EpicTest extends EpicTestFromTool {
     hasArticleCountInCopy: boolean;
     isSuperMode?: boolean;
     canShow?: (targeting: EpicTargeting) => boolean;
@@ -109,7 +109,7 @@ export interface EpicTest extends EpicTestDB {
     expiry?: string;
 }
 
-export const epicTestDBSchema = testSchema.extend({
+export const epicTestFromToolSchema = testSchema.extend({
     name: z.string(),
     status: testStatusSchema,
     locations: z.array(countryGroupIdSchema),

--- a/packages/shared/src/types/abTests/header.ts
+++ b/packages/shared/src/types/abTests/header.ts
@@ -6,30 +6,30 @@ import * as z from 'zod';
 /**
  * Models and schemas for data from the database
  */
-const headerVariantDBSchema = z.object({
+const headerVariantFromToolSchema = z.object({
     name: z.string(),
     content: headerContentSchema,
     mobileContent: headerContentSchema.optional(),
 });
-export type HeaderVariantDB = z.infer<typeof headerVariantDBSchema>;
+export type HeaderVariantFromTool = z.infer<typeof headerVariantFromToolSchema>;
 
-export const headerTestDBSchema = testSchema.extend({
+export const headerTestFromToolSchema = testSchema.extend({
     locations: z.array(countryGroupIdSchema),
     userCohort: userCohortSchema,
     purchaseInfo: purchaseInfoTestSchema.optional(),
-    variants: z.array(headerVariantDBSchema),
+    variants: z.array(headerVariantFromToolSchema),
 });
-export type HeaderTestDB = z.infer<typeof headerTestDBSchema>;
+export type HeaderTestFromTool = z.infer<typeof headerTestFromToolSchema>;
 
 /**
  * Models with additional properties determined by the server
  */
-export interface HeaderVariant extends HeaderVariantDB {
+export interface HeaderVariant extends HeaderVariantFromTool {
     modulePathBuilder?: (version?: string) => string;
     moduleName?: string;
 }
 
-export interface HeaderTest extends HeaderTestDB {
+export interface HeaderTest extends HeaderTestFromTool {
     variants: HeaderVariant[];
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Small followup to #1073 to use a consistent naming for our zod schemas that are coming from the tool. And make the schemas mandatory in `getTests`

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
