### PR TITLE
Abandoned Basket: target non-supporters only

### DIFF
--- a/packages/server/src/tests/banners/abandonedBasketTests.ts
+++ b/packages/server/src/tests/banners/abandonedBasketTests.ts
@@ -4,7 +4,7 @@ import type { BannerTest, BannerTestGenerator, BannerVariant } from '@sdc/shared
 const baseAbandonedBasketTest: Omit<BannerTest, 'name' | 'variants'> = {
     bannerChannel: 'abandonedBasket',
     isHardcoded: true,
-    userCohort: 'Everyone',
+    userCohort: 'AllNonSupporters',
     // We can use this as the feature switch
     status: 'Live',
     priority: 99,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Banner test should only target non-supporters
