### PR TITLE
Compare sticky vs non-sticky variants

### DIFF
--- a/packages/server/src/lib/ab.ts
+++ b/packages/server/src/lib/ab.ts
@@ -60,6 +60,11 @@ export const selectVariant = <V extends Variant, T extends Test<V>>(test: T, mvt
     return selectWithSeed(mvtId, seed, test.variants);
 };
 
+export const selectVariantNonSticky = <V extends Variant, T extends Test<V>>(test: T): V => {
+    const index = Math.floor(Math.random() * test.variants.length);
+    return test.variants[index];
+};
+
 export const selectAmountsTestVariant = (
     tests: AmountsTests,
     countryCode: string,

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -19,7 +19,7 @@ import {
     withinMaxViews,
     deviceTypeMatchesFilter,
     correctSignedInStatusFilter,
-    banditNullHypothesisFilter,
+    NonStickyVariantsTestNames,
 } from './epicSelection';
 import { BanditData } from '../../bandit/banditData';
 
@@ -855,9 +855,6 @@ describe('correctSignedInStatusFilter filter', () => {
     });
 });
 
-const BANDIT_TEST_NAME = '2024-04-16_BANDIT_NULL_HYPOTHESIS_TEST_BANDIT';
-const AB_TEST_TEST_NAME = '2024-04-16_BANDIT_NULL_HYPOTHESIS_TEST_AB';
-
 describe('bandit null hypothesis', () => {
     const variants = [
         {
@@ -869,14 +866,14 @@ describe('bandit null hypothesis', () => {
 
     const abTestTest: EpicTest = {
         ...testDefault,
-        name: AB_TEST_TEST_NAME,
+        name: NonStickyVariantsTestNames.Sticky,
         articlesViewedSettings: undefined,
         variants: variants,
     };
 
     const banditTest: EpicTest = {
         ...testDefault,
-        name: BANDIT_TEST_NAME,
+        name: NonStickyVariantsTestNames.NonSticky,
         isBanditTest: true,
         articlesViewedSettings: undefined,
         variants: variants,
@@ -884,7 +881,7 @@ describe('bandit null hypothesis', () => {
 
     const tests = [abTestTest, banditTest];
 
-    it('should return AB test and bandit ~ equally', () => {
+    it('should return sticky and non-sticky ~ equally', () => {
         const results: (string | undefined)[] = [];
 
         for (let i = 0; i < 5000; i++) {
@@ -902,92 +899,12 @@ describe('bandit null hypothesis', () => {
             results.push(got.result?.test.name);
         }
 
-        const abTestChosen = results.filter((r) => r === AB_TEST_TEST_NAME);
-        expect(abTestChosen.length).toBe(2550);
+        const stickyChosen = results.filter((r) => r === NonStickyVariantsTestNames.Sticky);
+        expect(stickyChosen.length).toBeGreaterThan(2400);
+        expect(stickyChosen.length).toBeLessThan(2600);
 
-        const banditChosen = results.filter((r) => r === BANDIT_TEST_NAME);
-        expect(banditChosen.length).toBe(2450);
-    });
-});
-
-describe('banditNullHypothesisFilter filter', () => {
-    it('should pass for mvtId = 1 and test is AB test', () => {
-        const test: EpicTest = {
-            ...testDefault,
-            name: AB_TEST_TEST_NAME,
-        };
-
-        const targeting = { ...targetingDefault, mvtId: 1 };
-        const got = banditNullHypothesisFilter.test(test, targeting);
-
-        expect(got).toBe(true);
-    });
-
-    it('should fail for mvtId = 2 and test is AB test', () => {
-        const test: EpicTest = {
-            ...testDefault,
-            name: AB_TEST_TEST_NAME,
-        };
-
-        const targeting = { ...targetingDefault, mvtId: 2 };
-        const got = banditNullHypothesisFilter.test(test, targeting);
-
-        expect(got).toBe(false);
-    });
-
-    it('should pass for mvtId = 2 and test is Bandit', () => {
-        const test: EpicTest = {
-            ...testDefault,
-            name: BANDIT_TEST_NAME,
-        };
-
-        const targeting = { ...targetingDefault, mvtId: 2 };
-        const got = banditNullHypothesisFilter.test(test, targeting);
-
-        expect(got).toBe(true);
-    });
-
-    it('should fail for mvtId = 1 and test is Bandit', () => {
-        const test: EpicTest = {
-            ...testDefault,
-            name: BANDIT_TEST_NAME,
-        };
-
-        const targeting = { ...targetingDefault, mvtId: 1 };
-        const got = banditNullHypothesisFilter.test(test, targeting);
-
-        expect(got).toBe(false);
-    });
-
-    it('should pass for ~50% of MVT IDs and test is AB test', () => {
-        const test: EpicTest = {
-            ...testDefault,
-            name: AB_TEST_TEST_NAME,
-        };
-
-        const results: boolean[] = [];
-        for (let mvt = 0; mvt < 5000; mvt++) {
-            const targeting = { ...targetingDefault, mvtId: mvt };
-            const got = banditNullHypothesisFilter.test(test, targeting);
-            results.push(got);
-        }
-
-        expect(results.filter((r) => r).length).toBe(2550);
-    });
-
-    it('should pass for ~50% of MVT IDs and test is Bandit', () => {
-        const test: EpicTest = {
-            ...testDefault,
-            name: BANDIT_TEST_NAME,
-        };
-
-        const results: boolean[] = [];
-        for (let mvt = 0; mvt < 5000; mvt++) {
-            const targeting = { ...targetingDefault, mvtId: mvt };
-            const got = banditNullHypothesisFilter.test(test, targeting);
-            results.push(got);
-        }
-
-        expect(results.filter((r) => r).length).toBe(2450);
+        const nonStickyChosen = results.filter((r) => r === NonStickyVariantsTestNames.NonSticky);
+        expect(nonStickyChosen.length).toBeGreaterThan(2400);
+        expect(nonStickyChosen.length).toBeLessThan(2600);
     });
 });

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -307,7 +307,7 @@ function selectEpicVariant(test: EpicTest, banditData: BanditData[], targeting: 
         return selectVariantUsingEpsilonGreedy(banditData, test);
     }
 
-    if (test.name.includes(NonStickyVariantsTestNames.NonSticky)) {
+    if (test.name === NonStickyVariantsTestNames.NonSticky) {
         // Do not use the mvt value
         const variant = selectVariantNonSticky<EpicVariant, EpicTest>(test);
         return {

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -10,7 +10,7 @@ import {
 } from '@sdc/shared/types';
 import { BanditData } from '../../bandit/banditData';
 import { selectVariantUsingEpsilonGreedy } from '../../bandit/banditSelection';
-import { getRandomNumber, selectVariant } from '../../lib/ab';
+import { getRandomNumber, selectVariantNonSticky, selectVariant } from '../../lib/ab';
 import { isRecentOneOffContributor } from '../../lib/dates';
 import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { TestVariant } from '../../lib/params';
@@ -190,14 +190,18 @@ export interface Result {
     debug?: Debug;
 }
 
-export const banditNullHypothesisFilter: Filter = {
-    id: 'matchesOneOfBanditNullHypothesisTests',
+export const NonStickyVariantsTestNames = {
+    Sticky: '2024-05-29_STICKY_VARIANTS',
+    NonSticky: '2024-05-29_NON_STICKY_VARIANTS',
+};
+export const nonStickyVariantsTestFilter: Filter = {
+    id: 'matchesNonStickyVariantsTests',
     test: (test, targeting): boolean => {
-        const fiftyFiftyChance = getRandomNumber('NULL_HYPOTHESIS', targeting.mvtId) % 2;
-        if (test.name === '2024-04-16_BANDIT_NULL_HYPOTHESIS_TEST_AB') {
+        const fiftyFiftyChance = getRandomNumber('NON_STICKY', targeting.mvtId) % 2;
+        if (test.name === NonStickyVariantsTestNames.Sticky) {
             return fiftyFiftyChance === 0;
         }
-        if (test.name === '2024-04-16_BANDIT_NULL_HYPOTHESIS_TEST_BANDIT') {
+        if (test.name === NonStickyVariantsTestNames.NonSticky) {
             return fiftyFiftyChance === 1;
         }
         return true;
@@ -232,7 +236,7 @@ export const findTestAndVariant = (
             withinArticleViewedSettings(targeting.weeklyArticleHistory || []),
             deviceTypeMatchesFilter(userDeviceType),
             correctSignedInStatusFilter,
-            banditNullHypothesisFilter,
+            nonStickyVariantsTestFilter,
             momentumMatches,
         ];
     };
@@ -301,6 +305,14 @@ export const findTestAndVariant = (
 function selectEpicVariant(test: EpicTest, banditData: BanditData[], targeting: EpicTargeting) {
     if (test.isBanditTest) {
         return selectVariantUsingEpsilonGreedy(banditData, test);
+    }
+
+    if (test.name.includes(NonStickyVariantsTestNames.NonSticky)) {
+        // Do not use the mvt value
+        const variant = selectVariantNonSticky<EpicVariant, EpicTest>(test);
+        return {
+            result: { test, variant },
+        };
     }
 
     const variant = selectVariant<EpicVariant, EpicTest>(test, targeting.mvtId || 1);


### PR DESCRIPTION
We're going to run an AB test which compares two ways of assigning browsers to variants within an AB test:
1. sticky variants - a browser stays in the same variant for the lifetime of a test (existing behaviour, using mvt cookie)
2. non-sticky variants - variant is selected randomly on each pageview

We're doing this by creating two identical AB tests in the Epic tool:
- `2024-05-29_STICKY_VARIANTS`
- `2024-05-29_NON_STICKY_VARIANTS`