### PR TITLE
set packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,6 @@
     "peerDependencies": {
         "zod": "^3.22.4",
         "@guardian/libs": "^17.0.0"
-    }
+    },
+    "packageManager": "pnpm@8.15.7"
 }


### PR DESCRIPTION
We recently migrated to pnpm.
I've gone with the same version as DCR: https://github.com/guardian/dotcom-rendering/blob/main/package.json#L33C1-L33C34