### PR TITLE
Banner layout tweaks

### DIFF
--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
@@ -41,23 +41,13 @@ const styles = {
     container: css`
         // This position: relative is necessary to stop it jumping to the top of the page when a button is clicked
         position: relative;
-        max-width: 296px;
 
-        ${from.mobile} {
-            max-width: 351px;
-        }
-
-        ${from.mobileMedium} {
-            max-width: 456px;
-        }
-
-        ${from.mobileLandscape} {
-            max-width: 716px;
+        ${from.tablet} {
+            width: 280px;
         }
 
         ${from.desktop} {
-            min-height: 208px;
-            max-width: 380px;
+            width: 380px;
         }
     `,
     ctaAndPaymentCardsContainer: css`

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -265,7 +265,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         </section>
                     )}
                 </div>
-                {templateSettings.imageSettings && (
+                {templateSettings.imageSettings ? (
                     <div
                         css={styles.bannerVisualContainer(
                             templateSettings.containerSettings.backgroundColour,
@@ -286,38 +286,37 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                     */}
                         {templateSettings.alternativeVisual}
                     </div>
+                ) : (
+                    <DesignableBannerCloseButton
+                        onCloseClick={onCloseClick}
+                        settings={templateSettings.closeButtonSettings}
+                        styleOverides={styles.closeButtonOverrides(true)}
+                    />
                 )}
                 {showChoiceCards && (
-                    <>
-                        <DesignableBannerCloseButton
-                            onCloseClick={onCloseClick}
-                            settings={templateSettings.closeButtonSettings}
-                            styleOverides={styles.closeButtonOverrides(true)}
+                    <div
+                        css={styles.choiceCardsContainer(
+                            templateSettings.containerSettings.backgroundColour,
+                        )}
+                    >
+                        <ChoiceCards
+                            setSelectionsCallback={setChoiceCardSelection}
+                            selection={choiceCardSelection}
+                            submitComponentEvent={submitComponentEvent}
+                            currencySymbol={currencySymbol}
+                            componentId={'contributions-banner-choice-cards'}
+                            amountsTest={choiceCardAmounts}
+                            design={templateSettings.choiceCardSettings}
+                            countryCode={countryCode}
+                            bannerTracking={tracking}
+                            numArticles={numArticles}
+                            content={content}
+                            getCtaText={getCtaText}
+                            cssCtaOverides={buttonStyles(templateSettings.primaryCtaSettings)}
+                            onCtaClick={onCtaClick}
+                            showMobilePaymentIcons={showMobilePaymentIcons}
                         />
-                        <div
-                            css={styles.choiceCardsContainer(
-                                templateSettings.containerSettings.backgroundColour,
-                            )}
-                        >
-                            <ChoiceCards
-                                setSelectionsCallback={setChoiceCardSelection}
-                                selection={choiceCardSelection}
-                                submitComponentEvent={submitComponentEvent}
-                                currencySymbol={currencySymbol}
-                                componentId={'contributions-banner-choice-cards'}
-                                amountsTest={choiceCardAmounts}
-                                design={templateSettings.choiceCardSettings}
-                                countryCode={countryCode}
-                                bannerTracking={tracking}
-                                numArticles={numArticles}
-                                content={content}
-                                getCtaText={getCtaText}
-                                cssCtaOverides={buttonStyles(templateSettings.primaryCtaSettings)}
-                                onCtaClick={onCtaClick}
-                                showMobilePaymentIcons={showMobilePaymentIcons}
-                            />
-                        </div>
-                    </>
+                    </div>
                 )}
                 <div css={styles.guardianLogoContainer}>
                     <SvgGuardianLogo textColor={hexColourToString(basic.logo)} />
@@ -450,6 +449,9 @@ const styles = {
         ${from.tablet} {
             grid-column: 2 / span 1;
             grid-row: 2 / span 1;
+            align-self: flex-start;
+            display: flex;
+            justify-content: flex-end;
         }
     `,
     ctasContainer: css`

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -222,11 +222,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
             )}
         >
             <div css={styles.containerOverrides}>
-                <DesignableBannerCloseButton
-                    onCloseClick={onCloseClick}
-                    settings={templateSettings.closeButtonSettings}
-                    styleOverides={styles.closeButtonOverrides}
-                />
                 <div css={getHeaderContainerCss()}>
                     <DesignableBannerHeader
                         heading={content.mainContent.heading}
@@ -270,42 +265,60 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         </section>
                     )}
                 </div>
-                <div
-                    css={styles.bannerVisualContainer(
-                        templateSettings.containerSettings.backgroundColour,
-                        !!templateSettings.choiceCardSettings,
-                    )}
-                >
-                    {templateSettings.imageSettings && (
+                {templateSettings.imageSettings && (
+                    <div
+                        css={styles.bannerVisualContainer(
+                            templateSettings.containerSettings.backgroundColour,
+                        )}
+                    >
+                        <DesignableBannerCloseButton
+                            onCloseClick={onCloseClick}
+                            settings={templateSettings.closeButtonSettings}
+                            styleOverides={styles.closeButtonOverrides(false)}
+                        />
                         <DesignableBannerVisual
                             settings={templateSettings.imageSettings}
                             bannerId={templateSettings.bannerId}
                         />
-                    )}
-                    {/*
+
+                        {/*
                         I think `alternativeVisual` was for using SVG as the image, which is currently beyond the scope of the design tool. Suggest we remove?
                     */}
-                    {templateSettings.alternativeVisual}
-                    {showChoiceCards && (
-                        <ChoiceCards
-                            setSelectionsCallback={setChoiceCardSelection}
-                            selection={choiceCardSelection}
-                            submitComponentEvent={submitComponentEvent}
-                            currencySymbol={currencySymbol}
-                            componentId={'contributions-banner-choice-cards'}
-                            amountsTest={choiceCardAmounts}
-                            design={templateSettings.choiceCardSettings}
-                            countryCode={countryCode}
-                            bannerTracking={tracking}
-                            numArticles={numArticles}
-                            content={content}
-                            getCtaText={getCtaText}
-                            cssCtaOverides={buttonStyles(templateSettings.primaryCtaSettings)}
-                            onCtaClick={onCtaClick}
-                            showMobilePaymentIcons={showMobilePaymentIcons}
+                        {templateSettings.alternativeVisual}
+                    </div>
+                )}
+                {showChoiceCards && (
+                    <>
+                        <DesignableBannerCloseButton
+                            onCloseClick={onCloseClick}
+                            settings={templateSettings.closeButtonSettings}
+                            styleOverides={styles.closeButtonOverrides(true)}
                         />
-                    )}
-                </div>
+                        <div
+                            css={styles.choiceCardsContainer(
+                                templateSettings.containerSettings.backgroundColour,
+                            )}
+                        >
+                            <ChoiceCards
+                                setSelectionsCallback={setChoiceCardSelection}
+                                selection={choiceCardSelection}
+                                submitComponentEvent={submitComponentEvent}
+                                currencySymbol={currencySymbol}
+                                componentId={'contributions-banner-choice-cards'}
+                                amountsTest={choiceCardAmounts}
+                                design={templateSettings.choiceCardSettings}
+                                countryCode={countryCode}
+                                bannerTracking={tracking}
+                                numArticles={numArticles}
+                                content={content}
+                                getCtaText={getCtaText}
+                                cssCtaOverides={buttonStyles(templateSettings.primaryCtaSettings)}
+                                onCtaClick={onCtaClick}
+                                showMobilePaymentIcons={showMobilePaymentIcons}
+                            />
+                        </div>
+                    </>
+                )}
                 <div css={styles.guardianLogoContainer}>
                     <SvgGuardianLogo textColor={hexColourToString(basic.logo)} />
                 </div>
@@ -366,7 +379,7 @@ const styles = {
         }
         ${templateSpacing.bannerContainer};
     `,
-    closeButtonOverrides: css`
+    closeButtonOverrides: (isGridCell: boolean) => css`
         ${until.tablet} {
             position: fixed;
             margin-top: ${space[3]}px;
@@ -375,8 +388,17 @@ const styles = {
         }
         ${from.tablet} {
             margin-top: ${space[3]}px;
-            grid-column: 2 / span 1;
-            grid-row: 1 / span 1;
+
+            ${isGridCell
+                ? css`
+                      grid-column: 2 / span 1;
+                      grid-row: 1 / span 1;
+                  `
+                : css`
+                      margin-bottom: ${space[3]}px;
+                      display: flex;
+                      justify-content: flex-end;
+                  `}
         }
     `,
     headerContainer: (background: string, bannerHasImage: boolean) => css`
@@ -413,13 +435,21 @@ const styles = {
             grid-row: 2 / span 2;
         }
     `,
-    bannerVisualContainer: (background: string, isChoiceCardsContainer?: boolean) => css`
-        order: ${isChoiceCardsContainer ? '3' : '1'};
+    bannerVisualContainer: (background: string) => css`
+        order: 1;
+        background: ${background};
+        ${from.tablet} {
+            grid-column: 2 / span 1;
+            grid-row: 1 / span 2;
+            align-self: flex-start;
+        }
+    `,
+    choiceCardsContainer: (background: string) => css`
+        order: 3;
         background: ${background};
         ${from.tablet} {
             grid-column: 2 / span 1;
             grid-row: 2 / span 1;
-            align-self: flex-start;
         }
     `,
     ctasContainer: css`


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Conditionally tweaks the grid in the banner so that when an image is present the close button and image are a single cell, when the choice cards are present, they are separate. See images to get a better idea, this has the greatest effect on wide. This also addresses the width of the choice cards, making them more consistent with designs.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->


## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<img width="1097" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/b2989e5d-a8c4-4437-8f55-7d6e7dfdadf0">
<img width="1092" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/ae0bfe2e-2015-4261-b8bf-a5a5fdc2c3d5">
