### PR TITLE
Hide Payment Icons when not support url

### DIFF
--- a/packages/server/src/api/ampEpicRouter.ts
+++ b/packages/server/src/api/ampEpicRouter.ts
@@ -13,6 +13,7 @@ import {
     buildReminderFields,
     countryCodeToCountryGroupId,
     getLocalCurrencySymbol,
+    isSupportUrl,
 } from '@sdc/shared/dist/lib';
 import { getAmpVariantAssignments } from '../lib/ampVariantAssignments';
 import { ampEpic } from '../tests/amp/ampEpic';
@@ -142,6 +143,7 @@ export const buildAmpEpicRouter = (
                     ctaUrl: `${epic.cta.url}?INTCMP=${
                         epic.cta.campaignCode
                     }&acquisitionData=${JSON.stringify(acquisitionData)}`,
+                    hidePaymentIcons: !isSupportUrl(epic.cta.url),
                     reminder: {
                         ...buildReminderFields(),
                         hideButtons: false,


### PR DESCRIPTION
## What does this change?

Adds a new state to amp-state which checks if the URL is support site.  If not, sets the state to true which is then picked up in the Epic.amp.tsx in DCR and used to hide the payment icons.

The epic is occasionally used for email sign up and similar where the payment cards are not relevant.

co-authored-by @andrewHEguardian 

[Trello card](https://trello.com/c/bf3uoki5) 

Related to PR in dotcom-rendering - [PR11476](https://github.com/guardian/dotcom-rendering/pull/11476)
This PR should be merged first.

## How to test

In RRCP, change the URL in the epic from support.theguardian.com to www.theguardian.com and view the amp epic.