### PR TITLE
Use url from RRCP in banner choice cards

### DIFF
--- a/packages/modules/src/hooks/useChoiceCards.ts
+++ b/packages/modules/src/hooks/useChoiceCards.ts
@@ -1,12 +1,14 @@
 import { ContributionFrequency, SelectedAmountsVariant } from '@sdc/shared/src/types/abTests/epic';
 import { useState, useEffect } from 'react';
 import { BannerTextContent } from '../modules/banners/common/types';
-import { getLocalCurrencySymbol } from '@sdc/shared/dist/lib';
+import { addChoiceCardsParams, getLocalCurrencySymbol } from '@sdc/shared/dist/lib';
 
 export interface ChoiceCardSelection {
     frequency: ContributionFrequency;
     amount: number | 'other';
 }
+
+export type ContentType = 'mainContent' | 'mobileContent';
 
 const useChoiceCards = (
     choiceCardAmounts: SelectedAmountsVariant | undefined,
@@ -15,7 +17,8 @@ const useChoiceCards = (
 ): {
     choiceCardSelection: ChoiceCardSelection | undefined;
     setChoiceCardSelection: (choiceCardSelection: ChoiceCardSelection) => void;
-    getCtaText: (contentType: 'mainContent' | 'mobileContent') => string;
+    getCtaText: (contentType: ContentType) => string;
+    getCtaUrl: (contentType: ContentType) => string;
     currencySymbol: string;
 } => {
     const [choiceCardSelection, setChoiceCardSelection] = useState<
@@ -36,10 +39,25 @@ const useChoiceCards = (
         }
     }, [choiceCardAmounts]);
 
-    const getCtaText = (contentType: 'mainContent' | 'mobileContent'): string => {
+    const getCtaText = (contentType: ContentType): string => {
         const primaryCtaText = content?.[contentType]?.primaryCta?.ctaText;
 
         return primaryCtaText ? primaryCtaText : 'Contribute';
+    };
+    const getCtaUrl = (contentType: ContentType): string => {
+        const primaryCtaUrl =
+            content?.[contentType]?.primaryCta?.ctaUrl ??
+            'https://support.theguardian.com/contribute';
+
+        if (choiceCardSelection) {
+            return addChoiceCardsParams(
+                primaryCtaUrl,
+                choiceCardSelection.frequency,
+                choiceCardSelection.amount,
+            );
+        } else {
+            return primaryCtaUrl;
+        }
     };
 
     const currencySymbol = getLocalCurrencySymbol(countryCode);
@@ -48,6 +66,7 @@ const useChoiceCards = (
         choiceCardSelection,
         setChoiceCardSelection,
         getCtaText,
+        getCtaUrl,
         currencySymbol,
     };
 };

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
@@ -6,9 +6,10 @@ import { ChoiceCardInteractive } from './ChoiceCardInteractive';
 import { ChoiceCardsSupportCta } from './ChoiceCardsSupportCta';
 import { PaymentCards } from '../PaymentCards';
 import { BannerTextContent } from '../../common/types';
-import { OphanComponentEvent, SelectedAmountsVariant, Tracking } from '@sdc/shared/src/types';
+import { OphanComponentEvent, SelectedAmountsVariant } from '@sdc/shared/src/types';
 import type { ReactComponent } from '../../../../types';
 import { ChoiceCardSelection } from '../../../shared/helpers/choiceCards';
+import { ContentType } from '../../../../hooks/useChoiceCards';
 
 export interface ChoiceCardSettings {
     buttonColour?: string;
@@ -25,12 +26,10 @@ interface ChoiceCardProps {
     submitComponentEvent?: (event: OphanComponentEvent) => void;
     currencySymbol: string;
     componentId: string;
-    getCtaText: (contentType: 'mainContent' | 'mobileContent') => string;
+    getCtaText: (contentType: ContentType) => string;
+    getCtaUrl: (contentType: ContentType) => string;
     amountsTest?: SelectedAmountsVariant;
     design?: ChoiceCardSettings;
-    countryCode?: string;
-    bannerTracking?: Tracking;
-    numArticles?: number;
     content?: BannerTextContent;
     cssCtaOverides?: SerializedStyles;
     onCtaClick: () => void;
@@ -106,10 +105,8 @@ export const ChoiceCards: ReactComponent<ChoiceCardProps> = ({
     componentId,
     amountsTest,
     design,
-    countryCode,
-    bannerTracking,
-    numArticles,
     getCtaText,
+    getCtaUrl,
     cssCtaOverides,
     onCtaClick,
     showMobilePaymentIcons = false,
@@ -153,28 +150,21 @@ export const ChoiceCards: ReactComponent<ChoiceCardProps> = ({
                 componentId={componentId}
             />
 
-            {bannerTracking && (
-                <div css={styles.ctaAndPaymentCardsContainer}>
-                    <ChoiceCardsSupportCta
-                        countryCode={countryCode}
-                        tracking={bannerTracking}
-                        amountsTestName={testName}
-                        amountsVariantName={variantName}
-                        numArticles={numArticles ?? 0}
-                        selection={selection}
-                        getCtaText={getCtaText}
-                        cssOverrides={css`
-                            ${cssCtaOverides}
-                            ${styles.ctaOverrides}
-                        `}
-                        onCtaClick={onCtaClick}
-                    />
-                    <PaymentCards
-                        cssOverrides={styles.paymentCardsSvgOverrides}
-                        showMobileIcons={showMobilePaymentIcons}
-                    />
-                </div>
-            )}
+            <div css={styles.ctaAndPaymentCardsContainer}>
+                <ChoiceCardsSupportCta
+                    getCtaText={getCtaText}
+                    getCtaUrl={getCtaUrl}
+                    cssOverrides={css`
+                        ${cssCtaOverides}
+                        ${styles.ctaOverrides}
+                    `}
+                    onCtaClick={onCtaClick}
+                />
+                <PaymentCards
+                    cssOverrides={styles.paymentCardsSvgOverrides}
+                    showMobileIcons={showMobilePaymentIcons}
+                />
+            </div>
         </div>
     );
 };

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardsSupportCta.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardsSupportCta.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/dist/lib';
-import { Tracking } from '@sdc/shared/dist/types';
 import { space } from '@guardian/source-foundations';
 import { css, SerializedStyles } from '@emotion/react';
 import { Hide, SvgArrowRightStraight, LinkButton } from '@guardian/source-react-components';
-import { ChoiceCardSelection } from '../../../shared/helpers/choiceCards';
+import { ContentType } from '../../../../hooks/useChoiceCards';
 
 const buttonOverrides = css`
     margin-right: ${space[3]}px;
@@ -13,45 +11,27 @@ const buttonOverrides = css`
 `;
 
 export const ChoiceCardsSupportCta = ({
-    tracking,
-    numArticles,
-    countryCode,
-    amountsTestName,
-    amountsVariantName,
-    selection,
     getCtaText,
+    getCtaUrl,
     cssOverrides,
     onCtaClick,
 }: {
-    tracking: Tracking;
-    numArticles: number;
-    countryCode?: string;
-    amountsTestName?: string;
-    amountsVariantName?: string;
-    selection: ChoiceCardSelection;
-    getCtaText: (contentType: 'mainContent' | 'mobileContent') => string;
+    getCtaText: (contentType: ContentType) => string;
+    getCtaUrl: (contentType: ContentType) => string;
     cssOverrides?: SerializedStyles;
     onCtaClick: () => void;
 }): JSX.Element | null => {
-    const url = `https://support.theguardian.com/contribute?selected-contribution-type=${selection.frequency}&selected-amount=${selection.amount}`;
-
     const mobileText = getCtaText('mobileContent');
     const desktopText = getCtaText('mainContent');
 
-    const supportUrl = addRegionIdAndTrackingParamsToSupportUrl(
-        url,
-        tracking,
-        numArticles,
-        countryCode,
-        amountsTestName,
-        amountsVariantName,
-    );
+    const mobileUrl = getCtaUrl('mobileContent');
+    const desktopUrl = getCtaUrl('mainContent');
 
     return (
         <>
             <Hide above="tablet">
                 <LinkButton
-                    href={supportUrl}
+                    href={mobileUrl}
                     onClick={onCtaClick}
                     priority="tertiary"
                     cssOverrides={[buttonOverrides, cssOverrides ?? css``]}
@@ -66,7 +46,7 @@ export const ChoiceCardsSupportCta = ({
 
             <Hide below="tablet">
                 <LinkButton
-                    href={supportUrl}
+                    href={desktopUrl}
                     onClick={onCtaClick}
                     priority="tertiary"
                     cssOverrides={[buttonOverrides, cssOverrides ?? css``]}

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -196,7 +196,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
     const isTabletOrAbove = useMediaQuery(from.tablet);
     const mainOrMobileContent = isTabletOrAbove ? content.mainContent : content.mobileContent;
 
-    const { choiceCardSelection, setChoiceCardSelection, getCtaText, currencySymbol } =
+    const { choiceCardSelection, setChoiceCardSelection, getCtaText, getCtaUrl, currencySymbol } =
         useChoiceCards(choiceCardAmounts, countryCode, content);
     const showChoiceCards = !!(
         templateSettings.choiceCardSettings && choiceCardAmounts?.amountsCardData
@@ -295,11 +295,9 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                             componentId={'contributions-banner-choice-cards'}
                             amountsTest={choiceCardAmounts}
                             design={templateSettings.choiceCardSettings}
-                            countryCode={countryCode}
-                            bannerTracking={tracking}
-                            numArticles={numArticles}
                             content={content}
                             getCtaText={getCtaText}
+                            getCtaUrl={getCtaUrl}
                             cssCtaOverides={buttonStyles(templateSettings.primaryCtaSettings)}
                             onCtaClick={onCtaClick}
                             showMobilePaymentIcons={showMobilePaymentIcons}

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -35,15 +35,19 @@ export function getMomentTemplateBanner(
         choiceCardAmounts,
         countryCode,
         submitComponentEvent,
-        tracking,
     }: BannerRenderProps): JSX.Element {
         const { isReminderActive, onReminderCtaClick, mobileReminderRef } =
             useReminder(reminderTracking);
         const isTabletOrAbove = useMediaQuery(from.tablet);
         const mainOrMobileContent = isTabletOrAbove ? content.mainContent : content.mobileContent;
 
-        const { choiceCardSelection, setChoiceCardSelection, getCtaText, currencySymbol } =
-            useChoiceCards(choiceCardAmounts, countryCode, content);
+        const {
+            choiceCardSelection,
+            setChoiceCardSelection,
+            getCtaText,
+            getCtaUrl,
+            currencySymbol,
+        } = useChoiceCards(choiceCardAmounts, countryCode, content);
 
         const showChoiceCards = !!(
             templateSettings.choiceCards && choiceCardAmounts?.amountsCardData
@@ -135,11 +139,9 @@ export function getMomentTemplateBanner(
                                 componentId={'choice-cards-buttons-banner-blue'}
                                 amountsTest={choiceCardAmounts}
                                 design={templateSettings.choiceCardSettings}
-                                countryCode={countryCode}
-                                bannerTracking={tracking}
-                                numArticles={numArticles}
                                 content={content}
                                 getCtaText={getCtaText}
+                                getCtaUrl={getCtaUrl}
                                 cssCtaOverides={buttonStyles(templateSettings.primaryCtaSettings)}
                                 onCtaClick={onCtaClick}
                             />

--- a/packages/shared/src/lib/tracking.test.ts
+++ b/packages/shared/src/lib/tracking.test.ts
@@ -5,6 +5,7 @@ import {
     addTrackingParamsToProfileUrl,
     addTrackingParamsToBodyLinks,
     addLabelToTracking,
+    addChoiceCardsParams,
 } from './tracking';
 import { factories } from '../factories/';
 
@@ -250,5 +251,29 @@ describe('addLabelToTracking', () => {
         const newTrackingData = addLabelToTracking(trackingData, newLabel);
 
         expect(newTrackingData.labels).toEqual([originalLabel, newLabel]);
+    });
+});
+
+describe('addChoiceCardsParams', () => {
+    it('adds choice cards params to url without existing querystring', () => {
+        const result = addChoiceCardsParams(
+            'https://support.theguardian.com/contribute',
+            'ONE_OFF',
+            5,
+        );
+        expect(result).toEqual(
+            'https://support.theguardian.com/contribute?selected-contribution-type=ONE_OFF&selected-amount=5',
+        );
+    });
+
+    it('adds choice cards params to url with existing querystring', () => {
+        const result = addChoiceCardsParams(
+            'https://support.theguardian.com/contribute?test=test',
+            'ONE_OFF',
+            5,
+        );
+        expect(result).toEqual(
+            'https://support.theguardian.com/contribute?test=test&selected-contribution-type=ONE_OFF&selected-amount=5',
+        );
     });
 });

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -7,6 +7,7 @@ import {
     TargetingAbTest,
     EpicTest,
     EpicVariant,
+    ContributionFrequency,
 } from '../types';
 
 // TRACKING VIA support.theguardian.com
@@ -191,6 +192,16 @@ export const addProfileTrackingParams = (baseUrl: string, params: Tracking): str
     const alreadyHasQueryString = baseUrl.includes('?');
 
     return `${baseUrl}${alreadyHasQueryString ? '&' : '?'}${queryString.join('&')}`;
+};
+
+export const addChoiceCardsParams = (
+    url: string,
+    frequency: ContributionFrequency,
+    amount: number | 'other',
+): string => {
+    const newParams = `selected-contribution-type=${frequency}&selected-amount=${amount}`;
+    const alreadyHasQueryString = url.includes('?');
+    return `${url}${alreadyHasQueryString ? '&' : '?'}${newParams}`;
 };
 
 export const isProfileUrl = (baseUrl: string): boolean => /\bprofile\./.test(baseUrl);


### PR DESCRIPTION
Currently the banner choice cards url is hardcoded. It should instead use the configuration from the RRCP.
Currently this means we cannot customise the url - in particular we cannot add a `promoCode` to the query string.

This PR adds a `getCtaUrl` function to the `useChoiceCards` hook, which means we don't have to pass as much data down into the CTA component.
I've also moved the logic for adding the query parameters into a `addChoiceCardsParams` function in the shared `tracking.ts` file. This will become available via the npm package for use by dotcom-rendering, where the epic component lives.