### PR TITLE
Support Multi Armed Bandit testing

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -9,6 +9,8 @@ Object {
       "GuAlarm",
       "GuAlarm",
       "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
       "GuDistributionBucketParameter",
       "GuGetS3ObjectsPolicy",
       "GuGetS3ObjectsPolicy",
@@ -259,6 +261,74 @@ chown -R dotcom-components:support /var/log/dotcom-components
         },
       },
       "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "BanditDataLoadError6659BF65": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":reader-revenue-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Error fetching bandit samples data from Dynamodb",
+        "AlarmName": "support-dotcom-components: Bandit Data loading error - TEST",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "bandit-data-load-error",
+        "Namespace": "support-dotcom-components-TEST",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "BanditDataSelectionError8734AF1A": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":reader-revenue-dev",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Error selecting variant for bandit test",
+        "AlarmName": "support-dotcom-components: Bandit Data selection error - TEST",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "bandit-selection-error",
+        "Namespace": "support-dotcom-components-TEST",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "CertificateDotcomcomponents88C2E1C7": Object {
       "DeletionPolicy": "Retain",

--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -19,6 +19,7 @@ Object {
       "GuPutCloudwatchMetricsPolicy",
       "GuDynamoDBReadPolicy",
       "GuDynamoDBReadPolicy",
+      "GuDynamoDBReadPolicy",
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuCertificate",
@@ -413,6 +414,48 @@ chown -R dotcom-components:support /var/log/dotcom-components
           "Version": "2012-10-17",
         },
         "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleDotcomcomponents2E8FDE7D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DynamoBanditReadPolicy18B1E556": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "dynamodb:BatchGetItem",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:GetRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:dynamodb:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":table/support-bandit-TEST",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DynamoBanditReadPolicy18B1E556",
         "Roles": Array [
           Object {
             "Ref": "InstanceRoleDotcomcomponents2E8FDE7D",

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -101,6 +101,43 @@ export class DotcomComponents extends GuStack {
 			treatMissingData: TreatMissingData.NOT_BREACHING,
 		});
 
+		new GuAlarm(this, 'BanditDataLoadError', {
+			app: appName,
+			alarmName: `support-${appName}: Bandit Data loading error - ${this.stage}`,
+			alarmDescription:
+				'Error fetching bandit samples data from Dynamodb',
+			snsTopicName,
+			metric: new Metric({
+				metricName: 'bandit-data-load-error',
+				namespace,
+				period: Duration.minutes(60),
+				statistic: 'sum',
+			}),
+			threshold: 1,
+			evaluationPeriods: 1,
+			comparisonOperator:
+				ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+			treatMissingData: TreatMissingData.NOT_BREACHING,
+		});
+
+		new GuAlarm(this, 'BanditDataSelectionError', {
+			app: appName,
+			alarmName: `support-${appName}: Bandit Data selection error - ${this.stage}`,
+			alarmDescription: 'Error selecting variant for bandit test',
+			snsTopicName,
+			metric: new Metric({
+				metricName: 'bandit-selection-error',
+				namespace,
+				period: Duration.minutes(60),
+				statistic: 'sum',
+			}),
+			threshold: 1,
+			evaluationPeriods: 1,
+			comparisonOperator:
+				ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+			treatMissingData: TreatMissingData.NOT_BREACHING,
+		});
+
 		const userData = `#!/bin/bash
 
 groupadd support

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -204,6 +204,9 @@ chown -R dotcom-components:support /var/log/dotcom-components
 			new GuDynamoDBReadPolicy(this, 'DynamoBannerDesignsReadPolicy', {
 				tableName: `support-admin-console-banner-designs-${this.stage}`,
 			}),
+			new GuDynamoDBReadPolicy(this, 'DynamoBanditReadPolicy', {
+				tableName: `support-bandit-${this.stage}`,
+			}),
 		];
 
 		const scaling: GuAsgCapacity = {

--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -27,6 +27,7 @@ import { logWarn } from '../utils/logging';
 import { SuperModeArticle } from '../lib/superMode';
 import { getDeviceType } from '../lib/deviceType';
 import { ValueProvider } from '../utils/valueReloader';
+import { BanditData } from '../bandit/banditData';
 
 interface EpicDataResponse {
     data?: {
@@ -50,6 +51,7 @@ export const buildEpicRouter = (
     liveblogEpicTests: ValueProvider<EpicTest[]>,
     choiceCardAmounts: ValueProvider<AmountsTests>,
     tickerData: TickerDataProvider,
+    banditData: ValueProvider<BanditData[]>,
 ): Router => {
     const router = Router();
 
@@ -100,6 +102,7 @@ export const buildEpicRouter = (
                   targeting,
                   getDeviceType(req),
                   enableSuperMode ? superModeArticles.get() : [],
+                  banditData.get(),
                   params.debug,
               );
 

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -1,0 +1,61 @@
+import { isProd } from '../lib/env';
+import * as AWS from 'aws-sdk';
+import { buildReloader, ValueProvider } from '../utils/valueReloader';
+import { EpicTest } from '@sdc/shared/dist/types';
+
+interface VariantSample {
+    variantName: string;
+    avGbp: number;
+    avGbpPerView: number;
+    views: number;
+}
+
+export interface TestSample {
+    testName: string;
+    variants: VariantSample[];
+    // the start of the interval
+    timestamp: string;
+}
+
+function queryForTestSamples(testName: string, nSamples: number) {
+    const docClient = new AWS.DynamoDB.DocumentClient({ region: 'eu-west-1' });
+    return docClient
+        .query({
+            TableName: `support-bandit-${isProd ? 'PROD' : 'CODE'}`,
+            KeyConditionExpression: 'testName = :testName',
+            ExpressionAttributeValues: {
+                ':testName': testName,
+            },
+            ScanIndexForward: false, // newest first
+            Limit: nSamples,
+        })
+        .promise();
+}
+
+function getBanditSamplesForTest(testName: string): Promise<TestSample[]> {
+    // TODO - fetch + validate
+    return Promise.resolve([]);
+}
+
+interface BanditData {
+    testName: string;
+    variants: {
+        variantName: string;
+        mean: number;
+    };
+}
+
+function buildBanditDataForTest(testName: string): Promise<BanditData> {
+    // TODO - get samples and calculate variant means
+}
+
+function buildBanditData(epicTestsProvider: ValueProvider<EpicTest[]>): Promise<BanditData[]> {
+    const testNames = epicTestsProvider.get().map((test) => test.name);
+    return Promise.all(testNames.map((name) => buildBanditDataForTest(name)));
+}
+
+const buildBanditDataReloader = (epicTestsProvider: ValueProvider<EpicTest[]>) =>
+    buildReloader(buildBanditData(epicTestsProvider), 60 * 1000);
+
+// TODO - pass to epicRouter and use
+export { getBanditSamplesForTest };

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -116,6 +116,6 @@ function buildBanditData(epicTestsProvider: ValueProvider<EpicTest[]>): Promise<
 }
 
 const buildBanditDataReloader = (epicTestsProvider: ValueProvider<EpicTest[]>) =>
-    buildReloader(() => buildBanditData(epicTestsProvider), 60 * 1000);
+    buildReloader(() => buildBanditData(epicTestsProvider), 60);
 
 export { buildBanditDataReloader };

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -84,7 +84,7 @@ function calculateMeanPerVariant(samples: TestSample[], epicTest: EpicTest): Ban
             (variantSample) => variantSample.variantName === variantName,
         );
 
-        const mean = calculateWeightedMeanOfSamples(variantSamples);
+        const mean = calculateOverallMeanForVariant(variantSamples);
 
         return {
             variantName,
@@ -93,7 +93,7 @@ function calculateMeanPerVariant(samples: TestSample[], epicTest: EpicTest): Ban
     });
 }
 
-function calculateWeightedMeanOfSamples(samples: VariantSample[]): number {
+function calculateOverallMeanForVariant(samples: VariantSample[]): number {
     const population = samples.reduce((acc, sample) => acc + sample.views, 0);
     return samples.reduce(
         (acc, sample) => acc + (sample.views / population) * sample.avGbpPerView,

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -111,7 +111,7 @@ function sampleMean(samples: VariantSample[]): number {
 }
 
 function buildBanditData(epicTestsProvider: ValueProvider<EpicTest[]>): Promise<BanditData[]> {
-    const banditTests = epicTestsProvider.get().filter((epicTest) => epicTest.banditTest);
+    const banditTests = epicTestsProvider.get().filter((epicTest) => epicTest.isBanditTest);
     return Promise.all(banditTests.map((epicTest) => buildBanditDataForTest(epicTest)));
 }
 

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -139,6 +139,6 @@ function buildBanditData(epicTestsProvider: ValueProvider<EpicTest[]>): Promise<
 }
 
 const buildBanditDataReloader = (epicTestsProvider: ValueProvider<EpicTest[]>) =>
-    buildReloader(() => buildBanditData(epicTestsProvider), 60);
+    buildReloader(() => buildBanditData(epicTestsProvider), 60 * 5);
 
 export { buildBanditDataReloader };

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -8,8 +8,8 @@ import { putMetric } from '../utils/cloudwatch';
 
 const variantSampleSchema = z.object({
     variantName: z.string(),
-    avGbp: z.number(),
-    avGbpPerView: z.number(),
+    annualisedValueInGBP: z.number(),
+    annualisedValueInGBPPerView: z.number(),
     views: z.number(),
 });
 
@@ -96,7 +96,7 @@ function calculateMeanPerVariant(samples: TestSample[], epicTest: EpicTest): Ban
 function calculateOverallMeanForVariant(samples: VariantSample[]): number {
     const population = samples.reduce((acc, sample) => acc + sample.views, 0);
     return samples.reduce(
-        (acc, sample) => acc + (sample.views / population) * sample.avGbpPerView,
+        (acc, sample) => acc + (sample.views / population) * sample.annualisedValueInGBPPerView,
         0,
     );
 }

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -58,7 +58,7 @@ interface BanditVariantData {
 
 export interface BanditData {
     testName: string;
-    variants: BanditVariantData[];
+    bestVariants: BanditVariantData[]; // will contain more than 1 variant if there is a tie
 }
 
 async function buildBanditDataForTest(testName: string): Promise<BanditData> {
@@ -81,10 +81,12 @@ async function buildBanditDataForTest(testName: string): Promise<BanditData> {
     });
 
     const sortedVariantMeans = variantMeans.sort((a, b) => b.mean - a.mean);
+    const highestMean = sortedVariantMeans[0].mean;
+    const bestVariants = variantMeans.filter((variant) => variant.mean === highestMean);
 
     return {
         testName,
-        variants: sortedVariantMeans,
+        bestVariants,
     };
 }
 

--- a/packages/server/src/bandit/banditSelection.test.ts
+++ b/packages/server/src/bandit/banditSelection.test.ts
@@ -1,0 +1,104 @@
+import { EpicTest } from '@sdc/shared/dist/types';
+import { BanditData } from './banditData';
+import { selectVariantWithHighestMean } from './banditSelection';
+
+const epicTest: EpicTest = {
+    name: 'example-1',
+    priority: 1,
+    status: 'Live',
+    locations: [],
+    tagIds: [],
+    sections: ['environment'],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: true,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
+    userCohort: 'AllNonSupporters',
+    hasCountryName: false,
+    variants: [
+        {
+            name: 'v1',
+            heading: '',
+            paragraphs: [''],
+            highlightedText: '',
+            cta: {
+                text: 'Support The Guardian',
+                baseUrl: 'https://support.theguardian.com/contribute',
+            },
+        },
+        {
+            name: 'v2',
+            heading: '',
+            paragraphs: [''],
+            highlightedText: '',
+            cta: {
+                text: 'Support The Guardian',
+                baseUrl: 'https://support.theguardian.com/contribute',
+            },
+        },
+        {
+            name: 'v3',
+            heading: '',
+            paragraphs: [''],
+            highlightedText: '',
+            cta: {
+                text: 'Support The Guardian',
+                baseUrl: 'https://support.theguardian.com/contribute',
+            },
+        },
+    ],
+    highPriority: false,
+    useLocalViewLog: false,
+    articlesViewedSettings: {
+        minViews: 5,
+        periodInWeeks: 52,
+    },
+    hasArticleCountInCopy: true,
+};
+
+const buildBanditData = (v1: number, v2: number, v3: number): BanditData => ({
+    testName: 'example-1',
+    variants: [
+        {
+            variantName: 'v1',
+            mean: v1,
+        },
+        {
+            variantName: 'v2',
+            mean: v2,
+        },
+        {
+            variantName: 'v3',
+            mean: v3,
+        },
+    ],
+});
+
+describe('selectVariantWithHighestMean', () => {
+    it('should return the only variant with highest mean', () => {
+        const banditData = buildBanditData(3, 2, 1);
+        expect(selectVariantWithHighestMean(banditData, epicTest)).toEqual(epicTest.variants[0]);
+    });
+
+    it('should return first of best variants', () => {
+        // v1 and v2 are tied
+        const banditData = buildBanditData(3, 3, 1);
+        // fix Math.random to always choose v1
+        jest.spyOn(global.Math, 'random').mockReturnValue(0.1);
+
+        expect(selectVariantWithHighestMean(banditData, epicTest)?.name).toEqual('v1');
+    });
+
+    it('should return second of best variants', () => {
+        // v1 and v2 are tied
+        const banditData = buildBanditData(3, 3, 1);
+        // fix Math.random to always choose v2
+        jest.spyOn(global.Math, 'random').mockReturnValue(0.8);
+
+        expect(selectVariantWithHighestMean(banditData, epicTest)?.name).toEqual('v2');
+    });
+});

--- a/packages/server/src/bandit/banditSelection.test.ts
+++ b/packages/server/src/bandit/banditSelection.test.ts
@@ -60,33 +60,31 @@ const epicTest: EpicTest = {
     hasArticleCountInCopy: true,
 };
 
-const buildBanditData = (v1: number, v2: number, v3: number): BanditData => ({
-    testName: 'example-1',
-    variants: [
-        {
-            variantName: 'v1',
-            mean: v1,
-        },
-        {
-            variantName: 'v2',
-            mean: v2,
-        },
-        {
-            variantName: 'v3',
-            mean: v3,
-        },
-    ],
-});
+const buildBanditData = (variants: number): BanditData => {
+    const bestVariants = [];
+    for (let i = 0; i < variants; i++) {
+        const variantName = `v${i + 1}`;
+        const mean = i + 1;
+        bestVariants.push({
+            variantName,
+            mean,
+        });
+    }
+    return {
+        testName: 'example-1',
+        bestVariants,
+    };
+};
 
 describe('selectVariantWithHighestMean', () => {
     it('should return the only variant with highest mean', () => {
-        const banditData = buildBanditData(3, 2, 1);
-        expect(selectVariantWithHighestMean(banditData, epicTest)).toEqual(epicTest.variants[0]);
+        const banditData = buildBanditData(1);
+        expect(selectVariantWithHighestMean(banditData, epicTest)?.name).toEqual('v1');
     });
 
     it('should return first of best variants', () => {
         // v1 and v2 are tied
-        const banditData = buildBanditData(3, 3, 1);
+        const banditData = buildBanditData(2);
         // fix Math.random to always choose v1
         jest.spyOn(global.Math, 'random').mockReturnValue(0.1);
 
@@ -95,7 +93,7 @@ describe('selectVariantWithHighestMean', () => {
 
     it('should return second of best variants', () => {
         // v1 and v2 are tied
-        const banditData = buildBanditData(3, 3, 1);
+        const banditData = buildBanditData(2);
         // fix Math.random to always choose v2
         jest.spyOn(global.Math, 'random').mockReturnValue(0.8);
 

--- a/packages/server/src/bandit/banditSelection.ts
+++ b/packages/server/src/bandit/banditSelection.ts
@@ -6,25 +6,14 @@ export function selectVariantWithHighestMean(
     testBanditData: BanditData,
     test: EpicTest,
 ): EpicVariant | undefined {
-    // The variants are sorted by mean
-    const highestMeanVariant = testBanditData.variants[0];
-
-    // If there's a tie then we will randomly select one of the top variants
-    const topVariants = [highestMeanVariant];
-    for (let i = 1; i < testBanditData.variants.length; i++) {
-        if (testBanditData.variants[i].mean === highestMeanVariant.mean) {
-            topVariants.push(testBanditData.variants[i]);
-        } else {
-            break;
-        }
-    }
-
     const variant =
-        topVariants.length < 2
-            ? highestMeanVariant
-            : topVariants[Math.floor(Math.random() * topVariants.length)];
+        testBanditData.bestVariants.length < 2
+            ? testBanditData.bestVariants[0]
+            : testBanditData.bestVariants[
+                  Math.floor(Math.random() * testBanditData.bestVariants.length)
+              ];
 
-    if (!highestMeanVariant) {
+    if (!variant) {
         return undefined;
     }
 

--- a/packages/server/src/bandit/banditSelection.ts
+++ b/packages/server/src/bandit/banditSelection.ts
@@ -2,6 +2,12 @@ import { EpicTest, EpicVariant } from '@sdc/shared/dist/types';
 import { BanditData } from './banditData';
 import { Result } from '../tests/epics/epicSelection';
 
+/**
+ * Select at random with probability epsilon.
+ * https://en.wikipedia.org/wiki/Multi-armed_bandit#Semi-uniform_strategies
+ */
+const EPSILON = 0.1;
+
 export function selectVariantWithHighestMean(
     testBanditData: BanditData,
     test: EpicTest,
@@ -34,10 +40,9 @@ export function selectVariantUsingEpsilonGreedy(banditData: BanditData[], test: 
     }
 
     // Choose at random with probability epsilon
-    const epsilon = 0.1;
     const random = Math.random();
 
-    if (epsilon > random) {
+    if (EPSILON > random) {
         const randomVariantData = selectRandomVariant(test.variants);
 
         if (!randomVariantData) {

--- a/packages/server/src/bandit/banditSelection.ts
+++ b/packages/server/src/bandit/banditSelection.ts
@@ -1,0 +1,77 @@
+import { EpicTest, EpicVariant } from '@sdc/shared/dist/types';
+import { BanditData } from './banditData';
+import { Result } from '../tests/epics/epicSelection';
+
+export function selectVariantWithHighestMean(
+    testBanditData: BanditData,
+    test: EpicTest,
+): EpicVariant | undefined {
+    // The variants are sorted by mean
+    const highestMeanVariant = testBanditData.variants[0];
+
+    // If there's a tie then we will randomly select one of the top variants
+    const topVariants = [highestMeanVariant];
+    for (let i = 1; i < testBanditData.variants.length; i++) {
+        if (testBanditData.variants[i].mean === highestMeanVariant.mean) {
+            topVariants.push(testBanditData.variants[i]);
+        } else {
+            break;
+        }
+    }
+
+    const variant =
+        topVariants.length < 2
+            ? highestMeanVariant
+            : topVariants[Math.floor(Math.random() * topVariants.length)];
+
+    if (!highestMeanVariant) {
+        return undefined;
+    }
+
+    return test.variants.find((v) => v.name === variant.variantName);
+}
+
+function selectRandomVariant(variants: EpicVariant[]): EpicVariant | undefined {
+    const randomVariantIndex = Math.floor(Math.random() * variants.length);
+    return variants[randomVariantIndex];
+}
+
+export function selectVariantUsingEpsilonGreedy(banditData: BanditData[], test: EpicTest): Result {
+    const testBanditData = banditData.find((bandit) => bandit.testName === test.name);
+
+    if (!testBanditData) {
+        // TODO: what do we do if the bandit data isn't there for the test?
+        return {};
+    }
+
+    // Choose at random with probability epsilon
+    const epsilon = 0.1;
+    const random = Math.random();
+
+    if (epsilon > random) {
+        const randomVariantData = selectRandomVariant(test.variants);
+
+        if (!randomVariantData) {
+            // TODO: what do we do if the random variant data is undefined?
+            return {};
+        }
+
+        return {
+            result: { test, variant: randomVariantData },
+        };
+    }
+
+    const highestMeanVariantData = selectVariantWithHighestMean(testBanditData, test);
+
+    if (!highestMeanVariantData) {
+        // TODO: what do we do if the chosen variant data is undefined?
+        return {};
+    }
+
+    return {
+        result: {
+            test,
+            variant: highestMeanVariantData,
+        },
+    };
+}

--- a/packages/server/src/bandit/banditSelection.ts
+++ b/packages/server/src/bandit/banditSelection.ts
@@ -5,7 +5,7 @@ import { putMetric } from '../utils/cloudwatch';
 import { logError } from '../utils/logging';
 
 /**
- * Select at random with probability epsilon.
+ * In general we select the best known variant, except with probability 'epsilon' when we select at random.
  * https://en.wikipedia.org/wiki/Multi-armed_bandit#Semi-uniform_strategies
  */
 const EPSILON = 0.1;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -7,6 +7,7 @@ import {
     errorHandling as errorHandlingMiddleware,
     logging as loggingMiddleware,
 } from './middleware';
+import { buildBanditDataReloader } from './bandit/banditData';
 import { logError } from './utils/logging';
 import { buildEpicRouter } from './api/epicRouter';
 import { buildBannerRouter } from './api/bannerRouter';
@@ -87,6 +88,8 @@ const buildApp = async (): Promise<Express> => {
         buildBannerDesignsReloader(),
     ]);
 
+    const banditData = await buildBanditDataReloader(articleEpicTests);
+
     // Build the routers
     app.use(
         buildEpicRouter(
@@ -96,6 +99,7 @@ const buildApp = async (): Promise<Express> => {
             liveblogEpicTests,
             choiceCardAmounts,
             tickerData,
+            banditData,
         ),
     );
     app.use(

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -19,6 +19,7 @@ import {
     deviceTypeMatchesFilter,
     correctSignedInStatusFilter,
 } from './epicSelection';
+import { BanditData } from '../../bandit/banditData';
 
 const testDefault: EpicTest = {
     name: 'example-1',
@@ -86,6 +87,8 @@ const targetingDefault: EpicTargeting = {
 
 const superModeArticles: SuperModeArticle[] = [];
 
+const banditData: BanditData[] = [];
+
 const userDeviceType = 'Desktop';
 
 describe('findTestAndVariant', () => {
@@ -100,7 +103,13 @@ describe('findTestAndVariant', () => {
             weeklyArticleHistory: [{ week: 18330, count: 45 }],
         };
 
-        const got = findTestAndVariant(tests, targeting, userDeviceType, superModeArticles);
+        const got = findTestAndVariant(
+            tests,
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+        );
 
         expect(got.result?.test.name).toBe('example-1');
         expect(got.result?.variant.name).toBe('control-example-1');
@@ -114,7 +123,13 @@ describe('findTestAndVariant', () => {
             hasOptedOutOfArticleCount: true,
         };
 
-        const got = findTestAndVariant(tests, targeting, userDeviceType, superModeArticles);
+        const got = findTestAndVariant(
+            tests,
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+        );
 
         expect(got.result).toBe(undefined);
     });
@@ -124,7 +139,13 @@ describe('findTestAndVariant', () => {
         const tests = [test];
         const targeting = { ...targetingDefault, sectionId: 'news' };
 
-        const got = findTestAndVariant(tests, targeting, userDeviceType, superModeArticles);
+        const got = findTestAndVariant(
+            tests,
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+        );
 
         expect(got.result).toBe(undefined);
     });
@@ -141,7 +162,13 @@ describe('findTestAndVariant', () => {
             showSupportMessaging: false,
         };
 
-        const got = findTestAndVariant(tests, targeting, userDeviceType, superModeArticles);
+        const got = findTestAndVariant(
+            tests,
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+        );
 
         expect(got.result?.variant.showReminderFields).toBe(undefined);
     });

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -282,7 +282,7 @@ export const findTestAndVariant = (
 };
 
 function selectEpicVariant(test: EpicTest, banditData: BanditData[], targeting: EpicTargeting) {
-    if (test.banditTest) {
+    if (test.isBanditTest) {
         return selectVariantUsingEpsilonGreedy(banditData, test);
     }
 

--- a/packages/server/src/utils/cloudwatch.ts
+++ b/packages/server/src/utils/cloudwatch.ts
@@ -7,7 +7,12 @@ const cloudwatch = new AWS.CloudWatch({ region: 'eu-west-1' });
 const stage = isProd ? 'PROD' : 'CODE';
 const namespace = `support-dotcom-components-${stage}`;
 
-type Metric = 'super-mode-error' | 'channel-tests-error' | 'banner-designs-load-error';
+type Metric =
+    | 'super-mode-error'
+    | 'channel-tests-error'
+    | 'banner-designs-load-error'
+    | 'bandit-data-load-error'
+    | 'bandit-selection-error';
 
 // Sends a single metric to cloudwatch.
 // Avoid doing this per-request, to avoid high costs. This should instead be called from within a cacheAsync

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -126,6 +126,7 @@ export const epicTestFromToolSchema = testSchema.extend({
     articlesViewedSettings: articlesViewedSettingsSchema.optional(),
     priority: z.number(),
     variants: variantSchema.array(),
+    banditTest: z.boolean().optional(),
 });
 
 export type EpicVariant = z.infer<typeof variantSchema>;

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -126,7 +126,7 @@ export const epicTestFromToolSchema = testSchema.extend({
     articlesViewedSettings: articlesViewedSettingsSchema.optional(),
     priority: z.number(),
     variants: variantSchema.array(),
-    banditTest: z.boolean().optional(),
+    isBanditTest: z.boolean().optional(),
 });
 
 export type EpicVariant = z.infer<typeof variantSchema>;


### PR DESCRIPTION
## What are we doing in this PR?
Create multi armed bandit selection algorithm for Epic selection within SDC. See point 5 in [this doc](https://docs.google.com/document/d/1jV6DkkLLH90PetO1Os7c6pi8WEiCx2t9BUIraqIEAHU/edit)

- Fetch and cache variant data (views and AV) for each bandit test
- Calculate sample mean of each variant
- Implement ε-greedy algorithm, with hardcoded ε value for now
- Add alarms for errors

This work follows up on the work done in `support-analytics` ([initial PR](https://github.com/guardian/support-analytics/pull/319)) to create a state machine to serve the initial variant data

## Architecture diagram

![image](https://github.com/guardian/support-dotcom-components/assets/114918544/e1288705-1b0b-4d63-8997-794ab2fa8d8b)
