### PR TITLE
Support querystring in AMP epic

### DIFF
--- a/src/server/api/ampEpicRouter.ts
+++ b/src/server/api/ampEpicRouter.ts
@@ -15,7 +15,7 @@ import { ValueProvider } from '../utils/valueReloader';
 import { TickerDataProvider } from '../lib/fetchTickerData';
 import { AmpEpicTest } from '../tests/amp/ampEpicModels';
 import { OphanComponentEvent } from '@guardian/libs';
-import { buildAmpEpicCampaignCode } from '../lib/tracking';
+import { addQueryParams, buildAmpEpicCampaignCode } from '../lib/tracking';
 
 const isSupportUrl = (baseUrl: string): boolean => /\bsupport\./.test(baseUrl);
 
@@ -136,10 +136,14 @@ export const buildAmpEpicRouter = (
                     },
                     referrerUrl: req.query.webUrl,
                 };
+
                 const ampState = {
-                    ctaUrl: `${epic.cta.url}?INTCMP=${
-                        epic.cta.campaignCode
-                    }&acquisitionData=${JSON.stringify(acquisitionData)}`,
+                    ctaUrl: addQueryParams(
+                        epic.cta.url,
+                        `INTCMP=${
+                            epic.cta.campaignCode
+                        }&acquisitionData=${JSON.stringify(acquisitionData)}`,
+                    ),
                     hidePaymentIcons: !isSupportUrl(epic.cta.url),
                     reminder: {
                         ...buildReminderFields(),

--- a/src/server/lib/tracking.ts
+++ b/src/server/lib/tracking.ts
@@ -10,3 +10,8 @@ export const buildBannerCampaignCode = (test: BannerTest, variant: BannerVariant
 
 export const buildAmpEpicCampaignCode = (testName: string, variantName: string): string =>
     `AMP__${testName}__${variantName}`;
+
+export const addQueryParams = (baseUrl: string, queryParams: string) => {
+    const alreadyHasQueryString = baseUrl.includes('?');
+    return `${baseUrl}${alreadyHasQueryString ? '&' : '?'}${queryParams}`;
+};


### PR DESCRIPTION
Currently we cannot add a querystring to the url in the RRCP. This is because SDC always adds another `?` onto it, so we get e.g.
`https://support.theguardian.com/contribute?promoCode=OCT_DISCOUNT_50_3_MONTHS?INTCMP=AMP__50_PERCENT__CONTROL&acquisitionData=...`