### PR TITLE
Live Blog Epic - update newsletter sign up props

### DIFF
--- a/packages/dotcom/.changeset/gorgeous-bulldogs-fix.md
+++ b/packages/dotcom/.changeset/gorgeous-bulldogs-fix.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+adding in newsletter sign up component

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -90,7 +90,8 @@ const selectedAmountsVariantSchema = z.object({
 });
 
 const newsletterSignupSchema = z.object({
-    url: z.string(),
+    newsletterUrl: z.string(),
+    text: z.string(),
 });
 
 export const variantSchema = z.object({

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -46,16 +46,6 @@ export const secondaryCtaSchema = z.discriminatedUnion('type', [
     contributionsReminderSecondaryCtaSchema,
 ]);
 
-export interface NewsletterSignup {
-    text: string;
-    newsletterUrl: string;
-}
-
-export const newsletterSignupSchema = z.object({
-    text: z.string(),
-    newsletterUrl: z.string(),
-});
-
 export enum TickerEndType {
     unlimited = 'unlimited',
     hardstop = 'hardstop', // currently unsupported

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -46,6 +46,16 @@ export const secondaryCtaSchema = z.discriminatedUnion('type', [
     contributionsReminderSecondaryCtaSchema,
 ]);
 
+export interface NewsletterSignup {
+    text: string;
+    newsletterUrl: string;
+}
+
+export const newsletterSignupSchema = z.object({
+    text: z.string(),
+    newsletterUrl: z.string(),
+});
+
 export enum TickerEndType {
     unlimited = 'unlimited',
     hardstop = 'hardstop', // currently unsupported


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
aligns the newsletter sign up component in the epic.props and updates the SDC version
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Released onto Code and triggered an Epic on an article to make sure that they still work as expected.
![image](https://github.com/guardian/support-dotcom-components/assets/115992455/e9b5535d-a0b1-4497-bd6b-a2abe8a34499)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
