### PR TITLE
Momentum Epic: update test to include medium increases

### DIFF
--- a/packages/server/src/tests/epics/momentumTest.ts
+++ b/packages/server/src/tests/epics/momentumTest.ts
@@ -21,7 +21,7 @@ Medium-High -- jumped four categories
 High -- jumped five categories
  */
 
-const jumps = {
+const JUMPS = {
     low: 2,
     medium: 3,
     mediumHigh: 4,
@@ -92,12 +92,14 @@ export function isIncreasedEngagement(
         count,
     }));
 
+    const categoryJumps = categoryForThirdMonth - categoryForFirstMonth;
+
     if (
+        // must be an increase month on month
         categoryForThirdMonth > categoryForSecondMonth &&
         categoryForSecondMonth > categoryForFirstMonth
     ) {
-        const isIncreasedEngagement =
-            categoryForThirdMonth - categoryForFirstMonth >= jumps.mediumHigh;
+        const isIncreasedEngagement = categoryJumps >= JUMPS.medium;
 
         logger.info({
             message: 'Decision to show Momentum Epic',
@@ -106,6 +108,7 @@ export function isIncreasedEngagement(
             categoryForSecondMonth,
             categoryForThirdMonth,
             articleHistoryWithoutTags,
+            categoryJumps,
         });
 
         return isIncreasedEngagement;
@@ -118,6 +121,7 @@ export function isIncreasedEngagement(
         categoryForSecondMonth,
         categoryForThirdMonth,
         articleHistoryWithoutTags,
+        categoryJumps,
     });
 
     return false;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update the momentum test filter to include medium engagement (i.e. jumped 3 categories). 

So far the test has had very few impressions and conversions, this would open it up to a wider audience who have still increased their reading of articles month on month.

![image](https://github.com/guardian/support-dotcom-components/assets/114918544/97192802-8477-40f4-bd59-b02108f53160)


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

More impressions in the pageview datalake table and AB test dashboard

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
