### PR TITLE
Enable suffix in sticky variant test names

### DIFF
--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -855,7 +855,7 @@ describe('correctSignedInStatusFilter filter', () => {
     });
 });
 
-describe('bandit null hypothesis', () => {
+describe('sticky variant test', () => {
     const variants = [
         {
             ...variantDefault,

--- a/packages/server/src/tests/epics/epicSelection.test.ts
+++ b/packages/server/src/tests/epics/epicSelection.test.ts
@@ -864,22 +864,22 @@ describe('bandit null hypothesis', () => {
         { ...variantDefault, name: 'variant' },
     ];
 
-    const abTestTest: EpicTest = {
+    const stickyTest: EpicTest = {
         ...testDefault,
-        name: NonStickyVariantsTestNames.Sticky,
+        name: `${NonStickyVariantsTestNames.Sticky}__UK`,
         articlesViewedSettings: undefined,
         variants: variants,
     };
 
-    const banditTest: EpicTest = {
+    const nonStickyTest: EpicTest = {
         ...testDefault,
-        name: NonStickyVariantsTestNames.NonSticky,
+        name: `${NonStickyVariantsTestNames.NonSticky}__UK`,
         isBanditTest: true,
         articlesViewedSettings: undefined,
         variants: variants,
     };
 
-    const tests = [abTestTest, banditTest];
+    const tests = [stickyTest, nonStickyTest];
 
     it('should return sticky and non-sticky ~ equally', () => {
         const results: (string | undefined)[] = [];
@@ -899,11 +899,11 @@ describe('bandit null hypothesis', () => {
             results.push(got.result?.test.name);
         }
 
-        const stickyChosen = results.filter((r) => r === NonStickyVariantsTestNames.Sticky);
+        const stickyChosen = results.filter((r) => r === stickyTest.name);
         expect(stickyChosen.length).toBeGreaterThan(2400);
         expect(stickyChosen.length).toBeLessThan(2600);
 
-        const nonStickyChosen = results.filter((r) => r === NonStickyVariantsTestNames.NonSticky);
+        const nonStickyChosen = results.filter((r) => r === nonStickyTest.name);
         expect(nonStickyChosen.length).toBeGreaterThan(2400);
         expect(nonStickyChosen.length).toBeLessThan(2600);
     });

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -191,8 +191,8 @@ export interface Result {
 }
 
 export const NonStickyVariantsTestNames = {
-    Sticky: '2024-05-29_STICKY_VARIANTS',
-    NonSticky: '2024-05-29_NON_STICKY_VARIANTS',
+    Sticky: '2024-05-24_STICKY_VARIANTS',
+    NonSticky: '2024-05-24_NON_STICKY_VARIANTS',
 };
 export const nonStickyVariantsTestFilter: Filter = {
     id: 'matchesNonStickyVariantsTests',

--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -198,10 +198,10 @@ export const nonStickyVariantsTestFilter: Filter = {
     id: 'matchesNonStickyVariantsTests',
     test: (test, targeting): boolean => {
         const fiftyFiftyChance = getRandomNumber('NON_STICKY', targeting.mvtId) % 2;
-        if (test.name === NonStickyVariantsTestNames.Sticky) {
+        if (test.name.startsWith(NonStickyVariantsTestNames.Sticky)) {
             return fiftyFiftyChance === 0;
         }
-        if (test.name === NonStickyVariantsTestNames.NonSticky) {
+        if (test.name.startsWith(NonStickyVariantsTestNames.NonSticky)) {
             return fiftyFiftyChance === 1;
         }
         return true;
@@ -307,7 +307,7 @@ function selectEpicVariant(test: EpicTest, banditData: BanditData[], targeting: 
         return selectVariantUsingEpsilonGreedy(banditData, test);
     }
 
-    if (test.name === NonStickyVariantsTestNames.NonSticky) {
+    if (test.name.startsWith(NonStickyVariantsTestNames.NonSticky)) {
         // Do not use the mvt value
         const variant = selectVariantNonSticky<EpicVariant, EpicTest>(test);
         return {


### PR DESCRIPTION
by convention we add e.g. `__UK` to the name of a test, if we want to target slightly different copy at different regions, but group them together in a single AB test.