### PR TITLE
Add logging for momentum isIncreasedEngagement decision

### DIFF
--- a/packages/server/src/tests/epics/momentumTest.ts
+++ b/packages/server/src/tests/epics/momentumTest.ts
@@ -2,6 +2,7 @@ import { getWeeksInWindow } from '../../lib/history';
 import { WeeklyArticleHistory, WeeklyArticleLog } from '@sdc/shared/types';
 import { Filter } from './epicSelection';
 import { subWeeks } from 'date-fns';
+import { logger } from '../../utils/logging';
 
 /*
 We categorize into 6 buckets of article count/engagement.
@@ -86,12 +87,38 @@ export function isIncreasedEngagement(
     const { categoryForThirdMonth, categoryForSecondMonth, categoryForFirstMonth } =
         getCategoriesForThreeMonths(articleHistory, now);
 
+    const articleHistoryWithoutTags = articleHistory.map(({ week, count }) => ({
+        week,
+        count,
+    }));
+
     if (
         categoryForThirdMonth > categoryForSecondMonth &&
         categoryForSecondMonth > categoryForFirstMonth
     ) {
-        return categoryForThirdMonth - categoryForFirstMonth >= jumps.mediumHigh;
+        const isIncreasedEngagement =
+            categoryForThirdMonth - categoryForFirstMonth >= jumps.mediumHigh;
+
+        logger.info({
+            message: 'Decision to show Momentum Epic',
+            isIncreasedEngagement,
+            categoryForFirstMonth,
+            categoryForSecondMonth,
+            categoryForThirdMonth,
+            articleHistoryWithoutTags,
+        });
+
+        return isIncreasedEngagement;
     }
+
+    logger.info({
+        message: 'Decision to show Momentum Epic',
+        isIncreasedEngagement: false,
+        categoryForFirstMonth,
+        categoryForSecondMonth,
+        categoryForThirdMonth,
+        articleHistoryWithoutTags,
+    });
 
     return false;
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add some logging when we make a Momentum Epic Test selection decision (see #1106), we can query this in Kibana to have some confidence SDC is making the right choice given the article history.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Deploy to CODE, have an Epic test with name including `MOMENTUM_EPIC` - see logs.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://github.com/guardian/support-dotcom-components/assets/114918544/61d80a1b-6db9-43af-9e29-0e0a7ccf6d2b)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

