### PR TITLE
Add copy for abandoned basket banner variants

### DIFF
--- a/packages/server/src/tests/banners/abandonedBasketTests.ts
+++ b/packages/server/src/tests/banners/abandonedBasketTests.ts
@@ -12,18 +12,13 @@ const baseAbandonedBasketTest: Omit<BannerTest, 'name' | 'variants'> = {
     contextTargeting: { tagIds: [], sectionIds: [], excludedTagIds: [], excludedSectionIds: [] },
 };
 
-const baseAbandonedBasketVariant: Omit<BannerVariant, 'bannerContent'> = {
-    name: 'control',
+const baseAbandonedBasketVariant: Omit<BannerVariant, 'bannerContent' | 'name'> = {
     modulePathBuilder: designableBanner.endpointPathBuilder,
     // Requires this design to exist in the RRCP!
     template: { designName: 'ABANDONEDBASKET' },
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
 };
 
-const heading = 'Finalise your subscription';
-const paragraphs = [
-    'To ensure you enjoy the full benefits of our all-access digital subscription, please return to the checkout to complete your subscription. ',
-];
 const cta = {
     baseUrl: 'https://support.theguardian.com',
     text: 'Return to checkout',
@@ -35,10 +30,23 @@ const abandonedBasketTest: BannerTest = {
     variants: [
         {
             ...baseAbandonedBasketVariant,
+            name: 'v1',
             bannerContent: {
-                heading,
-                paragraphs,
+                heading: 'Finish your order',
+                paragraphs: [
+                    'Your support is incredibly important to us and helps us keep our independent journalism open for all. Please consider finalising your support today.',
+                ],
                 cta,
+            },
+        },
+        {
+            ...baseAbandonedBasketVariant,
+            name: 'v2',
+            bannerContent: {
+                heading: 'Unfinished business?',
+                paragraphs: [
+                    'Your support is incredibly important to us and helps us keep our independent journalism open for all. Please consider finalising your support today.',
+                ],
             },
         },
     ],

--- a/packages/server/src/tests/banners/abandonedBasketTests.ts
+++ b/packages/server/src/tests/banners/abandonedBasketTests.ts
@@ -24,6 +24,10 @@ const cta = {
     text: 'Return to checkout',
 };
 
+const paragraphs = [
+    'Your support is incredibly important to us and helps us keep our independent journalism open for all. Please consider finalising your support today.',
+];
+
 const abandonedBasketTest: BannerTest = {
     ...baseAbandonedBasketTest,
     name: 'banner-abandoned-basket',
@@ -33,9 +37,7 @@ const abandonedBasketTest: BannerTest = {
             name: 'v1',
             bannerContent: {
                 heading: 'Finish your order',
-                paragraphs: [
-                    'Your support is incredibly important to us and helps us keep our independent journalism open for all. Please consider finalising your support today.',
-                ],
+                paragraphs,
                 cta,
             },
         },
@@ -44,9 +46,8 @@ const abandonedBasketTest: BannerTest = {
             name: 'v2',
             bannerContent: {
                 heading: 'Unfinished business?',
-                paragraphs: [
-                    'Your support is incredibly important to us and helps us keep our independent journalism open for all. Please consider finalising your support today.',
-                ],
+                paragraphs,
+                cta,
             },
         },
     ],


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add finalised copy for abandoned basket banner variants.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- Add cookie to browser by visiting https://support.theguardian.com/uk/contribute#ab-abandonedBasket=variant
- `showMeTheBanner`
- See abandoned basket banner

## Images

v1
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/e08134f0-e1c5-4ff6-aeb7-4a652cd0f621)

v2
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/d6d5cef7-cd5b-4ec4-9bf5-6c410ec417ff)<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

