### PR TITLE
Ticker update to banner and epics

### DIFF
--- a/packages/dotcom/src/index.ts
+++ b/packages/dotcom/src/index.ts
@@ -7,11 +7,7 @@ export {
 export * from '../../shared/src/lib/geolocation';
 export * from '../../shared/src/lib/viewLog';
 export * from '../../shared/src/lib/reminderFields';
-export {
-    SecondaryCtaType,
-    TickerCountType,
-    TickerEndType,
-} from '../../shared/src/types/props/shared';
+export { SecondaryCtaType, TickerCountType } from '../../shared/src/types/props/shared';
 export { contributionTabFrequencies } from '../../shared/src/types/abTests/epic';
 export { headerPropsSchema } from '../../shared/src/types/props/header';
 export { epicPropsSchema } from '../../shared/src/types/props/epic';

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -26,7 +26,7 @@ import {
     Image,
 } from '@sdc/shared/types';
 import { DesignableBannerReminder } from './components/DesignableBannerReminder';
-import DesignableBannerTicker from './components/DesignableBannerTicker';
+import { DesignableBannerTicker } from './components/DesignableBannerTicker';
 import { templateSpacing } from './styles/templateStyles';
 import useReminder from '../../../hooks/useReminder';
 import useMediaQuery from '../../../hooks/useMediaQuery';
@@ -189,7 +189,6 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
             textColour: hexColourToString(ticker.text),
             filledProgressColour: hexColourToString(ticker.filledProgress),
             progressBarBackgroundColour: hexColourToString(ticker.progressBarBackground),
-            goalMarkerColour: hexColourToString(ticker.goalMarker),
         },
     };
 
@@ -252,8 +251,12 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 
                     {tickerSettings?.tickerData && templateSettings.tickerStylingSettings && (
                         <DesignableBannerTicker
-                            tickerSettings={tickerSettings}
-                            stylingSettings={templateSettings.tickerStylingSettings}
+                            copy={tickerSettings.copy}
+                            tickerData={tickerSettings.tickerData}
+                            countType={tickerSettings.countType}
+                            currencySymbol={tickerSettings.currencySymbol}
+                            endType={tickerSettings.endType}
+                            name={tickerSettings.name}
                         />
                     )}
 

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -251,12 +251,8 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 
                     {tickerSettings?.tickerData && templateSettings.tickerStylingSettings && (
                         <DesignableBannerTicker
-                            copy={tickerSettings.copy}
-                            tickerData={tickerSettings.tickerData}
-                            countType={tickerSettings.countType}
-                            currencySymbol={tickerSettings.currencySymbol}
-                            endType={tickerSettings.endType}
-                            name={tickerSettings.name}
+                            tickerSettings={tickerSettings}
+                            stylingSettings={templateSettings.tickerStylingSettings}
                         />
                     )}
 

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerTicker.tsx
@@ -37,11 +37,12 @@ const styles = {
         position: relative;
     `,
     progressBarStyles: (backgroundColour: string) => css`
-        position: relative;
+        width: calc(100%);
+        height: ${space[3]}px;
         overflow: hidden;
-        width: 100%;
-        height: ${progressBarHeight}px;
-        background: ${backgroundColour};
+        background-color: ${backgroundColour};
+        position: absolute;
+        border-radius: ${space[2]}px;
     `,
     progressBarTransform: (end: number, runningTotal: number, total: number): string => {
         const haveStartedAnimating = runningTotal > 0;
@@ -54,26 +55,19 @@ const styles = {
 
         return `translate3d(${percentage >= 0 ? 0 : percentage}%, 0, 0)`;
     },
-    filledProgressStyles: (
-        end: number,
-        runningTotal: number,
-        total: number,
-        colour: string,
-        isGoalReached: boolean,
-    ): SerializedStyles => css`
-        height: ${progressBarHeight}px;
-        width: calc(100% - ${isGoalReached ? overFilledTickerOffset : tickerFillOffset}%);
-        transform: ${styles.progressBarTransform(end, runningTotal, total)};
-        transition: transform 3s cubic-bezier(0.25, 0.55, 0.2, 0.85);
+    filledProgressStyles: (colour: string): SerializedStyles => css`
         background-color: ${colour};
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        transform: translateX(-100%);
+        transition: transform 3s cubic-bezier(0.25, 0.55, 0.2, 0.85);
+        border-radius: ${space[2]}px;
     `,
     soFarContainerStyles: css`
         padding-right: ${space[5]}px;
-    `,
-    goalContainerStyles: css`
-        text-align: end;
-        margin-right: ${tickerFillOffset}%;
-        transform: translateX(50%);
     `,
     goalMarkerStyles: (colour: string): SerializedStyles => css`
         border-right: 2px solid ${colour};
@@ -84,7 +78,7 @@ const styles = {
     `,
 };
 
-type DesignableBannerTickerProps = {
+export type DesignableBannerTickerProps = {
     tickerSettings: TickerSettings;
     stylingSettings: TickerStylingSettings;
 };
@@ -135,7 +129,7 @@ const DesignableBannerTicker: ReactComponent<DesignableBannerTickerProps> = ({
                     </div>
                 </div>
 
-                <div css={styles.goalContainerStyles}>
+                <div>
                     <div css={styles.countLabelStyles(stylingSettings.textColour)}>
                         {currencySymbol}
                         {isGoalReached ? runningTotal.toLocaleString() : goal.toLocaleString()}{' '}
@@ -146,15 +140,7 @@ const DesignableBannerTicker: ReactComponent<DesignableBannerTickerProps> = ({
 
             <div css={styles.progressBarContainerStyles}>
                 <div css={styles.progressBarStyles(stylingSettings.progressBarBackgroundColour)}>
-                    <div
-                        css={styles.filledProgressStyles(
-                            goal,
-                            runningTotal,
-                            total,
-                            stylingSettings.filledProgressColour,
-                            isGoalReached,
-                        )}
-                    />
+                    <div css={styles.filledProgressStyles(stylingSettings.filledProgressColour)} />
                 </div>
                 <div css={styles.goalMarkerStyles(stylingSettings.goalMarkerColour)} />
             </div>

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerTicker.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { textSans, space } from '@guardian/source-foundations';
 import { TickerSettings } from '@sdc/shared/types';
-import { TickerStylingSettings } from '../settings';
 import { templateSpacing } from '../styles/templateStyles';
 import useTicker from '../../../../hooks/useTicker';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
+import { TickerStylingSettings } from '../../../shared/settings';
 
 const styles = {
     tickerProgressBar: css`

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerTicker.tsx
@@ -103,7 +103,7 @@ export function DesignableBannerTicker(props: DesignableBannerTickerProps): Reac
     const runningTotal = useTicker(props.tickerSettings.tickerData.total, readyToAnimate);
 
     return (
-        <div ref={setNode}>
+        <div ref={setNode} css={styles.containerStyles}>
             {isGoalReached ? (
                 <h2 css={styles.tickerHeadline}>{props.tickerSettings.copy.goalReachedPrimary}</h2>
             ) : (

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerTicker.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import { textSans, space } from '@guardian/source-foundations';
-import { TickerCountType, TickerSettings } from '@sdc/shared/types';
+import { TickerSettings } from '@sdc/shared/types';
 import { TickerStylingSettings } from '../settings';
 import { templateSpacing } from '../styles/templateStyles';
 
@@ -62,60 +62,25 @@ export type DesignableBannerTickerProps = {
     stylingSettings: TickerStylingSettings;
 };
 
-type TickerLabelProps = {
-    total: number;
-    goal: number;
-    countType: TickerCountType;
-    currencySymbol: string;
-};
-
 export function DesignableBannerTicker(props: DesignableBannerTickerProps): React.JSX.Element {
-    function progressBarTranslation(total: number, end: number) {
-        const percentage = (total / end) * 100 - 100;
+    function progressBarTranslation(total: number, goal: number) {
+        const percentage = (total / goal) * 100 - 100;
         return percentage > 0 ? 0 : percentage;
-    }
-
-    function TickerLabel(props: TickerLabelProps, style: TickerStylingSettings) {
-        if (props.countType === TickerCountType.people) {
-            return (
-                <div css={styles.tickerLabelContainer}>
-                    <p css={styles.tickerLabel}>
-                        <span css={styles.tickerLabelTotal(style.textColour)}>
-                            {props.total.toLocaleString()} supporters
-                        </span>{' '}
-                        of {props.goal.toLocaleString()} goal
-                    </p>
-                </div>
-            );
-        }
-
-        const currencySymbol = props.countType === 'money' ? props.currencySymbol : '';
-        return (
-            <div css={styles.tickerLabelContainer}>
-                <p css={styles.tickerLabel}>
-                    <span css={styles.tickerLabelTotal(style.textColour)}>
-                        {currencySymbol}
-                        {props.total.toLocaleString()}
-                    </span>{' '}
-                    of {currencySymbol}
-                    {props.goal.toLocaleString()} goal
-                </p>
-            </div>
-        );
     }
     const progressBarTransform = `translate3d(${progressBarTranslation(
         props.tickerSettings.tickerData.total,
         props.tickerSettings.tickerData.goal,
     )}%, 0, 0)`;
 
+    const currencySymbol =
+        props.tickerSettings.countType === 'money' ? props.tickerSettings.currencySymbol : '';
+
     return (
         <div>
             {props.tickerSettings.tickerData.total >= props.tickerSettings.tickerData.goal ? (
-                <h2 css={styles.tickerHeadline}>
-                    We&rsquo;ve met our goal but you can still contribute
-                </h2>
+                <h2 css={styles.tickerHeadline}>{props.tickerSettings.copy.goalReachedPrimary}</h2>
             ) : (
-                <h2 css={styles.tickerHeadline}>{props.tickerSettings.tickerData.total}</h2>
+                <h2 css={styles.tickerHeadline}>{props.tickerSettings.copy.countLabel}</h2>
             )}
             <div css={styles.tickerProgressBar}>
                 <div
@@ -133,12 +98,27 @@ export function DesignableBannerTicker(props: DesignableBannerTickerProps): Reac
                     />
                 </div>
             </div>
-            <TickerLabel
-                countType={props.tickerSettings.countType}
-                total={props.tickerSettings.tickerData.total}
-                goal={props.tickerSettings.tickerData.goal}
-                currencySymbol={props.tickerSettings.currencySymbol}
-            />
+            {props.tickerSettings.countType === 'people' ? (
+                <div css={styles.tickerLabelContainer}>
+                    <p css={styles.tickerLabel}>
+                        <span css={styles.tickerLabelTotal(props.stylingSettings.textColour)}>
+                            {props.tickerSettings.tickerData.total.toLocaleString()} supporters
+                        </span>{' '}
+                        of {props.tickerSettings.tickerData.goal.toLocaleString()} goal
+                    </p>
+                </div>
+            ) : (
+                <div css={styles.tickerLabelContainer}>
+                    <p css={styles.tickerLabel}>
+                        <span css={styles.tickerLabelTotal(props.stylingSettings.textColour)}>
+                            {currencySymbol}
+                            {props.tickerSettings.tickerData.total.toLocaleString()}
+                        </span>{' '}
+                        of {currencySymbol}
+                        {props.tickerSettings.tickerData.goal.toLocaleString()} goal
+                    </p>
+                </div>
+            )}
         </div>
     );
 }

--- a/packages/modules/src/modules/banners/designableBanner/settings.ts
+++ b/packages/modules/src/modules/banners/designableBanner/settings.ts
@@ -31,7 +31,6 @@ export interface TickerStylingSettings {
     textColour: string;
     filledProgressColour: string;
     progressBarBackgroundColour: string;
-    goalMarkerColour: string;
 }
 
 export interface HeaderSettings {

--- a/packages/modules/src/modules/banners/designableBanner/settings.ts
+++ b/packages/modules/src/modules/banners/designableBanner/settings.ts
@@ -2,6 +2,7 @@ import { Image } from '@sdc/shared/dist/types';
 import { ReactNode } from 'react';
 import { BannerId } from '../common/types';
 import { ChoiceCardSettings } from '../common/choiceCard/ChoiceCards';
+import { TickerStylingSettings } from '../../shared/settings';
 
 export type ContainerSettings = {
     backgroundColour: string;
@@ -25,12 +26,6 @@ export interface CtaSettings {
 export interface HighlightedTextSettings {
     textColour: string;
     highlightColour?: string;
-}
-
-export interface TickerStylingSettings {
-    textColour: string;
-    filledProgressColour: string;
-    progressBarBackgroundColour: string;
 }
 
 export interface HeaderSettings {

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -5,7 +5,6 @@ import {
     HexColour,
     SecondaryCtaType,
     TickerCountType,
-    TickerEndType,
     TickerSettings,
     SelectedAmountsVariant,
     ConfigurableDesign,
@@ -84,7 +83,6 @@ const mobileContentWithHeading = {
 
 const tickerSettings: TickerSettings = {
     countType: TickerCountType.money,
-    endType: TickerEndType.hardstop,
     currencySymbol: '',
     copy: {
         countLabel: 'Contributions in May',

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -87,7 +87,7 @@ const tickerSettings: TickerSettings = {
     endType: TickerEndType.hardstop,
     currencySymbol: '',
     copy: {
-        countLabel: 'contributions in May',
+        countLabel: 'Contributions in May - help us meet our goal',
         goalReachedPrimary: "We've met our goal - thank you!",
         goalReachedSecondary: '',
     },

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBanner.stories.tsx
@@ -87,7 +87,7 @@ const tickerSettings: TickerSettings = {
     endType: TickerEndType.hardstop,
     currencySymbol: '',
     copy: {
-        countLabel: 'Contributions in May - help us meet our goal',
+        countLabel: 'Contributions in May',
         goalReachedPrimary: "We've met our goal - thank you!",
         goalReachedSecondary: '',
     },

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBannerTicker.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBannerTicker.stories.tsx
@@ -60,7 +60,7 @@ PeopleTickerGoalMet.args = {
         name: 'US',
         copy: {
             countLabel: 'Help us reach our goal',
-            goalReachedPrimary: 'Weve met our goal but you can still contribute',
+            goalReachedPrimary: "We've met our goal but you can still contribute",
             goalReachedSecondary: '',
         },
     },

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBannerTicker.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBannerTicker.stories.tsx
@@ -16,28 +16,6 @@ export default {
     component: DesignableBannerTicker,
     title: 'Ticker',
     decorators: [TickerDecorator],
-    args: {
-        tickerSettings: {
-            tickerData: {
-                total: 5000,
-                goal: 200000,
-            },
-            countType: TickerCountType.people,
-            endType: TickerEndType.hardstop,
-            currencySymbol: '',
-            name: 'AU',
-            copy: {
-                countLabel: 'supporters',
-                goalReachedPrimary: 'We have reached our goal',
-                goalReachedSecondary: 'Thank you for your support',
-            },
-        },
-        stylingSettings: {
-            textColour: '#052962',
-            filledProgressColour: '#d9bd3c',
-            progressBarBackgroundColour: '#d30606',
-        },
-    },
 } as ComponentMeta<typeof DesignableBannerTicker>;
 
 // Define a template for the story
@@ -46,6 +24,52 @@ const Template: Story<DesignableBannerTickerProps> = (props: DesignableBannerTic
 );
 
 export const PeopleTicker = Template.bind({});
+PeopleTicker.args = {
+    tickerSettings: {
+        tickerData: {
+            total: 5000,
+            goal: 200000,
+        },
+        countType: TickerCountType.people,
+        endType: TickerEndType.hardstop,
+        currencySymbol: '',
+        name: 'AU',
+        copy: {
+            countLabel: 'Help us reach our goal',
+            goalReachedPrimary: 'We have reached our goal',
+            goalReachedSecondary: 'Thank you for your support',
+        },
+    },
+    stylingSettings: {
+        textColour: '#052962',
+        filledProgressColour: '#d9bd3c',
+        progressBarBackgroundColour: '#d30606',
+    },
+};
+
+export const PeopleTickerGoalMet = Template.bind({});
+PeopleTickerGoalMet.args = {
+    tickerSettings: {
+        tickerData: {
+            total: 50000000,
+            goal: 200000,
+        },
+        countType: TickerCountType.money,
+        endType: TickerEndType.hardstop,
+        currencySymbol: '$',
+        name: 'US',
+        copy: {
+            countLabel: 'Help us reach our goal',
+            goalReachedPrimary: 'Weve met our goal but you can still contribute',
+            goalReachedSecondary: '',
+        },
+    },
+    stylingSettings: {
+        textColour: '#48d900',
+        filledProgressColour: '#d9bd3c',
+        progressBarBackgroundColour: '#d30606',
+    },
+};
 
 export const MoneyTicker = Template.bind({});
 MoneyTicker.args = {
@@ -59,7 +83,7 @@ MoneyTicker.args = {
         currencySymbol: '$',
         name: 'US',
         copy: {
-            countLabel: 'supporters',
+            countLabel: '',
             goalReachedPrimary: 'We have reached our goal',
             goalReachedSecondary: 'Thank you for your support',
         },

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBannerTicker.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBannerTicker.stories.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { TickerCountType, TickerEndType } from '@sdc/shared/dist/types/props/shared';
+import { ComponentMeta, ComponentStory, DecoratorFn } from '@storybook/react';
+import DesignableBannerTicker, {
+    DesignableBannerTickerProps,
+} from '../components/DesignableBannerTicker';
+
+const TickerDecorator: DecoratorFn = (Story) => (
+    <div
+        style={{
+            width: '100%',
+            maxWidth: '500px',
+        }}
+    >
+        <Story />
+    </div>
+);
+
+export default {
+    component: DesignableBannerTicker,
+    title: 'Ticker',
+    decorators: [TickerDecorator],
+} as ComponentMeta<typeof DesignableBannerTicker>;
+
+const Template: ComponentStory<typeof DesignableBannerTicker> = (props) => (
+    <DesignableBannerTicker {...props} />
+);
+
+const baseArgs: DesignableBannerTickerProps = {
+    tickerSettings: {
+        tickerData: {
+            total: 5000,
+            goal: 200000,
+        },
+        countType: TickerCountType.people,
+        endType: TickerEndType.hardstop,
+        currencySymbol: '',
+        name: 'AU',
+        copy: {
+            countLabel: 'supporters',
+            goalReachedPrimary: 'We have reached our goal',
+            goalReachedSecondary: 'Thank you for your support',
+        },
+    },
+    stylingSettings: {
+        textColour: '#052962',
+        filledProgressColour: '#d9bd3c',
+        progressBarBackgroundColour: '#d30606',
+        goalMarkerColour: '#ecce43',
+    },
+} as const;
+
+export const PeopleHeader = Template.bind({});
+PeopleHeader.args = baseArgs;
+
+export const MoneyHeader = Template.bind({});
+MoneyHeader.args = {
+    tickerSettings: {
+        tickerData: {
+            total: 5000,
+            goal: 200000,
+        },
+        countType: TickerCountType.money,
+        endType: TickerEndType.hardstop,
+        currencySymbol: '$',
+        name: 'AU',
+        copy: {
+            countLabel: 'contributed',
+            goalReachedPrimary: 'We have reached our goal',
+            goalReachedSecondary: 'Thank you for your support',
+        },
+    },
+    stylingSettings: {
+        textColour: '#48d900',
+        filledProgressColour: '#d9bd3c',
+        progressBarBackgroundColour: '#802222',
+        goalMarkerColour: '#c7ec43',
+    },
+};

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBannerTicker.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBannerTicker.stories.tsx
@@ -4,7 +4,7 @@ import {
     DesignableBannerTicker,
     DesignableBannerTickerProps,
 } from '../components/DesignableBannerTicker';
-import { TickerCountType, TickerEndType } from '@sdc/shared/dist/types';
+import { TickerCountType } from '@sdc/shared/dist/types';
 
 const TickerDecorator: DecoratorFn = (Story) => (
     <div style={{ margin: '20px' }}>
@@ -31,7 +31,6 @@ PeopleTicker.args = {
             goal: 200000,
         },
         countType: TickerCountType.people,
-        endType: TickerEndType.hardstop,
         currencySymbol: '',
         name: 'AU',
         copy: {
@@ -55,7 +54,6 @@ PeopleTickerGoalMet.args = {
             goal: 200000,
         },
         countType: TickerCountType.money,
-        endType: TickerEndType.hardstop,
         currencySymbol: '$',
         name: 'US',
         copy: {
@@ -79,7 +77,6 @@ MoneyTicker.args = {
             goal: 200000,
         },
         countType: TickerCountType.money,
-        endType: TickerEndType.hardstop,
         currencySymbol: '$',
         name: 'US',
         copy: {

--- a/packages/modules/src/modules/banners/designableBanner/stories/DesignableBannerTicker.stories.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/stories/DesignableBannerTicker.stories.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
-import { TickerCountType, TickerEndType } from '@sdc/shared/dist/types/props/shared';
-import { ComponentMeta, ComponentStory, DecoratorFn } from '@storybook/react';
-import DesignableBannerTicker, {
+import { ComponentMeta, DecoratorFn, Story } from '@storybook/react';
+import {
+    DesignableBannerTicker,
     DesignableBannerTickerProps,
 } from '../components/DesignableBannerTicker';
+import { TickerCountType, TickerEndType } from '@sdc/shared/dist/types';
 
 const TickerDecorator: DecoratorFn = (Story) => (
-    <div
-        style={{
-            width: '100%',
-            maxWidth: '500px',
-        }}
-    >
+    <div style={{ margin: '20px' }}>
         <Story />
     </div>
 );
@@ -20,22 +16,48 @@ export default {
     component: DesignableBannerTicker,
     title: 'Ticker',
     decorators: [TickerDecorator],
+    args: {
+        tickerSettings: {
+            tickerData: {
+                total: 5000,
+                goal: 200000,
+            },
+            countType: TickerCountType.people,
+            endType: TickerEndType.hardstop,
+            currencySymbol: '',
+            name: 'AU',
+            copy: {
+                countLabel: 'supporters',
+                goalReachedPrimary: 'We have reached our goal',
+                goalReachedSecondary: 'Thank you for your support',
+            },
+        },
+        stylingSettings: {
+            textColour: '#052962',
+            filledProgressColour: '#d9bd3c',
+            progressBarBackgroundColour: '#d30606',
+        },
+    },
 } as ComponentMeta<typeof DesignableBannerTicker>;
 
-const Template: ComponentStory<typeof DesignableBannerTicker> = (props) => (
+// Define a template for the story
+const Template: Story<DesignableBannerTickerProps> = (props: DesignableBannerTickerProps) => (
     <DesignableBannerTicker {...props} />
 );
 
-const baseArgs: DesignableBannerTickerProps = {
+export const PeopleTicker = Template.bind({});
+
+export const MoneyTicker = Template.bind({});
+MoneyTicker.args = {
     tickerSettings: {
         tickerData: {
             total: 5000,
             goal: 200000,
         },
-        countType: TickerCountType.people,
+        countType: TickerCountType.money,
         endType: TickerEndType.hardstop,
-        currencySymbol: '',
-        name: 'AU',
+        currencySymbol: '$',
+        name: 'US',
         copy: {
             countLabel: 'supporters',
             goalReachedPrimary: 'We have reached our goal',
@@ -46,34 +68,5 @@ const baseArgs: DesignableBannerTickerProps = {
         textColour: '#052962',
         filledProgressColour: '#d9bd3c',
         progressBarBackgroundColour: '#d30606',
-        goalMarkerColour: '#ecce43',
-    },
-} as const;
-
-export const PeopleHeader = Template.bind({});
-PeopleHeader.args = baseArgs;
-
-export const MoneyHeader = Template.bind({});
-MoneyHeader.args = {
-    tickerSettings: {
-        tickerData: {
-            total: 5000,
-            goal: 200000,
-        },
-        countType: TickerCountType.money,
-        endType: TickerEndType.hardstop,
-        currencySymbol: '$',
-        name: 'AU',
-        copy: {
-            countLabel: 'contributed',
-            goalReachedPrimary: 'We have reached our goal',
-            goalReachedSecondary: 'Thank you for your support',
-        },
-    },
-    stylingSettings: {
-        textColour: '#48d900',
-        filledProgressColour: '#d9bd3c',
-        progressBarBackgroundColour: '#802222',
-        goalMarkerColour: '#c7ec43',
     },
 };

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -11,7 +11,6 @@ import { MomentTemplateBannerVisual } from './components/MomentTemplateBannerVis
 import { BannerTemplateSettings } from './settings';
 import { SecondaryCtaType, Image } from '@sdc/shared/types';
 import { MomentTemplateBannerReminder } from './components/MomentTemplateBannerReminder';
-import MomentTemplateBannerTicker from './components/MomentTemplateBannerTicker';
 import { templateSpacing } from './styles/templateStyles';
 import useReminder from '../../../hooks/useReminder';
 import useMediaQuery from '../../../hooks/useMediaQuery';
@@ -19,6 +18,7 @@ import useChoiceCards from '../../../hooks/useChoiceCards';
 import { ChoiceCards } from '../common/choiceCard/ChoiceCards';
 import { buttonStyles } from './styles/buttonStyles';
 import { ReactComponent } from '../../../types';
+import { MomentTemplateBannerTicker } from './components/MomentTemplateBannerTicker';
 
 export function getMomentTemplateBanner(
     templateSettings: BannerTemplateSettings,

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { textSans, space } from '@guardian/source-foundations';
 import { TickerSettings } from '@sdc/shared/types';
-import { TickerStylingSettings } from '../settings';
 import { templateSpacing } from '../styles/templateStyles';
 import useTicker from '../../../../hooks/useTicker';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
+import { TickerStylingSettings } from '../../../shared/settings';
 
 const styles = {
     tickerProgressBar: css`

--- a/packages/modules/src/modules/banners/momentTemplate/settings.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/settings.ts
@@ -2,6 +2,7 @@ import { Image } from '@sdc/shared/dist/types';
 import { ReactNode } from 'react';
 import { BannerId } from '../common/types';
 import { ChoiceCardSettings } from '../common/choiceCard/ChoiceCards';
+import { TickerStylingSettings } from '../../shared/settings';
 
 export type ContainerSettings = {
     backgroundColour: string;
@@ -31,13 +32,6 @@ export interface CtaSettings {
 export interface HighlightedTextSettings {
     textColour: string;
     highlightColour?: string;
-}
-
-export interface TickerStylingSettings {
-    textColour: string;
-    filledProgressColour: string;
-    progressBarBackgroundColour: string;
-    goalMarkerColour: string;
 }
 
 export interface HeaderSettings {

--- a/packages/modules/src/modules/banners/momentTemplate/stories/MomentTemplateBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/MomentTemplateBanner.stories.tsx
@@ -363,7 +363,7 @@ WithTicker.args = {
         endType: TickerEndType.hardstop,
         currencySymbol: '',
         copy: {
-            countLabel: 'contributions in May',
+            countLabel: 'Contributions in May so far',
             goalReachedPrimary: "We've met our goal - thank you!",
             goalReachedSecondary: '',
         },

--- a/packages/modules/src/modules/banners/momentTemplate/stories/MomentTemplateBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/MomentTemplateBanner.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/react';
 import { props } from '../../utils/storybook';
-import { SecondaryCtaType, TickerCountType, TickerEndType } from '@sdc/shared/types';
+import { SecondaryCtaType, TickerCountType } from '@sdc/shared/types';
 import { BannerWithReminderTemplate } from './WithReminder';
 import { BannerWithHeaderImageTemplate } from './WithHeaderImage';
 import { BannerWithChoiceCardsTemplate } from './WithChoiceCards';
@@ -360,7 +360,6 @@ WithTicker.args = {
     numArticles: 50,
     tickerSettings: {
         countType: TickerCountType.money,
-        endType: TickerEndType.hardstop,
         currencySymbol: '',
         copy: {
             countLabel: 'Contributions in May so far',

--- a/packages/modules/src/modules/banners/momentTemplate/stories/WithTicker.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/WithTicker.tsx
@@ -70,7 +70,6 @@ export const BannerWithTicker = bannerWrapper(
             textColour: '#052962',
             filledProgressColour: '#052962',
             progressBarBackgroundColour: '#fff',
-            goalMarkerColour: 'black',
         },
         bannerId: 'global-new-year-moment-banner',
     }),

--- a/packages/modules/src/modules/banners/utils/storybook.ts
+++ b/packages/modules/src/modules/banners/utils/storybook.ts
@@ -6,6 +6,7 @@ import {
     Tracking,
     TickerSettings,
 } from '@sdc/shared/types';
+import { TickerStylingSettings } from '../designableBanner/settings';
 
 export const tracking: Tracking = {
     ophanPageId: 'kbluzw2csbf83eabedel',

--- a/packages/modules/src/modules/banners/utils/storybook.ts
+++ b/packages/modules/src/modules/banners/utils/storybook.ts
@@ -6,7 +6,6 @@ import {
     Tracking,
     TickerSettings,
 } from '@sdc/shared/types';
-import { TickerStylingSettings } from '../designableBanner/settings';
 
 export const tracking: Tracking = {
     ophanPageId: 'kbluzw2csbf83eabedel',

--- a/packages/modules/src/modules/banners/utils/storybook.ts
+++ b/packages/modules/src/modules/banners/utils/storybook.ts
@@ -1,7 +1,6 @@
 import {
     BannerProps,
     TickerCountType,
-    TickerEndType,
     SecondaryCtaType,
     Tracking,
     TickerSettings,
@@ -44,7 +43,6 @@ export const content = {
 
 export const tickerSettings: TickerSettings = {
     countType: TickerCountType.money,
-    endType: TickerEndType.hardstop,
     currencySymbol: '$',
     copy: {
         countLabel: 'contributed',

--- a/packages/modules/src/modules/shared/settings.ts
+++ b/packages/modules/src/modules/shared/settings.ts
@@ -1,0 +1,5 @@
+export interface TickerStylingSettings {
+    textColour: string;
+    filledProgressColour: string;
+    progressBarBackgroundColour: string;
+}

--- a/packages/server/src/tests/amp/ampEpicSelection.test.ts
+++ b/packages/server/src/tests/amp/ampEpicSelection.test.ts
@@ -1,9 +1,13 @@
 import { CountryGroupId } from '@sdc/shared/lib';
-import { TickerCountType, TickerEndType, TickerSettings } from '@sdc/shared/types';
 import { AmpVariantAssignments } from '../../lib/ampVariantAssignments';
 import { AMPEpic, AmpEpicTest } from './ampEpicModels';
 import { selectAmpEpic } from './ampEpicSelection';
 import { TickerDataProvider } from '../../lib/fetchTickerData';
+import {
+    TickerCountType,
+    TickerEndType,
+    TickerSettings,
+} from '@sdc/shared/dist/types/props/shared';
 
 const tickerSettings: TickerSettings = {
     endType: TickerEndType.unlimited,
@@ -15,6 +19,10 @@ const tickerSettings: TickerSettings = {
         goalReachedSecondary: 'but you can still support us',
     },
     name: 'US',
+    tickerData: {
+        total: 5000,
+        goal: 200000,
+    },
 };
 
 const epicTest: AmpEpicTest = {

--- a/packages/server/src/tests/amp/ampEpicSelection.test.ts
+++ b/packages/server/src/tests/amp/ampEpicSelection.test.ts
@@ -3,14 +3,9 @@ import { AmpVariantAssignments } from '../../lib/ampVariantAssignments';
 import { AMPEpic, AmpEpicTest } from './ampEpicModels';
 import { selectAmpEpic } from './ampEpicSelection';
 import { TickerDataProvider } from '../../lib/fetchTickerData';
-import {
-    TickerCountType,
-    TickerEndType,
-    TickerSettings,
-} from '@sdc/shared/dist/types/props/shared';
+import { TickerCountType, TickerSettings } from '@sdc/shared/dist/types/props/shared';
 
 const tickerSettings: TickerSettings = {
-    endType: TickerEndType.unlimited,
     countType: TickerCountType.money,
     currencySymbol: '$',
     copy: {

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -46,13 +46,6 @@ export const secondaryCtaSchema = z.discriminatedUnion('type', [
     contributionsReminderSecondaryCtaSchema,
 ]);
 
-export enum TickerEndType {
-    unlimited = 'unlimited',
-    hardstop = 'hardstop', // currently unsupported
-}
-
-export const tickerEndTypeSchema = z.nativeEnum(TickerEndType);
-
 export enum TickerCountType {
     money = 'money',
     people = 'people',
@@ -88,7 +81,6 @@ export type TickerName = 'US' | 'AU';
 const ticketNameSchema = z.enum(['US', 'AU']);
 
 export interface TickerSettings {
-    endType: TickerEndType;
     countType: TickerCountType;
     currencySymbol: string;
     copy: TickerCopy;
@@ -97,7 +89,6 @@ export interface TickerSettings {
 }
 
 export const tickerSettingsSchema = z.object({
-    endType: tickerEndTypeSchema,
     countType: tickerCountTypeSchema,
     currencySymbol: z.string(),
     copy: tickerCopySchema,

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -55,6 +55,7 @@ export const tickerEndTypeSchema = z.nativeEnum(TickerEndType);
 
 export enum TickerCountType {
     money = 'money',
+    people = 'people',
 }
 
 export const tickerCountTypeSchema = z.nativeEnum(TickerCountType);

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -93,7 +93,7 @@ export interface TickerSettings {
     currencySymbol: string;
     copy: TickerCopy;
     name: TickerName;
-    tickerData?: TickerData;
+    tickerData: TickerData;
 }
 
 export const tickerSettingsSchema = z.object({
@@ -102,7 +102,7 @@ export const tickerSettingsSchema = z.object({
     currencySymbol: z.string(),
     copy: tickerCopySchema,
     name: ticketNameSchema,
-    tickerData: tickerDataSchema.optional(),
+    tickerData: tickerDataSchema,
 });
 
 export const ophanProductSchema = z.enum([


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Update to the ticker design to keep in line with what is current in [System Design ](https://www.figma.com/design/mkyzlXSnCGEOIRNncwziDC/Progress-bar-test?node-id=1-821&t=2pbFhkB0l1gZcf5D-0). This changes what the ticker looks like but the customisation of the copy and colours is still enabled.

There is a new storybook file to show the new ticker with three scenarios people ticker, money ticker and what happens when the goal is met.
  
## How to test
On Storybook open the Ticker component storybook and/or check out the ticker on the Designable Banner stories and/or the MomentTemplateBanner
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
