### PR TITLE
Fix the issue of region getting appended to GW checkout url on clicking Live preview 

### DIFF
--- a/packages/shared/src/lib/geolocation.ts
+++ b/packages/shared/src/lib/geolocation.ts
@@ -610,9 +610,6 @@ const countryCodeToSupportRegionId = (countryCode: string): SupportRegionId =>
 export const isGWCheckoutUrl = (baseUrl: string): boolean => /subscribe\/weekly\/checkout/.test(baseUrl);
 
 export const addRegionIdToSupportUrl = (originalUrl: string, countryCode?: string): string => {
-    console.log("originalUrl: ", originalUrl);
-    console.log("countryCode: ", countryCode);
-    console.log("isGWCheckoutUrl(originalUrl): ", isGWCheckoutUrl(originalUrl));
     if (countryCode) {
         const supportRegionId = countryCodeToSupportRegionId(countryCode);
         if (supportRegionId && !isGWCheckoutUrl(originalUrl)) {

--- a/packages/shared/src/lib/geolocation.ts
+++ b/packages/shared/src/lib/geolocation.ts
@@ -607,10 +607,15 @@ export const getCountryName = (geolocation?: string): string | undefined => {
 const countryCodeToSupportRegionId = (countryCode: string): SupportRegionId =>
     countryGroups[countryCodeToCountryGroupId(countryCode)]?.supportRegionId;
 
+export const isGWCheckoutUrl = (baseUrl: string): boolean => /subscribe\/weekly\/checkout/.test(baseUrl);
+
 export const addRegionIdToSupportUrl = (originalUrl: string, countryCode?: string): string => {
+    console.log("originalUrl: ", originalUrl);
+    console.log("countryCode: ", countryCode);
+    console.log("isGWCheckoutUrl(originalUrl): ", isGWCheckoutUrl(originalUrl));
     if (countryCode) {
         const supportRegionId = countryCodeToSupportRegionId(countryCode);
-        if (supportRegionId) {
+        if (supportRegionId && !isGWCheckoutUrl(originalUrl)) {
             return originalUrl.replace(
                 /(support.theguardian.com)\/(contribute-in-epic|contribute|subscribe)/,
                 (_, domain, path) => `${domain}/${supportRegionId.toLowerCase()}/${path}`,

--- a/packages/shared/src/lib/geolocation.ts
+++ b/packages/shared/src/lib/geolocation.ts
@@ -607,7 +607,8 @@ export const getCountryName = (geolocation?: string): string | undefined => {
 const countryCodeToSupportRegionId = (countryCode: string): SupportRegionId =>
     countryGroups[countryCodeToCountryGroupId(countryCode)]?.supportRegionId;
 
-export const isGWCheckoutUrl = (baseUrl: string): boolean => /subscribe\/weekly\/checkout/.test(baseUrl);
+export const isGWCheckoutUrl = (baseUrl: string): boolean =>
+    /subscribe\/weekly\/checkout/.test(baseUrl);
 
 export const addRegionIdToSupportUrl = (originalUrl: string, countryCode?: string): string => {
     if (countryCode) {


### PR DESCRIPTION
## What does this change?
Fix the issue of Banner CTAs for Guardian Weekly returning a 404 error

An issue occurred while setting up a banner test and using links, [like this one](https://support.theguardian.com/subscribe/weekly/checkout?threeTierCreateSupporterPlusSubscription=true&period=Monthly&promoCode=3TIER_WEEKLY_UK_MONTHLY_V2), to the second step of the checkout, giving a 404 error when clicking through on the banner.

On investigating , we understood that clicking the Live /Web preview in RRCP appends the region code to the url entered in the Button Destination box in the RRCP.
we have a check in support site as part of enabling/ disabling threeTierCheckout to see if window.location.pathname starts with '/subscribe/weekly/checkout' .That check fails as in this case it is pathname comes as /uk/subscribe/weekly/checkout', thus giving 404 .
‌
So we need to stop adding the region to the url for GW checkout 

## Before
<img width="1592" alt="image" src="https://github.com/user-attachments/assets/72ac55ff-2fdd-4fe2-aaa0-e29e7d1539a2">

