### PR TITLE
Add abandoned basket banner channel selection

### DIFF
--- a/packages/dotcom/.changeset/strange-eyes-tease.md
+++ b/packages/dotcom/.changeset/strange-eyes-tease.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+Add abandonedBasketLastClosedAt to targeting type and new channel

--- a/packages/modules/src/modules/banners/localStorage.ts
+++ b/packages/modules/src/modules/banners/localStorage.ts
@@ -1,6 +1,12 @@
 import { BannerChannel } from '@sdc/shared/types';
 
-const setBannerClosedTimestamp = (name: string): void =>
+type BannerLastClosedAt =
+    | 'engagementBannerLastClosedAt'
+    | 'subscriptionBannerLastClosedAt'
+    | 'signInBannerLastClosedAt'
+    | 'abandonedBasketLastClosedAt';
+
+const setBannerClosedTimestamp = (name: BannerLastClosedAt): void =>
     localStorage.setItem(
         `gu.prefs.${name}`,
         JSON.stringify({
@@ -8,21 +14,13 @@ const setBannerClosedTimestamp = (name: string): void =>
         }),
     );
 
-const setContributionsBannerClosedTimestamp = (): void =>
-    setBannerClosedTimestamp('engagementBannerLastClosedAt');
-
-const setSubscriptionsBannerClosedTimestamp = (): void =>
-    setBannerClosedTimestamp('subscriptionBannerLastClosedAt');
-
-const setSignInBannerClosedTimestamp = (): void =>
-    setBannerClosedTimestamp('signInBannerLastClosedAt');
+const bannerChannelToLastClosedMap = {
+    contributions: 'engagementBannerLastClosedAt',
+    subscriptions: 'subscriptionBannerLastClosedAt',
+    signIn: 'signInBannerLastClosedAt',
+    abandonedBasket: 'abandonedBasketLastClosedAt',
+} as const satisfies Record<BannerChannel, BannerLastClosedAt>;
 
 export const setChannelClosedTimestamp = (channel: BannerChannel): void => {
-    if (channel === 'contributions') {
-        setContributionsBannerClosedTimestamp();
-    } else if (channel === 'subscriptions') {
-        setSubscriptionsBannerClosedTimestamp();
-    } else if (channel === 'signIn') {
-        setSignInBannerClosedTimestamp();
-    }
+    setBannerClosedTimestamp(bannerChannelToLastClosedMap[channel]);
 };

--- a/packages/server/src/api/bannerRouter.ts
+++ b/packages/server/src/api/bannerRouter.ts
@@ -115,6 +115,7 @@ export const buildBannerRouter = (
                 prices: productPrices.get(),
                 choiceCardAmounts: variantAmounts,
                 design: getDesignForVariant(variant, bannerDesigns.get()),
+                abandonedBasket: targeting.abandonedBasket,
             };
 
             return {

--- a/packages/server/src/lib/dates.ts
+++ b/packages/server/src/lib/dates.ts
@@ -1,6 +1,6 @@
 const pauseDays = 90;
 
-export const daysSince = (then: Date, now: Date = new Date()): number => {
+export const daysSince = (then: Date, now: Date): number => {
     const oneDayMs = 1000 * 60 * 60 * 24;
     const diffMs = now.valueOf() - then.valueOf();
     return Math.floor(diffMs / oneDayMs);

--- a/packages/server/src/lib/dates.ts
+++ b/packages/server/src/lib/dates.ts
@@ -1,6 +1,6 @@
 const pauseDays = 90;
 
-export const daysSince = (then: Date, now: Date): number => {
+export const daysSince = (then: Date, now: Date = new Date()): number => {
     const oneDayMs = 1000 * 60 * 60 * 24;
     const diffMs = now.valueOf() - then.valueOf();
     return Math.floor(diffMs / oneDayMs);

--- a/packages/server/src/lib/targeting.ts
+++ b/packages/server/src/lib/targeting.ts
@@ -8,6 +8,8 @@ import {
     PageContextTargeting,
     UserDeviceType,
     ConsentStatus,
+    AbandonedBasket,
+    BannerChannel,
 } from '@sdc/shared/types';
 
 import { daysSince } from './dates';
@@ -122,6 +124,17 @@ export const consentStatusMatches = (
             return true;
     }
 };
+
+export function abandonedBasketMatches(
+    bannerChannel: BannerChannel,
+    abandonedBasket: AbandonedBasket | undefined,
+): boolean {
+    if (bannerChannel === 'abandonedBasket') {
+        return !!abandonedBasket;
+    }
+
+    return true;
+}
 
 interface PageContext {
     tagIds?: string[];

--- a/packages/server/src/tests/banners/abandonedBasketTests.ts
+++ b/packages/server/src/tests/banners/abandonedBasketTests.ts
@@ -1,0 +1,49 @@
+import { designableBanner } from '@sdc/shared/src/config/modules';
+import type { BannerTest, BannerTestGenerator, BannerVariant } from '@sdc/shared/types';
+
+const baseAbandonedBasketTest: Omit<BannerTest, 'name' | 'variants'> = {
+    bannerChannel: 'abandonedBasket',
+    isHardcoded: true,
+    userCohort: 'Everyone',
+    // We can use this as the feature switch
+    status: 'Draft',
+    priority: 99,
+    locations: [],
+    contextTargeting: { tagIds: [], sectionIds: [], excludedTagIds: [], excludedSectionIds: [] },
+};
+
+const baseAbandonedBasketVariant: Omit<BannerVariant, 'bannerContent'> = {
+    name: 'control',
+    modulePathBuilder: designableBanner.endpointPathBuilder,
+    // Requires this design to exist in the RRCP!
+    template: { designName: 'ABANDONEDBASKET' },
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+};
+
+const heading = 'Finalise your subscription';
+const paragraphs = [
+    'To ensure you enjoy the full benefits of our all-access digital subscription, please return to the checkout to complete your subscription. ',
+];
+const cta = {
+    baseUrl: 'https://support.theguardian.com',
+    text: 'Return to checkout',
+};
+
+const abandonedBasketTest: BannerTest = {
+    ...baseAbandonedBasketTest,
+    name: 'banner-abandoned-basket',
+    variants: [
+        {
+            ...baseAbandonedBasketVariant,
+            bannerContent: {
+                heading,
+                paragraphs,
+                cta,
+            },
+        },
+    ],
+};
+
+const tests = [abandonedBasketTest];
+
+export const abandonedBasketTests: BannerTestGenerator = () => Promise.resolve(tests);

--- a/packages/server/src/tests/banners/bannerSelection.test.ts
+++ b/packages/server/src/tests/banners/bannerSelection.test.ts
@@ -448,4 +448,127 @@ describe('selectBannerTest', () => {
             expect(result).toBeNull();
         });
     });
+
+    describe('Abandoned basket banner rules', () => {
+        const now = new Date('2020-03-31T12:30:00');
+
+        const bannerDeployTimes = getBannerDeployTimesReloader(secondDate);
+
+        const targeting: BannerTargeting = {
+            shouldHideReaderRevenue: false,
+            isPaidContent: false,
+            showSupportMessaging: true,
+            mvtId: 3,
+            countryCode: 'AU',
+            engagementBannerLastClosedAt: firstDate,
+            hasOptedOutOfArticleCount: false,
+            contentType: 'Article',
+            isSignedIn: false,
+            hasConsented: true,
+        };
+
+        const tracking = {
+            ophanPageId: '',
+            platformId: '',
+            referrerUrl: '',
+            clientName: '',
+        };
+
+        const test: BannerTest = {
+            name: 'abandonedBasket',
+            priority: 1,
+            status: 'Live',
+            bannerChannel: 'abandonedBasket',
+            isHardcoded: false,
+            userCohort: 'Everyone',
+            variants: [
+                {
+                    name: 'variant',
+                    modulePathBuilder: contributionsBanner.endpointPathBuilder,
+                    template: BannerTemplate.ContributionsBanner,
+                    bannerContent: {
+                        messageText: 'body',
+                        highlightedText: 'highlighted text',
+                        cta: {
+                            text: 'cta',
+                            baseUrl: 'https://support.theguardian.com',
+                        },
+                    },
+                    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+                },
+            ],
+            locations: [],
+            contextTargeting: {
+                tagIds: [],
+                sectionIds: [],
+                excludedTagIds: [],
+                excludedSectionIds: [],
+            },
+        };
+
+        it('returns abandoned basket banner when abandoned basket property present and not recently closed', () => {
+            const result = selectBannerTest(
+                {
+                    ...targeting,
+                    abandonedBasket: {
+                        amount: 5,
+                        billingPeriod: 'ANNUAL',
+                        region: 'au',
+                        product: 'Contribution',
+                    },
+                },
+                tracking,
+                userDeviceType,
+                '',
+                [test],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
+                undefined,
+                now,
+            );
+            expect(result && result.test.name).toBe('abandonedBasket');
+        });
+
+        it('returns null when abandoned basket property present and recently closed', () => {
+            const result = selectBannerTest(
+                {
+                    ...targeting,
+                    abandonedBasket: {
+                        amount: 5,
+                        billingPeriod: 'ANNUAL',
+                        region: 'au',
+                        product: 'Contribution',
+                    },
+                    abandonedBasketBannerLastClosedAt: now.toISOString(),
+                },
+                tracking,
+                userDeviceType,
+                '',
+                [test],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
+                undefined,
+                now,
+            );
+            expect(result).toBe(null);
+        });
+
+        it('returns null when abandoned basket property not present', () => {
+            const result = selectBannerTest(
+                targeting,
+                tracking,
+                userDeviceType,
+                '',
+                [test],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledBannerDeploys,
+                undefined,
+                now,
+            );
+            expect(result).toBe(null);
+        });
+    });
 });

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -28,6 +28,7 @@ import {
     ScheduledBannerDeploys,
     defaultDeploySchedule,
 } from './bannerDeploySchedule';
+import { daysSince } from '../../lib/dates';
 
 export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderRevenueRegion => {
     switch (true) {
@@ -70,8 +71,13 @@ export const canShowBannerAgain = (
         return !signInBannerLastClosedAt;
     }
 
+    // Don't show the abandonedBasket banner if it was closed less than 1 day ago
     if (bannerChannel === 'abandonedBasket') {
-        return !abandonedBasketBannerLastClosedAt; // ToDo can we show it again?
+        if (!abandonedBasketBannerLastClosedAt) {
+            return true;
+        }
+
+        return daysSince(new Date(abandonedBasketBannerLastClosedAt)) > 0;
     }
 
     const canShow = (lastClosedRaw: string | undefined): boolean => {

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -18,6 +18,7 @@ import {
     deviceTypeMatches,
     consentStatusMatches,
     pageContextMatches,
+    abandonedBasketMatches,
 } from '../../lib/targeting';
 import { BannerDeployTimesProvider, ReaderRevenueRegion } from './bannerDeployTimes';
 import { selectTargetingTest } from '../../lib/targetingTesting';
@@ -59,6 +60,7 @@ export const canShowBannerAgain = (
         subscriptionBannerLastClosedAt,
         engagementBannerLastClosedAt,
         signInBannerLastClosedAt,
+        abandonedBasketBannerLastClosedAt,
     } = targeting;
 
     const region = readerRevenueRegionFromCountryCode(targeting.countryCode);
@@ -66,6 +68,10 @@ export const canShowBannerAgain = (
     // Never show a sign in prompt banner if it has been closed previously
     if (bannerChannel === 'signIn') {
         return !signInBannerLastClosedAt;
+    }
+
+    if (bannerChannel === 'abandonedBasket') {
+        return !abandonedBasketBannerLastClosedAt; // ToDo can we show it again?
     }
 
     const canShow = (lastClosedRaw: string | undefined): boolean => {
@@ -207,9 +213,10 @@ export const selectBannerTest = (
                     excludedSectionIds: [],
                 },
             ) &&
-            consentStatusMatches(targeting.hasConsented, test.consentStatus)
+            consentStatusMatches(targeting.hasConsented, test.consentStatus) &&
+            abandonedBasketMatches(test.bannerChannel, targeting.abandonedBasket)
         ) {
-            const variant: BannerVariant = selectVariant(test, targeting.mvtId);
+            const variant = selectVariant<BannerVariant, BannerTest>(test, targeting.mvtId);
 
             return {
                 test,

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -48,12 +48,13 @@ export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderR
 // Don't show the abandonedBasket banner if it was closed less than 1 day ago
 function canShowAbandonedBasketBanner(
     abandonedBasketBannerLastClosedAt: string | undefined,
+    now: Date,
 ): boolean {
     if (!abandonedBasketBannerLastClosedAt) {
         return true;
     }
 
-    return daysSince(new Date(abandonedBasketBannerLastClosedAt)) > 0;
+    return daysSince(new Date(abandonedBasketBannerLastClosedAt), now) > 0;
 }
 
 /**
@@ -83,7 +84,7 @@ export const canShowBannerAgain = (
     }
 
     if (bannerChannel === 'abandonedBasket') {
-        return canShowAbandonedBasketBanner(abandonedBasketBannerLastClosedAt);
+        return canShowAbandonedBasketBanner(abandonedBasketBannerLastClosedAt, now);
     }
 
     const canShow = (lastClosedRaw: string | undefined): boolean => {

--- a/packages/server/src/tests/banners/bannerSelection.ts
+++ b/packages/server/src/tests/banners/bannerSelection.ts
@@ -45,6 +45,17 @@ export const readerRevenueRegionFromCountryCode = (countryCode: string): ReaderR
     }
 };
 
+// Don't show the abandonedBasket banner if it was closed less than 1 day ago
+function canShowAbandonedBasketBanner(
+    abandonedBasketBannerLastClosedAt: string | undefined,
+): boolean {
+    if (!abandonedBasketBannerLastClosedAt) {
+        return true;
+    }
+
+    return daysSince(new Date(abandonedBasketBannerLastClosedAt)) > 0;
+}
+
 /**
  * If the banner has been closed previously, can we show it again?
  * e.g. if changes have been deployed
@@ -71,13 +82,8 @@ export const canShowBannerAgain = (
         return !signInBannerLastClosedAt;
     }
 
-    // Don't show the abandonedBasket banner if it was closed less than 1 day ago
     if (bannerChannel === 'abandonedBasket') {
-        if (!abandonedBasketBannerLastClosedAt) {
-            return true;
-        }
-
-        return daysSince(new Date(abandonedBasketBannerLastClosedAt)) > 0;
+        return canShowAbandonedBasketBanner(abandonedBasketBannerLastClosedAt);
     }
 
     const canShow = (lastClosedRaw: string | undefined): boolean => {

--- a/packages/server/src/tests/banners/bannerTests.ts
+++ b/packages/server/src/tests/banners/bannerTests.ts
@@ -10,10 +10,10 @@ import { buildReloader, ValueReloader } from '../../utils/valueReloader';
 const flattenArray = <T>(array: T[][]): T[] => ([] as T[]).concat(...array);
 
 const testGenerators: BannerTestGenerator[] = [
+    abandonedBasketTests,
     channel1BannersAllTestsGenerator,
     channel2BannersAllTestsGenerator,
     signInPromptTests,
-    abandonedBasketTests,
 ];
 
 const getTests = (): Promise<BannerTest[]> =>

--- a/packages/server/src/tests/banners/bannerTests.ts
+++ b/packages/server/src/tests/banners/bannerTests.ts
@@ -3,6 +3,7 @@ import {
     channel1BannersAllTestsGenerator,
     channel2BannersAllTestsGenerator,
 } from './channelBannerTests';
+import { abandonedBasketTests } from './abandonedBasketTests';
 import { signInPromptTests } from './signInPromptTests';
 import { buildReloader, ValueReloader } from '../../utils/valueReloader';
 
@@ -12,6 +13,7 @@ const testGenerators: BannerTestGenerator[] = [
     channel1BannersAllTestsGenerator,
     channel2BannersAllTestsGenerator,
     signInPromptTests,
+    abandonedBasketTests,
 ];
 
 const getTests = (): Promise<BannerTest[]> =>

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -74,17 +74,6 @@ const buildBannerVariant =
         componentType: BannerTemplateComponentTypes[forChannel],
     });
 
-function addInAbandonedBasketChannel(
-    bannerChannel: BannerChannel,
-    testParams: BannerTestFromTool,
-): BannerChannel {
-    if (testParams.name.includes('ABANDONED_BASKET')) {
-        return 'abandonedBasket';
-    }
-
-    return bannerChannel;
-}
-
 const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTestGenerator => {
     const channel = bannerChannel === 'contributions' ? 'Banner1' : 'Banner2';
     return (): Promise<BannerTest[]> =>
@@ -92,7 +81,7 @@ const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTes
             return tests.map((testParams: BannerTestFromTool): BannerTest => {
                 return {
                     ...testParams,
-                    bannerChannel: addInAbandonedBasketChannel(bannerChannel, testParams),
+                    bannerChannel,
                     isHardcoded: false,
                     variants: testParams.variants.map(buildBannerVariant(bannerChannel)),
                 };

--- a/packages/server/src/tests/banners/channelBannerTests.ts
+++ b/packages/server/src/tests/banners/channelBannerTests.ts
@@ -42,6 +42,7 @@ export const BannerTemplateComponentTypes: {
     contributions: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     subscriptions: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
     signIn: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    abandonedBasket: 'ACQUISITIONS_ENGAGEMENT_BANNER',
 };
 
 const modulePathBuilder =
@@ -73,6 +74,17 @@ const buildBannerVariant =
         componentType: BannerTemplateComponentTypes[forChannel],
     });
 
+function addInAbandonedBasketChannel(
+    bannerChannel: BannerChannel,
+    testParams: BannerTestFromTool,
+): BannerChannel {
+    if (testParams.name.includes('ABANDONED_BASKET')) {
+        return 'abandonedBasket';
+    }
+
+    return bannerChannel;
+}
+
 const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTestGenerator => {
     const channel = bannerChannel === 'contributions' ? 'Banner1' : 'Banner2';
     return (): Promise<BannerTest[]> =>
@@ -80,7 +92,7 @@ const createTestsGeneratorForChannel = (bannerChannel: BannerChannel): BannerTes
             return tests.map((testParams: BannerTestFromTool): BannerTest => {
                 return {
                     ...testParams,
-                    bannerChannel,
+                    bannerChannel: addInAbandonedBasketChannel(bannerChannel, testParams),
                     isHardcoded: false,
                     variants: testParams.variants.map(buildBannerVariant(bannerChannel)),
                 };

--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -14,8 +14,14 @@ import * as z from 'zod';
 import { Prices } from '../prices';
 import { SelectedAmountsVariant } from '../abTests';
 import { ConfigurableDesign, configurableDesignSchema } from './design';
+import { AbandonedBasket } from '../targeting';
 
-export const bannerChannelSchema = z.enum(['contributions', 'subscriptions', 'signIn']);
+export const bannerChannelSchema = z.enum([
+    'contributions',
+    'subscriptions',
+    'signIn',
+    'abandonedBasket',
+]);
 
 export type BannerChannel = z.infer<typeof bannerChannelSchema>;
 
@@ -55,6 +61,7 @@ export interface BannerProps extends JSX.IntrinsicAttributes {
     prices?: Prices;
     choiceCardAmounts?: SelectedAmountsVariant;
     design?: ConfigurableDesign;
+    abandonedBasket?: AbandonedBasket;
 }
 
 export const bannerSchema = z.object({

--- a/packages/shared/src/types/targeting/banner.ts
+++ b/packages/shared/src/types/targeting/banner.ts
@@ -7,6 +7,7 @@ export type BannerTargeting = {
     engagementBannerLastClosedAt?: string;
     subscriptionBannerLastClosedAt?: string;
     signInBannerLastClosedAt?: string;
+    abandonedBasketBannerLastClosedAt?: string;
     mvtId: number;
     countryCode: string;
     weeklyArticleHistory?: WeeklyArticleHistory;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds selection logic for the abandoned basket banner based on the cookie data sent in the request. Also adds a new channel called 'abandonedBasket', similar to sign in prompt tests. Adds one hardcoded test, copy TBC. Returns the abandonedBasket data in the response to be used in the client to generate the CTA url.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Send a request to `/banner`. If the request has `abandonedBasket` property and not `abandonedBasketLastClosedAt` within the last 24 hours - the response should be the "ABANDONED_BASKET" test. Otherwise it should return any other test.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

![image](https://github.com/guardian/support-dotcom-components/assets/114918544/640f56f0-43e6-4bc0-ac14-f0935a44b837)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
