### PR TITLE
Add recipes tag to the list of tags in WeeklyArticleHistory

### DIFF
--- a/packages/dotcom/.changeset/thirty-eels-enjoy.md
+++ b/packages/dotcom/.changeset/thirty-eels-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+Adding recipe tag to be tracked in WeeeklyArticleHistory

--- a/packages/shared/src/lib/history.ts
+++ b/packages/shared/src/lib/history.ts
@@ -79,6 +79,7 @@ const tagsOfInterest = new Set<string>([
     'inequality/inequality',
     'technology/technology',
     'business/business',
+    'tone/recipes',
 ]);
 
 /**


### PR DESCRIPTION
## What does this change?
Adding 'tone/recipes' to the list of tags that are used for article count
