### PR TITLE
Fix right column width on banners

### DIFF
--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
@@ -71,7 +71,7 @@ const styles = {
             width: 100%;
         }
 
-        ${from.tablet} {
+        ${from.desktop} {
             flex-direction: row;
             gap: 0;
             margin-bottom: 0;
@@ -82,7 +82,7 @@ const styles = {
         }
     `,
     paymentCardsSvgOverrides: css`
-        ${from.tablet} {
+        ${from.desktop} {
             margin-top: -10px;
         }
     `,
@@ -90,7 +90,7 @@ const styles = {
         width: 100%;
         justify-content: center;
 
-        ${from.tablet} {
+        ${from.desktop} {
             width: auto;
         }
     `,

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -35,9 +35,9 @@ const buildImageSettings = (
     return {
         mainUrl: design.mobileUrl,
         mobileUrl: design.mobileUrl,
-        tabletUrl: design.tabletDesktopUrl,
-        desktopUrl: design.tabletDesktopUrl,
-        wideUrl: design.wideUrl,
+        tabletUrl: design.tabletUrl,
+        desktopUrl: design.desktopUrl,
+        wideUrl: design.desktopUrl,
         altText: design.altText,
     };
 };

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -349,7 +349,7 @@ const styles = {
         ${from.tablet} {
             position: static;
             display: grid;
-            grid-template-columns: 1.5fr 1fr;
+            grid-template-columns: 1fr 280px;
             grid-template-rows: auto 1fr auto;
             column-gap: ${space[5]}px;
             position: relative;
@@ -359,6 +359,7 @@ const styles = {
         }
         ${from.desktop} {
             column-gap: 60px;
+            grid-template-columns: 1fr 460px;
         }
         ${from.wide} {
             column-gap: 100px;
@@ -379,19 +380,14 @@ const styles = {
         }
     `,
     headerContainer: (background: string, bannerHasImage: boolean) => css`
-        order: 1;
-        ${until.tablet} {
-            max-width: calc(100% - 40px - ${space[3]}px);
-        }
-        ${between.mobileMedium.and.tablet} {
-            order: ${bannerHasImage ? '2' : '1'};
-            max-width: ${bannerHasImage ? '100%' : 'calc(100% - 40px - ${space[3]}px)'};
-        }
+        order: ${bannerHasImage ? '2' : '1'};
+
         ${from.tablet} {
             grid-column: 1 / span 1;
             grid-row: 1 / span 1;
             background: ${background};
         }
+
         ${templateSpacing.bannerHeader}
     `,
     headerWithImageContainer: (background: string) => css`
@@ -415,12 +411,8 @@ const styles = {
         }
     `,
     bannerVisualContainer: (background: string, isChoiceCardsContainer?: boolean) => css`
-        display: ${isChoiceCardsContainer ? 'block' : 'none'};
         order: ${isChoiceCardsContainer ? '3' : '1'};
         background: ${background};
-        ${from.mobileMedium} {
-            display: block;
-        }
         ${from.tablet} {
             grid-column: 2 / span 1;
             grid-row-start: ${isChoiceCardsContainer ? '2' : '1'};

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -415,10 +415,8 @@ const styles = {
         background: ${background};
         ${from.tablet} {
             grid-column: 2 / span 1;
-            grid-row-start: ${isChoiceCardsContainer ? '2' : '1'};
-            grid-row-end: span ${isChoiceCardsContainer ? '1' : '2'};
-            align-self: ${isChoiceCardsContainer ? 'start' : 'center'};
-            margin-top: ${isChoiceCardsContainer ? '0' : `calc(${space[3]}px + 40px)`};
+            grid-row: 2 / span 1;
+            align-self: flex-start;
         }
     `,
     ctasContainer: css`

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerHeader.tsx
@@ -59,7 +59,7 @@ const getStyles = (headerSettings: HeaderSettings | undefined) => {
                 ${from.tablet} {
                     ${headline.small({ fontWeight: 'bold' })}
                 }
-                ${from.desktop} {
+                ${from.leftCol} {
                     ${headline.medium({ fontWeight: 'bold' })}
                 }
             }

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
@@ -75,7 +75,6 @@ const getStyles = (isHeaderImage = false) => {
             margin-right: -10px;
 
             img {
-                max-height: 225px;
                 width: 100%;
                 object-fit: contain;
                 display: block;

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
@@ -32,20 +32,20 @@ export function DesignableBannerVisual({
     if (settings.tabletUrl) {
         images.push({ url: settings.tabletUrl, media: '(max-width: 979px)' });
     }
-    if (settings.desktopUrl) {
-        images.push({ url: settings.desktopUrl, media: '(max-width: 1139px)' });
-    }
     if (settings.leftColUrl) {
-        images.push({ url: settings.leftColUrl, media: '(max-width: 1299px)' });
+        images.push({ url: settings.leftColUrl, media: '(max-width: 1139px)' });
     }
     if (settings.wideUrl) {
         images.push({ url: settings.wideUrl, media: '' });
     }
 
     return (
-        <div css={styles.container}>
-            <ResponsiveImage baseImage={baseImage} images={images} bannerId={bannerId} />
-        </div>
+        <ResponsiveImage
+            baseImage={baseImage}
+            images={images}
+            bannerId={bannerId}
+            cssOverrides={styles.container}
+        />
     );
 }
 
@@ -69,15 +69,20 @@ const getStyles = (isHeaderImage = false) => {
     }
     return {
         container: css`
-            height: 140px;
-            display: flex;
-            justify-content: center;
+            display: block;
+            width: calc(100% + 20px);
+            margin-left: -10px;
+            margin-right: -10px;
 
             img {
-                height: 100%;
+                max-height: 225px;
                 width: 100%;
                 object-fit: contain;
                 display: block;
+
+                ${from.tablet} {
+                    max-height: none;
+                }
             }
 
             ${from.tablet} {

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
@@ -32,8 +32,11 @@ export function DesignableBannerVisual({
     if (settings.tabletUrl) {
         images.push({ url: settings.tabletUrl, media: '(max-width: 979px)' });
     }
+    if (settings.desktopUrl) {
+        images.push({ url: settings.desktopUrl, media: '(max-width: 1139px)' });
+    }
     if (settings.leftColUrl) {
-        images.push({ url: settings.leftColUrl, media: '(max-width: 1139px)' });
+        images.push({ url: settings.leftColUrl, media: '(max-width: 1299px)' });
     }
     if (settings.wideUrl) {
         images.push({ url: settings.wideUrl, media: '' });

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
@@ -88,6 +88,8 @@ const getStyles = (isHeaderImage = false) => {
                 height: 100%;
                 width: 100%;
                 align-items: center;
+                margin-left: 0;
+                margin-right: 0;
             }
         `,
     };

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -160,8 +160,12 @@ const headerImage: BannerDesignImage = {
     mobileUrl:
         'https://i.guim.co.uk/img/media/036510bc15ecdba97355f464006e3db5fbde9129/0_0_620_180/master/620.jpg?width=310&height=90&quality=100&s=01c604815a2f9980a1227c0d91ffa6b1',
     tabletDesktopUrl:
+        'https://i.guim.co.uk/img/media/7030f9d98e368d6e5c7a34c643c76d7d1f5ac63c/0_0_1056_366/master/1056.jpg?width=528&height=183&quality=100&s=f0c02cddda84dfaf4ef261d91bd26159', //deprecated
+    tabletUrl:
         'https://i.guim.co.uk/img/media/7030f9d98e368d6e5c7a34c643c76d7d1f5ac63c/0_0_1056_366/master/1056.jpg?width=528&height=183&quality=100&s=f0c02cddda84dfaf4ef261d91bd26159',
     wideUrl:
+        'https://i.guim.co.uk/img/media/3c1cb611785d3dccc2674636a6f692da1e2fcdb6/0_0_1392_366/master/1392.jpg?width=696&height=183&quality=100&s=5935c1ae5e8cbc5d9ed616bbadb3b09e', //deprecated
+    desktopUrl:
         'https://i.guim.co.uk/img/media/3c1cb611785d3dccc2674636a6f692da1e2fcdb6/0_0_1392_366/master/1392.jpg?width=696&height=183&quality=100&s=5935c1ae5e8cbc5d9ed616bbadb3b09e',
     altText: "Guardian: Our Planet can't Speak for itself",
 };
@@ -171,8 +175,12 @@ const regularImage: BannerDesignImage = {
     mobileUrl:
         'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
     tabletDesktopUrl:
+        'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f', //deprecated
+    tabletUrl:
         'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
     wideUrl:
+        'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b', //deprecated
+    desktopUrl:
         'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
     altText: 'Example alt text',
 };

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -169,11 +169,11 @@ const headerImage: BannerDesignImage = {
 const regularImage: BannerDesignImage = {
     kind: 'Image',
     mobileUrl:
-        'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
+        'https://i.guim.co.uk/img/media/058e7bd9d7a37983eb01cf981f67bd6efe42f95d/0_0_500_300/500.jpg?width=500&height=300&quality=75&s=632c02ed370780425b323aeb1e98cd80',
     tabletDesktopUrl:
-        'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
+        'https://i.guim.co.uk/img/media/cb654baf73bec78a73dbd656e865dedc3807ec74/0_0_300_300/300.jpg?width=300&height=300&quality=75&s=28324a5eb4f5f18eabd8c7b1a59ed150',
     wideUrl:
-        'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
+        'https://i.guim.co.uk/img/media/058e7bd9d7a37983eb01cf981f67bd6efe42f95d/0_0_500_300/500.jpg?width=500&height=300&quality=75&s=632c02ed370780425b323aeb1e98cd80',
     altText: 'Example alt text',
 };
 

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -169,11 +169,11 @@ const headerImage: BannerDesignImage = {
 const regularImage: BannerDesignImage = {
     kind: 'Image',
     mobileUrl:
-        'https://i.guim.co.uk/img/media/058e7bd9d7a37983eb01cf981f67bd6efe42f95d/0_0_500_300/500.jpg?width=500&height=300&quality=75&s=632c02ed370780425b323aeb1e98cd80',
+        'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
     tabletDesktopUrl:
-        'https://i.guim.co.uk/img/media/cb654baf73bec78a73dbd656e865dedc3807ec74/0_0_300_300/300.jpg?width=300&height=300&quality=75&s=28324a5eb4f5f18eabd8c7b1a59ed150',
+        'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
     wideUrl:
-        'https://i.guim.co.uk/img/media/058e7bd9d7a37983eb01cf981f67bd6efe42f95d/0_0_500_300/500.jpg?width=500&height=300&quality=75&s=632c02ed370780425b323aeb1e98cd80',
+        'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
     altText: 'Example alt text',
 };
 

--- a/packages/modules/src/modules/banners/designableBanner/styles/templateStyles.ts
+++ b/packages/modules/src/modules/banners/designableBanner/styles/templateStyles.ts
@@ -1,11 +1,10 @@
 import { css } from '@emotion/react';
-import { space, from, until } from '@guardian/source-foundations';
+import { space, from } from '@guardian/source-foundations';
 
 const templateSpacing = {
     bannerContainer: css`
-        ${until.tablet} {
-            margin-bottom: ${space[4]}px;
-        }
+        margin-bottom: ${space[4]}px;
+
         ${from.tablet} {
             margin-bottom: ${space[3]}px;
         }
@@ -14,17 +13,15 @@ const templateSpacing = {
         margin: 0;
     `,
     bannerBodyCopy: css`
-        ${until.tablet} {
-            margin-bottom: ${space[4]}px;
-        }
+        margin-bottom: ${space[4]}px;
+
         ${from.tablet} {
             margin-bottom: ${space[6]}px;
         }
     `,
     bannerTicker: css`
-        ${until.tablet} {
-            margin-bottom: ${space[4]}px;
-        }
+        margin-bottom: ${space[4]}px;
+
         ${from.tablet} {
             margin-bottom: ${space[3]}px;
         }

--- a/packages/modules/src/modules/shared/ResponsiveImage.tsx
+++ b/packages/modules/src/modules/shared/ResponsiveImage.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { SerializedStyles } from '@emotion/react';
 import React, { ReactElement } from 'react';
 import { BannerId } from '../banners/common/types';
 import type { ReactComponent } from '../../types';
@@ -13,6 +13,7 @@ type ResponsiveImageProps = {
     images: Array<ImageAttrs>;
     baseImage: ImageAttrs;
     bannerId?: BannerId;
+    cssOverrides?: SerializedStyles;
 };
 
 function createSource(image: ImageAttrs): ReactElement {
@@ -23,17 +24,12 @@ export const ResponsiveImage: ReactComponent<ResponsiveImageProps> = ({
     images,
     baseImage,
     bannerId,
+    cssOverrides,
 }: ResponsiveImageProps) => {
     return (
-        <picture css={container(bannerId)}>
+        <picture id={bannerId} css={cssOverrides}>
             {images.map(createSource)}
             <img src={baseImage.url} alt={baseImage.alt} />
         </picture>
     );
 };
-
-// ---- Styles ---- //
-
-const container = (bannerId?: BannerId) => css`
-    width: ${bannerId === 'us-eoy-giving-tues-banner' ? '100%' : ''};
-`;

--- a/packages/server/src/factories/bannerDesign.ts
+++ b/packages/server/src/factories/bannerDesign.ts
@@ -23,8 +23,12 @@ export default Factory.define<BannerDesignFromTool>(() => ({
         mobileUrl:
             'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
         tabletDesktopUrl:
+            'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f', // deprecated
+        tabletUrl:
             'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
         wideUrl:
+            'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b', //deprecated
+        desktopUrl:
             'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
         altText: 'Example alt text',
     },

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -97,8 +97,10 @@ interface TickerDesign {
 
 export interface BannerDesignHeaderImage {
     mobileUrl: string;
-    tabletDesktopUrl: string;
-    wideUrl: string;
+    tabletDesktopUrl: string; // deprecated
+    wideUrl: string; // deprecated
+    tabletUrl: string;
+    desktopUrl: string;
     altText: string;
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Fixes the right column width on banners for tablet and above

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Test visually with storybook

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

Choice card 280px width on Tablet 
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/c63a7eab-2f1e-43f4-8a8b-68caed501d31)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
