### PR TITLE
Revert "Changes to allow multiple tags"

### DIFF
--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -150,7 +150,7 @@ export const buildEpicRouter = (
             articleCounts: getArticleViewCounts(
                 targeting.weeklyArticleHistory,
                 test.articlesViewedSettings?.periodInWeeks,
-                test.articlesViewedSettings?.tagIds,
+                test.articlesViewedSettings?.tagId,
             ),
             countryCode: targeting.countryCode,
         };

--- a/packages/server/src/lib/history.test.ts
+++ b/packages/server/src/lib/history.test.ts
@@ -1,8 +1,4 @@
-import {
-    getArticleViewCountByMultipleTagForWeeks,
-    getArticleViewCountForWeeks,
-    getWeeksInWindow,
-} from './history';
+import { getArticleViewCountForWeeks, getWeeksInWindow } from './history';
 
 describe('getArticleViewCountForWeeks', () => {
     // Pass the current date into the tested function so the checks can be made
@@ -71,52 +67,5 @@ describe('getWeeksInWindow', () => {
         const result = getWeeksInWindow(articleHistory, 4, new Date('2024-04-16'));
         expect(result.length).toBe(5);
         expect(result[0].week).toBe(19828);
-    });
-});
-
-describe(' getArticleViewCountByMultipleTagForWeeks ', () => {
-    const rightNow = new Date('2020-03-16T09:30:00');
-
-    it('should count views for one week properly with multiple tags', () => {
-        const numWeeks = 1;
-        const articleHistoryWithOneWeekMultipleTags = [
-            {
-                week: 18330,
-                count: 53,
-                tags: {
-                    'environment/environment': 15,
-                    'environment/climate-crisis': 6,
-                    'world/world': 5,
-                    'business/business': 3,
-                    'us-news/us-politics': 1,
-                    'technology/technology': 1,
-                    'science/science': 1,
-                    'politics/politics': 3,
-                    'books/books': 1,
-                    'culture/culture': 1,
-                },
-            },
-        ];
-        const got = getArticleViewCountForWeeks(
-            articleHistoryWithOneWeekMultipleTags,
-            numWeeks,
-            rightNow,
-        );
-
-        const acTag = getArticleViewCountByMultipleTagForWeeks(
-            ['science/science'],
-            articleHistoryWithOneWeekMultipleTags,
-            numWeeks,
-            rightNow,
-        );
-        const acMultipleTag = getArticleViewCountByMultipleTagForWeeks(
-            ['science/science', 'environment/environment', 'business/business'],
-            articleHistoryWithOneWeekMultipleTags,
-            numWeeks,
-            rightNow,
-        );
-        expect(got).toBe(53);
-        expect(acTag).toBe(1);
-        expect(acMultipleTag).toBe(19);
     });
 });

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -38,34 +38,31 @@ export const getArticleViewCountForWeeks = (
     );
 };
 
-export const getArticleViewCountByMultipleTagForWeeks = (
-    tagIds: string[] = [],
+export const getArticleViewCountByTagForWeeks = (
+    tagId: string,
     history: WeeklyArticleHistory = [],
     weeks = 52,
     rightNow: Date = new Date(),
 ): number => {
     const weeksInWindow = getWeeksInWindow(history, weeks, rightNow);
 
-    const tagCount = tagIds.map((tagId) =>
-        weeksInWindow.reduce((accumulator: number, articleLog: WeeklyArticleLog) => {
-            const countForTag = articleLog.tags?.[tagId] ?? 0;
-            return accumulator + countForTag;
-        }, 0),
-    );
-    return tagCount.reduce((sum, value) => sum + value, 0);
+    return weeksInWindow.reduce((accumulator: number, articleLog: WeeklyArticleLog) => {
+        const countForTag = articleLog.tags?.[tagId] ?? 0;
+        return accumulator + countForTag;
+    }, 0);
 };
 
 // If tagId is set then use this for the `forTargetedWeeks` count
 export const getArticleViewCounts = (
     history: WeeklyArticleHistory = [],
     periodInWeeks = 52,
-    tagIds: string[] = [],
+    tagId?: string,
 ): ArticleCounts => {
     const for52Weeks = getArticleViewCountForWeeks(history, 52);
 
     const getCountForTargetingWeeks = (): number => {
-        if (tagIds) {
-            return getArticleViewCountByMultipleTagForWeeks(tagIds, history, periodInWeeks);
+        if (tagId) {
+            return getArticleViewCountByTagForWeeks(tagId, history, periodInWeeks);
         }
         return periodInWeeks === 52
             ? for52Weeks
@@ -88,10 +85,10 @@ export const historyWithinArticlesViewedSettings = (
         return true;
     }
 
-    const { minViews, maxViews, periodInWeeks, tagIds } = articlesViewedSettings;
+    const { minViews, maxViews, periodInWeeks, tagId } = articlesViewedSettings;
 
-    const viewCountForWeeks = tagIds
-        ? getArticleViewCountByMultipleTagForWeeks(tagIds, history, periodInWeeks, now)
+    const viewCountForWeeks = tagId
+        ? getArticleViewCountByTagForWeeks(tagId, history, periodInWeeks, now)
         : getArticleViewCountForWeeks(history, periodInWeeks, now);
 
     const minViewsOk = minViews ? viewCountForWeeks >= minViews : true;

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -437,7 +437,6 @@ describe('withinArticleViewedSettings filter', () => {
                 minViews: 5,
                 maxViews: 20,
                 periodInWeeks: 52,
-                tagIds: [],
             },
         };
         const history = [{ week: 18330, count: 21 }];
@@ -475,7 +474,7 @@ describe('withinArticleViewedSettings filter by tag', () => {
     const articlesViewedSettings: ArticlesViewedSettings = {
         minViews: 5,
         periodInWeeks: 52,
-        tagIds: ['environment/climate-change'],
+        tagId: 'environment/climate-change',
     };
 
     it('should pass when no articlesViewedByTagSettings', () => {

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -78,14 +78,14 @@ export const articlesViewedSettingsSchema = z.object({
     minViews: z.number(),
     maxViews: z.number().optional(),
     periodInWeeks: z.number(),
-    tagIds: z.array(z.string()).optional(),
+    tagId: z.string().optional(),
 });
 
 export interface ArticlesViewedSettings {
     minViews: number;
     maxViews?: number;
     periodInWeeks: number;
-    tagIds?: string[];
+    tagId?: string;
 }
 
 /**


### PR DESCRIPTION
Reverts guardian/support-dotcom-components#1127

It's causing an article count of 0 to be returned, so let's revert while we investigate -
![Screenshot 2024-05-13 at 16 01 41](https://github.com/guardian/support-dotcom-components/assets/1513454/abfe6097-4ecf-4bb4-adf5-e4f78eb6d2da)
