### PR TITLE
Lower banner height if app banner showing

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -199,8 +199,8 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
     const isTabletOrAbove = useMediaQuery(from.tablet);
     const mainOrMobileContent = isTabletOrAbove ? content.mainContent : content.mobileContent;
 
-    // We can use this to shorten the banner if the "open in app" banner is present. We're not currently doing this though
-    const iosAppBannerPresent = window.innerHeight != window.document.documentElement.clientHeight;
+    // We can use this to shorten the banner if the "open in app" banner is present
+    const iosAppBannerPresent = window.innerHeight === window.document.documentElement.clientHeight;
 
     useEffect(() => {
         if (iosAppBannerPresent) {
@@ -246,6 +246,7 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
         <div
             css={styles.outerContainer(
                 templateSettings.containerSettings.backgroundColour,
+                iosAppBannerPresent,
                 templateSettings.containerSettings.textColor,
             )}
         >
@@ -378,10 +379,14 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
 };
 
 const styles = {
-    outerContainer: (background: string, textColor: string = 'inherit') => css`
+    outerContainer: (
+        background: string,
+        limitHeight: boolean,
+        textColor: string = 'inherit',
+    ) => css`
         background: ${background};
         color: ${textColor};
-        max-height: 100vh;
+        max-height: ${limitHeight ? '70vh' : '100vh'};
         overflow: auto;
         * {
             box-sizing: border-box;


### PR DESCRIPTION
If we detect that the iOS "open in app" banner is displaying, limit the RRCP banner height to 70vh
There will be a separate PR in DCR to raise the overall max-height to 90vh