### PR TITLE
Prevent close button from covering banner header copy

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -382,6 +382,15 @@ const styles = {
     headerContainer: (background: string, bannerHasImage: boolean) => css`
         order: ${bannerHasImage ? '2' : '1'};
 
+        ${bannerHasImage
+            ? ''
+            : `${until.tablet} {
+                max-width: calc(100% - 40px - ${space[3]}px);
+            }
+            ${between.mobileMedium.and.tablet} {
+                max-width: ${bannerHasImage ? '100%' : 'calc(100% - 40px - ${space[3]}px)'};
+            }`}
+
         ${from.tablet} {
             grid-column: 1 / span 1;
             grid-row: 1 / span 1;


### PR DESCRIPTION
<img width="319" alt="Screenshot 2024-03-18 at 16 31 24" src="https://github.com/guardian/support-dotcom-components/assets/1513454/d211cad5-0803-46f0-b5be-386ab57e17fb">
<img width="319" alt="Screenshot 2024-03-18 at 16 31 45" src="https://github.com/guardian/support-dotcom-components/assets/1513454/47d1c99a-eae0-4d44-918b-4c9f0a9732a9">
<img width="319" alt="Screenshot 2024-03-18 at 16 31 54" src="https://github.com/guardian/support-dotcom-components/assets/1513454/432877e2-d079-4da7-baa2-022122711e0e">
