### PR TITLE
Bandit null hypothesis epic selection

### DIFF
--- a/packages/server/src/bandit/banditSelection.ts
+++ b/packages/server/src/bandit/banditSelection.ts
@@ -8,7 +8,10 @@ import { logError } from '../utils/logging';
  * In general we select the best known variant, except with probability 'epsilon' when we select at random.
  * https://en.wikipedia.org/wiki/Multi-armed_bandit#Semi-uniform_strategies
  */
-const EPSILON = 0.1;
+//const EPSILON = 0.1;
+
+// NULL HYPOTHESIS - always pick at random
+const EPSILON = 1;
 
 export function selectVariantWithHighestMean(
     testBanditData: BanditData,

--- a/packages/server/src/lib/ab.ts
+++ b/packages/server/src/lib/ab.ts
@@ -15,7 +15,7 @@ export const withinRange = (lower: number, proportion: number, mvtId: number): b
     }
 };
 
-const getRandomNumber = (seed: string, mvtId: number | string = ''): number => {
+export const getRandomNumber = (seed: string, mvtId: number | string = ''): number => {
     const rng = seedrandom(mvtId + seed);
     return Math.abs(rng.int32());
 };

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -854,6 +854,9 @@ describe('correctSignedInStatusFilter filter', () => {
     });
 });
 
+const BANDIT_TEST_NAME = '2024-04-16_BANDIT_NULL_HYPOTHESIS_TEST_BANDIT';
+const AB_TEST_TEST_NAME = '2024-04-16_BANDIT_NULL_HYPOTHESIS_TEST_AB';
+
 describe('bandit null hypothesis', () => {
     const variants = [
         {
@@ -865,14 +868,14 @@ describe('bandit null hypothesis', () => {
 
     const abTestTest: EpicTest = {
         ...testDefault,
-        name: 'AB_TEST_NULL_HYPOTHESIS',
+        name: AB_TEST_TEST_NAME,
         articlesViewedSettings: undefined,
         variants: variants,
     };
 
     const banditTest: EpicTest = {
         ...testDefault,
-        name: 'BANDIT_NULL_HYPOTHESIS',
+        name: BANDIT_TEST_NAME,
         isBanditTest: true,
         articlesViewedSettings: undefined,
         variants: variants,
@@ -898,10 +901,10 @@ describe('bandit null hypothesis', () => {
             results.push(got.result?.test.name);
         }
 
-        const abTestChosen = results.filter((r) => r === 'AB_TEST_NULL_HYPOTHESIS');
+        const abTestChosen = results.filter((r) => r === AB_TEST_TEST_NAME);
         expect(abTestChosen.length).toBe(2550);
 
-        const banditChosen = results.filter((r) => r === 'BANDIT_NULL_HYPOTHESIS');
+        const banditChosen = results.filter((r) => r === BANDIT_TEST_NAME);
         expect(banditChosen.length).toBe(2450);
     });
 });
@@ -910,7 +913,7 @@ describe('banditNullHypothesisFilter filter', () => {
     it('should pass for mvtId = 1 and test is AB test', () => {
         const test: EpicTest = {
             ...testDefault,
-            name: 'AB_TEST_NULL_HYPOTHESIS',
+            name: AB_TEST_TEST_NAME,
         };
 
         const targeting = { ...targetingDefault, mvtId: 1 };
@@ -922,7 +925,7 @@ describe('banditNullHypothesisFilter filter', () => {
     it('should fail for mvtId = 2 and test is AB test', () => {
         const test: EpicTest = {
             ...testDefault,
-            name: 'AB_TEST_NULL_HYPOTHESIS',
+            name: AB_TEST_TEST_NAME,
         };
 
         const targeting = { ...targetingDefault, mvtId: 2 };
@@ -934,7 +937,7 @@ describe('banditNullHypothesisFilter filter', () => {
     it('should pass for mvtId = 2 and test is Bandit', () => {
         const test: EpicTest = {
             ...testDefault,
-            name: 'BANDIT_NULL_HYPOTHESIS',
+            name: BANDIT_TEST_NAME,
         };
 
         const targeting = { ...targetingDefault, mvtId: 2 };
@@ -946,7 +949,7 @@ describe('banditNullHypothesisFilter filter', () => {
     it('should fail for mvtId = 1 and test is Bandit', () => {
         const test: EpicTest = {
             ...testDefault,
-            name: 'BANDIT_NULL_HYPOTHESIS',
+            name: BANDIT_TEST_NAME,
         };
 
         const targeting = { ...targetingDefault, mvtId: 1 };
@@ -958,7 +961,7 @@ describe('banditNullHypothesisFilter filter', () => {
     it('should pass for ~50% of MVT IDs and test is AB test', () => {
         const test: EpicTest = {
             ...testDefault,
-            name: 'AB_TEST_NULL_HYPOTHESIS',
+            name: AB_TEST_TEST_NAME,
         };
 
         const results: boolean[] = [];
@@ -974,7 +977,7 @@ describe('banditNullHypothesisFilter filter', () => {
     it('should pass for ~50% of MVT IDs and test is Bandit', () => {
         const test: EpicTest = {
             ...testDefault,
-            name: 'BANDIT_NULL_HYPOTHESIS',
+            name: BANDIT_TEST_NAME,
         };
 
         const results: boolean[] = [];

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -1,6 +1,7 @@
 import {
     ArticlesViewedSettings,
     DeviceType,
+    EpicVariant,
     SecondaryCtaType,
     UserDeviceType,
 } from '@sdc/shared/types';
@@ -18,8 +19,32 @@ import {
     withinMaxViews,
     deviceTypeMatchesFilter,
     correctSignedInStatusFilter,
+    banditNullHypothesisFilter,
 } from './epicSelection';
 import { BanditData } from '../../bandit/banditData';
+
+const variantDefault: EpicVariant = {
+    name: 'control-example-1',
+    heading: "We've got an announcement…",
+    paragraphs: [
+        '… on our progress as an organisation. In service of the escalating climate emergency, we have made an important decision – <a href="https://www.theguardian.com/media/2020/jan/29/guardian-to-ban-advertising-from-fossil-fuel-firms-climate-crisis#show-draft-epics">to renounce fossil fuel advertising</a>, becoming the first major global news organisation to institute an outright ban on taking money from companies that extract fossil fuels.',
+        '',
+    ],
+    highlightedText:
+        'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
+    cta: {
+        text: 'Support The Guardian',
+        baseUrl: 'https://support.theguardian.com/contribute',
+    },
+    secondaryCta: {
+        type: SecondaryCtaType.Custom,
+        cta: {
+            text: 'Read our pledge',
+            baseUrl:
+                'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?INTCMP=pledge_Jan_2020',
+        },
+    },
+};
 
 const testDefault: EpicTest = {
     name: 'example-1',
@@ -38,30 +63,7 @@ const testDefault: EpicTest = {
     },
     userCohort: 'AllNonSupporters',
     hasCountryName: false,
-    variants: [
-        {
-            name: 'control-example-1',
-            heading: "We've got an announcement…",
-            paragraphs: [
-                '… on our progress as an organisation. In service of the escalating climate emergency, we have made an important decision – <a href="https://www.theguardian.com/media/2020/jan/29/guardian-to-ban-advertising-from-fossil-fuel-firms-climate-crisis#show-draft-epics">to renounce fossil fuel advertising</a>, becoming the first major global news organisation to institute an outright ban on taking money from companies that extract fossil fuels.',
-                '',
-            ],
-            highlightedText:
-                'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
-            cta: {
-                text: 'Support The Guardian',
-                baseUrl: 'https://support.theguardian.com/contribute',
-            },
-            secondaryCta: {
-                type: SecondaryCtaType.Custom,
-                cta: {
-                    text: 'Read our pledge',
-                    baseUrl:
-                        'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?INTCMP=pledge_Jan_2020',
-                },
-            },
-        },
-    ],
+    variants: [variantDefault],
     highPriority: false,
     useLocalViewLog: false,
     articlesViewedSettings: {
@@ -849,5 +851,139 @@ describe('correctSignedInStatusFilter filter', () => {
         const got = correctSignedInStatusFilter.test(test, targeting);
 
         expect(got).toBe(true);
+    });
+});
+
+describe('bandit null hypothesis', () => {
+    const variants = [
+        {
+            ...variantDefault,
+            name: 'control',
+        },
+        { ...variantDefault, name: 'variant' },
+    ];
+
+    const abTestTest: EpicTest = {
+        ...testDefault,
+        name: 'AB_TEST_NULL_HYPOTHESIS',
+        articlesViewedSettings: undefined,
+        variants: variants,
+    };
+
+    const banditTest: EpicTest = {
+        ...testDefault,
+        name: 'BANDIT_NULL_HYPOTHESIS',
+        isBanditTest: true,
+        articlesViewedSettings: undefined,
+        variants: variants,
+    };
+
+    const tests = [abTestTest, banditTest];
+
+    it('should return AB test and bandit ~ equally', () => {
+        const results: (string | undefined)[] = [];
+
+        for (let i = 0; i < 5000; i++) {
+            const targeting = { ...targetingDefault, mvtId: i };
+
+            const got = findTestAndVariant(
+                tests,
+                targeting,
+                userDeviceType,
+                superModeArticles,
+                banditData,
+                true,
+            );
+
+            results.push(got.result?.test.name);
+        }
+
+        const abTestChosen = results.filter((r) => r === 'AB_TEST_NULL_HYPOTHESIS');
+        expect(abTestChosen.length).toBe(2550);
+
+        const banditChosen = results.filter((r) => r === 'BANDIT_NULL_HYPOTHESIS');
+        expect(banditChosen.length).toBe(2450);
+    });
+});
+
+describe('banditNullHypothesisFilter filter', () => {
+    it('should pass for mvtId = 1 and test is AB test', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            name: 'AB_TEST_NULL_HYPOTHESIS',
+        };
+
+        const targeting = { ...targetingDefault, mvtId: 1 };
+        const got = banditNullHypothesisFilter.test(test, targeting);
+
+        expect(got).toBe(true);
+    });
+
+    it('should fail for mvtId = 2 and test is AB test', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            name: 'AB_TEST_NULL_HYPOTHESIS',
+        };
+
+        const targeting = { ...targetingDefault, mvtId: 2 };
+        const got = banditNullHypothesisFilter.test(test, targeting);
+
+        expect(got).toBe(false);
+    });
+
+    it('should pass for mvtId = 2 and test is Bandit', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            name: 'BANDIT_NULL_HYPOTHESIS',
+        };
+
+        const targeting = { ...targetingDefault, mvtId: 2 };
+        const got = banditNullHypothesisFilter.test(test, targeting);
+
+        expect(got).toBe(true);
+    });
+
+    it('should fail for mvtId = 1 and test is Bandit', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            name: 'BANDIT_NULL_HYPOTHESIS',
+        };
+
+        const targeting = { ...targetingDefault, mvtId: 1 };
+        const got = banditNullHypothesisFilter.test(test, targeting);
+
+        expect(got).toBe(false);
+    });
+
+    it('should pass for ~50% of MVT IDs and test is AB test', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            name: 'AB_TEST_NULL_HYPOTHESIS',
+        };
+
+        const results: boolean[] = [];
+        for (let mvt = 0; mvt < 5000; mvt++) {
+            const targeting = { ...targetingDefault, mvtId: mvt };
+            const got = banditNullHypothesisFilter.test(test, targeting);
+            results.push(got);
+        }
+
+        expect(results.filter((r) => r).length).toBe(2550);
+    });
+
+    it('should pass for ~50% of MVT IDs and test is Bandit', () => {
+        const test: EpicTest = {
+            ...testDefault,
+            name: 'BANDIT_NULL_HYPOTHESIS',
+        };
+
+        const results: boolean[] = [];
+        for (let mvt = 0; mvt < 5000; mvt++) {
+            const targeting = { ...targetingDefault, mvtId: mvt };
+            const got = banditNullHypothesisFilter.test(test, targeting);
+            results.push(got);
+        }
+
+        expect(results.filter((r) => r).length).toBe(2450);
     });
 });

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -193,10 +193,10 @@ export const banditNullHypothesisFilter: Filter = {
     id: 'matchesOneOfBanditNullHypothesisTests',
     test: (test, targeting): boolean => {
         const fiftyFiftyChance = getRandomNumber('NULL_HYPOTHESIS', targeting.mvtId) % 2;
-        if (test.name === 'AB_TEST_NULL_HYPOTHESIS') {
+        if (test.name === '2024-04-16_BANDIT_NULL_HYPOTHESIS_TEST_AB') {
             return fiftyFiftyChance === 0;
         }
-        if (test.name === 'BANDIT_NULL_HYPOTHESIS') {
+        if (test.name === '2024-04-16_BANDIT_NULL_HYPOTHESIS_TEST_BANDIT') {
             return fiftyFiftyChance === 1;
         }
         return true;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Create a filter within epic selection to implement a null hypothesis test - testing that using multi armed bandit (MAB) selection (at random) does not show a statistical difference to using AB testing. Two RRCP Epic channel tests with hardcoded test names will be added and the new filter will pick between them at 50% probability, using a user's MVT cookie. Depending on which epic is chosen the respective selection logic will be used (AB testing vs MAB). 

We also set the probability of picking randomly, when using the MAB logic, to 100%. In other words when MAB logic is used, it will pick at random.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="911" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/114918544/0e8ae409-5bb5-4702-83cd-cdf86ba1f608">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

