### PR TITLE
use `"moduleResolution": "bundler”` in TypeScript

### DIFF
--- a/packages/dotcom/.changeset/mean-carrots-kiss.md
+++ b/packages/dotcom/.changeset/mean-carrots-kiss.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+Adds compatability with projects that consume `package.json#exports`

--- a/packages/dotcom/tsconfig.json
+++ b/packages/dotcom/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "CommonJS",
         "target": "ES2020",
         "esModuleInterop": true,
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "sourceMap": true,
         "strict": true,
         "outDir": "dist"

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -18,8 +18,8 @@
     "@babel/standalone": "^7.23.2",
     "@emotion/react": "^11.1.5",
     "@guardian/libs": "16.0.0",
-    "@guardian/source-foundations": "14.1.2",
-    "@guardian/source-react-components": "19.0.0",
+    "@guardian/source-foundations": "14.2.2",
+    "@guardian/source-react-components": "23.0.1",
     "@sdc/shared": "1.0.0",
     "@types/babel__standalone": "^7.1.6",
     "zod": "3.22.4"

--- a/packages/modules/src/modules/shared/ModuleWrapper.tsx
+++ b/packages/modules/src/modules/shared/ModuleWrapper.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { JSX } from '@emotion/react/jsx-runtime';
 import type { ReactComponent } from '../../types';
 
-export function withParsedProps<ModuleProps extends EmotionJSX.IntrinsicAttributes>(
+export function withParsedProps<ModuleProps extends JSX.IntrinsicAttributes>(
     Module: ReactComponent<ModuleProps>,
     validate: (props: unknown) => props is ModuleProps,
 ): ReactComponent<unknown> {

--- a/packages/modules/src/types.ts
+++ b/packages/modules/src/types.ts
@@ -1,4 +1,4 @@
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { JSX } from '@emotion/react/jsx-runtime';
 
 // This type can be used in place of React.FC<T> which was previously widespread
 // in this codebase but is no longer recommended. In many cases it's possible to
@@ -12,4 +12,4 @@ import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 
 export type ReactComponent<GenericProps = Record<string, never>> = (
     props: GenericProps,
-) => EmotionJSX.Element;
+) => JSX.Element;

--- a/packages/modules/tsconfig.json
+++ b/packages/modules/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "ESNext",
     "target": "ES2018",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "strict": true,
     "noImplicitReturns": true,

--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -1,4 +1,4 @@
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { JSX } from '@emotion/react/jsx-runtime';
 import {
     Cta,
     ctaSchema,
@@ -39,7 +39,7 @@ export const bannerContentSchema = z.object({
     secondaryCta: secondaryCtaSchema.optional(),
 });
 
-export interface BannerProps extends EmotionJSX.IntrinsicAttributes {
+export interface BannerProps extends JSX.IntrinsicAttributes {
     tracking: Tracking;
     bannerChannel: BannerChannel;
     content?: BannerContent;

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -1,4 +1,4 @@
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { JSX } from '@emotion/react/jsx-runtime';
 import * as z from 'zod';
 import {
     bylineWithImageSchema,
@@ -23,7 +23,7 @@ export type ArticleCounts = {
     [type in ArticleCountType]: number;
 };
 
-export interface EpicProps extends EmotionJSX.IntrinsicAttributes {
+export interface EpicProps extends JSX.IntrinsicAttributes {
     variant: EpicVariant;
     tracking: Tracking;
     countryCode?: string;

--- a/packages/shared/src/types/props/header.ts
+++ b/packages/shared/src/types/props/header.ts
@@ -1,4 +1,4 @@
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { JSX } from '@emotion/react/jsx-runtime';
 import * as z from 'zod';
 import { OphanComponentEvent } from '../ophan';
 import { Tracking, trackingSchema, Cta, ctaSchema } from './shared';
@@ -19,7 +19,7 @@ export const headerContentSchema = z.object({
     benefits: z.array(z.string()).optional(),
 });
 
-export interface HeaderProps extends EmotionJSX.IntrinsicAttributes {
+export interface HeaderProps extends JSX.IntrinsicAttributes {
     content: HeaderContent;
     tracking: Tracking;
     mobileContent?: HeaderContent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,17 +2584,17 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-5.0.0.tgz#0cd36b105512510192ea9fd18da3d3df2d7b3b72"
   integrity sha512-gJSQuuP7JVDOWQj4EUrwyJTnMt+frLkw0D2sLg70nHn76L3LmH2xTQtYMPUsqyqn37qocDPzgdvBdmATi50zRQ==
 
-"@guardian/source-foundations@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-14.1.2.tgz#cfa28a4f86570d5df4bf024da36cc46fb1b26105"
-  integrity sha512-SmAaYCMd8PtAo0h6PCtvZJGDdP/bKh86SjFUzjFagtHlPKBAUOOQ/juunHFYZrmDwTGGA7YtzduvN5esHjvegA==
+"@guardian/source-foundations@14.2.2":
+  version "14.2.2"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-14.2.2.tgz#c1e13d341a080861b036d1e71f9da460c7dcfde9"
+  integrity sha512-198Akw1RqufsX6Iu/qzqeR4eC9L3ezHURVzMqJeB3ZRZtabdkL2Q562mS1UnSdyACeCLRMqlOXqZDO38gsjP/g==
   dependencies:
     mini-svg-data-uri "1.4.4"
 
-"@guardian/source-react-components@19.0.0":
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-19.0.0.tgz#d01bf1f211ed52ed0749c71ffdad03986c430206"
-  integrity sha512-2CDMBxYJTgS6I8uqO6/s8eodptPbs8c7iYsqv/XKJEBDs8+I3iIlp31Y/QfoCOyrW+TT1hV3DQhqAuMNbY+Trg==
+"@guardian/source-react-components@23.0.1":
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-23.0.1.tgz#93baa7485826022350524dee39e8ef00a32038b6"
+  integrity sha512-gBxO7c24VZsYBUPXy507LWwNY1xxnh4VwCDibTK3a2AJat9D6+BTEmNaWD5e5S8pzmr3RY6hSrePGanw8bPYyA==
 
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
@@ -13463,7 +13463,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13480,15 +13480,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.1.1:
   version "2.1.1"
@@ -13599,7 +13590,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13633,13 +13624,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -15005,7 +14989,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15035,15 +15019,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- updates the `moduleResolution` in `@guardian/support-dotcom-components` to use `"bundler"`
- updates imports to use the correct path for emotion's JSX type which this change enforces
- bumps `@guardian/source-react-components` to v23.0.1


