### PR TITLE
Fix log file permission

### DIFF
--- a/packages/server/src/utils/logging.ts
+++ b/packages/server/src/utils/logging.ts
@@ -40,6 +40,8 @@ const log4jConfig = (layout: string): Configuration => ({
             backups: 5,
             compress: true,
             layout: { type: layout, separator: ',' },
+            // Owner Read & Write, Group Read
+            mode: 0o640,
         },
     },
     categories: {


### PR DESCRIPTION
The server stopped sending logs to kibana since the [storybook upgrade](https://github.com/guardian/support-dotcom-components/pull/1201).
This is because the local log file no longer has the right permissions.
This must be the result of an update to the `log4js` dependency, which has tightened up permissions.

We can fix this by using the [file mode](https://nodejs.org/dist/latest-v12.x/docs/api/fs.html#fs_file_modes) parameter in log4js.