### PR TITLE
Guard against tests with no variants

### DIFF
--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -108,6 +108,14 @@ function calculateBestVariants(variantMeans: BanditVariantData[]): BanditVariant
 }
 
 async function buildBanditDataForTest(epicTest: EpicTest): Promise<BanditData> {
+    if (epicTest.variants.length === 0) {
+        // No variants have been added to the test yet
+        return {
+            testName: epicTest.name,
+            bestVariants: [],
+        };
+    }
+
     const samples = await getBanditSamplesForTest(epicTest.name);
 
     if (samples.length === 0) {


### PR DESCRIPTION
Currently if an epic test has no variants then we get an error trying to access the mean of the highest performing variant -
`Cannot read properties of undefined (reading 'mean')`

This PR makes the `buildBanditDataForTest` function return early if there are no variants.

The `banditSelection.ts` logic already handles the case where no variant can be chosen