### PR TITLE
Update NON_STICKY test name check

### DIFF
--- a/packages/server/src/tests/epics/epicSelection.ts
+++ b/packages/server/src/tests/epics/epicSelection.ts
@@ -307,7 +307,7 @@ function selectEpicVariant(test: EpicTest, banditData: BanditData[], targeting: 
         return selectVariantUsingEpsilonGreedy(banditData, test);
     }
 
-    if (test.name.startsWith(NonStickyVariantsTestNames.NonSticky)) {
+    if (test.name.includes('NON_STICKY')) {
         // Do not use the mvt value
         const variant = selectVariantNonSticky<EpicVariant, EpicTest>(test);
         return {


### PR DESCRIPTION
While this is still experimental we're just using the name to enable non-sticky variants.
We're planning on using this for liveblog experiments