### PR TITLE
Update newsletter signup fields

### DIFF
--- a/packages/dotcom/.changeset/nervous-timers-travel.md
+++ b/packages/dotcom/.changeset/nervous-timers-travel.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+Change newsletter signup model

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -73,7 +73,8 @@ const selectedAmountsVariantSchema = z.object({
 });
 
 const newsletterSignupSchema = z.object({
-    url: z.string(),
+    newsletterId: z.string(),
+    successDescription: z.string(),
 });
 
 export const variantSchema = z.object({


### PR DESCRIPTION
We're changing our approach to the newsletter signup in the epic. DCR now has a component into which we can pass the `newsletterId`