### PR TITLE
Exports for banner migration to DCR

### DIFF
--- a/packages/dotcom/.changeset/short-stingrays-juggle.md
+++ b/packages/dotcom/.changeset/short-stingrays-juggle.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+Exports for banners migration

--- a/packages/dotcom/src/index.ts
+++ b/packages/dotcom/src/index.ts
@@ -12,8 +12,10 @@ export {
     TickerCountType,
     TickerEndType,
 } from '../../shared/src/types/props/shared';
+export { hexColourToString } from '../../shared/src/types/props/design';
 export { contributionTabFrequencies } from '../../shared/src/types/abTests/epic';
 export { headerPropsSchema } from '../../shared/src/types/props/header';
 export { epicPropsSchema } from '../../shared/src/types/props/epic';
+export { bannerSchema } from '../../shared/src/types/props/banner';
 export { abandonedBasketSchema } from '../../shared/src/types/targeting/shared';
 export * from './requests';

--- a/packages/dotcom/src/types.ts
+++ b/packages/dotcom/src/types.ts
@@ -8,3 +8,4 @@ export * from '../../shared/src/types/prices';
 export { EpicProps } from '../../shared/src/types/props/epic';
 export * from '../../shared/src/types/reminders';
 export { ModuleDataResponse, ModuleData } from './requests';
+export { Image } from '../../shared/src/types/props/shared';


### PR DESCRIPTION
We're moving the banner components over to DCR. [Draft PR here](https://github.com/guardian/dotcom-rendering/pull/12130).
To enable this we need to share a few things with DCR via the npm package.