### PR TITLE
use `"moduleResolution": "bundler”` in TypeScript (take 2)

### DIFF
--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -7,7 +7,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES2020",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "declaration": true,
     "strict": true,

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -7,7 +7,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES2020",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "lib": ["ES2020"],
     "declaration": true,
     "strict": true,

--- a/packages/dotcom/.changeset/egg-old-shoe.md
+++ b/packages/dotcom/.changeset/egg-old-shoe.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+Uses the new `@guardian/source` package.

--- a/packages/dotcom/.changeset/mean-carrots-kiss.md
+++ b/packages/dotcom/.changeset/mean-carrots-kiss.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+Adds compatability with projects that consume `package.json#exports`

--- a/packages/dotcom/tsconfig.json
+++ b/packages/dotcom/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "compilerOptions": {
-        "module": "CommonJS",
+        "module": "ESNext",
         "target": "ES2020",
         "esModuleInterop": true,
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "sourceMap": true,
         "strict": true,
         "outDir": "dist"

--- a/packages/modules/.storybook/preview.tsx
+++ b/packages/modules/.storybook/preview.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
-import { FocusStyleManager } from '@guardian/source-foundations';
-import { breakpoints } from '@guardian/source-foundations';
+import { FocusStyleManager } from '@guardian/source/foundations';
+import { breakpoints } from '@guardian/source/foundations';
 import { StylesDecorator } from './StylesDecorator';
 import { Preview } from '@storybook/react';
 

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -18,8 +18,7 @@
     "@babel/standalone": "^7.23.2",
     "@emotion/react": "^11.1.5",
     "@guardian/libs": "16.0.0",
-    "@guardian/source-foundations": "14.1.2",
-    "@guardian/source-react-components": "19.0.0",
+    "@guardian/source": "2.0.0",
     "@sdc/shared": "1.0.0",
     "@types/babel__standalone": "^7.1.6",
     "zod": "3.22.4"

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBanner.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/ChoiceCardsButtonsBanner.tsx
@@ -7,7 +7,7 @@ import {
     Button,
     SvgRoundelBrand,
     SvgCross,
-} from '@guardian/source-react-components';
+} from '@guardian/source/react-components';
 import { BannerText } from '../common/BannerText';
 import { BannerId, BannerRenderProps } from '../common/types';
 import {

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/choiceCardsButtonsBannerStyles.ts
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/choiceCardsButtonsBannerStyles.ts
@@ -8,7 +8,7 @@ import {
     neutral,
     space,
     height,
-} from '@guardian/source-foundations';
+} from '@guardian/source/foundations';
 
 export const banner = (backgroundColor: string): SerializedStyles => css`
     html {

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/Button.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/Button.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { SerializedStyles, css, ThemeProvider } from '@emotion/react';
-import { palette } from '@guardian/source-foundations';
+import { palette } from '@guardian/source/foundations';
 import {
     Button as DSButton,
     LinkButton,
     SvgArrowRightStraight,
-} from '@guardian/source-react-components';
+} from '@guardian/source/react-components';
 import type { ReactComponent } from '../../../../types';
 
 // Custom theme for Button/LinkButton

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardAmountButtons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChoiceCard } from '@guardian/source-react-components';
+import { ChoiceCard } from '@guardian/source/react-components';
 import {
     AmountsCardData,
     ContributionFrequency,
@@ -8,7 +8,7 @@ import {
 } from '@sdc/shared/dist/types';
 import { trackClick } from './ChoiceCardFrequencyTabs';
 import { SerializedStyles, css } from '@emotion/react';
-import { space, between, from, until } from '@guardian/source-foundations';
+import { space, between, from, until } from '@guardian/source/foundations';
 import { ChoiceCardSelection } from '../ChoiceCardsButtonsBanner';
 import { ChoiceCardBannerComponentId, ChoiceCardSettings } from './ChoiceCards';
 

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardFrequencyTabs.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardFrequencyTabs.tsx
@@ -6,9 +6,9 @@ import {
 } from '@sdc/shared/dist/types';
 import { ChoiceCardBannerComponentId, ChoiceCardSettings } from './ChoiceCards';
 import { ChoiceCardSelection } from '../ChoiceCardsButtonsBanner';
-import { ChoiceCard } from '@guardian/source-react-components';
+import { ChoiceCard } from '@guardian/source/react-components';
 import { css } from '@emotion/react';
-import { space } from '@guardian/source-foundations';
+import { space } from '@guardian/source/foundations';
 
 const container = (backgroundColour?: string) => css`
     display: flex;

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCards.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
-import { ChoiceCardGroup } from '@guardian/source-react-components';
+import { ChoiceCardGroup } from '@guardian/source/react-components';
 import { css, SerializedStyles } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
+import { from } from '@guardian/source/foundations';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
 import { ChoiceCardAmountButtons } from './ChoiceCardAmountButtons';
 import { ChoiceCardFrequencyTabs } from './ChoiceCardFrequencyTabs';

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardsBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/ChoiceCardsBannerArticleCount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, headline, space } from '@guardian/source-foundations';
+import { from, headline, space } from '@guardian/source/foundations';
 import { ArticleCountOptOutPopup } from '../../../shared/ArticleCountOptOutPopup';
 
 const styles = {

--- a/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/SupportCta.tsx
+++ b/packages/modules/src/modules/banners/choiceCardsButtonsBanner/components/SupportCta.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/dist/lib';
 import { Tracking } from '@sdc/shared/dist/types';
-import { space } from '@guardian/source-foundations';
+import { space } from '@guardian/source/foundations';
 import { css, SerializedStyles } from '@emotion/react';
-import { Hide } from '@guardian/source-react-components';
+import { Hide } from '@guardian/source/react-components';
 import { Button } from './Button';
 import { ChoiceCardSelection } from '../ChoiceCardsButtonsBanner';
 

--- a/packages/modules/src/modules/banners/common/BannerContentRenderer.tsx
+++ b/packages/modules/src/modules/banners/common/BannerContentRenderer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BannerTextContent, BannerRenderedContent } from './types';
-import { Hide } from '@guardian/source-react-components';
+import { Hide } from '@guardian/source/react-components';
 import type { ReactComponent } from '../../../types';
 
 type BannerContentForRender = {

--- a/packages/modules/src/modules/banners/common/PaymentCards.tsx
+++ b/packages/modules/src/modules/banners/common/PaymentCards.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { space, from } from '@guardian/source-foundations';
+import { space, from } from '@guardian/source/foundations';
 
 const paymentMethods = css`
     display: flex;

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardInteractive.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChoiceCardGroup, ChoiceCard } from '@guardian/source-react-components';
+import { ChoiceCardGroup, ChoiceCard } from '@guardian/source/react-components';
 import {
     ContributionFrequency,
     SelectedAmountsVariant,
@@ -9,7 +9,7 @@ import { contributionType, ChoiceCardSelection } from '../../../shared/helpers/c
 import { ChoiceCardSettings } from './ChoiceCards';
 import type { ReactComponent } from '../../../../types';
 import { css } from '@emotion/react';
-import { from, space, until } from '@guardian/source-foundations';
+import { from, space, until } from '@guardian/source/foundations';
 
 interface ChoiceCardInteractiveProps {
     selection?: ChoiceCardSelection;

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCards.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { from, space } from '@guardian/source-foundations';
+import { from, space } from '@guardian/source/foundations';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
 import { ChoiceCardInteractive } from './ChoiceCardInteractive';
 import { ChoiceCardsSupportCta } from './ChoiceCardsSupportCta';

--- a/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardsSupportCta.tsx
+++ b/packages/modules/src/modules/banners/common/choiceCard/ChoiceCardsSupportCta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { space } from '@guardian/source-foundations';
+import { space } from '@guardian/source/foundations';
 import { css, SerializedStyles } from '@emotion/react';
-import { Hide, SvgArrowRightStraight, LinkButton } from '@guardian/source-react-components';
+import { Hide, SvgArrowRightStraight, LinkButton } from '@guardian/source/react-components';
 import { ContentType } from '../../../../hooks/useChoiceCards';
 
 const buttonOverrides = css`

--- a/packages/modules/src/modules/banners/contributions/ContributionsBanner.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBanner.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { BannerRenderProps } from '../common/types';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
-import { Column, Columns, Container, Hide } from '@guardian/source-react-components';
+import { Column, Columns, Container, Hide } from '@guardian/source/react-components';
 import { commonStyles } from './ContributionsBannerCommonStyles';
 import { css } from '@emotion/react';
-import { between, from, headline, brandAlt, neutral, space } from '@guardian/source-foundations';
+import { between, from, headline, brandAlt, neutral, space } from '@guardian/source/foundations';
 import { ContributionsBannerMobile } from './ContributionsBannerMobile';
 import { ContributionsBannerCta } from './ContributionsBannerCta';
 import { ContributionsBannerSecondaryCta } from './ContributionsBannerSecondaryCta';

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerCloseButton.tsx
@@ -4,9 +4,9 @@ import {
     buttonThemeReaderRevenueBrandAlt,
     Button,
     SvgCross,
-} from '@guardian/source-react-components';
+} from '@guardian/source/react-components';
 import { ThemeProvider, css } from '@emotion/react';
-import { from, neutral } from '@guardian/source-foundations';
+import { from, neutral } from '@guardian/source/foundations';
 import type { ReactComponent } from '../../../types';
 
 const styles = {

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerCommonStyles.ts
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerCommonStyles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { brandAlt, neutral, body, until, from } from '@guardian/source-foundations';
+import { brandAlt, neutral, body, until, from } from '@guardian/source/foundations';
 
 export const commonStyles = {
     copy: css`

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerCta.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerCta.tsx
@@ -3,9 +3,9 @@ import {
     buttonThemeReaderRevenueBrandAlt,
     LinkButton,
     SvgArrowRightStraight,
-} from '@guardian/source-react-components';
+} from '@guardian/source/react-components';
 import React from 'react';
-import { from, space } from '@guardian/source-foundations';
+import { from, space } from '@guardian/source/foundations';
 import { isSupportUrl } from '@sdc/shared/dist/lib';
 import type { ReactComponent } from '../../../types';
 

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerMobile.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerMobile.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import { commonStyles } from './ContributionsBannerCommonStyles';
 import { css } from '@emotion/react';
-import { brandAlt, neutral, from, space, headline } from '@guardian/source-foundations';
+import { brandAlt, neutral, from, space, headline } from '@guardian/source/foundations';
 import { ContributionsBannerCta } from './ContributionsBannerCta';
 import { ContributionsBannerSecondaryCta } from './ContributionsBannerSecondaryCta';
 import { ContributionsBannerCloseButton } from './ContributionsBannerCloseButton';

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedIn.stories.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedIn.stories.tsx
@@ -5,7 +5,7 @@ import {
     ContributionsBannerReminderSignedInProps,
 } from './ContributionsBannerReminderSignedIn';
 import { css } from '@emotion/react';
-import { brandAlt } from '@guardian/source-foundations';
+import { brandAlt } from '@guardian/source/foundations';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { ReminderStatus } from '../../utils/reminders';
 

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedIn.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedIn.tsx
@@ -7,8 +7,8 @@ import {
     Column,
     Hide,
     SvgCheckmark,
-} from '@guardian/source-react-components';
-import { textSans, space, from } from '@guardian/source-foundations';
+} from '@guardian/source/react-components';
+import { textSans, space, from } from '@guardian/source/foundations';
 import { BannerEnrichedReminderCta } from '../common/types';
 import { ensureHasPreposition, ReminderStatus } from '../../utils/reminders';
 import { ErrorCopy, InfoCopy, ThankYou } from '../../shared/Reminders';

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedOut.stories.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedOut.stories.tsx
@@ -5,7 +5,7 @@ import {
     ContributionsBannerReminderSignedOutProps,
 } from './ContributionsBannerReminderSignedOut';
 import { css } from '@emotion/react';
-import { brandAlt } from '@guardian/source-foundations';
+import { brandAlt } from '@guardian/source/foundations';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { ReminderStatus } from '../../utils/reminders';
 

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedOut.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerReminderSignedOut.tsx
@@ -8,8 +8,8 @@ import {
     Hide,
     TextInput,
     SvgCheckmark,
-} from '@guardian/source-react-components';
-import { textSans, space, from } from '@guardian/source-foundations';
+} from '@guardian/source/react-components';
+import { textSans, space, from } from '@guardian/source/foundations';
 import { BannerEnrichedReminderCta } from '../common/types';
 import { ensureHasPreposition, ReminderStatus } from '../../utils/reminders';
 import { useContributionsReminderEmailForm } from '../../../hooks/useContributionsReminderEmailForm';

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerSecondaryCta.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerSecondaryCta.tsx
@@ -5,8 +5,8 @@ import {
     LinkButton,
     SvgArrowRightStraight,
     Button,
-} from '@guardian/source-react-components';
-import { space, neutral } from '@guardian/source-foundations';
+} from '@guardian/source/react-components';
+import { space, neutral } from '@guardian/source/foundations';
 import { BannerEnrichedSecondaryCta } from '../common/types';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { hasSetReminder } from '../../utils/reminders';

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerSignInCta.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerSignInCta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { neutral, space } from '@guardian/source-foundations';
-import { Link } from '@guardian/source-react-components';
+import { neutral, space } from '@guardian/source/foundations';
+import { Link } from '@guardian/source/react-components';
 import type { ReactComponent } from '../../../types';
 
 // TODO: replace with correct UTM parameters

--- a/packages/modules/src/modules/banners/contributions/ContributionsBannerWithSignIn.tsx
+++ b/packages/modules/src/modules/banners/contributions/ContributionsBannerWithSignIn.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { BannerRenderProps } from '../common/types';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
-import { Container, Columns, Column, Hide } from '@guardian/source-react-components';
+import { Container, Columns, Column, Hide } from '@guardian/source/react-components';
 import { commonStyles } from './ContributionsBannerCommonStyles';
 import { css } from '@emotion/react';
-import { between, from, headline, brandAlt, neutral, space } from '@guardian/source-foundations';
+import { between, from, headline, brandAlt, neutral, space } from '@guardian/source/foundations';
 import { ContributionsBannerMobile } from './ContributionsBannerMobile';
 import { ContributionsBannerCta } from './ContributionsBannerCta';
 import { ContributionsBannerSecondaryCta } from './ContributionsBannerSecondaryCta';

--- a/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplate.tsx
+++ b/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplate.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { space, from, neutral } from '@guardian/source-foundations';
-import { Hide } from '@guardian/source-react-components';
+import { space, from, neutral } from '@guardian/source/foundations';
+import { Hide } from '@guardian/source/react-components';
 import type { ReactComponent } from '../../../types';
 
 const banner = (backgroundColour: string): SerializedStyles => css`

--- a/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateBody.tsx
+++ b/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateBody.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { body } from '@guardian/source-foundations';
+import { body } from '@guardian/source/foundations';
 import type { ReactComponent } from '../../../types';
 
 const container = css`

--- a/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateCloseButton.tsx
+++ b/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateCloseButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { space, from } from '@guardian/source-foundations';
-import { Hide } from '@guardian/source-react-components';
+import { space, from } from '@guardian/source/foundations';
+import { Hide } from '@guardian/source/react-components';
 import type { ReactComponent } from '../../../types';
 
 const container = css`

--- a/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateCta.tsx
+++ b/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateCta.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { space, from } from '@guardian/source-foundations';
+import { space, from } from '@guardian/source/foundations';
 import type { ReactComponent } from '../../../types';
 
 const container = css`

--- a/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateHeader.tsx
+++ b/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { headline, from } from '@guardian/source-foundations';
+import { headline, from } from '@guardian/source/foundations';
 import type { ReactComponent } from '../../../types';
 
 const container = css`

--- a/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateSupportingText.tsx
+++ b/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateSupportingText.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { headline, from } from '@guardian/source-foundations';
+import { headline, from } from '@guardian/source/foundations';
 import type { ReactComponent } from '../../../types';
 
 const container = css`

--- a/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateTicker.tsx
+++ b/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateTicker.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { palette, headline } from '@guardian/source-foundations';
+import { palette, headline } from '@guardian/source/foundations';
 import useTicker from '../../../hooks/useTicker';
 import { useHasBeenSeen, HasBeenSeen } from '../../../hooks/useHasBeenSeen';
 import { TickerSettings } from '@sdc/shared/types';

--- a/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateVisual.tsx
+++ b/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateVisual.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
+import { from } from '@guardian/source/foundations';
 import type { ReactComponent } from '../../../types';
 
 const container = css`

--- a/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateWithVisual.tsx
+++ b/packages/modules/src/modules/banners/contributionsTemplate/ContributionsTemplateWithVisual.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { space, from } from '@guardian/source-foundations';
+import { space, from } from '@guardian/source/foundations';
 import type { ReactComponent } from '../../../types';
 
 const banner = (cssOverrides?: SerializedStyles): SerializedStyles => css`

--- a/packages/modules/src/modules/banners/contributionsTemplate/ExampleContributionsTemplateWithVisual.tsx
+++ b/packages/modules/src/modules/banners/contributionsTemplate/ExampleContributionsTemplateWithVisual.tsx
@@ -6,8 +6,8 @@ import {
     buttonThemeBrandAlt,
     SvgCross,
     Hide,
-} from '@guardian/source-react-components';
-import { neutral } from '@guardian/source-foundations';
+} from '@guardian/source/react-components';
+import { neutral } from '@guardian/source/foundations';
 import ContributionsTemplateWithVisual from './ContributionsTemplateWithVisual';
 import ContributionsTemplateVisual from './ContributionsTemplateVisual';
 import ContributionsTemplateCloseButton from './ContributionsTemplateCloseButton';

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -9,7 +9,7 @@ import {
     until,
     body,
     textSans,
-} from '@guardian/source-foundations';
+} from '@guardian/source/foundations';
 import { BannerEnrichedReminderCta, BannerRenderProps } from '../common/types';
 import { DesignableBannerHeader } from './components/DesignableBannerHeader';
 import { DesignableBannerArticleCount } from './components/DesignableBannerArticleCount';
@@ -36,7 +36,7 @@ import { buttonStyles } from './styles/buttonStyles';
 import { BannerTemplateSettings, CtaSettings } from './settings';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import type { ReactComponent } from '../../../types';
-import { Button, SvgGuardianLogo } from '@guardian/source-react-components';
+import { Button, SvgGuardianLogo } from '@guardian/source/react-components';
 
 const buildImageSettings = (
     design: BannerDesignImage | BannerDesignHeaderImage,

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, headline } from '@guardian/source-foundations';
+import { from, headline } from '@guardian/source/foundations';
 import { DesignableBannerArticleCountOptOut } from './DesignableBannerArticleCountOptOut';
 import { BannerTemplateSettings } from '../settings';
 

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCountOptOut.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCountOptOut.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
-import { textSans, neutral, space, from } from '@guardian/source-foundations';
-import { Button, SvgCross } from '@guardian/source-react-components';
+import { textSans, neutral, space, from } from '@guardian/source/foundations';
+import { Button, SvgCross } from '@guardian/source/react-components';
 import {
     addArticleCountOptOutCookie,
     removeArticleCountFromLocalStorage,

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerBody.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerBody.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, body } from '@guardian/source-foundations';
+import { from, body } from '@guardian/source/foundations';
 import { createBannerBodyCopy } from '../../common/BannerText';
 import { HighlightedTextSettings } from '../settings';
 import { BannerRenderedContent } from '../../common/types';

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCloseButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { SvgCross, Button } from '@guardian/source-react-components';
+import { SvgCross, Button } from '@guardian/source/react-components';
 import { buttonStyles } from '../styles/buttonStyles';
 import { CtaSettings } from '../settings';
 

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerCtas.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, space } from '@guardian/source-foundations';
-import { LinkButton } from '@guardian/source-react-components';
+import { from, space } from '@guardian/source/foundations';
+import { LinkButton } from '@guardian/source/react-components';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { BannerRenderedContent } from '../../common/types';
 import { PaymentCards } from '../../common/PaymentCards';

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, headline, neutral, space } from '@guardian/source-foundations';
+import { from, headline, neutral, space } from '@guardian/source/foundations';
 import { DesignableBannerVisual } from './DesignableBannerVisual';
 import { HeaderSettings } from '../settings';
 import useMediaQuery from '../../../../hooks/useMediaQuery';

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminder.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminder.tsx
@@ -4,7 +4,7 @@ import { BannerEnrichedReminderCta } from '../../common/types';
 import { CtaSettings } from '../settings';
 import { DesignableBannerReminderSignedOut } from './DesignableBannerReminderSignedOut';
 import { css } from '@emotion/react';
-import { space } from '@guardian/source-foundations';
+import { space } from '@guardian/source/foundations';
 
 export interface DesignableBannerReminderProps {
     reminderCta: BannerEnrichedReminderCta;

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminderSignedOut.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerReminderSignedOut.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
-import { Button, TextInput } from '@guardian/source-react-components';
-import { textSans, space, from } from '@guardian/source-foundations';
+import { Button, TextInput } from '@guardian/source/react-components';
+import { textSans, space, from } from '@guardian/source/foundations';
 import React from 'react';
 import { BannerEnrichedReminderCta } from '../../common/types';
 import { ensureHasPreposition, ReminderStatus } from '../../../utils/reminders';

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerTicker.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { textSans, from, space } from '@guardian/source-foundations';
+import { textSans, from, space } from '@guardian/source/foundations';
 import { TickerSettings } from '@sdc/shared/types';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
 import useTicker from '../../../../hooks/useTicker';

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerVisual.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
+import { from } from '@guardian/source/foundations';
 import { ImageAttrs, ResponsiveImage } from '../../../shared/ResponsiveImage';
 import { Image } from '@sdc/shared/types';
 import { BannerId } from '../../common/types';

--- a/packages/modules/src/modules/banners/designableBanner/styles/buttonStyles.ts
+++ b/packages/modules/src/modules/banners/designableBanner/styles/buttonStyles.ts
@@ -1,5 +1,5 @@
 import { css, SerializedStyles } from '@emotion/react';
-import { from, until } from '@guardian/source-foundations';
+import { from, until } from '@guardian/source/foundations';
 import { CtaSettings } from '../settings';
 
 export function buttonStyles(

--- a/packages/modules/src/modules/banners/designableBanner/styles/templateStyles.ts
+++ b/packages/modules/src/modules/banners/designableBanner/styles/templateStyles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space, from } from '@guardian/source-foundations';
+import { space, from } from '@guardian/source/foundations';
 
 const templateSpacing = {
     bannerContainer: css`

--- a/packages/modules/src/modules/banners/environment/EnvironmentBanner.tsx
+++ b/packages/modules/src/modules/banners/environment/EnvironmentBanner.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, space, neutral } from '@guardian/source-foundations';
+import { from, space, neutral } from '@guardian/source/foundations';
 import { EnvironmentBannerEarth } from './components/EnvironmentBannerEarth';
 import { EnvironmentBannerHeader } from './components/EnvironmentBannerHeader';
 import { EnvironmentBannerArticleCount } from './components/EnvironmentBannerArticleCount';

--- a/packages/modules/src/modules/banners/environment/components/EnvironmentBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/environment/components/EnvironmentBannerArticleCount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, headline } from '@guardian/source-foundations';
+import { from, headline } from '@guardian/source/foundations';
 import { ArticleCountOptOutPopup } from '../../../shared/ArticleCountOptOutPopup';
 import { GREEN_HEX } from '../utils/constants';
 

--- a/packages/modules/src/modules/banners/environment/components/EnvironmentBannerBody.tsx
+++ b/packages/modules/src/modules/banners/environment/components/EnvironmentBannerBody.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { body, from } from '@guardian/source-foundations';
-import { Hide } from '@guardian/source-react-components';
+import { body, from } from '@guardian/source/foundations';
+import { Hide } from '@guardian/source/react-components';
 
 import { BannerTextStyles, createBannerBodyCopy } from '../../common/BannerText';
 import type { ReactComponent } from '../../../../types';

--- a/packages/modules/src/modules/banners/environment/components/EnvironmentBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/environment/components/EnvironmentBannerCloseButton.tsx
@@ -4,7 +4,7 @@ import {
     Button,
     buttonThemeReaderRevenueBrandAlt,
     SvgCross,
-} from '@guardian/source-react-components';
+} from '@guardian/source/react-components';
 import type { ReactComponent } from '../../../../types';
 
 const button = css`

--- a/packages/modules/src/modules/banners/environment/components/EnvironmentBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/environment/components/EnvironmentBannerCtas.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { space, neutral } from '@guardian/source-foundations';
-import { Hide, LinkButton } from '@guardian/source-react-components';
+import { space, neutral } from '@guardian/source/foundations';
+import { Hide, LinkButton } from '@guardian/source/react-components';
 import { BannerEnrichedCta, BannerEnrichedSecondaryCta } from '../../common/types';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { BLUE_HEX, GREEN_HEX } from '../utils/constants';

--- a/packages/modules/src/modules/banners/environment/components/EnvironmentBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/environment/components/EnvironmentBannerHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, headline, space } from '@guardian/source-foundations';
-import { Hide } from '@guardian/source-react-components';
+import { from, headline, space } from '@guardian/source/foundations';
+import { Hide } from '@guardian/source/react-components';
 import { IconEarth } from './IconEarth';
 import { GREEN_HEX } from '../utils/constants';
 import type { ReactComponent } from '../../../../types';

--- a/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.stories.tsx
+++ b/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { brand, brandAlt, culture, neutral } from '@guardian/source-foundations';
+import { brand, brandAlt, culture, neutral } from '@guardian/source/foundations';
 import { bannerWrapper } from '../common/BannerWrapper';
 import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
 import { BannerProps } from '@sdc/shared/src/types';

--- a/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.tsx
+++ b/packages/modules/src/modules/banners/europeMomentLocalLanguage/EuropeMomentLocalLanguageBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { brand, brandAlt, culture, neutral } from '@guardian/source-foundations';
+import { brand, brandAlt, culture, neutral } from '@guardian/source/foundations';
 import { bannerWrapper, validatedBannerWrapper } from '../common/BannerWrapper';
 import { getMomentTemplateBanner } from '../momentTemplate/MomentTemplateBanner';
 import { HeaderImage } from './components/headerImage';

--- a/packages/modules/src/modules/banners/europeMomentLocalLanguage/components/headerImage.tsx
+++ b/packages/modules/src/modules/banners/europeMomentLocalLanguage/components/headerImage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { Hide } from '@guardian/source-react-components';
+import { Hide } from '@guardian/source/react-components';
 import { HeaderImageSvg } from './headerImageSvg';
 
 const styles = css`

--- a/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/MomentTemplateBanner.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { neutral, space, between, from, until } from '@guardian/source-foundations';
+import { neutral, space, between, from, until } from '@guardian/source/foundations';
 import { BannerEnrichedReminderCta, BannerRenderProps } from '../common/types';
 import { MomentTemplateBannerHeader } from './components/MomentTemplateBannerHeader';
 import { MomentTemplateBannerArticleCount } from './components/MomentTemplateBannerArticleCount';

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, headline } from '@guardian/source-foundations';
+import { from, headline } from '@guardian/source/foundations';
 import { MomentTemplateArticleCountOptOut } from './MomentTemplateBannerArticleCountOptOut';
 import { BannerTemplateSettings } from '../settings';
 

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerArticleCountOptOut.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
-import { textSans, neutral, space, from } from '@guardian/source-foundations';
-import { Button, SvgCross } from '@guardian/source-react-components';
+import { textSans, neutral, space, from } from '@guardian/source/foundations';
+import { Button, SvgCross } from '@guardian/source/react-components';
 import {
     addArticleCountOptOutCookie,
     removeArticleCountFromLocalStorage,

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerBody.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, body } from '@guardian/source-foundations';
+import { from, body } from '@guardian/source/foundations';
 import { createBannerBodyCopy } from '../../common/BannerText';
 import { HighlightedTextSettings } from '../settings';
 import { BannerRenderedContent } from '../../common/types';

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCloseButton.tsx
@@ -6,10 +6,10 @@ import {
     SvgRoundelBrand,
     SvgRoundelDefault,
     SvgRoundelInverse,
-} from '@guardian/source-react-components';
+} from '@guardian/source/react-components';
 import { buttonStyles } from '../styles/buttonStyles';
 import { CtaSettings } from '../settings';
-import { from, space } from '@guardian/source-foundations';
+import { from, space } from '@guardian/source/foundations';
 
 interface MomentTemplateBannerCloseButtonProps {
     onCloseClick: () => void;

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerCtas.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { neutral, space, from } from '@guardian/source-foundations';
-import { Button, LinkButton } from '@guardian/source-react-components';
+import { neutral, space, from } from '@guardian/source/foundations';
+import { Button, LinkButton } from '@guardian/source/react-components';
 import { SecondaryCtaType } from '@sdc/shared/types';
 import { BannerRenderedContent } from '../../common/types';
 import { PaymentCards } from '../../common/PaymentCards';

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, headline, neutral } from '@guardian/source-foundations';
+import { from, headline, neutral } from '@guardian/source/foundations';
 import { HeaderSettings } from '../settings';
 
 interface MomentTemplateBannerHeaderProps {

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerReminderSignedOut.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerReminderSignedOut.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
-import { Button, TextInput, Container, SvgCheckmark } from '@guardian/source-react-components';
-import { textSans, neutral, space, from } from '@guardian/source-foundations';
+import { Button, TextInput, Container, SvgCheckmark } from '@guardian/source/react-components';
+import { textSans, neutral, space, from } from '@guardian/source/foundations';
 import React from 'react';
 import { BannerEnrichedReminderCta } from '../../common/types';
 import { ensureHasPreposition, ReminderStatus } from '../../../utils/reminders';

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerTicker.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { textSans, from, space } from '@guardian/source-foundations';
+import { textSans, from, space } from '@guardian/source/foundations';
 import { TickerSettings } from '@sdc/shared/types';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
 import useTicker from '../../../../hooks/useTicker';

--- a/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/components/MomentTemplateBannerVisual.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
+import { from } from '@guardian/source/foundations';
 import { ImageAttrs, ResponsiveImage } from '../../../shared/ResponsiveImage';
 import { Image } from '@sdc/shared/types';
 import { BannerId } from '../../common/types';

--- a/packages/modules/src/modules/banners/momentTemplate/stories/Default.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/Default.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { brand, neutral, brandAlt } from '@guardian/source-foundations';
+import { brand, neutral, brandAlt } from '@guardian/source/foundations';
 import { BannerProps } from '@sdc/shared/src/types';
 import { Story } from '@storybook/react';
 import { bannerWrapper } from '../../common/BannerWrapper';

--- a/packages/modules/src/modules/banners/momentTemplate/stories/WithBackDrop.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/WithBackDrop.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { brand, neutral, brandAlt } from '@guardian/source-foundations';
+import { brand, neutral, brandAlt } from '@guardian/source/foundations';
 import { BannerProps } from '@sdc/shared/src/types';
 import { Story } from '@storybook/react';
 import { bannerWrapper } from '../../common/BannerWrapper';

--- a/packages/modules/src/modules/banners/momentTemplate/stories/WithChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/WithChoiceCards.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { brand, neutral, brandAlt } from '@guardian/source-foundations';
+import { brand, neutral, brandAlt } from '@guardian/source/foundations';
 import { BannerProps } from '@sdc/shared/src/types';
 import { Story } from '@storybook/react';
 import { bannerWrapper } from '../../common/BannerWrapper';

--- a/packages/modules/src/modules/banners/momentTemplate/stories/WithChoiceCardsHeaderImage.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/WithChoiceCardsHeaderImage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { brand, neutral, brandAlt } from '@guardian/source-foundations';
+import { brand, neutral, brandAlt } from '@guardian/source/foundations';
 import { BannerProps } from '@sdc/shared/src/types';
 import { Story } from '@storybook/react';
 import { bannerWrapper } from '../../common/BannerWrapper';

--- a/packages/modules/src/modules/banners/momentTemplate/stories/WithHeaderImage.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/WithHeaderImage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { brand, neutral, brandAlt } from '@guardian/source-foundations';
+import { brand, neutral, brandAlt } from '@guardian/source/foundations';
 import { BannerProps } from '@sdc/shared/src/types';
 import { Story } from '@storybook/react';
 import { bannerWrapper } from '../../common/BannerWrapper';

--- a/packages/modules/src/modules/banners/momentTemplate/stories/WithReminder.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/WithReminder.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { neutral } from '@guardian/source-foundations';
+import { neutral } from '@guardian/source/foundations';
 import { BannerProps } from '@sdc/shared/src/types';
 import { Story } from '@storybook/react';
 import { bannerWrapper } from '../../common/BannerWrapper';

--- a/packages/modules/src/modules/banners/momentTemplate/stories/WithTicker.tsx
+++ b/packages/modules/src/modules/banners/momentTemplate/stories/WithTicker.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { brand, neutral, brandAlt } from '@guardian/source-foundations';
+import { brand, neutral, brandAlt } from '@guardian/source/foundations';
 import { BannerProps } from '@sdc/shared/src/types';
 import { Story } from '@storybook/react';
 import { bannerWrapper } from '../../common/BannerWrapper';

--- a/packages/modules/src/modules/banners/momentTemplate/styles/buttonStyles.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/styles/buttonStyles.ts
@@ -1,5 +1,5 @@
 import { css, SerializedStyles } from '@emotion/react';
-import { from, until } from '@guardian/source-foundations';
+import { from, until } from '@guardian/source/foundations';
 import { CtaSettings } from '../settings';
 
 export function buttonStyles(

--- a/packages/modules/src/modules/banners/momentTemplate/styles/templateStyles.ts
+++ b/packages/modules/src/modules/banners/momentTemplate/styles/templateStyles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { space, from, until } from '@guardian/source-foundations';
+import { space, from, until } from '@guardian/source/foundations';
 
 // WIP - Any styling changes made to base moment template styling here should be reviewed by a designer!
 const templateSpacing = {

--- a/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
+++ b/packages/modules/src/modules/banners/signInPrompt/SignInPromptBanner.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ThemeProvider, css } from '@emotion/react';
-import { brand, brandAlt, space, neutral, headline, until } from '@guardian/source-foundations';
+import { brand, brandAlt, space, neutral, headline, until } from '@guardian/source/foundations';
 import {
     Button,
     LinkButton,
@@ -9,7 +9,7 @@ import {
     Container,
     Column,
     Columns,
-} from '@guardian/source-react-components';
+} from '@guardian/source/react-components';
 import { SecondaryCtaType } from '@sdc/shared/types';
 
 import { BannerRenderProps } from '../common/types';

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/WorldPressFreedomDayBanner.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/WorldPressFreedomDayBanner.tsx
@@ -7,7 +7,7 @@ import {
     Button,
     SvgRoundelBrand,
     SvgCross,
-} from '@guardian/source-react-components';
+} from '@guardian/source/react-components';
 import { BannerText } from '../common/BannerText';
 import { BannerRenderProps } from '../common/types';
 import {

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/ArticleCount.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/ArticleCount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, headline, space } from '@guardian/source-foundations';
+import { from, headline, space } from '@guardian/source/foundations';
 import { ArticleCountOptOutPopup } from '../../../shared/ArticleCountOptOutPopup';
 
 const styles = {

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/BottomImage.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/BottomImage.tsx
@@ -5,7 +5,7 @@ import {
     BottomImageSvgMobile,
     BottomImageSvgTablet,
 } from './BottomImageSvg';
-import { Hide } from '@guardian/source-react-components';
+import { Hide } from '@guardian/source/react-components';
 
 const styles = css`
     svg {

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/Button.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/Button.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { SerializedStyles, css, ThemeProvider } from '@emotion/react';
-import { palette } from '@guardian/source-foundations';
+import { palette } from '@guardian/source/foundations';
 import {
     Button as DSButton,
     LinkButton,
     SvgArrowRightStraight,
-} from '@guardian/source-react-components';
+} from '@guardian/source/react-components';
 import type { ReactComponent } from '../../../../types';
 
 // Custom theme for Button/LinkButton

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/ChoiceCardAmountButtons.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/ChoiceCardAmountButtons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChoiceCard } from '@guardian/source-react-components';
+import { ChoiceCard } from '@guardian/source/react-components';
 import {
     AmountsCardData,
     ContributionFrequency,
@@ -8,7 +8,7 @@ import {
 } from '@sdc/shared/dist/types';
 import { trackClick } from './FrequencyTabs';
 import { SerializedStyles, css } from '@emotion/react';
-import { space, between, from, until } from '@guardian/source-foundations';
+import { space, between, from, until } from '@guardian/source/foundations';
 import { ChoiceCardSelection } from '../WorldPressFreedomDayBanner';
 
 const container = css`

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/ChoiceCards.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/ChoiceCards.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
-import { ChoiceCardGroup } from '@guardian/source-react-components';
+import { ChoiceCardGroup } from '@guardian/source/react-components';
 import { css, SerializedStyles } from '@emotion/react';
-import { from, visuallyHidden, neutral, space } from '@guardian/source-foundations';
+import { from, visuallyHidden, neutral, space } from '@guardian/source/foundations';
 import { HasBeenSeen, useHasBeenSeen } from '../../../../hooks/useHasBeenSeen';
 import { ChoiceCardAmountButtons } from './ChoiceCardAmountButtons';
 import { FrequencyTabs } from './FrequencyTabs';

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/SupportCta.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/SupportCta.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { addRegionIdAndTrackingParamsToSupportUrl } from '@sdc/shared/dist/lib';
 import { Tracking } from '@sdc/shared/dist/types';
-import { brandAlt, neutral, space } from '@guardian/source-foundations';
+import { brandAlt, neutral, space } from '@guardian/source/foundations';
 import { css, SerializedStyles } from '@emotion/react';
-import { Hide } from '@guardian/source-react-components';
+import { Hide } from '@guardian/source/react-components';
 import { Button } from './Button';
 import { ChoiceCardSelection } from '../WorldPressFreedomDayBanner';
 

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/TopImage.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/TopImage.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from } from '@guardian/source-foundations';
+import { from } from '@guardian/source/foundations';
 import { TopImageSvgDesktop, TopImageSvgMobile, TopImageSvgTablet } from './TopImageSvg';
-import { Hide } from '@guardian/source-react-components';
+import { Hide } from '@guardian/source/react-components';
 
 const styles = css`
     padding-right: 50px; // prevent overlap with close button

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/paymentFrequencyTabs/PaymentFrequencyTabButton.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/paymentFrequencyTabs/PaymentFrequencyTabButton.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { css } from '@emotion/react';
-import { brand, neutral, space, textSans } from '@guardian/source-foundations';
+import { brand, neutral, space, textSans } from '@guardian/source/foundations';
 
 const tabButtonStyles = css`
     ${textSans.medium({ fontWeight: 'bold' })}

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/components/paymentFrequencyTabs/PaymentFrequencyTabsBox.tsx
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/components/paymentFrequencyTabs/PaymentFrequencyTabsBox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { neutral, space, from } from '@guardian/source-foundations';
+import { neutral, space, from } from '@guardian/source/foundations';
 
 const mainStyles = css`
     display: block;

--- a/packages/modules/src/modules/banners/worldPressFreedomDay/worldPressFreedomDayBannerStyles.ts
+++ b/packages/modules/src/modules/banners/worldPressFreedomDay/worldPressFreedomDayBannerStyles.ts
@@ -8,7 +8,7 @@ import {
     neutral,
     space,
     height,
-} from '@guardian/source-foundations';
+} from '@guardian/source/foundations';
 
 export const banner = css`
     html {

--- a/packages/modules/src/modules/headers/Header.tsx
+++ b/packages/modules/src/modules/headers/Header.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { css, ThemeProvider } from '@emotion/react';
-import { from, brandAlt, brandText, headline, textSans } from '@guardian/source-foundations';
+import { from, brandAlt, brandText, headline, textSans } from '@guardian/source/foundations';
 import {
     LinkButton,
     Hide,
     SvgArrowRightStraight,
     buttonThemeReaderRevenueBrand,
-} from '@guardian/source-react-components';
+} from '@guardian/source/react-components';
 import { HeaderRenderProps, headerWrapper, validatedHeaderWrapper } from './HeaderWrapper';
 import type { ReactComponent } from '../../types';
 

--- a/packages/modules/src/modules/headers/SignInPromptHeader.tsx
+++ b/packages/modules/src/modules/headers/SignInPromptHeader.tsx
@@ -9,8 +9,8 @@ import {
     textSans,
     from,
     until,
-} from '@guardian/source-foundations';
-import { LinkButton, buttonThemeBrand, Hide } from '@guardian/source-react-components';
+} from '@guardian/source/foundations';
+import { LinkButton, buttonThemeBrand, Hide } from '@guardian/source/react-components';
 import { HeaderRenderProps, headerWrapper, validatedHeaderWrapper } from './HeaderWrapper';
 import type { ReactComponent } from '../../types';
 

--- a/packages/modules/src/modules/headers/common/HeaderDecorator.tsx
+++ b/packages/modules/src/modules/headers/common/HeaderDecorator.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DecoratorFn } from '@storybook/react';
 import { css } from '@emotion/react';
-import { brand } from '@guardian/source-foundations';
+import { brand } from '@guardian/source/foundations';
 
 const background = css`
     background-color: ${brand[400]};

--- a/packages/modules/src/modules/shared/ArticleCountOptOutOverlay.tsx
+++ b/packages/modules/src/modules/shared/ArticleCountOptOutOverlay.tsx
@@ -11,14 +11,14 @@ import {
     space,
     background,
     from,
-} from '@guardian/source-foundations';
+} from '@guardian/source/foundations';
 import {
     Button,
     buttonThemeBrand,
     buttonThemeBrandAlt,
     buttonThemeDefault,
     SvgCross,
-} from '@guardian/source-react-components';
+} from '@guardian/source/react-components';
 
 import { ArticleCountOptOutType } from './ArticleCountOptOutPopup';
 import type { ReactComponent } from '../../types';

--- a/packages/modules/src/modules/shared/ArticleCountOptOutPopup.tsx
+++ b/packages/modules/src/modules/shared/ArticleCountOptOutPopup.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { space, from } from '@guardian/source-foundations';
+import { space, from } from '@guardian/source/foundations';
 
 import { ArticleCountOptOutOverlay } from './ArticleCountOptOutOverlay';
 import { OphanComponentEvent, OphanComponentType } from '@sdc/shared/types';

--- a/packages/modules/src/modules/shared/Lines.tsx
+++ b/packages/modules/src/modules/shared/Lines.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { border, remSpace } from '@guardian/source-foundations';
+import { border, remSpace } from '@guardian/source/foundations';
 import type { ReactComponent } from '../../types';
 
 const lineGap = remSpace[1];

--- a/packages/modules/src/modules/shared/ModuleWrapper.tsx
+++ b/packages/modules/src/modules/shared/ModuleWrapper.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { JSX } from '@emotion/react/jsx-runtime';
 import type { ReactComponent } from '../../types';
 
-export function withParsedProps<ModuleProps extends EmotionJSX.IntrinsicAttributes>(
+export function withParsedProps<ModuleProps extends JSX.IntrinsicAttributes>(
     Module: ReactComponent<ModuleProps>,
     validate: (props: unknown) => props is ModuleProps,
 ): ReactComponent<unknown> {

--- a/packages/modules/src/modules/shared/Reminders.tsx
+++ b/packages/modules/src/modules/shared/Reminders.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { error, neutral, space, textSans } from '@guardian/source-foundations';
+import { error, neutral, space, textSans } from '@guardian/source/foundations';
 
 // ---- Thank you component ---- //
 

--- a/packages/modules/src/types.ts
+++ b/packages/modules/src/types.ts
@@ -1,4 +1,4 @@
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { JSX } from '@emotion/react/jsx-runtime';
 
 // This type can be used in place of React.FC<T> which was previously widespread
 // in this codebase but is no longer recommended. In many cases it's possible to
@@ -12,4 +12,4 @@ import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 
 export type ReactComponent<GenericProps = Record<string, never>> = (
     props: GenericProps,
-) => EmotionJSX.Element;
+) => JSX.Element;

--- a/packages/modules/tsconfig.json
+++ b/packages/modules/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "ESNext",
     "target": "ES2018",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "strict": true,
     "noImplicitReturns": true,

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "ESNext",
     "target": "ES2020",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "strict": true,
     "outDir": "dist"

--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -1,4 +1,4 @@
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { JSX } from '@emotion/react/jsx-runtime';
 import {
     Cta,
     ctaSchema,
@@ -39,7 +39,7 @@ export const bannerContentSchema = z.object({
     secondaryCta: secondaryCtaSchema.optional(),
 });
 
-export interface BannerProps extends EmotionJSX.IntrinsicAttributes {
+export interface BannerProps extends JSX.IntrinsicAttributes {
     tracking: Tracking;
     bannerChannel: BannerChannel;
     content?: BannerContent;

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -1,4 +1,4 @@
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { JSX } from '@emotion/react/jsx-runtime';
 import * as z from 'zod';
 import {
     bylineWithImageSchema,
@@ -23,7 +23,7 @@ export type ArticleCounts = {
     [type in ArticleCountType]: number;
 };
 
-export interface EpicProps extends EmotionJSX.IntrinsicAttributes {
+export interface EpicProps extends JSX.IntrinsicAttributes {
     variant: EpicVariant;
     tracking: Tracking;
     countryCode?: string;

--- a/packages/shared/src/types/props/header.ts
+++ b/packages/shared/src/types/props/header.ts
@@ -1,4 +1,4 @@
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { JSX } from '@emotion/react/jsx-runtime';
 import * as z from 'zod';
 import { OphanComponentEvent } from '../ophan';
 import { Tracking, trackingSchema, Cta, ctaSchema } from './shared';
@@ -19,7 +19,7 @@ export const headerContentSchema = z.object({
     benefits: z.array(z.string()).optional(),
 });
 
-export interface HeaderProps extends EmotionJSX.IntrinsicAttributes {
+export interface HeaderProps extends JSX.IntrinsicAttributes {
     content: HeaderContent;
     tracking: Tracking;
     mobileContent?: HeaderContent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,17 +2584,17 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-5.0.0.tgz#0cd36b105512510192ea9fd18da3d3df2d7b3b72"
   integrity sha512-gJSQuuP7JVDOWQj4EUrwyJTnMt+frLkw0D2sLg70nHn76L3LmH2xTQtYMPUsqyqn37qocDPzgdvBdmATi50zRQ==
 
-"@guardian/source-foundations@14.1.2":
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-14.1.2.tgz#cfa28a4f86570d5df4bf024da36cc46fb1b26105"
-  integrity sha512-SmAaYCMd8PtAo0h6PCtvZJGDdP/bKh86SjFUzjFagtHlPKBAUOOQ/juunHFYZrmDwTGGA7YtzduvN5esHjvegA==
+"@guardian/source-foundations@14.2.2":
+  version "14.2.2"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-14.2.2.tgz#c1e13d341a080861b036d1e71f9da460c7dcfde9"
+  integrity sha512-198Akw1RqufsX6Iu/qzqeR4eC9L3ezHURVzMqJeB3ZRZtabdkL2Q562mS1UnSdyACeCLRMqlOXqZDO38gsjP/g==
   dependencies:
     mini-svg-data-uri "1.4.4"
 
-"@guardian/source-react-components@19.0.0":
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-19.0.0.tgz#d01bf1f211ed52ed0749c71ffdad03986c430206"
-  integrity sha512-2CDMBxYJTgS6I8uqO6/s8eodptPbs8c7iYsqv/XKJEBDs8+I3iIlp31Y/QfoCOyrW+TT1hV3DQhqAuMNbY+Trg==
+"@guardian/source-react-components@23.0.1":
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-23.0.1.tgz#93baa7485826022350524dee39e8ef00a32038b6"
+  integrity sha512-gBxO7c24VZsYBUPXy507LWwNY1xxnh4VwCDibTK3a2AJat9D6+BTEmNaWD5e5S8pzmr3RY6hSrePGanw8bPYyA==
 
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
@@ -13463,7 +13463,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13480,15 +13480,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.1.1:
   version "2.1.1"
@@ -13599,7 +13590,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13633,13 +13624,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -14993,7 +14977,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15023,15 +15007,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- adopts TypeScript's `bundler` module resolution algorithm, to bring it into line with webpack
- moves from the old source packages to the new, single `@guardian/source` (which also works with `bundler`)

This is a 2nd pass at #1119.