### PR TITLE
Fix article count targeting

### DIFF
--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -96,9 +96,10 @@ export const historyWithinArticlesViewedSettings = (
 
     const { minViews, maxViews, periodInWeeks, tagIds } = articlesViewedSettings;
 
-    const viewCountForWeeks = tagIds
-        ? getArticleViewCountByMultipleTagForWeeks(tagIds, history, periodInWeeks, now)
-        : getArticleViewCountForWeeks(history, periodInWeeks, now);
+    const viewCountForWeeks =
+        (tagIds ?? []).length > 0
+            ? getArticleViewCountByMultipleTagForWeeks(tagIds, history, periodInWeeks, now)
+            : getArticleViewCountForWeeks(history, periodInWeeks, now);
 
     const minViewsOk = minViews ? viewCountForWeeks >= minViews : true;
     const maxViewsOk = maxViews ? viewCountForWeeks <= maxViews : true;

--- a/packages/server/src/lib/history.ts
+++ b/packages/server/src/lib/history.ts
@@ -94,10 +94,10 @@ export const historyWithinArticlesViewedSettings = (
         return true;
     }
 
-    const { minViews, maxViews, periodInWeeks, tagIds } = articlesViewedSettings;
+    const { minViews, maxViews, periodInWeeks, tagIds = [] } = articlesViewedSettings;
 
     const viewCountForWeeks =
-        (tagIds ?? []).length > 0
+        tagIds.length > 0
             ? getArticleViewCountByMultipleTagForWeeks(tagIds, history, periodInWeeks, now)
             : getArticleViewCountForWeeks(history, periodInWeeks, now);
 


### PR DESCRIPTION
Currently only epics can have `tagIds` set in the `articlesViewedSettings` targeting config.
There is a bug where if `tagIds` is defined but empty, the calculated article count is 0.
This means that newer epic tests (ones with `tagIds` set) are not targeting users by article count.