### PR TITLE
Fix CTA on mobile safari

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -274,7 +274,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         />
                     )}
 
-                    {!templateSettings.choiceCardSettings && (
+                    {!showChoiceCards && (
                         <DesignableBannerCtas
                             mainOrMobileContent={mainOrMobileContent}
                             onPrimaryCtaClick={onCtaClick}


### PR DESCRIPTION
We're now hiding the choice cards if the safari "open in app" banner is detected.
However, the other CTA also fails to render.

Fixed -
<img width="377" alt="Screenshot 2024-06-17 at 15 10 12" src="https://github.com/guardian/support-dotcom-components/assets/1513454/39b1557a-29b0-4b1b-9f6c-71ebda1056d0">
