### PR TITLE
Fix zod dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,45 +1,46 @@
 {
-  "name": "@sdc/mono",
-  "version": "1.0.0",
-  "description": "Service to serve Reader Revenue components to dotcom",
-  "repository": "github:guardian/support-dotcom-components",
-  "author": "The Guardian",
-  "license": "MIT",
-  "private": true,
-  "scripts": {
-    "server": "yarn workspace @sdc/server",
-    "modules": "yarn workspace @sdc/modules",
-    "shared": "yarn workspace @sdc/shared",
-    "dotcom": "yarn workspace @guardian/support-dotcom-components",
-    "lint": "yarn workspaces run lint",
-    "clean-dist": "find ./packages -path '**/node_modules' -prune -false -o -type d -name 'dist' -exec rm -r {} +",
-    "clean-tsbuildinfo": "find ./packages -type f -name '*.tsbuildinfo' -exec rm {} +",
-    "clean": "yarn clean-dist && yarn clean-tsbuildinfo",
-    "prebuild": "yarn clean",
-    "build": "yarn workspaces run build",
-    "presetup": "yarn clean",
-    "setup": "tsc --build",
-    "test": "export stage=DEV; yarn workspaces run test",
-    "riffraff": "node-riffraff-artifact"
-  },
-  "workspaces": [
-    "packages/*"
-  ],
-  "devDependencies": {
-    "@guardian/eslint-config-typescript": "^7.0.0",
-    "@guardian/node-riffraff-artifact": "^0.3.2",
-    "@guardian/prettier": "^5.0.0",
-    "eslint": "^8.47.0",
-    "eslint-plugin-prettier": "5.1.3",
-    "eslint-plugin-react": "^7.33.2",
-    "prettier": "^3.0.0",
-    "ts-loader": "^9.2.5",
-    "tslib": "^2.5.3",
-    "typescript": "~5.1.3",
-    "webpack": "^5.76.0"
-  },
-  "resolutions": {
-    "**/simple-update-notifier/**/semver": "7.5.2",
-    "@babel/traverse": "^7.23.2"
-  }
+    "name": "@sdc/mono",
+    "version": "1.0.0",
+    "description": "Service to serve Reader Revenue components to dotcom",
+    "repository": "github:guardian/support-dotcom-components",
+    "author": "The Guardian",
+    "license": "MIT",
+    "private": true,
+    "scripts": {
+        "server": "yarn workspace @sdc/server",
+        "modules": "yarn workspace @sdc/modules",
+        "shared": "yarn workspace @sdc/shared",
+        "dotcom": "yarn workspace @guardian/support-dotcom-components",
+        "lint": "yarn workspaces run lint",
+        "clean-dist": "find ./packages -path '**/node_modules' -prune -false -o -type d -name 'dist' -exec rm -r {} +",
+        "clean-tsbuildinfo": "find ./packages -type f -name '*.tsbuildinfo' -exec rm {} +",
+        "clean": "yarn clean-dist && yarn clean-tsbuildinfo",
+        "prebuild": "yarn clean",
+        "build": "yarn workspaces run build",
+        "presetup": "yarn clean",
+        "setup": "tsc --build",
+        "test": "export stage=DEV; yarn workspaces run test",
+        "riffraff": "node-riffraff-artifact"
+    },
+    "workspaces": [
+        "packages/*"
+    ],
+    "devDependencies": {
+        "@guardian/eslint-config-typescript": "^7.0.0",
+        "@guardian/node-riffraff-artifact": "^0.3.2",
+        "@guardian/prettier": "^5.0.0",
+        "eslint": "^8.47.0",
+        "eslint-plugin-prettier": "5.1.3",
+        "eslint-plugin-react": "^7.33.2",
+        "prettier": "^3.0.0",
+        "ts-loader": "^9.2.5",
+        "tslib": "^2.5.3",
+        "typescript": "~5.1.3",
+        "webpack": "^5.76.0",
+        "zod": "3.22.4"
+    },
+    "resolutions": {
+        "**/simple-update-notifier/**/semver": "7.5.2",
+        "@babel/traverse": "^7.23.2"
+    }
 }

--- a/packages/dotcom/.changeset/good-spoons-stare.md
+++ b/packages/dotcom/.changeset/good-spoons-stare.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+Fix zod dev dependency version

--- a/packages/dotcom/package.json
+++ b/packages/dotcom/package.json
@@ -35,7 +35,7 @@
         "ts-jest": "^29.1.1",
         "ts-loader": "^9.2.5",
         "typescript": "~5.1.3",
-        "zod": "3.23.4"
+        "zod": "3.22.4"
     },
     "dependencies": {},
     "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13463,7 +13463,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13480,15 +13480,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.1.1:
   version "2.1.1"
@@ -13599,7 +13590,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13633,13 +13624,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -15005,7 +14989,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15035,15 +15019,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -15318,8 +15293,3 @@ zod@3.22.4:
   version "3.22.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
   integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
-
-zod@3.23.4:
-  version "3.23.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.4.tgz#c63805b2f39e10d4ab3d55eb3c8cdb472c79dfb1"
-  integrity sha512-/AtWOKbBgjzEYYQRNfoGKHObgfAZag6qUJX1VbHo2PRBgS+wfWagEY2mizjfyAPcGesrJOcx/wcl0L9WnVrHFw==


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Use the correct version of Zod in dev dependencies of `dotcom` as is in the peer dependencies (this was a typo in #1107). 

Also add Zod as a dev dependency of the mono `package.json`. This is to fix a warning that `@guardian/support-dotcom-components` has an unmet peer dependency while running `yarn install` from the root of the project.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Run `yarn install` and do not see warning about zod.

## Images

Before
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/1958bd05-e10b-4a00-86fd-d5ba2b9cae01)
After
<img width="571" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/114918544/e90c20be-8ede-47a6-b0ba-fb10525513cd">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
