### PR TITLE
Fix zod wildcard imports and bump rollup commonJS

### DIFF
--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -33,7 +33,7 @@
     "@emotion/babel-preset-css-prop": "^11.2.0",
     "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-babel": "^5.2.3",
-    "@rollup/plugin-commonjs": "^12.0.0",
+    "@rollup/plugin-commonjs": "15.0.0",
     "@rollup/plugin-json": "^4.0.3",
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@rollup/plugin-typescript": "^8.2.0",

--- a/packages/server/src/bandit/banditData.ts
+++ b/packages/server/src/bandit/banditData.ts
@@ -2,7 +2,7 @@ import { isProd } from '../lib/env';
 import * as AWS from 'aws-sdk';
 import { buildReloader, ValueProvider } from '../utils/valueReloader';
 import { EpicTest } from '@sdc/shared/dist/types';
-import * as z from 'zod';
+import { z } from 'zod';
 import { logError } from '../utils/logging';
 import { putMetric } from '../utils/cloudwatch';
 

--- a/packages/server/src/tests/amp/ampEpicModels.ts
+++ b/packages/server/src/tests/amp/ampEpicModels.ts
@@ -1,6 +1,6 @@
 import { ContributionFrequency, SecondaryCta, secondaryCtaSchema } from '@sdc/shared/types';
 import { AMPTicker } from './ampTicker';
-import * as z from 'zod';
+import { z } from 'zod';
 import {
     contributionFrequencySchema,
     ctaSchema,

--- a/packages/shared/src/lib/geolocation.ts
+++ b/packages/shared/src/lib/geolocation.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import { z } from 'zod';
 
 export const CountryGroupId = [
     'GBPCountries',

--- a/packages/shared/src/types/abTests/banner.ts
+++ b/packages/shared/src/types/abTests/banner.ts
@@ -15,7 +15,7 @@ import {
 import { countryGroupIdSchema } from '../../lib';
 import { BannerTargeting, PageTracking } from '../targeting';
 import { PurchaseInfoTest } from './shared';
-import * as z from 'zod';
+import { z } from 'zod';
 import { OphanComponentType, OphanProduct } from '@guardian/libs';
 
 export enum BannerTemplate {

--- a/packages/shared/src/types/abTests/epic.ts
+++ b/packages/shared/src/types/abTests/epic.ts
@@ -7,7 +7,7 @@ import {
 } from './shared';
 import { EpicTargeting } from '../targeting';
 import { variantSchema } from '../props';
-import * as z from 'zod';
+import { z } from 'zod';
 
 export type EpicType = 'ARTICLE' | 'LIVEBLOG';
 

--- a/packages/shared/src/types/abTests/header.ts
+++ b/packages/shared/src/types/abTests/header.ts
@@ -1,7 +1,7 @@
 import { testSchema, userCohortSchema, purchaseInfoTestSchema } from './shared';
 import { headerContentSchema } from '../props';
 import { countryGroupIdSchema } from '../../lib';
-import * as z from 'zod';
+import { z } from 'zod';
 
 /**
  * Models and schemas for data from the database

--- a/packages/shared/src/types/abTests/shared.ts
+++ b/packages/shared/src/types/abTests/shared.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import { z } from 'zod';
 import {
     purchaseInfoProduct,
     purchaseInfoProductSchema,

--- a/packages/shared/src/types/props/banner.ts
+++ b/packages/shared/src/types/props/banner.ts
@@ -12,7 +12,7 @@ import {
     Tracking,
     trackingSchema,
 } from './shared';
-import * as z from 'zod';
+import { z } from 'zod';
 import { Prices } from '../prices';
 import { SelectedAmountsVariant } from '../abTests';
 import { ConfigurableDesign, configurableDesignSchema } from './design';

--- a/packages/shared/src/types/props/design.ts
+++ b/packages/shared/src/types/props/design.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import { z } from 'zod';
 
 const hexValueRegex = /^[0-9A-F]{2}$/;
 

--- a/packages/shared/src/types/props/epic.ts
+++ b/packages/shared/src/types/props/epic.ts
@@ -1,5 +1,5 @@
 import { JSX } from '@emotion/react/jsx-runtime';
-import * as z from 'zod';
+import { z } from 'zod';
 import {
     articleCountsSchema,
     bylineWithImageSchema,

--- a/packages/shared/src/types/props/header.ts
+++ b/packages/shared/src/types/props/header.ts
@@ -1,5 +1,5 @@
 import { JSX } from '@emotion/react/jsx-runtime';
-import * as z from 'zod';
+import { z } from 'zod';
 import { OphanComponentEvent } from '@guardian/libs';
 
 import { Tracking, trackingSchema, Cta, ctaSchema } from './shared';

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import { z } from 'zod';
 import { PageTracking } from '../targeting';
 import { TestTracking } from '../abTests';
 

--- a/packages/shared/src/types/purchaseInfo.ts
+++ b/packages/shared/src/types/purchaseInfo.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import { z } from 'zod';
 
 const purchaseInfoProduct = ['Contribution', 'SupporterPlus', 'GuardianWeekly', 'Paper'] as const;
 export type purchaseInfoProduct = (typeof purchaseInfoProduct)[number];

--- a/packages/shared/src/types/targeting/shared.ts
+++ b/packages/shared/src/types/targeting/shared.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import { z } from 'zod';
 import { purchaseInfoProduct, purchaseInfoUser } from '../purchaseInfo';
 
 export type PageTracking = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3231,18 +3231,18 @@
     "@babel/helper-module-imports" "^7.10.4"
     "@rollup/pluginutils" "^3.1.0"
 
-"@rollup/plugin-commonjs@^12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-12.0.0.tgz#e2f308ae6057499e0f413f878fff7c3a0fdc02a1"
-  integrity sha512-8+mDQt1QUmN+4Y9D3yCG8AJNewuTSLYPJVzKKUZ+lGeQrI+bV12Tc5HCyt2WdlnG6ihIL/DPbKRJlB40DX40mw==
+"@rollup/plugin-commonjs@15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-15.0.0.tgz#690d15a9d54ba829db93555bff9b98ff34e08574"
+  integrity sha512-8uAdikHqVyrT32w1zB9VhW6uGwGjhKgnDNP4pQJsjdnyF4FgCj6/bmv24c7v2CuKhq32CcyCwRzMPEElaKkn0w==
   dependencies:
-    "@rollup/pluginutils" "^3.0.8"
+    "@rollup/pluginutils" "^3.1.0"
     commondir "^1.0.1"
-    estree-walker "^1.0.1"
-    glob "^7.1.2"
-    is-reference "^1.1.2"
-    magic-string "^0.25.2"
-    resolve "^1.11.0"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
 
 "@rollup/plugin-commonjs@^14.0.0":
   version "14.0.0"
@@ -7822,6 +7822,11 @@ estree-walker@^1.0.0, estree-walker@^1.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
+estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -9402,7 +9407,7 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
-is-reference@^1.1.2, is-reference@^1.1.4:
+is-reference@^1.1.2, is-reference@^1.1.4, is-reference@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
   integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
@@ -13453,7 +13458,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13470,6 +13475,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.1.1:
   version "2.1.1"
@@ -13580,7 +13594,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13614,6 +13628,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -14967,7 +14988,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -14997,6 +15018,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Change Zod wildcard imports from `import * as z from 'zod'` to `import { z } from 'zod'`, and bump `@rollup/plugin-commonjs`. 

## Why

Importing with the wildcard is not standard and draws attention in PRs, but isn't really a problem. However previously if you did `import {z}` - as your IDE autocomplete will probably suggest - you will see a runtime error in DCR and support components won't load ([see previous fix](https://github.com/guardian/support-dotcom-components/commit/6547348113888f9d85241ef7029d9e45dd90dcc5)).

The error message is not very helpful "Cannot read properties of undefined (reading 'object')". So in DCR I logged the error's stacktrace and saw it came from a rollup function with this error message ([stackoverflow](https://stackoverflow.com/questions/63691616/how-to-track-down-dynamic-requires-are-not-currently-supported-by-rollup-plugin)). I tried the suggestion of bumping the rollup CommonJS package to 15.0 and it worked!

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Build the modules `yarn modules build`
Run the server `yarn server start`
Run local DCR pointing to local SDC server

See images for what happened when using `import { z }` before and after bumping the package

Tested on CODE

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

I checked the logs for a potential dependency mismatch after bumping just one rollup package but it didn't seem to have any

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
DCR console logs
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/63564464-8903-458c-a0df-edcde17979f0)
DCR Header
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/b0626e64-4089-4e6b-abd4-072e1c811c89)

After
(No errors logged)
![image](https://github.com/guardian/support-dotcom-components/assets/114918544/04e4dc5c-7343-4c1f-8667-2ce1b8cb1a8d)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
