### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/dotcom-components.yml
+++ b/.github/workflows/dotcom-components.yml
@@ -93,7 +93,6 @@ jobs:
             - name: Release
               uses: changesets/action@v1
               with:
-                  cwd: packages/dotcom
                   publish: yarn changeset publish
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This was broken by the recent removal of yarn workspaces.
The workflow still had the old path.