### PR TITLE
Remove dependabot exception from build workflow

### DIFF
--- a/.github/workflows/dotcom-components.yml
+++ b/.github/workflows/dotcom-components.yml
@@ -1,103 +1,102 @@
 name: Build dotcom-components
 
 on:
-  pull_request:
-    branches:
-      - "**"
-  push:
-    branches:
-      - main
+    pull_request:
+        branches:
+            - '**'
+    push:
+        branches:
+            - main
 
 jobs:
-  dotcom-components:
-    if: >-
-      (github.actor != 'dependabot[bot]') &&
-        (github.event.pull_request.head.repo.owner.login == 'guardian' ||
-          github.event_name == 'push')
-    # Required by actions-assume-aws-role
-    permissions:
-      id-token: write
-      contents: read
+    dotcom-components:
+        if: >-
+            (github.event.pull_request.head.repo.owner.login == 'guardian' ||
+              github.event_name == 'push')
+        # Required by actions-assume-aws-role
+        permissions:
+            id-token: write
+            contents: read
 
-    name: dotcom-components
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
+        name: dotcom-components
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v3
 
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-            node-version-file: '.nvmrc'
+            - name: Use Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: '.nvmrc'
 
-      - name: Test + build
-        run: |
-          npm install -g yarn
-          yarn install
-          yarn setup
-          yarn lint
-          yarn test
+            - name: Test + build
+              run: |
+                  npm install -g yarn
+                  yarn install
+                  yarn setup
+                  yarn lint
+                  yarn test
 
-          NODE_ENV=production yarn server build
-          NODE_ENV=production NODE_OPTIONS="--max-old-space-size=16384" yarn modules build
+                  NODE_ENV=production yarn server build
+                  NODE_ENV=production NODE_OPTIONS="--max-old-space-size=16384" yarn modules build
 
-      - name: cdk
-        working-directory: ./cdk
-        run: |
-          npm install -g yarn
-          yarn install
-          yarn lint
-          yarn test
-          yarn synth
+            - name: cdk
+              working-directory: ./cdk
+              run: |
+                  npm install -g yarn
+                  yarn install
+                  yarn lint
+                  yarn test
+                  yarn synth
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2.2.0
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v2.2.0
+              with:
+                  role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+                  aws-region: eu-west-1
 
-      - name: riffraff
-        run: |
-          export LAST_TEAMCITY_BUILD=4000
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+            - name: riffraff
+              run: |
+                  export LAST_TEAMCITY_BUILD=4000
+                  export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
 
-          npm install -g yarn
-          yarn install
-          yarn run riffraff
+                  npm install -g yarn
+                  yarn install
+                  yarn run riffraff
 
-  release:
-    name: Release
-    needs: [ dotcom-components ]
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # in order to write labels to main branch?
-      pull-requests: write # to be able to comment on released pull requests
-      id-token: write # to enable use of OIDC for npm provenance
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+    release:
+        name: Release
+        needs: [dotcom-components]
+        if: github.ref == 'refs/heads/main'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write # in order to write labels to main branch?
+            pull-requests: write # to be able to comment on released pull requests
+            id-token: write # to enable use of OIDC for npm provenance
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+                  persist-credentials: false
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
+            - name: Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: '.nvmrc'
 
-      - name: Build
-        run: |
-          npm install -g yarn
-          yarn install
-          yarn dotcom build
-          yarn dotcom types
+            - name: Build
+              run: |
+                  npm install -g yarn
+                  yarn install
+                  yarn dotcom build
+                  yarn dotcom types
 
-      - name: Release
-        uses: changesets/action@v1
-        with:
-          cwd: packages/dotcom
-          publish: yarn changeset publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+            - name: Release
+              uses: changesets/action@v1
+              with:
+                  cwd: packages/dotcom
+                  publish: yarn changeset publish
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove the line that excludes Dependabot PRs from running the build check Github action. 

Currently Dependabot PRs skip the build check, so they do not get unit tested and cannot be deployed to test on riff-raff.

![image](https://github.com/guardian/support-dotcom-components/assets/114918544/78752d94-a330-4e89-b117-1602e0372f9c)


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
