### PR TITLE
Momentum epic selection 

### DIFF
--- a/packages/server/src/lib/history.test.ts
+++ b/packages/server/src/lib/history.test.ts
@@ -54,7 +54,7 @@ describe('getWeeksInWindow', () => {
         expect(result[0].week).toBe(19835);
     });
 
-    it('cuts off entries after right now when it is in the past', () => {
+    it('includes correct window when end date is in the past', () => {
         const articleHistory = [
             { week: 19835, count: 2 },
             { week: 19828, count: 25 },

--- a/packages/server/src/lib/history.test.ts
+++ b/packages/server/src/lib/history.test.ts
@@ -53,4 +53,19 @@ describe('getWeeksInWindow', () => {
         expect(result.length).toBe(5);
         expect(result[0].week).toBe(19835);
     });
+
+    it('cuts off entries after right now when it is in the past', () => {
+        const articleHistory = [
+            { week: 19835, count: 2 },
+            { week: 19828, count: 25 },
+            { week: 19821, count: 20 },
+            { week: 19814, count: 20 },
+            { week: 19807, count: 20 },
+            { week: 19800, count: 20 },
+        ];
+
+        const result = getWeeksInWindow(articleHistory, 4, new Date('2024-04-16'));
+        expect(result.length).toBe(5);
+        expect(result[0].week).toBe(19828);
+    });
 });

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -33,7 +33,6 @@ export const getArticleViewCountForWeeks = (
     );
 };
 
-
 export const getArticleViewCountByTagForWeeks = (
     tagId: string,
     history: WeeklyArticleHistory = [],

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -6,13 +6,17 @@ import {
 } from '@sdc/shared/types';
 import { getMondayFromDate } from '@sdc/shared/lib';
 
+/**
+ *    Gets a window of entries from the weekly article history array
+ *    Includes the week of the end date
+ */
 export const getWeeksInWindow = (
     history: WeeklyArticleHistory = [],
-    weeks = 52,
-    rightNow: Date = new Date(),
+    windowWeeks = 52,
+    endDateInclusive: Date = new Date(),
 ): WeeklyArticleLog[] => {
-    const mondayThisWeek = getMondayFromDate(rightNow);
-    const cutOffWeek = mondayThisWeek - weeks * 7;
+    const mondayThisWeek = getMondayFromDate(endDateInclusive);
+    const cutOffWeek = mondayThisWeek - windowWeeks * 7;
 
     // Filter only weeks within cutoff period
     return history.filter(

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -6,7 +6,7 @@ import {
 } from '@sdc/shared/types';
 import { getMondayFromDate } from '@sdc/shared/lib';
 
-const getWeeksInWindow = (
+export const getWeeksInWindow = (
     history: WeeklyArticleHistory = [],
     weeks = 52,
     rightNow: Date = new Date(),
@@ -32,6 +32,7 @@ export const getArticleViewCountForWeeks = (
         0,
     );
 };
+
 
 export const getArticleViewCountByTagForWeeks = (
     tagId: string,

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -8,7 +8,7 @@ import { getMondayFromDate } from '@sdc/shared/lib';
 
 /**
  *    Gets a window of entries from the weekly article history array
- *    Includes the week of the end date
+ *    Includes the week of the end date plus the number of window weeks
  */
 export const getWeeksInWindow = (
     history: WeeklyArticleHistory = [],

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -23,8 +23,9 @@ import {
     shouldNotRenderEpic,
     shouldThrottle,
 } from '../../lib/targeting';
+import { momentumMatches } from "./momentumTest";
 
-interface Filter {
+export interface Filter {
     id: string;
     test: (test: EpicTest, targeting: EpicTargeting) => boolean;
 }
@@ -232,6 +233,7 @@ export const findTestAndVariant = (
             deviceTypeMatchesFilter(userDeviceType),
             correctSignedInStatusFilter,
             banditNullHypothesisFilter,
+            momentumMatches,
         ];
     };
 

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -23,7 +23,7 @@ import {
     shouldNotRenderEpic,
     shouldThrottle,
 } from '../../lib/targeting';
-import { momentumMatches } from "./momentumTest";
+import { momentumMatches } from './momentumTest';
 
 export interface Filter {
     id: string;

--- a/packages/server/src/tests/epics/momentumTest.test.ts
+++ b/packages/server/src/tests/epics/momentumTest.test.ts
@@ -7,7 +7,7 @@ import {
 } from './momentumTest';
 
 const testDefault: EpicTest = {
-    name: 'momentumEpic',
+    name: '2024-04-29_MOMENTUM_EPIC',
     priority: 1,
     status: 'Live',
     locations: [],

--- a/packages/server/src/tests/epics/momentumTest.test.ts
+++ b/packages/server/src/tests/epics/momentumTest.test.ts
@@ -85,6 +85,12 @@ describe('momentumMatches', () => {
         const result = momentumMatches.test(test, targetingDefault);
         expect(result).toBe(true);
     });
+
+    it('should return false when no article history', () => {
+        const targeting = { ...targetingDefault, weeklyArticleHistory: [] };
+        const result = momentumMatches.test(testDefault, targeting);
+        expect(result).toBe(false);
+    });
 });
 
 describe('isIncreasedEngagement', () => {

--- a/packages/server/src/tests/epics/momentumTest.test.ts
+++ b/packages/server/src/tests/epics/momentumTest.test.ts
@@ -1,0 +1,132 @@
+import { EpicTargeting, EpicTest } from '@sdc/shared/dist/types';
+import { momentumMatches } from './momentumTest';
+
+const testDefault: EpicTest = {
+    name: 'momentumEpic',
+    priority: 1,
+    status: 'Live',
+    locations: [],
+    tagIds: [],
+    sections: ['environment'],
+    excludedTagIds: [],
+    excludedSections: [],
+    alwaysAsk: true,
+    maxViews: {
+        maxViewsCount: 4,
+        maxViewsDays: 30,
+        minDaysBetweenViews: 0,
+    },
+    userCohort: 'AllNonSupporters',
+    hasCountryName: false,
+    variants: [],
+    highPriority: false,
+    useLocalViewLog: false,
+    articlesViewedSettings: {
+        minViews: 5,
+        periodInWeeks: 52,
+    },
+    hasArticleCountInCopy: true,
+};
+
+const targetingDefault: EpicTargeting = {
+    contentType: 'Article',
+    sectionId: 'environment',
+    shouldHideReaderRevenue: false,
+    isMinuteArticle: false,
+    isPaidContent: false,
+    tags: [{ id: 'environment/series/the-polluters', type: 'tone' }],
+    showSupportMessaging: true,
+    isRecurringContributor: false,
+    lastOneOffContributionDate: undefined,
+    mvtId: 2,
+    hasOptedOutOfArticleCount: false,
+};
+
+const weeklyArticleHistory = [
+    { week: 19793, count: 24 },
+    { week: 19792, count: 22 },
+    { week: 19791, count: 20 },
+    { week: 19790, count: 18 },
+    { week: 19789, count: 6 },
+    { week: 19788, count: 14 },
+    { week: 19787, count: 12 },
+    { week: 19786, count: 3 },
+    { week: 19785, count: 0 },
+    { week: 19784, count: 6 },
+    { week: 19783, count: 4 },
+    { week: 19782, count: 0 },
+    { week: 19781, count: 0 }
+]
+const weeklyArticleHistoryIdentical = [
+    { week: 19793, count: 2 },
+    { week: 19792, count: 2 },
+    { week: 19791, count: 2 },
+    { week: 19790, count: 2 },
+    { week: 19789, count: 2 },
+    { week: 19788, count: 2 },
+    { week: 19787, count: 2 },
+    { week: 19786, count: 2 },
+    { week: 19785, count: 2 },
+    { week: 19784, count: 2 },
+    { week: 19783, count: 2 },
+    { week: 19782, count: 2 },
+    { week: 19781, count: 2 }
+]
+
+
+describe('momentumMatches', () => {
+    it('should return true for momentum tests and increasing article count', () => {
+        const targeting: EpicTargeting = {
+            ...targetingDefault,
+            weeklyArticleHistory: weeklyArticleHistory,
+        };
+        const NOW = '2023-01-18T08:00:00.000Z';
+
+        const result = momentumMatches.test(testDefault, targeting);
+        expect(result).toBe(true);
+    });
+
+    it('should return false for momentum tests and article count is same for all the months', () => {
+        const targeting: EpicTargeting = {
+            ...targetingDefault,
+            weeklyArticleHistory: weeklyArticleHistoryIdentical,
+        };
+        const NOW = '2024-01-18T08:00:00.000Z';
+        const mockDateNow = jest
+            .spyOn(global.Date, 'now')
+            .mockImplementation(() => new Date(NOW).getTime());
+        const result = momentumMatches.test(testDefault, targeting);
+        expect(result).toBe(false);
+    });
+
+    it('should return true for any tests other than momentum test', () => {
+        const test = { ...testDefault, name:'test'};
+        const targeting: EpicTargeting = {
+            ...targetingDefault,
+            weeklyArticleHistory: weeklyArticleHistoryIdentical,
+        };
+        const NOW = '2024-01-18T08:00:00.000Z';
+        const mockDateNow = jest
+            .spyOn(global.Date, 'now')
+            .mockImplementation(() => new Date(NOW).getTime());
+
+        const result = momentumMatches.test(test, targeting);
+        expect(result).toBe(true);
+    });
+
+    it('should return false if the article history count is less than 12 weeks ', () => {
+
+        const targeting: EpicTargeting = {
+            ...targetingDefault,
+            weeklyArticleHistory: weeklyArticleHistory.slice(0, 4),
+        };
+        const NOW = '2024-01-18T08:00:00.000Z';
+        const mockDateNow = jest
+            .spyOn(global.Date, 'now')
+            .mockImplementation(() => new Date(NOW).getTime());
+
+        const result = momentumMatches.test(testDefault, targeting);
+        expect(result).toBe(false);
+    });
+
+});

--- a/packages/server/src/tests/epics/momentumTest.test.ts
+++ b/packages/server/src/tests/epics/momentumTest.test.ts
@@ -43,45 +43,51 @@ const targetingDefault: EpicTargeting = {
 };
 
 const weeklyArticleHistory = [
-    { week: 19793, count: 24 },
-    { week: 19792, count: 22 },
-    { week: 19791, count: 20 },
-    { week: 19790, count: 18 },
-    { week: 19789, count: 6 },
-    { week: 19788, count: 14 },
-    { week: 19787, count: 12 },
-    { week: 19786, count: 3 },
-    { week: 19785, count: 0 },
-    { week: 19784, count: 6 },
-    { week: 19783, count: 4 },
-    { week: 19782, count: 0 },
-    { week: 19781, count: 0 }
-]
-const weeklyArticleHistoryIdentical = [
-    { week: 19793, count: 2 },
-    { week: 19792, count: 2 },
-    { week: 19791, count: 2 },
-    { week: 19790, count: 2 },
-    { week: 19789, count: 2 },
-    { week: 19788, count: 2 },
-    { week: 19787, count: 2 },
-    { week: 19786, count: 2 },
-    { week: 19785, count: 2 },
-    { week: 19784, count: 2 },
-    { week: 19783, count: 2 },
-    { week: 19782, count: 2 },
-    { week: 19781, count: 2 }
-]
+    { week: 19828, count: 24 },
+    { week: 19821, count: 22 },
+    { week: 19814, count: 20 },
+    { week: 19807, count: 18 },
+    { week: 19800, count: 6 },
+    { week: 19793, count: 14 },
+    { week: 19786, count: 12 },
+    { week: 19779, count: 3 },
+    { week: 19772, count: 0 },
+    { week: 19765, count: 6 },
+    { week: 19758, count: 4 },
+    { week: 19751, count: 0 },
+    { week: 19744, count: 0 },
+];
 
+const weeklyArticleHistoryIdentical = [
+    { week: 19828, count: 2 },
+    { week: 19821, count: 2 },
+    { week: 19814, count: 2 },
+    { week: 19807, count: 2 },
+    { week: 19800, count: 2 },
+    { week: 19793, count: 2 },
+    { week: 19786, count: 2 },
+    { week: 19779, count: 2 },
+    { week: 19772, count: 2 },
+    { week: 19765, count: 2 },
+    { week: 19758, count: 2 },
+    { week: 19751, count: 2 },
+    { week: 19744, count: 2 },
+];
 
 describe('momentumMatches', () => {
+    beforeAll(() => {
+        jest.spyOn(global.Date, 'UTC').mockImplementation(() => Date.parse('2024-04-19'));
+    });
+
+    afterAll(() => {
+        jest.spyOn(global.Date, 'UTC').mockRestore();
+    });
+
     it('should return true for momentum tests and increasing article count', () => {
         const targeting: EpicTargeting = {
             ...targetingDefault,
             weeklyArticleHistory: weeklyArticleHistory,
         };
-        const NOW = '2023-01-18T08:00:00.000Z';
-
         const result = momentumMatches.test(testDefault, targeting);
         expect(result).toBe(true);
     });
@@ -91,42 +97,29 @@ describe('momentumMatches', () => {
             ...targetingDefault,
             weeklyArticleHistory: weeklyArticleHistoryIdentical,
         };
-        const NOW = '2024-01-18T08:00:00.000Z';
-        const mockDateNow = jest
-            .spyOn(global.Date, 'now')
-            .mockImplementation(() => new Date(NOW).getTime());
+
         const result = momentumMatches.test(testDefault, targeting);
         expect(result).toBe(false);
     });
 
     it('should return true for any tests other than momentum test', () => {
-        const test = { ...testDefault, name:'test'};
+        const test = { ...testDefault, name: 'test' };
         const targeting: EpicTargeting = {
             ...targetingDefault,
             weeklyArticleHistory: weeklyArticleHistoryIdentical,
         };
-        const NOW = '2024-01-18T08:00:00.000Z';
-        const mockDateNow = jest
-            .spyOn(global.Date, 'now')
-            .mockImplementation(() => new Date(NOW).getTime());
 
         const result = momentumMatches.test(test, targeting);
         expect(result).toBe(true);
     });
 
     it('should return false if the article history count is less than 12 weeks ', () => {
-
         const targeting: EpicTargeting = {
             ...targetingDefault,
             weeklyArticleHistory: weeklyArticleHistory.slice(0, 4),
         };
-        const NOW = '2024-01-18T08:00:00.000Z';
-        const mockDateNow = jest
-            .spyOn(global.Date, 'now')
-            .mockImplementation(() => new Date(NOW).getTime());
 
         const result = momentumMatches.test(testDefault, targeting);
         expect(result).toBe(false);
     });
-
 });

--- a/packages/server/src/tests/epics/momentumTest.ts
+++ b/packages/server/src/tests/epics/momentumTest.ts
@@ -2,6 +2,59 @@ import { getWeeksInWindow } from '../../lib/history';
 import { WeeklyArticleHistory, WeeklyArticleLog } from '@sdc/shared/types';
 import { Filter } from './epicSelection';
 
+/*
+We categorize into 6 buckets of article count/engagement.
+
+    1. 1-10
+    2. 11-20
+    3. 21-30
+    4. 31-40
+    5.41-50
+    6. 50+
+
+We use the below logic to measure the momentum of engagement.
+Low  -- jumped two categories
+Medium -- jumped three categories
+Medium-High -- jumped four categories
+High -- jumped five categories
+ */
+
+const jumps = {
+    low: 2,
+    medium: 3,
+    mediumHigh: 4,
+    high: 5
+} as const;
+
+function isIncreasedEngagement(weeksInWindow: WeeklyArticleHistory): boolean {
+    const categoryForThirdMonth = getCategoryOfArticleViewed(weeksInWindow.slice(0, 4));
+    const categoryForSecondMonth = getCategoryOfArticleViewed(weeksInWindow.slice(4, 8));
+    const categoryForFirstMonth = getCategoryOfArticleViewed(weeksInWindow.slice(8));
+    if (
+        categoryForThirdMonth >= categoryForSecondMonth &&
+        categoryForSecondMonth >= categoryForFirstMonth
+    ) {
+        return categoryForThirdMonth - categoryForFirstMonth >= jumps.mediumHigh;
+    }
+    return false;
+}
+
+const getCategoryOfArticleViewed = (history: WeeklyArticleHistory): number => {
+    const sum = history.reduce(
+        (accumulator: number, articleLog: WeeklyArticleLog) => articleLog.count + accumulator,
+        0,
+    );
+    return getCategory(sum);
+};
+
+const getCategory = (count: number): number => {
+    if (count > 50) {
+        return 6;
+    }
+
+    return Math.ceil(count / 10);
+};
+
 export const momentumMatches: Filter = {
     id: 'momentumMatches',
     test: (test, targeting): boolean => {
@@ -17,48 +70,4 @@ export const momentumMatches: Filter = {
         }
         return true;
     },
-};
-
-function isIncreasedEngagement(weeksInWindow: WeeklyArticleHistory): boolean {
-    const categoryForThirdMonth = getCategoryOfArticleViewed(weeksInWindow.slice(0, 4));
-    const categoryForSecondMonth = getCategoryOfArticleViewed(weeksInWindow.slice(4, 8));
-    const categoryForFirstMonth = getCategoryOfArticleViewed(weeksInWindow.slice(8));
-    if (
-        categoryForThirdMonth >= categoryForSecondMonth &&
-        categoryForSecondMonth >= categoryForFirstMonth
-    ) {
-        return categoryForThirdMonth - categoryForFirstMonth >= 5;
-    }
-    return false;
-}
-
-const getCategoryOfArticleViewed = (history: WeeklyArticleHistory): number => {
-    const sum = history.reduce(
-        (accumulator: number, articleLog: WeeklyArticleLog) => articleLog.count + accumulator,
-        0,
-    );
-    return getCategory(sum);
-};
-
-//We categorize into 6 buckets of article count/engagement.
-/*
-    1. 1-10
-    2. 11-20
-    3. 21-30
-    4. 31-40
-    5.41-50
-    6. 50+
-
-We use te below logic to measure the momentum of engagement.
-Low  -- jumped two categories
-Medium-- jumped three categories
-Medium-High-- jumped four categories
-High -- jumped five categories
-
- */
-const getCategory = (count: number): number => {
-    if (count > 50) {
-        return 6;
-    }
-    return Math.ceil(count / 10);
 };

--- a/packages/server/src/tests/epics/momentumTest.ts
+++ b/packages/server/src/tests/epics/momentumTest.ts
@@ -33,21 +33,21 @@ export function getThreeMonthsHistory(
 ) {
     const mostRecentMonthHistory = getWeeksInWindow(articleHistory, 4, now);
 
-    const startOfSecondMostRecentMonth = subWeeks(now, 4);
+    const startOfSecondMostRecentMonth = subWeeks(now, 5);
 
     const secondMostRecentMonthHistory = getWeeksInWindow(
         articleHistory,
-        4,
+        3,
         startOfSecondMostRecentMonth,
-    ).slice(1); // remove overlapping week
+    );
 
-    const startOfThirdMostRecentMonth = subWeeks(now, 8);
+    const startOfThirdMostRecentMonth = subWeeks(now, 9);
 
     const thirdMostRecentMonthHistory = getWeeksInWindow(
         articleHistory,
-        4,
+        3,
         startOfThirdMostRecentMonth,
-    ).slice(1); // remove overlapping week
+    );
 
     return { mostRecentMonthHistory, secondMostRecentMonthHistory, thirdMostRecentMonthHistory };
 }

--- a/packages/server/src/tests/epics/momentumTest.ts
+++ b/packages/server/src/tests/epics/momentumTest.ts
@@ -1,0 +1,42 @@
+import { getWeeksInWindow } from '../../lib/history';
+import { WeeklyArticleHistory, WeeklyArticleLog } from '@sdc/shared/types';
+import { Filter } from './epicSelection';
+
+export const momentumMatches: Filter = {
+    id: 'momentumMatches',
+    test: (test, targeting): boolean => {
+        if (test.name === 'momentumEpic') {
+            if (!targeting.weeklyArticleHistory || targeting.weeklyArticleHistory.length < 12) {
+                return false;
+            }
+            const weeksInWindow = getWeeksInWindow(targeting.weeklyArticleHistory, 12, new Date());
+            console.log("weeksInWindow", weeksInWindow);
+            const categoryForThirdMonth = getCategoryOfArticleViewed(weeksInWindow.slice(0, 4));
+            const categoryForSecondMonth = getCategoryOfArticleViewed(weeksInWindow.slice(4, 8));
+            const categoryForFirstMonth = getCategoryOfArticleViewed(weeksInWindow.slice(8));
+            if (
+                categoryForThirdMonth >= categoryForSecondMonth &&
+                categoryForSecondMonth >= categoryForFirstMonth
+            ) {
+                return categoryForThirdMonth - categoryForFirstMonth >= 4;
+            }
+            return false;
+        }
+        return true;
+    },
+};
+
+const getCategoryOfArticleViewed = (history: WeeklyArticleHistory): number => {
+    const sum = history.reduce(
+        (accumulator: number, articleLog: WeeklyArticleLog) => articleLog.count + accumulator,
+        0,
+    );
+    return getCategory(sum);
+};
+
+const getCategory = (count: number): number => {
+    if (count >= 50) {
+        return 5;
+    }
+    return Math.ceil(count / 10);
+};

--- a/packages/server/src/tests/epics/momentumTest.ts
+++ b/packages/server/src/tests/epics/momentumTest.ts
@@ -31,7 +31,7 @@ export function getThreeMonthsHistory(
     articleHistory: WeeklyArticleHistory,
     now: Date = new Date(),
 ) {
-    const mostRecentMonthHistory = getWeeksInWindow(articleHistory, 4);
+    const mostRecentMonthHistory = getWeeksInWindow(articleHistory, 4, now);
 
     const startOfSecondMostRecentMonth = subWeeks(now, 4);
 

--- a/packages/server/src/tests/epics/momentumTest.ts
+++ b/packages/server/src/tests/epics/momentumTest.ts
@@ -99,7 +99,7 @@ export function isIncreasedEngagement(
 export const momentumMatches: Filter = {
     id: 'momentumMatches',
     test: (test, targeting): boolean => {
-        if (test.name === 'momentumEpic') {
+        if (test.name.includes('MOMENTUM_EPIC')) {
             if (!targeting.weeklyArticleHistory) {
                 return false;
             }

--- a/packages/server/src/tests/epics/momentumTest.ts
+++ b/packages/server/src/tests/epics/momentumTest.ts
@@ -23,7 +23,7 @@ const jumps = {
     low: 2,
     medium: 3,
     mediumHigh: 4,
-    high: 5
+    high: 5,
 } as const;
 
 function isIncreasedEngagement(weeksInWindow: WeeklyArticleHistory): boolean {

--- a/packages/server/src/tests/epics/momentumTest.ts
+++ b/packages/server/src/tests/epics/momentumTest.ts
@@ -10,21 +10,27 @@ export const momentumMatches: Filter = {
                 return false;
             }
             const weeksInWindow = getWeeksInWindow(targeting.weeklyArticleHistory, 12, new Date());
-            console.log("weeksInWindow", weeksInWindow);
-            const categoryForThirdMonth = getCategoryOfArticleViewed(weeksInWindow.slice(0, 4));
-            const categoryForSecondMonth = getCategoryOfArticleViewed(weeksInWindow.slice(4, 8));
-            const categoryForFirstMonth = getCategoryOfArticleViewed(weeksInWindow.slice(8));
-            if (
-                categoryForThirdMonth >= categoryForSecondMonth &&
-                categoryForSecondMonth >= categoryForFirstMonth
-            ) {
-                return categoryForThirdMonth - categoryForFirstMonth >= 4;
+            if (weeksInWindow.length < 12) {
+                return false;
             }
-            return false;
+            return isIncreasedEngagement(weeksInWindow);
         }
         return true;
     },
 };
+
+function isIncreasedEngagement(weeksInWindow: WeeklyArticleHistory): boolean {
+    const categoryForThirdMonth = getCategoryOfArticleViewed(weeksInWindow.slice(0, 4));
+    const categoryForSecondMonth = getCategoryOfArticleViewed(weeksInWindow.slice(4, 8));
+    const categoryForFirstMonth = getCategoryOfArticleViewed(weeksInWindow.slice(8));
+    if (
+        categoryForThirdMonth >= categoryForSecondMonth &&
+        categoryForSecondMonth >= categoryForFirstMonth
+    ) {
+        return categoryForThirdMonth - categoryForFirstMonth >= 5;
+    }
+    return false;
+}
 
 const getCategoryOfArticleViewed = (history: WeeklyArticleHistory): number => {
     const sum = history.reduce(
@@ -34,9 +40,25 @@ const getCategoryOfArticleViewed = (history: WeeklyArticleHistory): number => {
     return getCategory(sum);
 };
 
+//We categorize into 6 buckets of article count/engagement.
+/*
+    1. 1-10
+    2. 11-20
+    3. 21-30
+    4. 31-40
+    5.41-50
+    6. 50+
+
+We use te below logic to measure the momentum of engagement.
+Low  -- jumped two categories
+Medium-- jumped three categories
+Medium-High-- jumped four categories
+High -- jumped five categories
+
+ */
 const getCategory = (count: number): number => {
-    if (count >= 50) {
-        return 5;
+    if (count > 50) {
+        return 6;
     }
     return Math.ceil(count / 10);
 };


### PR DESCRIPTION
**Co-authored by** : Andrew Howe-Ely. and Lakshmi Pillai 

## What does this change?
This is the first PR with the changes for Article Count: Momentum test

Here we are adding a new filter to epicSelection to show the **momentum epic**  to user who have increased engagement in last three months.The different categories are defined by D&I  [ here ](https://docs.google.com/spreadsheets/d/1XgSXBiE_moxCW9ka37uENW0KltLGUEQfHNaqQ-8-yRA/edit#gid=0)

[Trello card](https://trello.com/c/TddHzNCk/261-article-count-momentum-test-m)



## How to test

Tested by API to /epic with constructed WeeklyArticleHistory data  and defining an epic with hard coded test name "MOMENTUM_EPIC" .

