### PR TITLE
Use secondaryCta existence to show or hide the reminder CTA for amp epics

### DIFF
--- a/packages/server/src/api/ampEpicRouter.ts
+++ b/packages/server/src/api/ampEpicRouter.ts
@@ -6,6 +6,7 @@ import {
     AmountsCardData,
     OneOffSignupRequest,
     OphanComponentEvent,
+    SecondaryCtaType,
 } from '@sdc/shared/dist/types';
 import fetch from 'node-fetch';
 import {
@@ -150,7 +151,7 @@ export const buildAmpEpicRouter = (
                         hideReminderWrapper: true,
                         hideSuccessMessage: true,
                         hideFailureMessage: true,
-                        hideReminderCta: false,
+                        hideReminderCta: !epic.secondaryCta,
                         hideReminderForm: false,
                     },
                     choiceCards:

--- a/packages/server/src/api/ampEpicRouter.ts
+++ b/packages/server/src/api/ampEpicRouter.ts
@@ -6,7 +6,6 @@ import {
     AmountsCardData,
     OneOffSignupRequest,
     OphanComponentEvent,
-    SecondaryCtaType,
 } from '@sdc/shared/dist/types';
 import fetch from 'node-fetch';
 import {

--- a/packages/server/src/tests/amp/ampEpicModels.ts
+++ b/packages/server/src/tests/amp/ampEpicModels.ts
@@ -1,4 +1,4 @@
-import { ContributionFrequency } from '@sdc/shared/types';
+import { ContributionFrequency, SecondaryCta, secondaryCtaSchema } from '@sdc/shared/types';
 import { AMPTicker } from './ampTicker';
 import * as z from 'zod';
 import {
@@ -26,6 +26,7 @@ export interface AMPEpic {
     paragraphs: string[];
     highlightedText?: string;
     cta: AMPCta;
+    secondaryCta?: SecondaryCta;
     ticker?: AMPTicker;
     showChoiceCards?: boolean;
     defaultChoiceCardFrequency?: ContributionFrequency;
@@ -40,6 +41,7 @@ const ampEpicTestVariantSchema = z.object({
     paragraphs: z.array(z.string()),
     highlightedText: z.string().optional(),
     cta: ctaSchema.optional(),
+    secondaryCta: secondaryCtaSchema.optional(),
     tickerSettings: tickerSettingsSchema.optional(),
     showChoiceCards: z.boolean().optional(),
     defaultChoiceCardFrequency: contributionFrequencySchema.optional(),

--- a/packages/server/src/tests/amp/ampEpicSelection.ts
+++ b/packages/server/src/tests/amp/ampEpicSelection.ts
@@ -98,6 +98,7 @@ const selectAmpEpicTestAndVariant = async (
                     componentId: campaignCode,
                     campaignCode: campaignCode,
                 },
+                secondaryCta: variant.secondaryCta,
                 showChoiceCards: variant.showChoiceCards,
                 defaultChoiceCardFrequency: variant.defaultChoiceCardFrequency,
             };


### PR DESCRIPTION
## What does this change?

co-authored-by: @andrewHEguardian 

In conjunction with [support-admin-console PR598](https://github.com/guardian/support-admin-console/pull/598), this change hides the secondary button which is used as a support reminder to toggle the reminder element of the epic when the appropriate change is made in RRCP for Amp Epics.

NOTE: [support-admin-console PR598](https://github.com/guardian/support-admin-console/pull/598) needs to be merged first.

This change re-uses existing code from Epics.

We created a new value in the AmpEpicModel for secondaryCta.  It is set to 'undefined' if the secondary button in RRCP for the AMP Epic Test is set to 'None' and 'SecondaryCta' type if the RRCP dropdown is set to 'Contribution Reminder'. 

We use this to hide the secondaryCta button when the value is 'undefined'. 

## How to test

In RRCP CODE, open an AMP Epic test and choose edit - you will have the ability to change the default of the secondary button from 'Contributions Reminder' to 'None'. Run SDC with DCR locally to see the secondary button disappear and reappear in an AMP Epic as you change this value (after a short renewal cache wait and browser refresh).

Check Epics, Live Blog Epics and Apple News Epics to see that have been no changes to them.

## How can we measure success?

The secondary button (support reminder) is hidden in AMP Epics when this dropdown is set to 'None' and reappears when set to 'Contributions Reminder'.   Wait a few moments for the cache and refresh the browser.

## Have we considered potential risks?

We plan to update the user documentation with this change so ensure that users of the new secondary button dropdown understand the consequences of choosing the two options.

## Images

When the secondary button dropdown in AMP Epics is set to 'None':

<img width="647" alt="amp-epic-with-hidden-2nd-cta" src="https://github.com/guardian/support-dotcom-components/assets/9384003/5070751a-ab7f-49b6-a79e-4a0ac2d2ef97">

When the secondary button dropdown in AMP Epics is set to 'Contributions Reminder':

<img width="750" alt="amp-epic-with-2nd-cta-showing" src="https://github.com/guardian/support-dotcom-components/assets/9384003/51aaef79-59c8-4785-87ab-b633d7e55a42">

## Accessibility

Removing an existing element rather than adding one.