### PR TITLE
Implement WIP bandit data

### DIFF
--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -27,6 +27,7 @@ import { logWarn } from '../utils/logging';
 import { SuperModeArticle } from '../lib/superMode';
 import { getDeviceType } from '../lib/deviceType';
 import { ValueProvider } from '../utils/valueReloader';
+import { BanditData } from '../bandit/banditData';
 
 interface EpicDataResponse {
     data?: {
@@ -50,6 +51,7 @@ export const buildEpicRouter = (
     liveblogEpicTests: ValueProvider<EpicTest[]>,
     choiceCardAmounts: ValueProvider<AmountsTests>,
     tickerData: TickerDataProvider,
+    banditData: ValueProvider<BanditData[]>,
 ): Router => {
     const router = Router();
 
@@ -101,6 +103,7 @@ export const buildEpicRouter = (
                   getDeviceType(req),
                   enableSuperMode ? superModeArticles.get() : [],
                   params.debug,
+                  banditData.get(),
               );
 
         if (!result.result) {

--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -102,8 +102,8 @@ export const buildEpicRouter = (
                   targeting,
                   getDeviceType(req),
                   enableSuperMode ? superModeArticles.get() : [],
-                  params.debug,
                   banditData.get(),
+                  params.debug,
               );
 
         if (!result.result) {

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -80,9 +80,11 @@ async function buildBanditDataForTest(testName: string): Promise<BanditData> {
         };
     });
 
+    const sortedVariantMeans = variantMeans.sort((a, b) => b.mean - a.mean);
+
     return {
         testName,
-        variants: variantMeans,
+        variants: sortedVariantMeans,
     };
 }
 

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -62,7 +62,7 @@ interface BanditVariantData {
     mean: number;
 }
 
-interface BanditData {
+export interface BanditData {
     testName: string;
     variants: BanditVariantData[];
 }

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -23,8 +23,8 @@ const queryResultSchema = z.array(testSampleSchema);
 type TestSample = z.infer<typeof testSampleSchema>;
 
 export async function testBanditLocally(): Promise<string> {
-    const queryResult = await getBanditSamplesForTest('2024-03-05_EPIC_PRIMARY__US');
-    console.log('getBanditSamplesForTest', queryResult);
+    const queryResult = await buildBanditDataForTest('2024-03-05_EPIC_PRIMARY__US');
+    console.log('buildBanditDataForTest', queryResult);
     return 'success';
 }
 
@@ -44,7 +44,7 @@ function queryForTestSamples(testName: string, nSamples: number) {
 }
 
 async function getBanditSamplesForTest(testName: string): Promise<TestSample[]> {
-    const queryResult = await queryForTestSamples(testName, 1);
+    const queryResult = await queryForTestSamples(testName, 2);
 
     const parsedResults = queryResultSchema.safeParse(queryResult.Items);
 
@@ -55,17 +55,41 @@ async function getBanditSamplesForTest(testName: string): Promise<TestSample[]> 
     return parsedResults.data;
 }
 
-interface BanditData {
-    testName: string;
-    variants: {
-        variantName: string;
-        mean: number;
-    };
+interface BanditVariantData {
+    variantName: string;
+    mean: number;
 }
 
-// function buildBanditDataForTest(testName: string): Promise<BanditData> {
-//     // TODO - get samples and calculate variant means
-// }
+interface BanditData {
+    testName: string;
+    variants: BanditVariantData[];
+}
+
+async function buildBanditDataForTest(testName: string): Promise<BanditData> {
+    const samples = await getBanditSamplesForTest(testName);
+
+    const variantsData = samples.flatMap((sample) => sample.variants);
+    const variantNames = Array.from(new Set(variantsData.map((variant) => variant.variantName)));
+
+    const variantMeans = variantNames.map((variantName) => {
+        const filteredVariantsData = variantsData.filter(
+            (variant) => variant.variantName === variantName,
+        );
+
+        const sum = filteredVariantsData.reduce((acc, curr) => acc + curr.avGbpPerView, 0);
+        const mean = sum / filteredVariantsData.length;
+
+        return {
+            variantName,
+            mean,
+        };
+    });
+
+    return {
+        testName,
+        variants: variantMeans,
+    };
+}
 
 // function buildBanditData(epicTestsProvider: ValueProvider<EpicTest[]>): Promise<BanditData[]> {
 //     const testNames = epicTestsProvider.get().map((test) => test.name);

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -24,12 +24,6 @@ const queryResultSchema = z.array(testSampleSchema);
 
 type TestSample = z.infer<typeof testSampleSchema>;
 
-export async function testBanditLocally(): Promise<string> {
-    const queryResult = await buildBanditDataForTest('2024-03-05_EPIC_PRIMARY__US');
-    console.log('buildBanditDataForTest', queryResult);
-    return 'success';
-}
-
 function queryForTestSamples(testName: string, nSamples: number) {
     const docClient = new AWS.DynamoDB.DocumentClient({ region: 'eu-west-1' });
     return docClient
@@ -108,5 +102,4 @@ function buildBanditData(epicTestsProvider: ValueProvider<EpicTest[]>): Promise<
 const buildBanditDataReloader = (epicTestsProvider: ValueProvider<EpicTest[]>) =>
     buildReloader(() => buildBanditData(epicTestsProvider), 60 * 1000);
 
-// TODO - pass to epicRouter and use
 export { buildBanditDataReloader };

--- a/packages/server/src/bandit/banditSelection.test.ts
+++ b/packages/server/src/bandit/banditSelection.test.ts
@@ -1,0 +1,104 @@
+import { EpicTest } from '@sdc/shared/dist/types';
+import { BanditData } from './banditData';
+import { selectVariantWithHighestMean } from './banditSelection';
+
+const epicTest: EpicTest = {
+    name: 'example-1',
+    priority: 1,
+    status: 'Live',
+    locations: [],
+    tagIds: [],
+    sections: ['environment'],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: true,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
+    userCohort: 'AllNonSupporters',
+    hasCountryName: false,
+    variants: [
+        {
+            name: 'v1',
+            heading: '',
+            paragraphs: [''],
+            highlightedText: '',
+            cta: {
+                text: 'Support The Guardian',
+                baseUrl: 'https://support.theguardian.com/contribute',
+            },
+        },
+        {
+            name: 'v2',
+            heading: '',
+            paragraphs: [''],
+            highlightedText: '',
+            cta: {
+                text: 'Support The Guardian',
+                baseUrl: 'https://support.theguardian.com/contribute',
+            },
+        },
+        {
+            name: 'v3',
+            heading: '',
+            paragraphs: [''],
+            highlightedText: '',
+            cta: {
+                text: 'Support The Guardian',
+                baseUrl: 'https://support.theguardian.com/contribute',
+            },
+        },
+    ],
+    highPriority: false,
+    useLocalViewLog: false,
+    articlesViewedSettings: {
+        minViews: 5,
+        periodInWeeks: 52,
+    },
+    hasArticleCountInCopy: true,
+};
+
+const buildBanditData = (v1: number, v2: number, v3: number): BanditData => ({
+    testName: 'example-1',
+    variants: [
+        {
+            variantName: 'v1',
+            mean: v1,
+        },
+        {
+            variantName: 'v2',
+            mean: v2,
+        },
+        {
+            variantName: 'v3',
+            mean: v3,
+        },
+    ],
+});
+
+describe('selectVariantWithHighestMean', () => {
+    it('should return the only variant with highest mean', () => {
+        const banditData = buildBanditData(3, 2, 1);
+        expect(selectVariantWithHighestMean(banditData, epicTest)).toEqual(epicTest.variants[0]);
+    });
+
+    it('should return first of best variants', () => {
+        // v1 and v2 are tied
+        const banditData = buildBanditData(3, 3, 1);
+        // fix Math.random to always choose v1
+        jest.spyOn(global.Math, 'random').mockReturnValue(0.1);
+
+        expect(selectVariantWithHighestMean(banditData, epicTest)?.name).toEqual('v1');
+    });
+
+    it('should return second of best variants', () => {
+        // v1 and v2 are tied
+        const banditData = buildBanditData(3, 3, 1);
+        // fix Math.random to always choose v2
+        jest.spyOn(global.Math, 'random').mockReturnValue(0.8);
+
+        expect(selectVariantWithHighestMean(banditData, epicTest)?.name).toEqual('v2');
+    });
+});

--- a/packages/server/src/bandit/banditSelection.ts
+++ b/packages/server/src/bandit/banditSelection.ts
@@ -15,15 +15,9 @@ function selectVariantWithHighestMean(
     return test.variants.find((v) => v.name === highestMeanVariant.variantName);
 }
 
-function selectRandomVariant(testBanditData: BanditData, test: EpicTest): EpicVariant | undefined {
-    const randomVariantIndex = Math.floor(Math.random() * testBanditData.variants.length);
-    const chosenVariant = testBanditData.variants[randomVariantIndex];
-
-    if (!chosenVariant) {
-        return undefined;
-    }
-
-    return test.variants.find((v) => v.name === chosenVariant.variantName);
+function selectRandomVariant(variants: EpicVariant[]): EpicVariant | undefined {
+    const randomVariantIndex = Math.floor(Math.random() * variants.length);
+    return variants[randomVariantIndex];
 }
 
 export function selectVariantUsingEpsilonGreedy(banditData: BanditData[], test: EpicTest): Result {
@@ -39,7 +33,7 @@ export function selectVariantUsingEpsilonGreedy(banditData: BanditData[], test: 
     const random = Math.random();
 
     if (epsilon > random) {
-        const randomVariantData = selectRandomVariant(testBanditData, test);
+        const randomVariantData = selectRandomVariant(test.variants);
 
         if (!randomVariantData) {
             // TODO: what do we do if the random variant data is undefined?

--- a/packages/server/src/bandit/banditSelection.ts
+++ b/packages/server/src/bandit/banditSelection.ts
@@ -1,0 +1,67 @@
+import { EpicTest, EpicVariant } from '@sdc/shared/dist/types';
+import { BanditData } from './banditData';
+import { Result } from '../tests/epics/epicSelection';
+
+function selectVariantWithHighestMean(
+    testBanditData: BanditData,
+    test: EpicTest,
+): EpicVariant | undefined {
+    const highestMeanVariant = testBanditData.variants.sort((a, b) => b.mean - a.mean)[0];
+
+    if (!highestMeanVariant) {
+        return undefined;
+    }
+
+    return test.variants.find((v) => v.name === highestMeanVariant.variantName);
+}
+
+function selectRandomVariant(testBanditData: BanditData, test: EpicTest): EpicVariant | undefined {
+    const randomVariantIndex = Math.floor(Math.random() * testBanditData.variants.length);
+    const chosenVariant = testBanditData.variants[randomVariantIndex];
+
+    if (!chosenVariant) {
+        return undefined;
+    }
+
+    return test.variants.find((v) => v.name === chosenVariant.variantName);
+}
+
+export function selectVariantUsingEpsilonGreedy(banditData: BanditData[], test: EpicTest): Result {
+    const testBanditData = banditData.find((bandit) => bandit.testName === test.name);
+
+    if (!testBanditData) {
+        // TODO: what do we do if the bandit data isn't there for the test?
+        return {};
+    }
+
+    // Choose at random with probability epsilon
+    const epsilon = 0.1;
+    const random = Math.random();
+
+    if (epsilon > random) {
+        const randomVariantData = selectRandomVariant(testBanditData, test);
+
+        if (!randomVariantData) {
+            // TODO: what do we do if the random variant data is undefined?
+            return {};
+        }
+
+        return {
+            result: { test, variant: randomVariantData },
+        };
+    }
+
+    const highestMeanVariantData = selectVariantWithHighestMean(testBanditData, test);
+
+    if (!highestMeanVariantData) {
+        // TODO: what do we do if the chosen variant data is undefined?
+        return {};
+    }
+
+    return {
+        result: {
+            test,
+            variant: highestMeanVariantData,
+        },
+    };
+}

--- a/packages/server/src/bandit/banditSelection.ts
+++ b/packages/server/src/bandit/banditSelection.ts
@@ -2,17 +2,33 @@ import { EpicTest, EpicVariant } from '@sdc/shared/dist/types';
 import { BanditData } from './banditData';
 import { Result } from '../tests/epics/epicSelection';
 
-function selectVariantWithHighestMean(
+export function selectVariantWithHighestMean(
     testBanditData: BanditData,
     test: EpicTest,
 ): EpicVariant | undefined {
-    const highestMeanVariant = testBanditData.variants.sort((a, b) => b.mean - a.mean)[0];
+    // The variants are sorted by mean
+    const highestMeanVariant = testBanditData.variants[0];
+
+    // If there's a tie then we will randomly select one of the top variants
+    const topVariants = [highestMeanVariant];
+    for (let i = 1; i < testBanditData.variants.length; i++) {
+        if (testBanditData.variants[i].mean === highestMeanVariant.mean) {
+            topVariants.push(testBanditData.variants[i]);
+        } else {
+            break;
+        }
+    }
+
+    const variant =
+        topVariants.length < 2
+            ? highestMeanVariant
+            : topVariants[Math.floor(Math.random() * topVariants.length)];
 
     if (!highestMeanVariant) {
         return undefined;
     }
 
-    return test.variants.find((v) => v.name === highestMeanVariant.variantName);
+    return test.variants.find((v) => v.name === variant.variantName);
 }
 
 function selectRandomVariant(variants: EpicVariant[]): EpicVariant | undefined {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -7,6 +7,7 @@ import {
     errorHandling as errorHandlingMiddleware,
     logging as loggingMiddleware,
 } from './middleware';
+import { testBanditLocally } from './bandit/banditData';
 import { logError } from './utils/logging';
 import { buildEpicRouter } from './api/epicRouter';
 import { buildBannerRouter } from './api/bannerRouter';
@@ -86,6 +87,10 @@ const buildApp = async (): Promise<Express> => {
         buildHeaderTestsReloader(),
         buildBannerDesignsReloader(),
     ]);
+
+    // little hack while developing bandit stuff :)
+    const bandit = await testBanditLocally();
+    console.log(bandit);
 
     // Build the routers
     app.use(

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -7,7 +7,7 @@ import {
     errorHandling as errorHandlingMiddleware,
     logging as loggingMiddleware,
 } from './middleware';
-import { testBanditLocally } from './bandit/banditData';
+import { buildBanditDataReloader } from './bandit/banditData';
 import { logError } from './utils/logging';
 import { buildEpicRouter } from './api/epicRouter';
 import { buildBannerRouter } from './api/bannerRouter';
@@ -88,9 +88,7 @@ const buildApp = async (): Promise<Express> => {
         buildBannerDesignsReloader(),
     ]);
 
-    // little hack while developing bandit stuff :)
-    const bandit = await testBanditLocally();
-    console.log(bandit);
+    const banditData = await buildBanditDataReloader(articleEpicTests);
 
     // Build the routers
     app.use(
@@ -101,6 +99,7 @@ const buildApp = async (): Promise<Express> => {
             liveblogEpicTests,
             choiceCardAmounts,
             tickerData,
+            banditData,
         ),
     );
     app.use(

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -19,6 +19,7 @@ import {
     deviceTypeMatchesFilter,
     correctSignedInStatusFilter,
 } from './epicSelection';
+import { BanditData } from '../../bandit/banditData';
 
 const testDefault: EpicTest = {
     name: 'example-1',
@@ -86,6 +87,8 @@ const targetingDefault: EpicTargeting = {
 
 const superModeArticles: SuperModeArticle[] = [];
 
+const banditData: BanditData[] = [];
+
 const userDeviceType = 'Desktop';
 
 describe('findTestAndVariant', () => {
@@ -100,7 +103,13 @@ describe('findTestAndVariant', () => {
             weeklyArticleHistory: [{ week: 18330, count: 45 }],
         };
 
-        const got = findTestAndVariant(tests, targeting, userDeviceType, superModeArticles);
+        const got = findTestAndVariant(
+            tests,
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+        );
 
         expect(got.result?.test.name).toBe('example-1');
         expect(got.result?.variant.name).toBe('control-example-1');
@@ -114,7 +123,13 @@ describe('findTestAndVariant', () => {
             hasOptedOutOfArticleCount: true,
         };
 
-        const got = findTestAndVariant(tests, targeting, userDeviceType, superModeArticles);
+        const got = findTestAndVariant(
+            tests,
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+        );
 
         expect(got.result).toBe(undefined);
     });
@@ -124,7 +139,13 @@ describe('findTestAndVariant', () => {
         const tests = [test];
         const targeting = { ...targetingDefault, sectionId: 'news' };
 
-        const got = findTestAndVariant(tests, targeting, userDeviceType, superModeArticles);
+        const got = findTestAndVariant(
+            tests,
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+        );
 
         expect(got.result).toBe(undefined);
     });
@@ -141,7 +162,13 @@ describe('findTestAndVariant', () => {
             showSupportMessaging: false,
         };
 
-        const got = findTestAndVariant(tests, targeting, userDeviceType, superModeArticles);
+        const got = findTestAndVariant(
+            tests,
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+        );
 
         expect(got.result?.variant.showReminderFields).toBe(undefined);
     });

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -189,14 +189,13 @@ export interface Result {
     debug?: Debug;
 }
 
-//TODO can we get rid of includeDebug and Debug objects?
 export const findTestAndVariant = (
     tests: EpicTest[],
     targeting: EpicTargeting,
     userDeviceType: UserDeviceType,
     superModeArticles: SuperModeArticle[],
-    includeDebug = false,
     banditData: BanditData[],
+    includeDebug = false,
 ): Result => {
     const debug: Debug = {};
 
@@ -273,7 +272,10 @@ export const findTestAndVariant = (
         : filterTestsWithoutSuperModePass(priorityOrdered);
 
     if (test) {
-        return selectEpicVariant(test, banditData, targeting);
+        return {
+            ...selectEpicVariant(test, banditData, targeting),
+            debug: includeDebug ? debug : undefined,
+        };
     }
 
     return { debug: includeDebug ? debug : undefined };

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -126,6 +126,7 @@ export const epicTestFromToolSchema = testSchema.extend({
     articlesViewedSettings: articlesViewedSettingsSchema.optional(),
     priority: z.number(),
     variants: variantSchema.array(),
+    banditTest: z.boolean().optional(),
 });
 
 export type EpicVariant = z.infer<typeof variantSchema>;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
