### PR TITLE
RRCP field tidy up

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -159,12 +159,8 @@ const headerImage: BannerDesignImage = {
     kind: 'Image',
     mobileUrl:
         'https://i.guim.co.uk/img/media/036510bc15ecdba97355f464006e3db5fbde9129/0_0_620_180/master/620.jpg?width=310&height=90&quality=100&s=01c604815a2f9980a1227c0d91ffa6b1',
-    tabletDesktopUrl:
-        'https://i.guim.co.uk/img/media/7030f9d98e368d6e5c7a34c643c76d7d1f5ac63c/0_0_1056_366/master/1056.jpg?width=528&height=183&quality=100&s=f0c02cddda84dfaf4ef261d91bd26159', //deprecated
     tabletUrl:
         'https://i.guim.co.uk/img/media/7030f9d98e368d6e5c7a34c643c76d7d1f5ac63c/0_0_1056_366/master/1056.jpg?width=528&height=183&quality=100&s=f0c02cddda84dfaf4ef261d91bd26159',
-    wideUrl:
-        'https://i.guim.co.uk/img/media/3c1cb611785d3dccc2674636a6f692da1e2fcdb6/0_0_1392_366/master/1392.jpg?width=696&height=183&quality=100&s=5935c1ae5e8cbc5d9ed616bbadb3b09e', //deprecated
     desktopUrl:
         'https://i.guim.co.uk/img/media/3c1cb611785d3dccc2674636a6f692da1e2fcdb6/0_0_1392_366/master/1392.jpg?width=696&height=183&quality=100&s=5935c1ae5e8cbc5d9ed616bbadb3b09e',
     altText: "Guardian: Our Planet can't Speak for itself",
@@ -174,12 +170,8 @@ const regularImage: BannerDesignImage = {
     kind: 'Image',
     mobileUrl:
         'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
-    tabletDesktopUrl:
-        'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f', //deprecated
     tabletUrl:
         'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
-    wideUrl:
-        'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b', //deprecated
     desktopUrl:
         'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
     altText: 'Example alt text',

--- a/packages/server/src/factories/bannerDesign.ts
+++ b/packages/server/src/factories/bannerDesign.ts
@@ -22,12 +22,8 @@ export default Factory.define<BannerDesignFromTool>(() => ({
         kind: 'Image',
         mobileUrl:
             'https://i.guim.co.uk/img/media/630a3735c02e195be89ab06fd1b8192959e282ab/0_0_1172_560/500.png?width=500&quality=75&s=937595b3f471d6591475955335c7c023',
-        tabletDesktopUrl:
-            'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f', // deprecated
         tabletUrl:
             'https://i.guim.co.uk/img/media/20cc6e0fa146574bb9c4ed410ac1a089fab02ce0/0_0_1428_1344/500.png?width=500&quality=75&s=fe64f647f74a3cb671f8035a473b895f',
-        wideUrl:
-            'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b', //deprecated
         desktopUrl:
             'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
         altText: 'Example alt text',

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -20,8 +20,8 @@ export const hexColourSchema = z.object({
 
 const imageSchema = z.object({
     mobileUrl: z.string(),
-    tabletDesktopUrl: z.string(),
-    wideUrl: z.string(),
+    tabletUrl: z.string(),
+    desktopUrl: z.string(),
     altText: z.string(),
     kind: z.literal('Image'),
 });

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -97,8 +97,6 @@ interface TickerDesign {
 
 export interface BannerDesignHeaderImage {
     mobileUrl: string;
-    tabletDesktopUrl: string; // deprecated
-    wideUrl: string; // deprecated
     tabletUrl: string;
     desktopUrl: string;
     altText: string;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
As part of updating the image ratios as part of [this card](https://trello.com/c/aLG1cg3T/133-rrcp-banner-image-ratio), for backwards compatibility we had kept the 'old' fields `tabletDesktop` and `wideURL`. The release has been successful (at this point) so this PR is to remove some of the usages of the old fields.

## How to test
Tested in RRCP code that the deprecated fields are no longer displayed and the live preview functionality works (See image)

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/c80dc544-a0a5-4b10-88f2-d2176cd2a650)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
