### PR TITLE
Hide choice cards when we think ios app banner is present

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { css } from '@emotion/react';
 import {
     neutral,
@@ -198,11 +198,28 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
     const isTabletOrAbove = useMediaQuery(from.tablet);
     const mainOrMobileContent = isTabletOrAbove ? content.mainContent : content.mobileContent;
 
+    const iosAppBannerPresent = window.innerHeight != window.document.documentElement.clientHeight;
+
+    useEffect(() => {
+        if (iosAppBannerPresent) {
+            // send ophan event
+            if (submitComponentEvent) {
+                submitComponentEvent({
+                    component: {
+                        componentType: 'ACQUISITIONS_OTHER',
+                        id: 'safari-ios-banner-present',
+                    },
+                    action: 'VIEW',
+                });
+            }
+        }
+    }, []);
+
     const { choiceCardSelection, setChoiceCardSelection, getCtaText, getCtaUrl, currencySymbol } =
         useChoiceCards(choiceCardAmounts, countryCode, content);
-    const showChoiceCards = !!(
-        templateSettings.choiceCardSettings && choiceCardAmounts?.amountsCardData
-    );
+    const showChoiceCards =
+        !!(templateSettings.choiceCardSettings && choiceCardAmounts?.amountsCardData) &&
+        !iosAppBannerPresent;
 
     const getHeaderContainerCss = () => {
         if (!!templateSettings?.headerSettings?.headerImage) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds detection for the ios Safari app banner, and hides the choice cards if so (and send an ophan event).

## Why are we doing this?

When the RRCP banner is at `max-height: 90vh` and the ios Safari app banner is present the close button becomes blocked.

[Trello](https://trello.com/c/EnnzXAHB/510-make-rrcp-banner-smaller-if-safari-app-banner-shows)
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

We tested in storybook by setting the window.innerHeight to a smaller value in the storybook code. (ie added `window.innerHeight = 900;` to `DesignableBanner.stories.tsx`

We'll test in `CODE` to see that the banner renders as normal.

But we'll have to test in prod on an iPhone to check that this actually works

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
