### PR TITLE
changing banner size when on mobile to be 60% height

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -357,7 +357,10 @@ const styles = {
     outerContainer: (background: string, textColor: string = 'inherit') => css`
         background: ${background};
         color: ${textColor};
-        max-height: 100vh;
+        max-height: 60vh;
+        ${from.tablet} {
+            max-height: 100vh;
+        }
         overflow: auto;
         * {
             box-sizing: border-box;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Makes the banner height 60% size to enable users to closing the banner on mobil devices.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
On storybook check that screen sizes smaller than tablet have a scrollable banner.

https://github.com/guardian/support-dotcom-components/assets/115992455/54cc33c9-7517-42e0-a0e0-e420a7c29cba

Locally on DCR, trigger a banner on a mobile size screen and check that the banner is closable and scrollable.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
