### PR TITLE
Abandoned Basket: Create URL to return to checkout

### DIFF
--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -1,5 +1,4 @@
 import {
-    addAbandonedBasketParamsToUrl,
     addRegionIdAndTrackingParamsToSupportUrl,
     addTrackingParamsToProfileUrl,
     createClickEventFromTracking,
@@ -9,6 +8,7 @@ import {
     containsNonArticleCountPlaceholder,
     replaceNonArticleCountPlaceholders,
     getReminderFields,
+    addAbandonedBasketAndTrackingParamsToUrl,
 } from '@sdc/shared/lib';
 import React, { useEffect, useState } from 'react';
 import {
@@ -167,7 +167,11 @@ const withBannerData =
 
                 if (bannerChannel === 'abandonedBasket' && abandonedBasket) {
                     return {
-                        ctaUrl: addAbandonedBasketParamsToUrl(cta.baseUrl, abandonedBasket),
+                        ctaUrl: addAbandonedBasketAndTrackingParamsToUrl(
+                            cta.baseUrl,
+                            abandonedBasket,
+                            tracking,
+                        ),
                         ctaText: cta.text,
                     };
                 }

--- a/packages/modules/src/modules/banners/common/BannerWrapper.tsx
+++ b/packages/modules/src/modules/banners/common/BannerWrapper.tsx
@@ -1,4 +1,5 @@
 import {
+    addAbandonedBasketParamsToUrl,
     addRegionIdAndTrackingParamsToSupportUrl,
     addTrackingParamsToProfileUrl,
     createClickEventFromTracking,
@@ -96,6 +97,8 @@ const withBannerData =
             separateArticleCount,
             choiceCardAmounts,
             design,
+            bannerChannel,
+            abandonedBasket,
         } = bannerProps;
 
         const [canShow, setCanShow] = useState<boolean>(false);
@@ -158,6 +161,13 @@ const withBannerData =
                 if (isProfileUrl(cta.baseUrl)) {
                     return {
                         ctaUrl: addTrackingParamsToProfileUrl(cta.baseUrl, tracking),
+                        ctaText: cta.text,
+                    };
+                }
+
+                if (bannerChannel === 'abandonedBasket' && abandonedBasket) {
+                    return {
+                        ctaUrl: addAbandonedBasketParamsToUrl(cta.baseUrl, abandonedBasket),
                         ctaText: cta.text,
                     };
                 }

--- a/packages/shared/src/lib/tracking.test.ts
+++ b/packages/shared/src/lib/tracking.test.ts
@@ -7,6 +7,7 @@ import {
     addLabelToTracking,
     addChoiceCardsParams,
     addAbandonedBasketParamsToUrl,
+    addAbandonedBasketAndTrackingParamsToUrl,
 } from './tracking';
 import { factories } from '../factories/';
 import { AbandonedBasket } from '../types';
@@ -62,7 +63,7 @@ describe('addTrackingParams', () => {
     });
 });
 
-describe('addAbandonedBasketParamsToUrl', () => {
+describe('addAbandonedBasketAndTrackingParamsToUrl', () => {
     it('should return a correctly formatted URL when contributions abandoned basket is present', () => {
         const abandonedBasketData: AbandonedBasket = {
             region: 'uk',
@@ -92,6 +93,41 @@ describe('addAbandonedBasketParamsToUrl', () => {
 
         const got = addAbandonedBasketParamsToUrl(baseUrl, abandonedBasketData);
         const want = 'https://support.theguardian.com';
+
+        expect(got).toEqual(want);
+    });
+});
+
+describe('addAbandonedBasketAndTrackingParamsToUrl', () => {
+    it('adds tracking params to the URL for returning to checkout', () => {
+        const abandonedBasketData: AbandonedBasket = {
+            region: 'uk',
+            amount: 5,
+            billingPeriod: 'MONTHLY',
+            product: 'Contribution',
+        };
+
+        const trackingData = factories.tracking.build({
+            ophanPageId: 'k5nxn0mxg7ytwpkxuwms',
+            campaignCode:
+                'gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet',
+            campaignId: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestName: '2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron',
+            abTestVariant: 'v2_stay_quiet',
+            referrerUrl:
+                'http://localhost:3000/politics/2020/jan/17/uk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit',
+        });
+
+        const baseUrl = 'https://support.theguardian.com';
+
+        const got = addAbandonedBasketAndTrackingParamsToUrl(
+            baseUrl,
+            abandonedBasketData,
+            trackingData,
+        );
+
+        const want =
+            'https://support.theguardian.com/uk/contribute/checkout?selected-amount=5&selected-contribution-type=MONTHLY&REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTests%22%3A%5B%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%5D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=0';
 
         expect(got).toEqual(want);
     });

--- a/packages/shared/src/lib/tracking.test.ts
+++ b/packages/shared/src/lib/tracking.test.ts
@@ -6,8 +6,10 @@ import {
     addTrackingParamsToBodyLinks,
     addLabelToTracking,
     addChoiceCardsParams,
+    addAbandonedBasketParamsToUrl,
 } from './tracking';
 import { factories } from '../factories/';
+import { AbandonedBasket } from '../types';
 
 describe('addTrackingParams', () => {
     it('should return a correctly formatted URL', () => {
@@ -56,6 +58,41 @@ describe('addTrackingParams', () => {
 
         const want =
             'https://support.theguardian.com/contribute/climate-pledge-2019?foo=bar&REFPVID=k5nxn0mxg7ytwpkxuwms&INTCMP=gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet&acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22componentType%22%3A%22ACQUISITIONS_EPIC%22%2C%22campaignCode%22%3A%22gdnwb_copts_memco_2019-10-14_moment_climate_pledge__multi_UKUS_nonenviron_v2_stay_quiet%22%2C%22abTests%22%3A%5B%7B%22name%22%3A%222019-10-14_moment_climate_pledge__multi_UKUS_nonenviron%22%2C%22variant%22%3A%22v2_stay_quiet%22%7D%5D%2C%22referrerPageviewId%22%3A%22k5nxn0mxg7ytwpkxuwms%22%2C%22referrerUrl%22%3A%22http%3A%2F%2Flocalhost%3A3000%2Fpolitics%2F2020%2Fjan%2F17%2Fuk-rules-out-automatic-deportation-of-eu-citizens-verhofstadt-brexit%22%2C%22isRemote%22%3Atrue%7D&numArticles=88';
+        expect(got).toEqual(want);
+    });
+});
+
+describe('addAbandonedBasketParamsToUrl', () => {
+    it('should return a correctly formatted URL when contributions abandoned basket is present', () => {
+        const abandonedBasketData: AbandonedBasket = {
+            region: 'uk',
+            amount: 5,
+            billingPeriod: 'MONTHLY',
+            product: 'Contribution',
+        };
+
+        const baseUrl = 'https://support.theguardian.com';
+
+        const got = addAbandonedBasketParamsToUrl(baseUrl, abandonedBasketData);
+        const want =
+            'https://support.theguardian.com/uk/contribute/checkout?selected-amount=5&selected-contribution-type=MONTHLY';
+
+        expect(got).toEqual(want);
+    });
+
+    it('should return the base URL when product is Guardian Weekly', () => {
+        const abandonedBasketData: AbandonedBasket = {
+            region: 'uk',
+            amount: 5,
+            billingPeriod: 'MONTHLY',
+            product: 'GuardianWeekly',
+        };
+
+        const baseUrl = 'https://support.theguardian.com';
+
+        const got = addAbandonedBasketParamsToUrl(baseUrl, abandonedBasketData);
+        const want = 'https://support.theguardian.com';
+
         expect(got).toEqual(want);
     });
 });

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -129,6 +129,14 @@ export const addAbandonedBasketParamsToUrl = (
     }
 };
 
+export const addAbandonedBasketAndTrackingParamsToUrl = (
+    baseUrl: string,
+    abandonedBasket: AbandonedBasket,
+    tracking: Tracking,
+) => {
+    return addTrackingParams(addAbandonedBasketParamsToUrl(baseUrl, abandonedBasket), tracking);
+};
+
 export const isSupportUrl = (baseUrl: string): boolean => /\bsupport\./.test(baseUrl);
 
 export const addRegionIdAndTrackingParamsToSupportUrl = (

--- a/packages/shared/src/lib/tracking.ts
+++ b/packages/shared/src/lib/tracking.ts
@@ -8,6 +8,7 @@ import {
     EpicTest,
     EpicVariant,
     ContributionFrequency,
+    AbandonedBasket,
 } from '../types';
 
 // TRACKING VIA support.theguardian.com
@@ -106,6 +107,26 @@ export const addTrackingParams = (
     const queryString = generateQueryString(params, acquisitionData, numArticles ?? 0);
     const alreadyHasQueryString = baseUrl.includes('?');
     return `${baseUrl}${alreadyHasQueryString ? '&' : '?'}${queryString}`;
+};
+
+const addAbandonedBasketContributionParams = (
+    baseUrl: string,
+    { region, amount, billingPeriod }: AbandonedBasket,
+): string => {
+    return `${baseUrl}/${region}/contribute/checkout?selected-amount=${amount}&selected-contribution-type=${billingPeriod}`;
+};
+
+export const addAbandonedBasketParamsToUrl = (
+    baseUrl: string,
+    abandonedBasket: AbandonedBasket,
+): string => {
+    switch (abandonedBasket.product) {
+        case 'Contribution':
+        case 'SupporterPlus':
+            return addAbandonedBasketContributionParams(baseUrl, abandonedBasket);
+        default:
+            return baseUrl;
+    }
 };
 
 export const isSupportUrl = (baseUrl: string): boolean => /\bsupport\./.test(baseUrl);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add params to the support URL if the banner channel is abandoned basket. This is applicable for contributions and supporter plus products only.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

(Locally)
Build the modules. Turn the abandoned banner hardcoded test from 'Draft' to 'Live'. Use `showMeTheBanner` in DCR - click the CTA and the URL should have the correct params.


## Images

The banner with correct CTA URL
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/9cf8b3f3-a57a-4a6c-9c49-4123b7f4bb51)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

