### PR TITLE
Scale up for election

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -109,7 +109,7 @@ Object {
           },
         },
         "MaxSize": "18",
-        "MinSize": "3",
+        "MinSize": "6",
         "Tags": Array [
           Object {
             "Key": "App",

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -210,7 +210,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
 		];
 
 		const scaling: GuAsgCapacity = {
-			minimumInstances: this.stage === 'CODE' ? 1 : 3,
+			minimumInstances: this.stage === 'CODE' ? 1 : 6,
 			maximumInstances: this.stage === 'CODE' ? 2 : 18,
 		};
 


### PR DESCRIPTION
We already have autoscaling, but let's start with 6 instances instead of the normal 3

2019 election web traffic -
<img width="607" alt="Screenshot 2024-07-03 at 10 35 40" src="https://github.com/guardian/support-dotcom-components/assets/1513454/c94dcbea-4dd8-4bda-8830-44dd43b0b2b2">
