### PR TITLE
Add abandoned basket to banner payload type

### DIFF
--- a/packages/dotcom/.changeset/curvy-jokes-boil.md
+++ b/packages/dotcom/.changeset/curvy-jokes-boil.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+Add abandonedBasket schema and type and add to BannerPayload type

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -1,4 +1,4 @@
-import { PageTracking, WeeklyArticleHistory, PurchaseInfo } from './shared';
+import { PageTracking, WeeklyArticleHistory, PurchaseInfo, AbandonedBasket } from './shared';
 
 export type BannerTargeting = {
     shouldHideReaderRevenue?: boolean;
@@ -21,6 +21,7 @@ export type BannerTargeting = {
     isSignedIn: boolean;
     lastOneOffContributionDate?: string;
     hasConsented: boolean;
+    abandonedBasket?: AbandonedBasket;
 };
 
 export type BannerPayload = {

--- a/packages/shared/src/types/targeting/shared.ts
+++ b/packages/shared/src/types/targeting/shared.ts
@@ -41,7 +41,11 @@ export const abandonedBasketSchema = z.object({
     product: z.union([
         z.literal('Contribution'),
         z.literal('SupporterPlus'),
-        z.literal('SubscriptionProduct'),
+        z.literal('PremiumTier'),
+        z.literal('DailyEdition'),
+        z.literal('GuardianWeekly'),
+        z.literal('Paper'),
+        z.literal('PaperAndDigital'),
     ]),
     //values for region should match allowable values for supportInternationalisationId in
     //support-frontend/assets/helpers/internationalisation/countryGroup.ts

--- a/packages/shared/src/types/targeting/shared.ts
+++ b/packages/shared/src/types/targeting/shared.ts
@@ -1,3 +1,4 @@
+import * as z from 'zod';
 import { purchaseInfoProduct, purchaseInfoUser } from '../purchaseInfo';
 
 export type PageTracking = {
@@ -33,3 +34,12 @@ export interface PurchaseInfo {
     userType: purchaseInfoUser;
     product: purchaseInfoProduct;
 }
+
+export const AbandonedBasketSchema = z.object({
+    amount: z.union([z.number(), z.literal('other')]),
+    billingPeriod: z.string(),
+    product: z.string(),
+    region: z.string(),
+});
+
+export type AbandonedBasket = z.infer<typeof AbandonedBasketSchema>;

--- a/packages/shared/src/types/targeting/shared.ts
+++ b/packages/shared/src/types/targeting/shared.ts
@@ -37,7 +37,11 @@ export interface PurchaseInfo {
 
 export const abandonedBasketSchema = z.object({
     amount: z.union([z.number(), z.literal('other')]),
-    billingPeriod: z.string(),
+    billingPeriod: z.union([
+        z.literal('Contribution'),
+        z.literal('SupporterPlus'),
+        z.literal('SubscriptionProduct'),
+    ]),
     product: z.string(),
     region: z.string(),
 });

--- a/packages/shared/src/types/targeting/shared.ts
+++ b/packages/shared/src/types/targeting/shared.ts
@@ -37,12 +37,12 @@ export interface PurchaseInfo {
 
 export const abandonedBasketSchema = z.object({
     amount: z.union([z.number(), z.literal('other')]),
-    billingPeriod: z.union([
+    billingPeriod: z.union([z.literal('ONE_OFF'), z.literal('MONTHLY'), z.literal('ANNUAL')]),
+    product: z.union([
         z.literal('Contribution'),
         z.literal('SupporterPlus'),
         z.literal('SubscriptionProduct'),
     ]),
-    product: z.string(),
     region: z.string(),
 });
 

--- a/packages/shared/src/types/targeting/shared.ts
+++ b/packages/shared/src/types/targeting/shared.ts
@@ -43,7 +43,17 @@ export const abandonedBasketSchema = z.object({
         z.literal('SupporterPlus'),
         z.literal('SubscriptionProduct'),
     ]),
-    region: z.string(),
+    //values for region should match allowable values for supportInternationalisationId in
+    //support-frontend/assets/helpers/internationalisation/countryGroup.ts
+    region: z.union([
+        z.literal('uk'),
+        z.literal('us'),
+        z.literal('au'),
+        z.literal('eu'),
+        z.literal('int'),
+        z.literal('nz'),
+        z.literal('ca'),
+    ]),
 });
 
 export type AbandonedBasket = z.infer<typeof abandonedBasketSchema>;

--- a/packages/shared/src/types/targeting/shared.ts
+++ b/packages/shared/src/types/targeting/shared.ts
@@ -35,11 +35,11 @@ export interface PurchaseInfo {
     product: purchaseInfoProduct;
 }
 
-export const AbandonedBasketSchema = z.object({
+export const abandonedBasketSchema = z.object({
     amount: z.union([z.number(), z.literal('other')]),
     billingPeriod: z.string(),
     product: z.string(),
     region: z.string(),
 });
 
-export type AbandonedBasket = z.infer<typeof AbandonedBasketSchema>;
+export type AbandonedBasket = z.infer<typeof abandonedBasketSchema>;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new schema and type for the Abandoned Basket object, and adds it to the banner payload Type. This will be used in DCR when creating the payload to send to the SDC API.

The schema is a duplicate of the one in [support-frontend](https://github.com/guardian/support-frontend/blob/fc67babcbcb729a519c5d24ae1377b7e1816c490/support-frontend/assets/helpers/storage/abandonedBasketCookies.ts#L11)

[Trello](https://trello.com/c/HK9pkXd5/414-abandoned-basket-send-cookie-data-to-api)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Created the `/dist` folder with the new property `abandonedBasket` of `BannerPayload`, manually copied into DCR `node_modules` and can see `abandonedBasket` is present. 

I'm not sure how to test more thoroughly besides publishing a new version and consuming it in DCR

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
