### PR TITLE
feat: add checkout to addRegionIdToSupportUrl

### DIFF
--- a/packages/shared/src/lib/geolocation.test.ts
+++ b/packages/shared/src/lib/geolocation.test.ts
@@ -32,6 +32,8 @@ describe('getCountryName', () => {
 
 describe('addRegionIdToSupportUrl', () => {
     const originalUrl = 'https://support.theguardian.com/contribute';
+    const checkoutUrl = 'https://support.theguardian.com/checkout';
+
     it('should modify the URL to include UK if country code is GB', () => {
         const countryCode = 'GB';
         const modifiedUrl = addRegionIdToSupportUrl(originalUrl, countryCode);
@@ -48,6 +50,24 @@ describe('addRegionIdToSupportUrl', () => {
         const countryCode = 'asdasd';
         const modifiedUrl = addRegionIdToSupportUrl(originalUrl, countryCode);
         expect(modifiedUrl).toEqual('https://support.theguardian.com/int/contribute');
+    });
+
+    it('should modify the URL to include UK if country code is GB and URL is checkout', () => {
+        const countryCode = 'GB';
+        const modifiedUrl = addRegionIdToSupportUrl(checkoutUrl, countryCode);
+        expect(modifiedUrl).toEqual('https://support.theguardian.com/uk/checkout');
+    });
+
+    it('should modify the URL to include EU if country code is PT and URL is checkout', () => {
+        const countryCode = 'PT';
+        const modifiedUrl = addRegionIdToSupportUrl(checkoutUrl, countryCode);
+        expect(modifiedUrl).toEqual('https://support.theguardian.com/eu/checkout');
+    });
+
+    it('should modify the URL to include INT if country code is unknown and URL is checkout', () => {
+        const countryCode = 'asdasd';
+        const modifiedUrl = addRegionIdToSupportUrl(checkoutUrl, countryCode);
+        expect(modifiedUrl).toEqual('https://support.theguardian.com/int/checkout');
     });
 
     it('should not modify the URL if country code is missing', () => {

--- a/packages/shared/src/lib/geolocation.ts
+++ b/packages/shared/src/lib/geolocation.ts
@@ -615,7 +615,7 @@ export const addRegionIdToSupportUrl = (originalUrl: string, countryCode?: strin
         const supportRegionId = countryCodeToSupportRegionId(countryCode);
         if (supportRegionId && !isGWCheckoutUrl(originalUrl)) {
             return originalUrl.replace(
-                /(support.theguardian.com)\/(contribute-in-epic|contribute|subscribe)/,
+                /(support.theguardian.com)\/(contribute-in-epic|contribute|subscribe|checkout)/,
                 (_, domain, path) => `${domain}/${supportRegionId.toLowerCase()}/${path}`,
             );
         }

--- a/packages/shared/src/lib/geolocation.ts
+++ b/packages/shared/src/lib/geolocation.ts
@@ -615,7 +615,7 @@ export const addRegionIdToSupportUrl = (originalUrl: string, countryCode?: strin
         const supportRegionId = countryCodeToSupportRegionId(countryCode);
         if (supportRegionId && !isGWCheckoutUrl(originalUrl)) {
             return originalUrl.replace(
-                /(support.theguardian.com)\/(contribute-in-epic|contribute|subscribe|checkout)/,
+                /(support\.theguardian\.com)\/(contribute-in-epic|contribute|subscribe|checkout)/,
                 (_, domain, path) => `${domain}/${supportRegionId.toLowerCase()}/${path}`,
             );
         }


### PR DESCRIPTION
## What does this change?
Adds the URL `/checkout` to the `addRegionIdToSupportUrl`.

This needs to be done before we can merge https://github.com/guardian/dotcom-rendering/pull/12403 that is moving from the generic checkout (`/contribute/checkout`) to the generic checkout (`/checkout`).

## How to test

Tests are provided in the test suite.

[This is used here in DCR](https://github.com/guardian/dotcom-rendering/blob/e2511167d3e3ca4ae83fd9f5e04f36bfa0c22b07/dotcom-rendering/src/components/marketing/lib/tracking.ts#L173).

## How can we measure success?
We unblock the above mentioned PR.

## Have we considered potential risks?

This is additive so should be good to go.

## Images

### Before code change
![Screenshot 2024-09-18 at 11 55 06](https://github.com/user-attachments/assets/5e59b84e-c8d5-44ea-a034-c27ac0d555c3)

### After code change
![Screenshot 2024-09-18 at 11 55 11](https://github.com/user-attachments/assets/83ebb6b4-d3b6-4cc7-ab80-2741b5226eb6)

