### PR TITLE
Configurable remind me later

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -489,6 +489,7 @@ const styles = {
         grid-row: 3;
         order: 4;
         align-self: center;
+        margin-top: ${space[2]}px;
 
         ${from.tablet} {
             align-self: end;

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCtas.tsx
@@ -62,7 +62,6 @@ const styles = {
         display: flex;
         flex-wrap: wrap;
         gap: ${space[4]}px;
-        margin-bottom: ${space[2]}px;
         justify-content: center;
 
         > a {

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCtas.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { neutral, space, from } from '@guardian/source-foundations';
-import { Button, LinkButton } from '@guardian/source-react-components';
+import { from, space } from '@guardian/source-foundations';
+import { LinkButton } from '@guardian/source-react-components';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { BannerRenderedContent } from '../../common/types';
 import { PaymentCards } from '../../common/PaymentCards';
@@ -13,7 +13,6 @@ interface DesignableBannerCtasProps {
     mainOrMobileContent: BannerRenderedContent;
     onPrimaryCtaClick: () => void;
     onSecondaryCtaClick: () => void;
-    onReminderCtaClick: () => void;
     primaryCtaSettings: CtaSettings;
     secondaryCtaSettings: CtaSettings;
 }
@@ -22,7 +21,6 @@ export function DesignableBannerCtas({
     mainOrMobileContent,
     onPrimaryCtaClick,
     onSecondaryCtaClick,
-    onReminderCtaClick,
     primaryCtaSettings,
     secondaryCtaSettings,
 }: DesignableBannerCtasProps): JSX.Element {
@@ -30,72 +28,54 @@ export function DesignableBannerCtas({
     const hasSupportCta = primaryCta ? isSupportUrl(primaryCta.ctaUrl) : false;
 
     return (
-        <div>
-            <div css={styles.ctasContainer}>
-                {primaryCta && (
-                    <LinkButton
-                        href={primaryCta?.ctaUrl}
-                        onClick={onPrimaryCtaClick}
-                        size="small"
-                        priority="primary"
-                        cssOverrides={buttonStyles(primaryCtaSettings)}
-                    >
-                        {primaryCta?.ctaText}
-                    </LinkButton>
-                )}
+        <div css={styles.container}>
+            {primaryCta && (
+                <LinkButton
+                    href={primaryCta?.ctaUrl}
+                    onClick={onPrimaryCtaClick}
+                    size="small"
+                    priority="primary"
+                    cssOverrides={buttonStyles(primaryCtaSettings)}
+                >
+                    {primaryCta?.ctaText}
+                </LinkButton>
+            )}
+            {secondaryCta?.type === SecondaryCtaType.Custom && (
+                <LinkButton
+                    href={secondaryCta?.cta.ctaUrl}
+                    onClick={onSecondaryCtaClick}
+                    size="small"
+                    priority="tertiary"
+                    cssOverrides={buttonStyles(secondaryCtaSettings)}
+                >
+                    {secondaryCta.cta.ctaText}
+                </LinkButton>
+            )}
 
-                {secondaryCta?.type === SecondaryCtaType.Custom && (
-                    <LinkButton
-                        href={secondaryCta?.cta.ctaUrl}
-                        onClick={onSecondaryCtaClick}
-                        size="small"
-                        priority="tertiary"
-                        cssOverrides={buttonStyles(secondaryCtaSettings)}
-                    >
-                        {secondaryCta.cta.ctaText}
-                    </LinkButton>
-                )}
-
-                {secondaryCta?.type === SecondaryCtaType.ContributionsReminder && (
-                    <Button
-                        priority="subdued"
-                        onClick={onReminderCtaClick}
-                        cssOverrides={styles.reminderCta}
-                    >
-                        Remind me later
-                    </Button>
-                )}
-            </div>
-
-            <div>{primaryCta && hasSupportCta && <PaymentCards />}</div>
+            {primaryCta && hasSupportCta && <PaymentCards />}
         </div>
     );
 }
 
 const styles = {
-    ctasContainer: css`
+    container: css`
         display: flex;
         flex-wrap: wrap;
+        gap: ${space[4]}px;
+        margin-bottom: ${space[2]}px;
+        justify-content: center;
 
-        & a {
-            margin-bottom: ${space[2]}px;
+        > a {
+            flex: 1 0 100%;
+            justify-content: center;
+
+            ${from.tablet} {
+                flex: 0 1 auto;
+            }
         }
-        & a:not(:last-child) {
-            margin-right: ${space[3]}px;
-        }
-    `,
-    paymentMethods: css`
-        display: block;
-        height: 1.1rem;
-        width: auto;
-        margin-left: ${space[1]}px;
 
         ${from.tablet} {
-            margin-left: ${space[2]}px;
-            height: 1.25rem;
+            justify-content: start;
         }
-    `,
-    reminderCta: css`
-        color: ${neutral[0]};
     `,
 };

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminder.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminder.tsx
@@ -4,31 +4,21 @@ import { BannerEnrichedReminderCta } from '../../common/types';
 import { CtaSettings } from '../settings';
 import { DesignableBannerReminderSignedOut } from './DesignableBannerReminderSignedOut';
 import { css } from '@emotion/react';
-import { neutral, space } from '@guardian/source-foundations';
-import { ReminderFields } from '@sdc/shared/src/lib';
+import { space } from '@guardian/source-foundations';
 
 export interface DesignableBannerReminderProps {
     reminderCta: BannerEnrichedReminderCta;
     trackReminderSetClick: () => void;
     setReminderCtaSettings?: CtaSettings;
     mobileReminderRef: React.RefObject<HTMLDivElement> | null;
-    reminderFields: ReminderFields;
 }
 
 const styles = {
     container: css`
         grid-row: 4;
         grid-column: 1 / span 2;
-        margin-top: ${space[3]}px;
-        padding-bottom: ${space[5]}px;
         order: 5;
-    `,
-
-    rule: css`
-        width: calc(100% + ${space[10]}px);
-        border: 0;
-        border-top: 2px solid ${neutral[0]};
-        margin: 0 -${space[5]}px ${space[2]}px -${space[5]}px;
+        margin-top: ${space[3]}px;
     `,
 };
 
@@ -37,14 +27,13 @@ export function DesignableBannerReminder({
     trackReminderSetClick,
     setReminderCtaSettings,
     mobileReminderRef,
-    reminderFields,
 }: DesignableBannerReminderProps): JSX.Element {
     const { reminderStatus, createReminder } = useContributionsReminderSignup(
-        /*reminderCta.*/ reminderFields.reminderPeriod,
+        reminderCta.reminderFields.reminderPeriod,
         'WEB',
         'BANNER',
         'PRE',
-        /*reminderCta.*/ reminderFields.reminderOption,
+        reminderCta.reminderFields.reminderOption,
     );
 
     const onReminderSetClick = (email: string) => {
@@ -54,13 +43,11 @@ export function DesignableBannerReminder({
 
     return (
         <div ref={mobileReminderRef} css={styles.container}>
-            <hr css={styles.rule} />
             <DesignableBannerReminderSignedOut
                 reminderCta={reminderCta}
                 reminderStatus={reminderStatus}
                 onReminderSetClick={onReminderSetClick}
                 setReminderCtaSettings={setReminderCtaSettings}
-                reminderFields={reminderFields}
             />
         </div>
     );

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminderSignedOut.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminderSignedOut.tsx
@@ -8,7 +8,6 @@ import { useContributionsReminderEmailForm } from '../../../../hooks/useContribu
 import { CtaSettings } from '../settings';
 import { buttonStyles } from '../styles/buttonStyles';
 import { ErrorCopy, InfoCopy, ThankYou } from '../../../shared/Reminders';
-import { ReminderFields } from '@sdc/shared/src/lib';
 
 // ---- Component ---- //
 
@@ -17,18 +16,16 @@ export interface DesignableBannerReminderSignedOutProps {
     reminderStatus: ReminderStatus;
     onReminderSetClick: (email: string) => void;
     setReminderCtaSettings?: CtaSettings;
-    reminderFields: ReminderFields;
 }
 
 export function DesignableBannerReminderSignedOut({
-    //reminderCta,
+    reminderCta,
     reminderStatus,
     onReminderSetClick,
     setReminderCtaSettings,
-    reminderFields,
 }: DesignableBannerReminderSignedOutProps): JSX.Element {
     const reminderLabelWithPreposition = ensureHasPreposition(
-        /*reminderCta.*/ reminderFields.reminderLabel,
+        reminderCta.reminderFields.reminderLabel,
     );
 
     return (
@@ -80,6 +77,7 @@ function Signup({
                     error={inputError}
                     value={email}
                     width={30}
+                    placeholder="Enter your email"
                 />
 
                 <div css={styles.ctaContainer}>
@@ -127,6 +125,14 @@ const styles = {
         ${from.tablet} {
             flex-direction: row;
             align-items: flex-end;
+        }
+
+        > input {
+            min-width: 100%;
+
+            ${from.tablet} {
+                min-width: auto;
+            }
         }
     `,
     ctaContainer: css`

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -234,13 +234,38 @@ const design: ConfigurableDesign = {
 export const DesignOneImageOnly = DefaultTemplate.bind({});
 DesignOneImageOnly.args = {
     ...props,
-    content: contentWithHeading,
-    mobileContent: mobileContentWithHeading,
+    content: {
+        ...contentWithHeading,
+        secondaryCta: {
+            ...contentWithHeading.secondaryCta,
+            type: SecondaryCtaType.ContributionsReminder,
+        },
+    },
+    mobileContent: {
+        ...mobileContentWithHeading,
+        secondaryCta: {
+            ...mobileContentWithHeading.secondaryCta,
+            type: SecondaryCtaType.ContributionsReminder,
+        },
+    },
     numArticles: 50,
     tickerSettings,
     design: {
         ...design,
         visual: regularImage,
+        colours: {
+            ...design.colours,
+            secondaryCta: {
+                default: {
+                    background: stringToHexColour('052962'),
+                    text: stringToHexColour('FFFFFF'),
+                },
+                hover: {
+                    background: stringToHexColour('234B8A'),
+                    text: stringToHexColour('FFFFFF'),
+                },
+            },
+        },
     },
 };
 
@@ -367,8 +392,20 @@ WithNonSupportUrl.args = {
 export const WithRemindMeLater = DefaultTemplate.bind({});
 WithRemindMeLater.args = {
     ...props,
-    content: contentWithHeading,
-    mobileContent: mobileContentWithHeading,
+    content: {
+        ...contentWithHeading,
+        secondaryCta: {
+            ...contentWithHeading.secondaryCta,
+            type: SecondaryCtaType.ContributionsReminder,
+        },
+    },
+    mobileContent: {
+        ...mobileContentWithHeading,
+        secondaryCta: {
+            ...mobileContentWithHeading.secondaryCta,
+            type: SecondaryCtaType.ContributionsReminder,
+        },
+    },
     numArticles: 50,
     tickerSettings,
     design: {
@@ -377,11 +414,19 @@ WithRemindMeLater.args = {
             kind: 'ChoiceCards',
             buttonColour: stringToHexColour('E5E5E5'),
         },
+        colours: {
+            ...design.colours,
+            secondaryCta: {
+                default: {
+                    background: stringToHexColour('052962'),
+                    text: stringToHexColour('FFFFFF'),
+                },
+                hover: {
+                    background: stringToHexColour('234B8A'),
+                    text: stringToHexColour('FFFFFF'),
+                },
+            },
+        },
     },
     choiceCardAmounts: regularChoiceCardAmounts,
-    tracking: {
-        ...props.tracking,
-        abTestName: 'REMIND_ME_LATER',
-        abTestVariant: 'V1_SHOW_REMIND_ME_LATER',
-    },
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Re-tools the new remind me later functionality to use the RRCP configuration options for the secondary CTA. This allows for the link colour and bg/border/text colours of the submit button on the reminder for to be adjusted in RRCP. Also adjusts the appearance of the CTAs on mobile breakpoints to be inline with the CTA under the choice cards

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Have tweaked the stories to display the new feature by passing in the props related to RRCP data instead of tracking data so that storybook can demonstrate all changes in this PR

## Images

<img width="317" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/a583412f-cee3-4ab3-a267-19438e431e58">
<img width="319" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/bff0093b-8f4e-4571-9ff4-b4bb236cf55a">
<img width="320" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/2146c60a-1cbf-478f-b4ef-10cfda0ce605">
<img width="318" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/64b5b014-b265-4ac6-bc4f-e0445ed5af29">
<img width="1454" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/99400613/5c4ed291-3328-406f-81d5-5eeb0008ca4d">

