### PR TITLE
Use position sticky for close button

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -258,6 +258,12 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         headerSettings={templateSettings.headerSettings}
                     />
                 </div>
+                <DesignableBannerCloseButton
+                    onCloseClick={onCloseClick}
+                    settings={templateSettings.closeButtonSettings}
+                    styleOverides={styles.closeButtonOverrides(!!templateSettings.imageSettings)}
+                />
+
                 <div css={styles.contentContainer(showReminder)}>
                     {showAboveArticleCount && (
                         <DesignableBannerArticleCount
@@ -292,33 +298,21 @@ const DesignableBanner: ReactComponent<BannerRenderProps> = ({
                         />
                     )}
                 </div>
-                {templateSettings.imageSettings ? (
+                {templateSettings.imageSettings && (
                     <div
                         css={styles.bannerVisualContainer(
                             templateSettings.containerSettings.backgroundColour,
                         )}
                     >
-                        <DesignableBannerCloseButton
-                            onCloseClick={onCloseClick}
-                            settings={templateSettings.closeButtonSettings}
-                            styleOverides={styles.closeButtonOverrides(false)}
-                        />
                         <DesignableBannerVisual
                             settings={templateSettings.imageSettings}
                             bannerId={templateSettings.bannerId}
                         />
-
                         {/*
                         I think `alternativeVisual` was for using SVG as the image, which is currently beyond the scope of the design tool. Suggest we remove?
                     */}
                         {templateSettings.alternativeVisual}
                     </div>
-                ) : (
-                    <DesignableBannerCloseButton
-                        onCloseClick={onCloseClick}
-                        settings={templateSettings.closeButtonSettings}
-                        styleOverides={styles.closeButtonOverrides(true)}
-                    />
                 )}
                 {showChoiceCards && (
                     <div
@@ -387,7 +381,6 @@ const styles = {
         background: ${background};
         color: ${textColor};
         ${limitHeight ? 'max-height: 70vh;' : ''}
-        overflow: auto;
         * {
             box-sizing: border-box;
         }
@@ -400,13 +393,15 @@ const styles = {
         }
     `,
     containerOverrides: css`
-        display: flex;
-        flex-direction: column;
         position: relative;
         padding: 0 10px;
+        display: grid;
+
+        ${until.tablet} {
+            grid-template-columns: auto;
+        }
         ${from.tablet} {
             position: static;
-            display: grid;
             grid-template-columns: 1fr 280px;
             grid-template-rows: auto 1fr auto;
             column-gap: ${space[5]}px;
@@ -427,10 +422,13 @@ const styles = {
     `,
     closeButtonOverrides: (isGridCell: boolean) => css`
         ${until.tablet} {
-            position: fixed;
+            position: sticky;
+            top: 0;
             margin-top: ${space[3]}px;
             padding-right: 10px;
             right: 0;
+            grid-row: 1;
+            grid-column: 1;
         }
         ${from.tablet} {
             margin-top: ${space[3]}px;
@@ -484,6 +482,10 @@ const styles = {
     bannerVisualContainer: (background: string) => css`
         order: 1;
         background: ${background};
+        ${until.tablet} {
+            grid-row: 1;
+            grid-column: 1;
+        }
         ${from.tablet} {
             grid-column: 2;
             grid-row: 1 / span 2;

--- a/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/DesignableBanner.tsx
@@ -401,7 +401,6 @@ const styles = {
             grid-template-columns: auto;
         }
         ${from.tablet} {
-            position: static;
             grid-template-columns: 1fr 280px;
             grid-template-rows: auto 1fr auto;
             column-gap: ${space[5]}px;
@@ -423,7 +422,7 @@ const styles = {
     closeButtonOverrides: (isGridCell: boolean) => css`
         ${until.tablet} {
             position: sticky;
-            top: 0;
+            top: ${space[3]}px;
             margin-top: ${space[3]}px;
             padding-right: 10px;
             right: 0;
@@ -449,6 +448,12 @@ const styles = {
         order: ${bannerHasImage ? '2' : '1'};
         ${until.tablet} {
             ${bannerHasImage ? '' : `max-width: calc(100% - 40px - ${space[3]}px);`}
+            ${bannerHasImage
+                ? ''
+                : css`
+                      grid-row: 1;
+                      grid-column: 1;
+                  `}
         }
 
         ${from.tablet} {
@@ -487,6 +492,7 @@ const styles = {
             grid-column: 1;
         }
         ${from.tablet} {
+            margin-top: ${space[10]}px;
             grid-column: 2;
             grid-row: 1 / span 2;
             align-self: flex-start;
@@ -516,14 +522,15 @@ const styles = {
     `,
     reminderContainer: css`
         ${body.small({ lineHeight: 'regular' })};
-        grid-column: 1;
-        grid-row: 3;
         order: 4;
-        align-self: center;
+        justify-self: center;
         margin-top: ${space[2]}px;
 
         ${from.tablet} {
             align-self: end;
+            justify-self: start;
+            grid-column: 1;
+            grid-row: 3;
         }
     `,
     reminderText: css`

--- a/packages/modules/src/modules/banners/designableBanner/styles/templateStyles.ts
+++ b/packages/modules/src/modules/banners/designableBanner/styles/templateStyles.ts
@@ -3,10 +3,10 @@ import { space, from } from '@guardian/source/foundations';
 
 const templateSpacing = {
     bannerContainer: css`
-        margin-bottom: ${space[4]}px;
+        padding-bottom: ${space[4]}px;
 
         ${from.tablet} {
-            margin-bottom: ${space[3]}px;
+            padding-bottom: ${space[3]}px;
         }
     `,
     bannerHeader: css`


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Use position sticky instead of position fixed to place the close button. There's an issue on some browsers where the close button jumps out of place when scrolling the banner/page. See [Trello ticket](https://trello.com/c/gSzqd66Y/174-banner-close-button-jumps-when-scrolling-on-some-browsers
). I'd like to see if this approach could fix the issue.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Should be no visual regressions
I will deploy to CODE and test on my Android phone (where I have reproduced the existing issue)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Result 

Success! The janky button jumping is gone when I scroll. Obviously there are some visual regressions in this PR so far but we might be on to something with the `position:sticky`

