### PR TITLE
Add export for abandonedBasketSchema

### DIFF
--- a/packages/dotcom/.changeset/lucky-pugs-yell.md
+++ b/packages/dotcom/.changeset/lucky-pugs-yell.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+export abandonedBasketSchema

--- a/packages/dotcom/src/index.ts
+++ b/packages/dotcom/src/index.ts
@@ -15,4 +15,5 @@ export {
 export { contributionTabFrequencies } from '../../shared/src/types/abTests/epic';
 export { headerPropsSchema } from '../../shared/src/types/props/header';
 export { epicPropsSchema } from '../../shared/src/types/props/epic';
+export { abandonedBasketSchema } from '../../shared/src/types/targeting/shared';
 export * from './requests';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds `abandonedBasketSchema` to the `index.ts` exports, in order to be used from the npm package. Exporting it from its own file means it cannot be used downstream, only its type. In other words we have to export it as javascript

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Tested locally with `pnpm link` 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
