### PR TITLE
Fix close button overlapping headline on mobile banner

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -381,6 +381,9 @@ const styles = {
     `,
     headerContainer: (background: string, bannerHasImage: boolean) => css`
         order: ${bannerHasImage ? '2' : '1'};
+        ${until.tablet} {
+            ${bannerHasImage ? '' : `max-width: calc(100% - 40px - ${space[3]}px);`}
+        }
 
         ${from.tablet} {
             grid-column: 1 / span 1;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fix the close button overlapping the headline text in mobile banners.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Storybook - mobile screen sizes

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

No header image
Before
<img width="355" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/114918544/7608e94a-fb89-489a-a082-15a35f631dc1">
After
<img width="344" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/114918544/35f9f83c-dc86-45f7-ac80-41afe261d77b">


Header image
After
<img width="339" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/114918544/f9c46478-3cb7-4a4c-b5e4-5b3f19936652">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
