### PR TITLE
Update to ticker model

### DIFF
--- a/packages/dotcom/.changeset/good-chefs-marry.md
+++ b/packages/dotcom/.changeset/good-chefs-marry.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+update to ticker models to include ticker styles

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -86,6 +86,22 @@ export type TickerName = 'US' | 'AU';
 
 const ticketNameSchema = z.enum(['US', 'AU']);
 
+export interface TickerStylingSettings {
+    headlineColour: string;
+    totalColour: string;
+    goalColour: string;
+    filledProgressColour: string;
+    progressBarBackgroundColour: string;
+}
+
+export const tickerStylingSettingsSchema = z.object({
+    headlineColour: z.string(),
+    totalColour: z.string(),
+    goalColour: z.string(),
+    filledProgressColour: z.string(),
+    progressBarBackgroundColour: z.string(),
+});
+
 export interface TickerSettings {
     endType: TickerEndType;
     countType: TickerCountType;
@@ -93,6 +109,7 @@ export interface TickerSettings {
     copy: TickerCopy;
     name: TickerName;
     tickerData?: TickerData;
+    tickerStylingSettings?: TickerStylingSettings;
 }
 
 export const tickerSettingsSchema = z.object({
@@ -102,6 +119,7 @@ export const tickerSettingsSchema = z.object({
     copy: tickerCopySchema,
     name: ticketNameSchema,
     tickerData: tickerDataSchema.optional(),
+    tickerStylingSettings: tickerStylingSettingsSchema.optional(),
 });
 
 export const articleCountsSchema = z.object({


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Update to the ticker model to have the ticker styling settings. This is a new addition from the source-development -kitchen which will allow for the ticker config to be customisable 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
tested on code to make sure it hasn't broken anything
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
