### PR TITLE
Bug fix for article count in forTargetedWeeks and changes to allow multiple tags 

### DIFF
--- a/packages/server/src/api/epicRouter.ts
+++ b/packages/server/src/api/epicRouter.ts
@@ -150,7 +150,7 @@ export const buildEpicRouter = (
             articleCounts: getArticleViewCounts(
                 targeting.weeklyArticleHistory,
                 test.articlesViewedSettings?.periodInWeeks,
-                test.articlesViewedSettings?.tagId,
+                test.articlesViewedSettings?.tagIds,
             ),
             countryCode: targeting.countryCode,
         };

--- a/packages/server/src/lib/history.test.ts
+++ b/packages/server/src/lib/history.test.ts
@@ -4,7 +4,6 @@ import {
     getArticleViewCounts,
     getWeeksInWindow,
 } from './history';
-import { WeeklyArticleHistory } from '@sdc/shared/dist/types/targeting/shared';
 
 describe('getArticleViewCountForWeeks', () => {
     // Pass the current date into the tested function so the checks can be made

--- a/packages/server/src/lib/history.test.ts
+++ b/packages/server/src/lib/history.test.ts
@@ -1,8 +1,10 @@
 import {
     getArticleViewCountByMultipleTagForWeeks,
     getArticleViewCountForWeeks,
+    getArticleViewCounts,
     getWeeksInWindow,
 } from './history';
+import { WeeklyArticleHistory } from '@sdc/shared/dist/types/targeting/shared';
 
 describe('getArticleViewCountForWeeks', () => {
     // Pass the current date into the tested function so the checks can be made
@@ -118,5 +120,75 @@ describe(' getArticleViewCountByMultipleTagForWeeks ', () => {
         expect(got).toBe(53);
         expect(acTag).toBe(1);
         expect(acMultipleTag).toBe(19);
+    });
+});
+
+describe(' getArticleViewCounts ', () => {
+    const rightNow = new Date('2020-03-16T09:30:00');
+
+    it('should count views for one week properly with multiple tags', () => {
+        const numWeeks = 52;
+        const articleHistoryWithOneWeekMultipleTags = [
+            {
+                week: 18330,
+                count: 53,
+                tags: {
+                    'environment/environment': 15,
+                    'environment/climate-crisis': 6,
+                    'world/world': 5,
+                    'business/business': 3,
+                    'us-news/us-politics': 1,
+                    'technology/technology': 1,
+                    'science/science': 1,
+                    'politics/politics': 3,
+                    'books/books': 1,
+                    'culture/culture': 1,
+                },
+            },
+        ];
+        const tagIds = ['science/science', 'environment/environment'];
+
+        const got = getArticleViewCounts(
+            articleHistoryWithOneWeekMultipleTags,
+            numWeeks,
+            tagIds,
+            rightNow,
+        );
+
+        expect(got.for52Weeks).toBe(53);
+        expect(got.forTargetedWeeks).toBe(16);
+    });
+
+    it('should count views for one week properly without tags ', () => {
+        const numWeeks = 52;
+        const articleHistoryWithOneWeekMultipleTags = [
+            {
+                week: 18330,
+                count: 53,
+                tags: {
+                    'environment/environment': 15,
+                    'environment/climate-crisis': 6,
+                    'world/world': 5,
+                    'business/business': 3,
+                    'us-news/us-politics': 1,
+                    'technology/technology': 1,
+                    'science/science': 1,
+                    'politics/politics': 3,
+                    'books/books': 1,
+                    'culture/culture': 1,
+                },
+            },
+        ];
+        const tagIds: string[] = [];
+
+        const got = getArticleViewCounts(
+            articleHistoryWithOneWeekMultipleTags,
+            numWeeks,
+            tagIds,
+            rightNow,
+        );
+
+        expect(got.for52Weeks).toBe(53);
+        expect(got.forTargetedWeeks).toBe(53);
     });
 });

--- a/packages/server/src/lib/history.test.ts
+++ b/packages/server/src/lib/history.test.ts
@@ -1,4 +1,8 @@
-import { getArticleViewCountForWeeks, getWeeksInWindow } from './history';
+import {
+    getArticleViewCountByMultipleTagForWeeks,
+    getArticleViewCountForWeeks,
+    getWeeksInWindow,
+} from './history';
 
 describe('getArticleViewCountForWeeks', () => {
     // Pass the current date into the tested function so the checks can be made
@@ -67,5 +71,52 @@ describe('getWeeksInWindow', () => {
         const result = getWeeksInWindow(articleHistory, 4, new Date('2024-04-16'));
         expect(result.length).toBe(5);
         expect(result[0].week).toBe(19828);
+    });
+});
+
+describe(' getArticleViewCountByMultipleTagForWeeks ', () => {
+    const rightNow = new Date('2020-03-16T09:30:00');
+
+    it('should count views for one week properly with multiple tags', () => {
+        const numWeeks = 1;
+        const articleHistoryWithOneWeekMultipleTags = [
+            {
+                week: 18330,
+                count: 53,
+                tags: {
+                    'environment/environment': 15,
+                    'environment/climate-crisis': 6,
+                    'world/world': 5,
+                    'business/business': 3,
+                    'us-news/us-politics': 1,
+                    'technology/technology': 1,
+                    'science/science': 1,
+                    'politics/politics': 3,
+                    'books/books': 1,
+                    'culture/culture': 1,
+                },
+            },
+        ];
+        const got = getArticleViewCountForWeeks(
+            articleHistoryWithOneWeekMultipleTags,
+            numWeeks,
+            rightNow,
+        );
+
+        const acTag = getArticleViewCountByMultipleTagForWeeks(
+            ['science/science'],
+            articleHistoryWithOneWeekMultipleTags,
+            numWeeks,
+            rightNow,
+        );
+        const acMultipleTag = getArticleViewCountByMultipleTagForWeeks(
+            ['science/science', 'environment/environment', 'business/business'],
+            articleHistoryWithOneWeekMultipleTags,
+            numWeeks,
+            rightNow,
+        );
+        expect(got).toBe(53);
+        expect(acTag).toBe(1);
+        expect(acMultipleTag).toBe(19);
     });
 });

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -38,31 +38,34 @@ export const getArticleViewCountForWeeks = (
     );
 };
 
-export const getArticleViewCountByTagForWeeks = (
-    tagId: string,
+export const getArticleViewCountByMultipleTagForWeeks = (
+    tagIds: string[] = [],
     history: WeeklyArticleHistory = [],
     weeks = 52,
     rightNow: Date = new Date(),
 ): number => {
     const weeksInWindow = getWeeksInWindow(history, weeks, rightNow);
 
-    return weeksInWindow.reduce((accumulator: number, articleLog: WeeklyArticleLog) => {
-        const countForTag = articleLog.tags?.[tagId] ?? 0;
-        return accumulator + countForTag;
-    }, 0);
+    const tagCount = tagIds.map((tagId) =>
+        weeksInWindow.reduce((accumulator: number, articleLog: WeeklyArticleLog) => {
+            const countForTag = articleLog.tags?.[tagId] ?? 0;
+            return accumulator + countForTag;
+        }, 0),
+    );
+    return tagCount.reduce((sum, value) => sum + value, 0);
 };
 
 // If tagId is set then use this for the `forTargetedWeeks` count
 export const getArticleViewCounts = (
     history: WeeklyArticleHistory = [],
     periodInWeeks = 52,
-    tagId?: string,
+    tagIds: string[] = [],
 ): ArticleCounts => {
     const for52Weeks = getArticleViewCountForWeeks(history, 52);
 
     const getCountForTargetingWeeks = (): number => {
-        if (tagId) {
-            return getArticleViewCountByTagForWeeks(tagId, history, periodInWeeks);
+        if (tagIds) {
+            return getArticleViewCountByMultipleTagForWeeks(tagIds, history, periodInWeeks);
         }
         return periodInWeeks === 52
             ? for52Weeks
@@ -85,10 +88,10 @@ export const historyWithinArticlesViewedSettings = (
         return true;
     }
 
-    const { minViews, maxViews, periodInWeeks, tagId } = articlesViewedSettings;
+    const { minViews, maxViews, periodInWeeks, tagIds } = articlesViewedSettings;
 
-    const viewCountForWeeks = tagId
-        ? getArticleViewCountByTagForWeeks(tagId, history, periodInWeeks, now)
+    const viewCountForWeeks = tagIds
+        ? getArticleViewCountByMultipleTagForWeeks(tagIds, history, periodInWeeks, now)
         : getArticleViewCountForWeeks(history, periodInWeeks, now);
 
     const minViewsOk = minViews ? viewCountForWeeks >= minViews : true;

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -60,16 +60,22 @@ export const getArticleViewCounts = (
     history: WeeklyArticleHistory = [],
     periodInWeeks = 52,
     tagIds: string[] = [],
+    rightNow: Date = new Date(),
 ): ArticleCounts => {
-    const for52Weeks = getArticleViewCountForWeeks(history, 52);
+    const for52Weeks = getArticleViewCountForWeeks(history, 52, rightNow);
 
     const getCountForTargetingWeeks = (): number => {
-        if (tagIds) {
-            return getArticleViewCountByMultipleTagForWeeks(tagIds, history, periodInWeeks);
+        if (tagIds.length !== 0) {
+            return getArticleViewCountByMultipleTagForWeeks(
+                tagIds,
+                history,
+                periodInWeeks,
+                rightNow,
+            );
         }
         return periodInWeeks === 52
             ? for52Weeks
-            : getArticleViewCountForWeeks(history, periodInWeeks);
+            : getArticleViewCountForWeeks(history, periodInWeeks, rightNow);
     };
 
     return {

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -437,6 +437,7 @@ describe('withinArticleViewedSettings filter', () => {
                 minViews: 5,
                 maxViews: 20,
                 periodInWeeks: 52,
+                tagIds: [],
             },
         };
         const history = [{ week: 18330, count: 21 }];
@@ -474,7 +475,7 @@ describe('withinArticleViewedSettings filter by tag', () => {
     const articlesViewedSettings: ArticlesViewedSettings = {
         minViews: 5,
         periodInWeeks: 52,
-        tagId: 'environment/climate-change',
+        tagIds: ['environment/climate-change'],
     };
 
     it('should pass when no articlesViewedByTagSettings', () => {

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -78,14 +78,14 @@ export const articlesViewedSettingsSchema = z.object({
     minViews: z.number(),
     maxViews: z.number().optional(),
     periodInWeeks: z.number(),
-    tagId: z.string().optional(),
+    tagIds: z.array(z.string()).optional(),
 });
 
 export interface ArticlesViewedSettings {
     minViews: number;
     maxViews?: number;
     periodInWeeks: number;
-    tagId?: string;
+    tagIds?: string[];
 }
 
 /**


### PR DESCRIPTION
Reverts guardian/support-dotcom-components#1132


This is to   allow multiple tags in SDC article count logic.

These are the same changes as in  #1127  +the bug fix for article count in forTargetedWeek getting 0

