### PR TITLE
Cc/ticker model change

### DIFF
--- a/.changeset/twenty-students-push.md
+++ b/.changeset/twenty-students-push.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+update to the ticker copy model to have two optional feilds

--- a/packages/server/src/tests/amp/ampTicker.ts
+++ b/packages/server/src/tests/amp/ampTicker.ts
@@ -20,11 +20,11 @@ export const ampTicker = (tickerSettings: TickerSettings, tickerData: TickerData
         : undefined;
 
     const topLeft = goalReached
-        ? tickerSettings.copy.goalReachedPrimary
+        ? tickerSettings.copy.goalReachedPrimary || `${prefix}${tickerData.total.toLocaleString()}`
         : `${prefix}${tickerData.total.toLocaleString()}`;
 
     const bottomLeft = goalReached
-        ? tickerSettings.copy.goalReachedSecondary
+        ? tickerSettings.copy.goalReachedSecondary || tickerSettings.copy.countLabel
         : tickerSettings.copy.countLabel;
 
     const topRight = goalReached

--- a/packages/server/src/tests/amp/ampTicker.ts
+++ b/packages/server/src/tests/amp/ampTicker.ts
@@ -20,11 +20,11 @@ export const ampTicker = (tickerSettings: TickerSettings, tickerData: TickerData
         : undefined;
 
     const topLeft = goalReached
-        ? tickerSettings.copy.goalReachedPrimary || `${prefix}${tickerData.total.toLocaleString()}`
+        ? tickerSettings.copy.goalReachedPrimary
         : `${prefix}${tickerData.total.toLocaleString()}`;
 
     const bottomLeft = goalReached
-        ? tickerSettings.copy.goalReachedSecondary || tickerSettings.copy.countLabel
+        ? tickerSettings.copy.goalReachedSecondary
         : tickerSettings.copy.countLabel;
 
     const topRight = goalReached

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -61,14 +61,14 @@ export const tickerCountTypeSchema = z.nativeEnum(TickerCountType);
 
 interface TickerCopy {
     countLabel: string;
-    goalReachedPrimary: string;
-    goalReachedSecondary: string;
+    goalReachedPrimary?: string;
+    goalReachedSecondary?: string;
 }
 
 export const tickerCopySchema = z.object({
     countLabel: z.string(),
-    goalReachedPrimary: z.string(),
-    goalReachedSecondary: z.string(),
+    goalReachedPrimary: z.string().optional(),
+    goalReachedSecondary: z.string().optional(),
 });
 
 export interface TickerData {

--- a/packages/shared/src/types/props/shared.ts
+++ b/packages/shared/src/types/props/shared.ts
@@ -61,14 +61,14 @@ export const tickerCountTypeSchema = z.nativeEnum(TickerCountType);
 
 interface TickerCopy {
     countLabel: string;
-    goalReachedPrimary?: string;
-    goalReachedSecondary?: string;
+    goalReachedPrimary: string;
+    goalReachedSecondary: string;
 }
 
 export const tickerCopySchema = z.object({
     countLabel: z.string(),
-    goalReachedPrimary: z.string().optional(),
-    goalReachedSecondary: z.string().optional(),
+    goalReachedPrimary: z.string(),
+    goalReachedSecondary: z.string(),
 });
 
 export interface TickerData {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Changes the model for the Ticker copy for some fields to be optional
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested locally with the changes on DCR and SAC. Checked that the banners and Epics are working as expected.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
