### PR TITLE
Add new tag for investigation

### DIFF
--- a/packages/dotcom/.changeset/plenty-carrots-melt.md
+++ b/packages/dotcom/.changeset/plenty-carrots-melt.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+Add new tag for investigations

--- a/packages/shared/src/lib/history.ts
+++ b/packages/shared/src/lib/history.ts
@@ -84,6 +84,7 @@ const tagsOfInterest = new Set<string>([
     'football/football',
     'sport/olympic-games',
     'sport/olympic-games-2024',
+    'tracking/commissioningdesk/uk-investigations',
 ]);
 
 /**


### PR DESCRIPTION

## What does this change?
Add new tag for investigation to the list of tags we track in WeeklyArticleHistory