### PR TITLE
Remind me later

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -180,6 +180,7 @@ const withBannerData =
                     return {
                         type: SecondaryCtaType.Custom,
                         cta: buildEnrichedCta(secondaryCta.cta),
+                        reminderFields: getReminderFields(countryCode),
                     };
                 }
 

--- a/packages/modules/src/modules/banners/common/types.tsx
+++ b/packages/modules/src/modules/banners/common/types.tsx
@@ -41,6 +41,7 @@ export interface BannerEnrichedCta {
 export interface BannerEnrichedCustomCta {
     type: SecondaryCtaType.Custom;
     cta: BannerEnrichedCta;
+    reminderFields?: ReminderFields;
 }
 
 export interface BannerEnrichedReminderCta {

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -336,7 +336,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                     <>
                         <div css={styles.reminderContainer}>
                             <div css={styles.reminderCtaContainer}>
-                                Not ready to support today?{' '}
+                                <span css={styles.reminderText}>Not ready to support today? </span>
                                 <Button
                                     priority="subdued"
                                     onClick={onReminderCtaClick}
@@ -504,9 +504,22 @@ const styles = {
         display: flex;
         flex-direction: column;
         justify-content: flex-end;
+        order: 4;
+    `,
+    reminderText: css`
+        display: none;
+
+        ${from.tablet} {
+            display: inline;
+        }
     `,
     reminderCtaContainer: css`
-        display: block;
+        display: flex;
+        justify-content: center;
+
+        ${from.tablet} {
+            display: block;
+        }
     `,
     reminderCta: css`
         ${body.small({ lineHeight: 'regular' })};

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { neutral, space, specialReport, between, from, until } from '@guardian/source-foundations';
+import {
+    neutral,
+    space,
+    specialReport,
+    between,
+    from,
+    until,
+    body,
+} from '@guardian/source-foundations';
 import { BannerEnrichedReminderCta, BannerRenderProps } from '../common/types';
 import { DesignableBannerHeader } from './components/DesignableBannerHeader';
 import { DesignableBannerArticleCount } from './components/DesignableBannerArticleCount';
@@ -27,7 +35,7 @@ import { buttonStyles } from './styles/buttonStyles';
 import { BannerTemplateSettings } from './settings';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import type { ReactComponent } from '../../../types';
-import { SvgGuardianLogo } from '@guardian/source-react-components';
+import { Button, SvgGuardianLogo } from '@guardian/source-react-components';
 
 const buildImageSettings = (
     design: BannerDesignImage | BannerDesignHeaderImage,
@@ -214,6 +222,10 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
         );
     };
 
+    const showReminder =
+        (abTestName.includes('REMIND_ME_LATER') && abTestVariant === 'V1_SHOW_REMIND_ME_LATER') ||
+        mainOrMobileContent.secondaryCta?.type === SecondaryCtaType.ContributionsReminder;
+
     return (
         <div
             css={styles.outerContainer(
@@ -321,16 +333,34 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                 <div css={styles.guardianLogoContainer}>
                     <SvgGuardianLogo textColor={hexColourToString(basic.logo)} />
                 </div>
-            </div>
-            {mainOrMobileContent.secondaryCta?.type === SecondaryCtaType.ContributionsReminder &&
-                isReminderActive && (
-                    <DesignableBannerReminder
-                        reminderCta={mainOrMobileContent.secondaryCta as BannerEnrichedReminderCta}
-                        trackReminderSetClick={reminderTracking.onReminderSetClick}
-                        setReminderCtaSettings={templateSettings.setReminderCtaSettings}
-                        mobileReminderRef={isTabletOrAbove ? null : mobileReminderRef}
-                    />
+
+                {showReminder && (
+                    <>
+                        <div css={styles.reminderContainer}>
+                            <div css={styles.reminderCtaContainer}>
+                                Not ready to support today?{' '}
+                                <Button
+                                    priority="subdued"
+                                    onClick={onReminderCtaClick}
+                                    cssOverrides={styles.reminderCta}
+                                >
+                                    Remind me later
+                                </Button>
+                            </div>
+                        </div>
+                        {isReminderActive && (
+                            <DesignableBannerReminder
+                                reminderCta={
+                                    mainOrMobileContent.secondaryCta as BannerEnrichedReminderCta
+                                }
+                                trackReminderSetClick={reminderTracking.onReminderSetClick}
+                                setReminderCtaSettings={templateSettings.setReminderCtaSettings}
+                                mobileReminderRef={isTabletOrAbove ? null : mobileReminderRef}
+                            />
+                        )}
+                    </>
                 )}
+            </div>
         </div>
     );
 };
@@ -390,8 +420,8 @@ const styles = {
 
             ${isGridCell
                 ? css`
-                      grid-column: 2 / span 1;
-                      grid-row: 1 / span 1;
+                      grid-column: 2;
+                      grid-row: 1;
                   `
                 : css`
                       margin-bottom: ${space[3]}px;
@@ -407,8 +437,8 @@ const styles = {
         }
 
         ${from.tablet} {
-            grid-column: 1 / span 1;
-            grid-row: 1 / span 1;
+            grid-column: 1;
+            grid-row: 1;
             background: ${background};
         }
 
@@ -421,8 +451,8 @@ const styles = {
             order: '2';
         }
         ${from.tablet} {
-            grid-column: 1 / span 1;
-            grid-row: 1 / span 1;
+            grid-column: 1;
+            grid-row: 1;
             background: ${background};
         }
         ${templateSpacing.bannerHeader}
@@ -430,15 +460,15 @@ const styles = {
     contentContainer: css`
         order: 2;
         ${from.tablet} {
-            grid-column: 1 / span 1;
-            grid-row: 2 / span 2;
+            grid-column: 1;
+            grid-row: 2;
         }
     `,
     bannerVisualContainer: (background: string) => css`
         order: 1;
         background: ${background};
         ${from.tablet} {
-            grid-column: 2 / span 1;
+            grid-column: 2;
             grid-row: 1 / span 2;
             align-self: flex-start;
         }
@@ -447,8 +477,8 @@ const styles = {
         order: 3;
         background: ${background};
         ${from.tablet} {
-            grid-column: 2 / span 1;
-            grid-row: 2 / span 1;
+            grid-column: 2;
+            grid-row: 2;
             align-self: flex-start;
             display: flex;
             justify-content: flex-end;
@@ -464,10 +494,26 @@ const styles = {
             display: block;
             width: 100px;
         }
-        grid-column: 2 / span 1;
-        grid-row: 3 / span 1;
+        grid-column: 2;
+        grid-row: 3;
         justify-self: end;
         padding-top: ${space[3]}px;
+    `,
+    reminderContainer: css`
+        ${body.small({ lineHeight: 'regular' })};
+        grid-column: 1;
+        grid-row: 3;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+    `,
+    reminderCtaContainer: css`
+        display: block;
+    `,
+    reminderCta: css`
+        ${body.small({ lineHeight: 'regular' })};
+        color: ${neutral[0]};
+        display: inline;
     `,
 };
 

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminder.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminder.tsx
@@ -3,6 +3,8 @@ import { useContributionsReminderSignup } from '../../../../hooks/useContributio
 import { BannerEnrichedReminderCta } from '../../common/types';
 import { CtaSettings } from '../settings';
 import { DesignableBannerReminderSignedOut } from './DesignableBannerReminderSignedOut';
+import { css } from '@emotion/react';
+import { neutral, space } from '@guardian/source-foundations';
 
 export interface DesignableBannerReminderProps {
     reminderCta: BannerEnrichedReminderCta;
@@ -10,6 +12,22 @@ export interface DesignableBannerReminderProps {
     setReminderCtaSettings?: CtaSettings;
     mobileReminderRef: React.RefObject<HTMLDivElement> | null;
 }
+
+const styles = {
+    container: css`
+        grid-row: 4;
+        grid-column: 1 / span 2;
+        margin-top: ${space[3]}px;
+        padding-bottom: ${space[5]}px;
+    `,
+
+    rule: css`
+        width: calc(100% + ${space[10]});
+        border: 0;
+        border-top: 2px solid ${neutral[0]};
+        margin: 0 -${space[5]}px ${space[2]}px -${space[5]}px;
+    `,
+};
 
 export function DesignableBannerReminder({
     reminderCta,
@@ -31,7 +49,8 @@ export function DesignableBannerReminder({
     };
 
     return (
-        <div ref={mobileReminderRef}>
+        <div ref={mobileReminderRef} css={styles.container}>
+            <hr css={styles.rule} />
             <DesignableBannerReminderSignedOut
                 reminderCta={reminderCta}
                 reminderStatus={reminderStatus}

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminder.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminder.tsx
@@ -19,6 +19,7 @@ const styles = {
         grid-column: 1 / span 2;
         margin-top: ${space[3]}px;
         padding-bottom: ${space[5]}px;
+        order: 5;
     `,
 
     rule: css`

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminderSignedOut.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminderSignedOut.tsx
@@ -84,9 +84,10 @@ function Signup({
                         iconSide="right"
                         priority="primary"
                         disabled={reminderStatus === ReminderStatus.Submitting}
-                        cssOverrides={
-                            setReminderCtaSettings && buttonStyles(setReminderCtaSettings)
-                        }
+                        cssOverrides={css`
+                            ${styles.button}
+                            ${setReminderCtaSettings && buttonStyles(setReminderCtaSettings)}
+                        `}
                     >
                         Set reminder
                     </Button>
@@ -137,5 +138,13 @@ const styles = {
     `,
     infoCopyContainer: css`
         margin-top: ${space[3]}px;
+    `,
+    button: css`
+        width: 100%;
+        justify-content: center;
+
+        ${from.tablet} {
+            width: auto;
+        }
     `,
 };

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminderSignedOut.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminderSignedOut.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
-import { Button, TextInput, Container, SvgCheckmark } from '@guardian/source-react-components';
-import { textSans, neutral, space, from } from '@guardian/source-foundations';
+import { Button, TextInput } from '@guardian/source-react-components';
+import { textSans, space, from } from '@guardian/source-foundations';
 import React from 'react';
 import { BannerEnrichedReminderCta } from '../../common/types';
 import { ensureHasPreposition, ReminderStatus } from '../../../utils/reminders';
@@ -29,22 +29,18 @@ export function DesignableBannerReminderSignedOut({
     );
 
     return (
-        <div css={styles.container}>
-            <Container>
-                {reminderStatus !== ReminderStatus.Completed && (
-                    <Signup
-                        reminderLabelWithPreposition={reminderLabelWithPreposition}
-                        reminderStatus={reminderStatus}
-                        onSubmit={onReminderSetClick}
-                        setReminderCtaSettings={setReminderCtaSettings}
-                    />
-                )}
-
-                {reminderStatus === ReminderStatus.Completed && (
-                    <ThankYou reminderLabelWithPreposition={reminderLabelWithPreposition} />
-                )}
-            </Container>
-        </div>
+        <>
+            {reminderStatus === ReminderStatus.Completed ? (
+                <ThankYou reminderLabelWithPreposition={reminderLabelWithPreposition} />
+            ) : (
+                <Signup
+                    reminderLabelWithPreposition={reminderLabelWithPreposition}
+                    reminderStatus={reminderStatus}
+                    onSubmit={onReminderSetClick}
+                    setReminderCtaSettings={setReminderCtaSettings}
+                />
+            )}
+        </>
     );
 }
 
@@ -66,7 +62,7 @@ function Signup({
     const { email, inputError, updateEmail, handleSubmit } = useContributionsReminderEmailForm();
 
     return (
-        <div>
+        <>
             <header>
                 <h3 css={styles.headerCopy}>
                     Remind me to support {reminderLabelWithPreposition} please
@@ -75,7 +71,7 @@ function Signup({
 
             <form css={styles.form} onSubmit={handleSubmit(() => onSubmit(email))}>
                 <TextInput
-                    label="Email address"
+                    label=""
                     onChange={updateEmail}
                     error={inputError}
                     value={email}
@@ -85,15 +81,14 @@ function Signup({
                 <div css={styles.ctaContainer}>
                     <Button
                         type="submit"
-                        icon={<SvgCheckmark />}
                         iconSide="right"
-                        priority="tertiary"
+                        priority="primary"
                         disabled={reminderStatus === ReminderStatus.Submitting}
                         cssOverrides={
                             setReminderCtaSettings && buttonStyles(setReminderCtaSettings)
                         }
                     >
-                        Set a reminder
+                        Set reminder
                     </Button>
                 </div>
 
@@ -107,21 +102,15 @@ function Signup({
             <div css={styles.infoCopyContainer}>
                 <InfoCopy reminderLabelWithPreposition={reminderLabelWithPreposition} />
             </div>
-        </div>
+        </>
     );
 }
 
 // ---- Styles ---- //
 
 const styles = {
-    container: css`
-        border-top: 2px solid ${neutral[0]};
-
-        padding-top: ${space[2]}px;
-        padding-bottom: ${space[5]}px;
-    `,
     headerCopy: css`
-        ${textSans.medium()};
+        ${textSans.medium({ fontWeight: 'bold' })};
         margin: 0;
     `,
     form: css`

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -14,7 +14,6 @@ import { DefaultTemplate } from './Default';
 
 export default {
     title: 'Banners/Designable',
-
     args: props,
 } as Meta;
 
@@ -384,5 +383,27 @@ WithMobileIcons.args = {
         ...props.tracking,
         abTestName: 'MOBILE_PAYMENT_ICONS',
         abTestVariant: 'V1_SHOW_MOBILE_PAYMENT_ICONS',
+    },
+};
+
+export const WithRemindMeLater = DefaultTemplate.bind({});
+WithRemindMeLater.args = {
+    ...props,
+    content: contentWithHeading,
+    mobileContent: mobileContentWithHeading,
+    numArticles: 50,
+    tickerSettings,
+    design: {
+        ...design,
+        visual: {
+            kind: 'ChoiceCards',
+            buttonColour: stringToHexColour('E5E5E5'),
+        },
+    },
+    choiceCardAmounts: regularChoiceCardAmounts,
+    tracking: {
+        ...props.tracking,
+        abTestName: 'REMIND_ME_LATER',
+        abTestVariant: 'V1_SHOW_REMIND_ME_LATER',
     },
 };

--- a/packages/modules/src/modules/shared/Reminders.tsx
+++ b/packages/modules/src/modules/shared/Reminders.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { error, neutral, textSans } from '@guardian/source-foundations';
+import { error, neutral, space, textSans } from '@guardian/source-foundations';
 
 // ---- Thank you component ---- //
 
@@ -96,6 +96,7 @@ const styles = {
     thankYouHeaderCopy: (foreColor: string) => css`
         ${textSans.small({ fontWeight: 'bold' })}
         margin: 0;
+        margin-bottom: ${space[3]}px;
         color: ${foreColor};
     `,
     thankYouBodyCopy: (foreColor: string) => css`


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds "remind me later" functionality to the designable banner as an A/B test by extending and adapting previously implemented functionality. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
A new story has been added to demo this specifically, otherwise follow links from RRCP to view the test variant.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
This is an A/B test with the current banner as the control and the new functionality as the variant. 

## Images

| Mobile | Desktop |
| ------ | --------- |
| <img width="319" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/5adff46d-acf0-4150-ba17-9ae3e9311648"> |  <img width="977" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/7e22a5a9-eb42-4950-adf7-5d23bdbec965"> |
| <img width="317" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/33c42852-a23d-432b-865a-987f3ceceaa7"> | <img width="978" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/35728e7c-50a8-433f-997b-99cb2ec7fef5"> |
| <img width="316" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/5040570a-308f-47dd-85c0-7c2d154fff6e"> | <img width="978" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/47dbcfb6-7901-48f2-b9d2-76fe733015a1"> |







<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
