### PR TITLE
Fix keyboard navigation of choice cards

### DIFF
--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
@@ -1,17 +1,26 @@
 import React from 'react';
-import { ChoiceCardGroup, ChoiceCard } from '@guardian/source-react-components';
+import { ChoiceCardGroup, ChoiceCard, Stack } from '@guardian/source-react-components';
 import {
     ContributionFrequency,
     SelectedAmountsVariant,
     OphanComponentEvent,
 } from '@sdc/shared/types';
-import { css } from '@emotion/react';
-import { between, from, until, space } from '@guardian/source-foundations';
 import { contributionType, ChoiceCardSelection } from '../../../shared/helpers/choiceCards';
 import { ChoiceCardSettings } from './ChoiceCards';
 import type { ReactComponent } from '../../../../types';
+import { css } from '@emotion/react';
 
-const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: number) => {
+interface ChoiceCardInteractiveProps {
+    selection?: ChoiceCardSelection;
+    setSelectionsCallback: (choiceCardSelection: ChoiceCardSelection) => void;
+    submitComponentEvent?: (event: OphanComponentEvent) => void;
+    currencySymbol: string;
+    amountsTest?: SelectedAmountsVariant;
+    componentId: string;
+    design?: ChoiceCardSettings;
+}
+
+const buildStyles = (design: ChoiceCardSettings | undefined) => {
     const {
         buttonColour,
         buttonTextColour,
@@ -22,94 +31,17 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
     } = design || {};
 
     return {
-        bannerFrequenciesGroupOverrides: css`
-            display: grid;
-
-            ${from.tablet} {
-                grid-template-columns: repeat(${frequencyColumns}, minmax(93px, 200px));
-            }
-
-            > div:first-of-type {
-                display: inline;
-                grid-column: 1 / span ${frequencyColumns};
-            }
-        `,
-        frequencyContainer: css`
-            display: flex;
-
-            > label {
-                margin-right: ${space[2]}px !important;
-                margin-bottom: ${space[3]}px !important;
-                min-width: 0;
-            }
-
-            > label > div {
-                padding-left: 0;
-                padding-right: 0;
-            }
-
-            > label:last-of-type {
-                margin-right: 0 !important;
-            }
-        `,
-        bannerAmountsGroupOverrides: css`
-            > div:first-of-type {
-                display: block !important;
-            }
-        `,
-        amountsContainer: css`
-            display: flex;
-            flex-direction: column;
-        `,
-        amountsButton: css`
-            display: flex;
-            flex-direction: row;
-            margin-bottom: ${space[2]}px;
-
-            > label {
-                margin: 0 !important;
-            }
-
-            > label:first-of-type {
-                margin-right: ${space[2]}px !important;
-            }
-
-            > label:last-of-type {
-                margin-right: 0 !important;
-            }
-
-            > label > div {
-                ${between.tablet.and.desktop} {
-                    padding-left: 0 !important;
-                    padding-right: 0 !important;
-                }
-            }
-        `,
-        amountsOrOtherButton: css`
-            margin-bottom: ${space[1]}px;
-
-            ${from.mobileLandscape} { 
-                margin-bottom: ${space[3]}px;
-            }}
-        `,
-
         buttonOverride: css`
-            border-radius: ${space[3]}px;
-            ${until.mobileMedium} {
-                font-size: 10px;
-            }
-
             & + label {
                 ${buttonTextColour && `color: ${buttonTextColour};`}
                 ${buttonColour && `background-color: ${buttonColour};`}
-                ${buttonBorderColour && `box-shadow: inset 0 0 0 2px ${buttonBorderColour};`}
+    ${buttonBorderColour && `box-shadow: inset 0 0 0 2px ${buttonBorderColour};`}
             }
 
             &:hover + label {
                 ${buttonTextColour && `color: ${buttonTextColour};`}
                 ${buttonColour && `background-color: ${buttonColour};`}
-                ${buttonSelectBorderColour &&
-                `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`}
+    ${buttonSelectBorderColour && `box-shadow: inset 0 0 0 4px ${buttonSelectBorderColour};`}
             }
 
             &:checked + label {
@@ -121,18 +53,20 @@ const buildStyles = (design: ChoiceCardSettings | undefined, frequencyColumns: n
                 ${buttonSelectTextColour && `color: ${buttonSelectTextColour};`}
             }
         `,
+        amountsOverride: css`
+            > div > label > div {
+                padding-left: 0 !important;
+                padding-right: 0 !important;
+            }
+        `,
+        lastAmountOverride: css`
+            > div > label:last-of-type {
+                grid-column-start: 1;
+                grid-column-end: 3;
+            }
+        `,
     };
 };
-
-interface ChoiceCardInteractiveProps {
-    selection?: ChoiceCardSelection;
-    setSelectionsCallback: (choiceCardSelection: ChoiceCardSelection) => void;
-    submitComponentEvent?: (event: OphanComponentEvent) => void;
-    currencySymbol: string;
-    amountsTest?: SelectedAmountsVariant;
-    componentId: string;
-    design?: ChoiceCardSettings;
-}
 
 export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> = ({
     selection,
@@ -188,10 +122,11 @@ export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> =
         });
     };
 
-    const ChoiceCardAmount = ({ amount }: { amount?: number }) => {
+    const choiceCardAmount = (amount?: number) => {
         if (amount) {
             return (
                 <ChoiceCard
+                    key={amount}
                     value={`${amount}`}
                     label={`${currencySymbol}${amount} ${
                         contributionType[selection.frequency].suffix
@@ -203,7 +138,7 @@ export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> =
                 />
             );
         }
-        return null;
+        return <></>;
     };
 
     const generateChoiceCardAmountsButtons = () => {
@@ -213,39 +148,33 @@ export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> =
         // Something is wrong with the data
         if (!Array.isArray(requiredAmounts) || !requiredAmounts.length) {
             return (
-                <div css={style.amountsOrOtherButton}>
-                    <ChoiceCard
-                        value="third"
-                        label="Other"
-                        id="contributions-banner-third"
-                        checked={true}
-                        cssOverrides={style.buttonOverride}
-                    />
-                </div>
+                <ChoiceCard
+                    value="third"
+                    label="Other"
+                    id="contributions-banner-third"
+                    checked={true}
+                    cssOverrides={style.buttonOverride}
+                />
             );
         }
 
         return (
             <>
-                <div css={style.amountsButton}>
-                    <ChoiceCardAmount amount={requiredAmounts[0]} />
-                    <ChoiceCardAmount amount={requiredAmounts[1]} />
-                </div>
+                {choiceCardAmount(requiredAmounts[0])}
+                {choiceCardAmount(requiredAmounts[1])}
+
                 {hideChooseYourAmount ? (
-                    <div css={style.amountsOrOtherButton}>
-                        <ChoiceCardAmount amount={requiredAmounts[2]} />
-                    </div>
+                    choiceCardAmount(requiredAmounts[2])
                 ) : (
-                    <div css={style.amountsOrOtherButton}>
-                        <ChoiceCard
-                            value="other"
-                            label="Other"
-                            id="contributions-banner-other"
-                            checked={selection.amount === 'other'}
-                            onChange={() => updateAmount('other')}
-                            cssOverrides={style.buttonOverride}
-                        />
-                    </div>
+                    <ChoiceCard
+                        key={2}
+                        value="other"
+                        label="Other"
+                        id="contributions-banner-other"
+                        checked={selection.amount === 'other'}
+                        onChange={() => updateAmount('other')}
+                        cssOverrides={style.buttonOverride}
+                    />
                 )}
             </>
         );
@@ -268,30 +197,37 @@ export const ChoiceCardInteractive: ReactComponent<ChoiceCardInteractiveProps> =
 
     return (
         <>
-            <ChoiceCardGroup
-                name="contribution-frequency"
-                label="Contribution frequency"
-                columns={noOfContributionTabs}
-                hideLabel
-                cssOverrides={style.bannerFrequenciesGroupOverrides}
-            >
-                <div css={style.frequencyContainer}>
-                    {contributionTypeTabOrder.map((f) =>
-                        displayContributionType.includes(f)
-                            ? generateChoiceCardFrequencyTab(f)
-                            : null,
-                    )}
+            <Stack space={3}>
+                <div>
+                    <ChoiceCardGroup
+                        name="contribution-frequency"
+                        label="Contribution frequency"
+                        columns={noOfContributionTabs}
+                        hideLabel
+                        cssOverrides={style.amountsOverride}
+                    >
+                        {contributionTypeTabOrder.map((f) =>
+                            displayContributionType.includes(f) ? (
+                                generateChoiceCardFrequencyTab(f)
+                            ) : (
+                                <></>
+                            ),
+                        )}
+                    </ChoiceCardGroup>
                 </div>
-            </ChoiceCardGroup>
-            <ChoiceCardGroup
-                name="contribution-amount"
-                label="Contribution amount"
-                hideLabel
-                cssOverrides={style.bannerAmountsGroupOverrides}
-                aria-labelledby={selection.frequency}
-            >
-                <div css={style.amountsContainer}>{generateChoiceCardAmountsButtons()}</div>
-            </ChoiceCardGroup>
+                <div>
+                    <ChoiceCardGroup
+                        name="contribution-amount"
+                        label="Contribution amount"
+                        columns={2}
+                        hideLabel
+                        aria-labelledby={selection.frequency}
+                        cssOverrides={style.lastAmountOverride}
+                    >
+                        {generateChoiceCardAmountsButtons()}
+                    </ChoiceCardGroup>
+                </div>
+            </Stack>
         </>
     );
 };

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
@@ -65,6 +65,7 @@ const styles = {
         align-items: center;
         flex-direction: column;
         gap: ${space[4]}px;
+        margin-top: ${space[3]}px;
         margin-bottom: ${space[2]}px;
 
         > span {


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update the markup of the interactive choice cards in the designable banner to allow keyboard tab navigation between frequency and amount, and arrow key navigation within each group.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Tab from close arrow to the first choice card in the frequency group
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/23437337-f75e-4a14-87ce-8c352aaefe7e)

arrow key ➡️ between them, then tab once again to the different amounts, can arrow key between them successfully.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
