### PR TITLE
Fix Article Count Opt Out on banners for top readers

### DIFF
--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, headline, palette } from '@guardian/source/foundations';
+import { from, headline } from '@guardian/source/foundations';
 import { DesignableBannerArticleCountOptOut } from './DesignableBannerArticleCountOptOut';
 import { BannerTemplateSettings } from '../settings';
 import {

--- a/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
+++ b/packages/modules/src/modules/banners/designableBanner/components/DesignableBannerArticleCount.tsx
@@ -27,7 +27,12 @@ export function DesignableBannerArticleCount({
         return (
             <div css={styles.container(settings.articleCountTextColour)}>
                 Congratulations on being one of our top readers globally – you&apos;ve read{' '}
-                <span css={optOutContainer}>{numArticles} articles</span> in the last year
+                <DesignableBannerArticleCountOptOut
+                    numArticles={numArticles}
+                    nextWord=" articles"
+                    settings={settings}
+                />{' '}
+                in the last year
             </div>
         );
     } else {
@@ -58,7 +63,3 @@ const styles = {
         }
     `,
 };
-
-const optOutContainer = css`
-    color: ${palette.opinion[400]};
-`;


### PR DESCRIPTION
## What does this change?

The Article Count Opt out link options were not visible for the readers with more than 50 article counts on the banners 

## Images
## Before Change

<img width="1726" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/73653255/353e094f-9d45-4de6-84a2-f73ac0d053b7">

## After Change

<img width="1726" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/73653255/e603515e-5f90-4320-bf39-309cb7b04ab9">

<img width="1726" alt="image" src="https://github.com/guardian/support-dotcom-components/assets/73653255/c93cf3ef-2123-4e73-b61c-ecab8e59f8ca">
