### PR TITLE
header image on mobile breakpoints are full width

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
@@ -63,9 +63,11 @@ const getStyles = (isHeaderImage = false) => {
 
                 img {
                     height: 100%;
-                    width: 100%;
                     object-fit: contain;
                     display: block;
+                    margin-left: -10px;
+                    margin-right: -10px;
+                    width: calc(100% + 20px);
                 }
             `,
         };

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -334,20 +334,6 @@ DesignFourHeaderImageAndCopy.args = {
     choiceCardAmounts: regularChoiceCardAmounts,
 };
 
-export const DesignFiveHeaderImageAndImage = DefaultTemplate.bind({});
-DesignFiveHeaderImageAndImage.args = {
-    ...props,
-    content: contentWithHeading,
-    mobileContent: mobileContentWithHeading,
-    numArticles: 50,
-    tickerSettings,
-    design: {
-        ...design,
-        headerImage,
-        visual: regularImage,
-    },
-};
-
 export const NoChoiceCardOrImage = DefaultTemplate.bind({});
 NoChoiceCardOrImage.args = {
     ...props,

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -334,6 +334,20 @@ DesignFourHeaderImageAndCopy.args = {
     choiceCardAmounts: regularChoiceCardAmounts,
 };
 
+export const DesignFiveHeaderImageAndImage = DefaultTemplate.bind({});
+DesignFiveHeaderImageAndImage.args = {
+    ...props,
+    content: contentWithHeading,
+    mobileContent: mobileContentWithHeading,
+    numArticles: 50,
+    tickerSettings,
+    design: {
+        ...design,
+        headerImage,
+        visual: regularImage,
+    },
+};
+
 export const NoChoiceCardOrImage = DefaultTemplate.bind({});
 NoChoiceCardOrImage.args = {
     ...props,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Banner header images on mobile and phablet breakpoints are now full width of the banner

[Trello card](https://trello.com/c/SU2sakWt/162-rrcp-banner-update-the-top-padding-of-header-image-s) part two of the card had already been done 🎉 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
Mobile
<img width="335" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/115992455/9f9c7adf-07b9-4993-b316-a966a5c97c9a">

Mobile medium
<img width="386" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/115992455/03daebac-32dc-4f8f-a5bd-9c5d8edd3dee">

Phablet
<img width="681" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/115992455/fe825688-b0d7-4ab5-934b-e0847d8ae0da">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
