### PR TITLE
Cc dp/add new reject all targeting field

### DIFF
--- a/packages/dotcom/.changeset/good-wasps-play.md
+++ b/packages/dotcom/.changeset/good-wasps-play.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+Update to banner targeting model to include user consent as a targeting option

--- a/packages/server/src/lib/targeting.test.ts
+++ b/packages/server/src/lib/targeting.test.ts
@@ -1,6 +1,7 @@
 import { factories } from '../factories';
 import {
     audienceMatches,
+    consentStatusMatches,
     pageContextMatches,
     shouldNotRenderEpic,
     shouldThrottle,
@@ -266,5 +267,28 @@ describe('pageContextMatches', () => {
             excludedSectionIds: ['environment'],
         });
         expect(result).toBe(true);
+    });
+});
+
+describe('consentStatusMatches', () => {
+    
+    it('checks user consent when a test targets HasConsented', () => {
+        expect(consentStatusMatches(true, 'HasConsented')).toBe(true);
+        expect(consentStatusMatches(false, 'HasConsented')).toBe(false);
+    });
+
+    it('checks user consent when a test targets HasNotConsented', () => {
+        expect(consentStatusMatches(true, 'HasNotConsented')).toBe(true);
+        expect(consentStatusMatches(false, 'HasNotConsented')).toBe(false);
+    });
+
+    it('checks user consent when a test targets Everyone', () => {
+        expect(consentStatusMatches(true, 'Everyone')).toBe(true);
+        expect(consentStatusMatches(false, 'Everyone')).toBe(true);
+    });
+
+    it('checks user consent when a test does not target by consent status', () => {
+        expect(consentStatusMatches(true, undefined)).toBe(true);
+        expect(consentStatusMatches(false, undefined)).toBe(true);
     });
 });

--- a/packages/server/src/lib/targeting.test.ts
+++ b/packages/server/src/lib/targeting.test.ts
@@ -271,15 +271,14 @@ describe('pageContextMatches', () => {
 });
 
 describe('consentStatusMatches', () => {
-    
     it('checks user consent when a test targets HasConsented', () => {
         expect(consentStatusMatches(true, 'HasConsented')).toBe(true);
         expect(consentStatusMatches(false, 'HasConsented')).toBe(false);
     });
 
     it('checks user consent when a test targets HasNotConsented', () => {
-        expect(consentStatusMatches(true, 'HasNotConsented')).toBe(true);
-        expect(consentStatusMatches(false, 'HasNotConsented')).toBe(false);
+        expect(consentStatusMatches(true, 'HasNotConsented')).toBe(false);
+        expect(consentStatusMatches(false, 'HasNotConsented')).toBe(true);
     });
 
     it('checks user consent when a test targets Everyone', () => {

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -120,8 +120,6 @@ export const consentStatusMatches = (
             return true;
         case undefined:
             return true;
-        default: 
-            return true;
     }
 };
 

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -116,6 +116,10 @@ export const hasConsentedStatus = (
             return hasConsented === true;
         case 'HasNotConsented':
             return hasConsented === false;
+        case 'Everyone':
+            return true;
+        case undefined:
+            return true;
         default:
             return false;
     }

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -6,7 +6,8 @@ import {
     Variant,
     SignedInStatus,
     PageContextTargeting,
-    UserDeviceType, ConsentStatus,
+    UserDeviceType,
+    ConsentStatus,
 } from '@sdc/shared/types';
 
 import { daysSince } from './dates';

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -6,7 +6,7 @@ import {
     Variant,
     SignedInStatus,
     PageContextTargeting,
-    UserDeviceType,
+    UserDeviceType, ConsentStatus,
 } from '@sdc/shared/types';
 
 import { daysSince } from './dates';
@@ -103,6 +103,20 @@ export const correctSignedInStatus = (
             return isSignedIn === false;
         default:
             return true;
+    }
+};
+
+export const hasConsentedStatus = (
+    hasConsented: boolean,
+    consentStatus?: ConsentStatus,
+): boolean => {
+    switch (consentStatus) {
+        case 'HasConsented':
+            return hasConsented === true;
+        case 'HasNotConsented':
+            return hasConsented === false;
+        default:
+            return false;
     }
 };
 

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -120,8 +120,8 @@ export const hasConsentedStatus = (
             return true;
         case undefined:
             return true;
-        default:
-            return false;
+        default: 
+            return true;
     }
 };
 

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -107,7 +107,7 @@ export const correctSignedInStatus = (
     }
 };
 
-export const hasConsentedStatus = (
+export const consentStatusMatches = (
     hasConsented: boolean,
     consentStatus?: ConsentStatus,
 ): boolean => {

--- a/packages/server/src/lib/targetingTesting.test.ts
+++ b/packages/server/src/lib/targetingTesting.test.ts
@@ -30,6 +30,7 @@ const targeting: BannerTargeting = {
     hasOptedOutOfArticleCount: false,
     contentType: 'Article',
     isSignedIn: false,
+    hasConsented: true,
 };
 
 describe('selectTargetingTest', () => {

--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -49,6 +49,7 @@ describe('selectBannerTest', () => {
             hasOptedOutOfArticleCount: false,
             contentType: 'Article',
             isSignedIn: false,
+            hasConsented: true,
         };
 
         const tracking = {
@@ -227,6 +228,7 @@ describe('selectBannerTest', () => {
             hasOptedOutOfArticleCount: false,
             contentType: 'Article',
             isSignedIn: false,
+            hasConsented: true,
         };
 
         const tracking = {
@@ -345,6 +347,7 @@ describe('selectBannerTest', () => {
             hasOptedOutOfArticleCount: false,
             contentType: 'Article',
             isSignedIn: false,
+            hasConsented: true,
         };
 
         const tracking = {

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -16,6 +16,7 @@ import {
     audienceMatches,
     correctSignedInStatus,
     deviceTypeMatches,
+    hasConsentedStatus,
     pageContextMatches,
 } from '../../lib/targeting';
 import { BannerDeployTimesProvider, ReaderRevenueRegion } from './bannerDeployTimes';
@@ -205,7 +206,8 @@ export const selectBannerTest = (
                     excludedTagIds: [],
                     excludedSectionIds: [],
                 },
-            )
+            ) &&
+            hasConsentedStatus(targeting.hasConsented, test.consentStatus)
         ) {
             const variant: BannerVariant = selectVariant(test, targeting.mvtId);
 

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -16,7 +16,7 @@ import {
     audienceMatches,
     correctSignedInStatus,
     deviceTypeMatches,
-    hasConsentedStatus,
+    consentStatusMatches,
     pageContextMatches,
 } from '../../lib/targeting';
 import { BannerDeployTimesProvider, ReaderRevenueRegion } from './bannerDeployTimes';
@@ -207,7 +207,7 @@ export const selectBannerTest = (
                     excludedSectionIds: [],
                 },
             ) &&
-            hasConsentedStatus(targeting.hasConsented, test.consentStatus)
+            consentStatusMatches(targeting.hasConsented, test.consentStatus)
         ) {
             const variant: BannerVariant = selectVariant(test, targeting.mvtId);
 

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -79,7 +79,7 @@ export const bannerTestFromToolSchema = testSchema.extend({
     locations: z.array(countryGroupIdSchema),
     contextTargeting: pageContextTargetingSchema,
     variants: z.array(bannerVariantFromToolSchema),
-    articlesViewedSettings: articlesViewedSettingsSchema.optional(),
+    articlesViewedSettings: articlesViewedSettingsSchema.optional(),    
 });
 
 export type BannerTestFromTool = z.infer<typeof bannerTestFromToolSchema>;

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -79,7 +79,7 @@ export const bannerTestFromToolSchema = testSchema.extend({
     locations: z.array(countryGroupIdSchema),
     contextTargeting: pageContextTargetingSchema,
     variants: z.array(bannerVariantFromToolSchema),
-    articlesViewedSettings: articlesViewedSettingsSchema.optional(),    
+    articlesViewedSettings: articlesViewedSettingsSchema.optional(),
 });
 
 export type BannerTestFromTool = z.infer<typeof bannerTestFromToolSchema>;

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -38,6 +38,7 @@ export interface Test<V extends Variant> {
     controlProportionSettings?: ControlProportionSettings;
     deviceType?: DeviceType;
     signedInStatus?: SignedInStatus;
+    consentStatus?: ConsentStatus;
 }
 
 export const testSchema = z.object({
@@ -52,6 +53,7 @@ export const testSchema = z.object({
         .optional(),
     deviceType: deviceTypeSchema.optional(),
     signedInStatus: signedInStatusSchema.optional(),
+    consentStatus: ConsentStatusSchema.optional(),
 });
 
 export interface ControlProportionSettings {

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -23,6 +23,10 @@ export type SignedInStatus = (typeof SignedInStatus)[number];
 
 export const signedInStatusSchema = z.enum(SignedInStatus);
 
+const ConsentStatus = ['HasConsented', 'HasNotConsented', 'Everyone'] as const;
+export type ConsentStatus = (typeof ConsentStatus)[number];
+export const ConsentStatusSchema = z.enum(ConsentStatus);
+
 export interface Variant {
     name: string;
 }

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -20,6 +20,7 @@ export type BannerTargeting = {
     purchaseInfo?: PurchaseInfo;
     isSignedIn: boolean;
     lastOneOffContributionDate?: string;
+    hasConsented?: boolean
 };
 
 export type BannerPayload = {

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -20,7 +20,7 @@ export type BannerTargeting = {
     purchaseInfo?: PurchaseInfo;
     isSignedIn: boolean;
     lastOneOffContributionDate?: string;
-    hasConsented?: boolean
+    hasConsented: boolean;
 };
 
 export type BannerPayload = {


### PR DESCRIPTION
## What does this change?
We have updated the model for bannertargeting  by adding hasConsented flag to the model, so that it aligns with the model in DCR (PR to follow)

We've also updated the testSchema model with a new type (ConsentStatus), so that the it aligns with the model in dynamodb table

![image](https://github.com/guardian/support-dotcom-components/assets/36296660/2c157afc-59e7-497c-897c-fa20737a77b0)

## Background
we want to target banners from the Reader Revenue Control Panel based on what users have consented to

## How to test
We have tested that the new hasConsented flag has been passed through from the API.

Changes were made in several systems. To test that they have the expected results, we performed integration testing by:

Reject-all
- load an article on localhost via DCR
- reject all by clicking 'reject all' the banner window
- using a console.log, observe that the boolean for hasConsented is set to false

Accepting
- load an article on localhost via DCR
- click on 'accept' in the banner
- using a console.log, observe that the boolean for hasConsented is set to true

## Related PRs 
- to follow (DCR)
- to follow (SAC)


