### PR TITLE
Enable bandit testing on banners

### DIFF
--- a/src/server/api/bannerRouter.ts
+++ b/src/server/api/bannerRouter.ts
@@ -23,6 +23,7 @@ import { getDeviceType } from '../lib/deviceType';
 import { ValueProvider } from '../utils/valueReloader';
 import { getDesignForVariant } from '../tests/banners/channelBannerTests';
 import { buildBannerCampaignCode } from '../lib/tracking';
+import { BanditData } from '../bandit/banditData';
 
 interface BannerDataResponse {
     data?: {
@@ -43,6 +44,7 @@ export const buildBannerRouter = (
     bannerDeployTimes: BannerDeployTimesProvider,
     choiceCardAmounts: ValueProvider<AmountsTests>,
     bannerDesigns: ValueProvider<BannerDesignFromTool[]>,
+    banditData: ValueProvider<BanditData[]>,
 ): Router => {
     const router = Router();
 
@@ -68,6 +70,7 @@ export const buildBannerRouter = (
             bannerDeployTimes,
             enableHardcodedBannerTests,
             enableScheduledBannerDeploys,
+            banditData.get(),
             params.force,
         );
 

--- a/src/server/bandit/banditData.ts
+++ b/src/server/bandit/banditData.ts
@@ -117,7 +117,6 @@ function calculateBestVariants(variantMeans: BanditVariantData[]): BanditVariant
 
 async function buildBanditDataForTest<V extends Variant, T extends Test<V>>(
     test: T,
-    channel: ChannelTypes,
 ): Promise<BanditData> {
     if (test.variants.length === 0) {
         // No variants have been added to the test yet
@@ -127,7 +126,7 @@ async function buildBanditDataForTest<V extends Variant, T extends Test<V>>(
         };
     }
 
-    const samples = await getBanditSamplesForTest(test.name, channel);
+    const samples = await getBanditSamplesForTest(test.name, test.channel);
 
     if (samples.length === 0) {
         return getDefaultWeighting(test);
@@ -155,7 +154,7 @@ function buildBanditData(
     );
     return Promise.all(
         banditTests.map((test) =>
-            buildBanditDataForTest(test, test.channel).catch((error) => {
+            buildBanditDataForTest(test).catch((error) => {
                 logError(
                     `Error fetching bandit samples for test ${test.name} from Dynamo: ${error.message}`,
                 );

--- a/src/server/bandit/banditData.ts
+++ b/src/server/bandit/banditData.ts
@@ -1,11 +1,10 @@
 import { isProd } from '../lib/env';
 import * as AWS from 'aws-sdk';
 import { buildReloader, ValueProvider } from '../utils/valueReloader';
-import { BannerTest, EpicTest, Test, Variant } from '../../shared/types';
+import { BannerTest, Channel, EpicTest, Test, Variant } from '../../shared/types';
 import { z } from 'zod';
 import { logError } from '../utils/logging';
 import { putMetric } from '../utils/cloudwatch';
-import { ChannelTypes } from '../tests/store';
 
 const variantSampleSchema = z.object({
     variantName: z.string(),
@@ -28,7 +27,7 @@ const queryResultSchema = z.array(testSampleSchema);
 type TestSample = z.infer<typeof testSampleSchema>;
 
 // If sampleCount is not provided, all samples will be returned
-function queryForTestSamples(testName: string, channel: ChannelTypes, sampleCount?: number) {
+function queryForTestSamples(testName: string, channel: Channel, sampleCount?: number) {
     const docClient = new AWS.DynamoDB.DocumentClient({ region: 'eu-west-1' });
     return docClient
         .query({
@@ -44,10 +43,7 @@ function queryForTestSamples(testName: string, channel: ChannelTypes, sampleCoun
         .promise();
 }
 
-async function getBanditSamplesForTest(
-    testName: string,
-    channel: ChannelTypes,
-): Promise<TestSample[]> {
+async function getBanditSamplesForTest(testName: string, channel: Channel): Promise<TestSample[]> {
     const queryResult = await queryForTestSamples(testName, channel);
 
     const parsedResults = queryResultSchema.safeParse(queryResult.Items);

--- a/src/server/bandit/banditData.ts
+++ b/src/server/bandit/banditData.ts
@@ -1,10 +1,11 @@
 import { isProd } from '../lib/env';
 import * as AWS from 'aws-sdk';
 import { buildReloader, ValueProvider } from '../utils/valueReloader';
-import { EpicTest } from '../../shared/types';
+import { Test, Variant } from '../../shared/types';
 import { z } from 'zod';
 import { logError } from '../utils/logging';
 import { putMetric } from '../utils/cloudwatch';
+import { ChannelTypes } from '../tests/store';
 
 const variantSampleSchema = z.object({
     variantName: z.string(),
@@ -27,14 +28,15 @@ const queryResultSchema = z.array(testSampleSchema);
 type TestSample = z.infer<typeof testSampleSchema>;
 
 // If sampleCount is not provided, all samples will be returned
-function queryForTestSamples(testName: string, sampleCount?: number) {
+function queryForTestSamples(testName: string, channel: ChannelTypes, sampleCount?: number) {
     const docClient = new AWS.DynamoDB.DocumentClient({ region: 'eu-west-1' });
     return docClient
         .query({
             TableName: `support-bandit-${isProd ? 'PROD' : 'CODE'}`,
             KeyConditionExpression: 'testName = :testName',
             ExpressionAttributeValues: {
-                ':testName': testName,
+                // In the bandit data table we prefix the testName with the channel
+                ':testName': `${channel}_${testName}`,
             },
             ScanIndexForward: false, // newest first
             ...(sampleCount ? { Limit: sampleCount } : {}),
@@ -42,8 +44,11 @@ function queryForTestSamples(testName: string, sampleCount?: number) {
         .promise();
 }
 
-async function getBanditSamplesForTest(testName: string): Promise<TestSample[]> {
-    const queryResult = await queryForTestSamples(testName);
+async function getBanditSamplesForTest(
+    testName: string,
+    channel: ChannelTypes,
+): Promise<TestSample[]> {
+    const queryResult = await queryForTestSamples(testName, channel);
 
     const parsedResults = queryResultSchema.safeParse(queryResult.Items);
 
@@ -64,20 +69,23 @@ export interface BanditData {
     bestVariants: BanditVariantData[]; // will contain more than 1 variant if there is a tie
 }
 
-function getDefaultWeighting(epicTest: EpicTest): BanditData {
+function getDefaultWeighting<V extends Variant, T extends Test<V>>(test: T): BanditData {
     // No samples yet, set all means to zero to allow random selection
     return {
-        testName: epicTest.name,
-        bestVariants: epicTest.variants.map((variant) => ({
+        testName: test.name,
+        bestVariants: test.variants.map((variant) => ({
             variantName: variant.name,
             mean: 0,
         })),
     };
 }
 
-function calculateMeanPerVariant(samples: TestSample[], epicTest: EpicTest): BanditVariantData[] {
+function calculateMeanPerVariant<V extends Variant, T extends Test<V>>(
+    samples: TestSample[],
+    test: T,
+): BanditVariantData[] {
     const allVariantSamples = samples.flatMap((sample) => sample.variants);
-    const variantNames = epicTest.variants.map((variant) => variant.name);
+    const variantNames = test.variants.map((variant) => variant.name);
 
     return variantNames.map((variantName) => {
         const variantSamples = allVariantSamples.filter(
@@ -107,41 +115,47 @@ function calculateBestVariants(variantMeans: BanditVariantData[]): BanditVariant
     return variantMeans.filter((variant) => variant.mean === highestMean);
 }
 
-async function buildBanditDataForTest(epicTest: EpicTest): Promise<BanditData> {
-    if (epicTest.variants.length === 0) {
+async function buildBanditDataForTest<V extends Variant, T extends Test<V>>(
+    test: T,
+    channel: ChannelTypes,
+): Promise<BanditData> {
+    if (test.variants.length === 0) {
         // No variants have been added to the test yet
         return {
-            testName: epicTest.name,
+            testName: test.name,
             bestVariants: [],
         };
     }
 
-    const samples = await getBanditSamplesForTest(epicTest.name);
+    const samples = await getBanditSamplesForTest(test.name, channel);
 
     if (samples.length === 0) {
-        return getDefaultWeighting(epicTest);
+        return getDefaultWeighting(test);
     }
 
-    const variantMeans = calculateMeanPerVariant(samples, epicTest);
+    const variantMeans = calculateMeanPerVariant(samples, test);
     const bestVariants = calculateBestVariants(variantMeans);
 
     return {
-        testName: epicTest.name,
+        testName: test.name,
         bestVariants,
     };
 }
 
-function hasBanditMethodology(test: EpicTest): boolean {
+function hasBanditMethodology<V extends Variant, T extends Test<V>>(test: T): boolean {
     return !!test.methodologies?.find((method) => method.name === 'EpsilonGreedyBandit');
 }
 
-function buildBanditData(epicTestsProvider: ValueProvider<EpicTest[]>): Promise<BanditData[]> {
-    const banditTests = epicTestsProvider.get().filter(hasBanditMethodology);
+function buildBanditData<V extends Variant, T extends Test<V>>(
+    testsProvider: ValueProvider<T[]>,
+    channel: ChannelTypes,
+): Promise<BanditData[]> {
+    const banditTests = testsProvider.get().filter(hasBanditMethodology);
     return Promise.all(
-        banditTests.map((epicTest) =>
-            buildBanditDataForTest(epicTest).catch((error) => {
+        banditTests.map((test) =>
+            buildBanditDataForTest(test, channel).catch((error) => {
                 logError(
-                    `Error fetching bandit samples for test ${epicTest.name} from Dynamo: ${error.message}`,
+                    `Error fetching bandit samples for test ${test.name} from Dynamo: ${error.message}`,
                 );
                 putMetric('bandit-data-load-error');
                 return Promise.reject(error);
@@ -150,7 +164,9 @@ function buildBanditData(epicTestsProvider: ValueProvider<EpicTest[]>): Promise<
     );
 }
 
-const buildBanditDataReloader = (epicTestsProvider: ValueProvider<EpicTest[]>) =>
-    buildReloader(() => buildBanditData(epicTestsProvider), 60 * 5);
+const buildBanditDataReloader = <V extends Variant, T extends Test<V>>(
+    testsProvider: ValueProvider<T[]>,
+    channel: ChannelTypes,
+) => buildReloader(() => buildBanditData(testsProvider, channel), 60 * 5);
 
 export { buildBanditDataReloader };

--- a/src/server/bandit/banditSelection.test.ts
+++ b/src/server/bandit/banditSelection.test.ts
@@ -3,6 +3,7 @@ import { BanditData } from './banditData';
 import { selectVariantWithHighestMean } from './banditSelection';
 
 const epicTest: EpicTest = {
+    channel: 'Epic',
     name: 'example-1',
     priority: 1,
     status: 'Live',

--- a/src/server/factories/test.ts
+++ b/src/server/factories/test.ts
@@ -2,6 +2,7 @@ import { EpicTest } from '../../shared/types';
 import { Factory } from 'fishery';
 
 export default Factory.define<EpicTest>(({ factories }) => ({
+    channel: 'Epic',
     name: '2020-02-11_enviro_fossil_fuel_r2_Epic__no_article_count',
     priority: 1,
     status: 'Live',

--- a/src/server/lib/ab.test.ts
+++ b/src/server/lib/ab.test.ts
@@ -2,6 +2,7 @@ import { EpicTest } from '../../shared/types';
 import { selectVariantUsingMVT, withinRange, selectWithSeed, selectVariant } from './ab';
 
 const test: EpicTest = {
+    channel: 'Epic',
     name: 'example-1', // note - changing this name will change the results of the tests, as it's used for the seed
     priority: 1,
     status: 'Live',

--- a/src/server/lib/targetingTesting.test.ts
+++ b/src/server/lib/targetingTesting.test.ts
@@ -3,6 +3,7 @@ import { BannerTargeting } from '../../shared/types';
 
 const bannerTargetingTests: TargetingTest<BannerTargeting>[] = [
     {
+        channel: 'Banner1',
         name: 'BannerTargetingTest',
         priority: 1,
         status: 'Live',

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -109,7 +109,7 @@ const buildApp = async (): Promise<Express> => {
             bannerDeployTimes,
             choiceCardAmounts,
             bannerDesigns,
-            bannerbanditDataBanditData,
+            banditData,
         ),
     );
     app.use(buildHeaderRouter(channelSwitches, headerTests));

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -86,8 +86,7 @@ const buildApp = async (): Promise<Express> => {
         buildBannerDesignsReloader(),
     ]);
 
-    const epicBanditData = await buildBanditDataReloader(articleEpicTests, 'Epic');
-    const bannerBanditData = await buildBanditDataReloader(bannerTests, 'Epic');
+    const banditData = await buildBanditDataReloader(articleEpicTests, bannerTests);
 
     // Build the routers
     app.use(
@@ -98,7 +97,7 @@ const buildApp = async (): Promise<Express> => {
             liveblogEpicTests,
             choiceCardAmounts,
             tickerData,
-            epicBanditData,
+            banditData,
         ),
     );
     app.use(
@@ -110,7 +109,7 @@ const buildApp = async (): Promise<Express> => {
             bannerDeployTimes,
             choiceCardAmounts,
             bannerDesigns,
-            bannerBanditData,
+            bannerbanditDataBanditData,
         ),
     );
     app.use(buildHeaderRouter(channelSwitches, headerTests));

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -86,7 +86,8 @@ const buildApp = async (): Promise<Express> => {
         buildBannerDesignsReloader(),
     ]);
 
-    const banditData = await buildBanditDataReloader(articleEpicTests);
+    const epicBanditData = await buildBanditDataReloader(articleEpicTests, 'Epic');
+    const bannerBanditData = await buildBanditDataReloader(bannerTests, 'Epic');
 
     // Build the routers
     app.use(
@@ -97,7 +98,7 @@ const buildApp = async (): Promise<Express> => {
             liveblogEpicTests,
             choiceCardAmounts,
             tickerData,
-            banditData,
+            epicBanditData,
         ),
     );
     app.use(
@@ -109,6 +110,7 @@ const buildApp = async (): Promise<Express> => {
             bannerDeployTimes,
             choiceCardAmounts,
             bannerDesigns,
+            bannerBanditData,
         ),
     );
     app.use(buildHeaderRouter(channelSwitches, headerTests));

--- a/src/server/tests/amp/ampEpicSelection.test.ts
+++ b/src/server/tests/amp/ampEpicSelection.test.ts
@@ -18,6 +18,7 @@ const tickerSettings: TickerSettings = {
 };
 
 const epicTest: AmpEpicTest = {
+    channel: 'EpicAMP',
     name: 'TEST1',
     priority: 1,
     nickname: 'TEST1',

--- a/src/server/tests/banners/abandonedBasketTests.ts
+++ b/src/server/tests/banners/abandonedBasketTests.ts
@@ -1,6 +1,7 @@
 import type { BannerTest, BannerTestGenerator, BannerVariant } from '../../../shared/types';
 
 const baseAbandonedBasketTest: Omit<BannerTest, 'name' | 'variants'> = {
+    channel: 'Banner1',
     bannerChannel: 'abandonedBasket',
     isHardcoded: true,
     userCohort: 'AllNonSupporters',

--- a/src/server/tests/banners/bannerSelection.test.ts
+++ b/src/server/tests/banners/bannerSelection.test.ts
@@ -1,6 +1,7 @@
 import { BannerTargeting, BannerTest } from '../../../shared/types';
 import { BannerDeployTimesProvider } from './bannerDeployTimes';
 import { canShowBannerAgain, selectBannerTest } from './bannerSelection';
+import { BanditData } from '../../bandit/banditData';
 
 const getBannerDeployTimesReloader = (date: string) =>
     new BannerDeployTimesProvider({
@@ -25,6 +26,7 @@ const getBannerDeployTimesReloader = (date: string) =>
     });
 
 const userDeviceType = 'Desktop';
+const banditData: BanditData[] = [];
 
 describe('selectBannerTest', () => {
     const firstDate = 'Mon Jun 06 2020 19:20:10 GMT+0100';
@@ -107,6 +109,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -125,6 +128,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 false,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -143,6 +147,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -166,6 +171,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -184,6 +190,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -205,6 +212,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -286,6 +294,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -304,6 +313,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -327,6 +337,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -407,6 +418,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -527,6 +539,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -552,6 +565,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );
@@ -568,6 +582,7 @@ describe('selectBannerTest', () => {
                 bannerDeployTimes,
                 enableHardcodedBannerTests,
                 enableScheduledBannerDeploys,
+                banditData,
                 undefined,
                 now,
             );

--- a/src/server/tests/banners/bannerSelection.test.ts
+++ b/src/server/tests/banners/bannerSelection.test.ts
@@ -61,6 +61,7 @@ describe('selectBannerTest', () => {
         };
 
         const test: BannerTest = {
+            channel: 'Banner1',
             name: 'test',
             priority: 1,
             status: 'Live',
@@ -247,6 +248,7 @@ describe('selectBannerTest', () => {
         };
 
         const test: BannerTest = {
+            channel: 'Banner1',
             name: 'test',
             priority: 1,
             status: 'Live',
@@ -370,6 +372,7 @@ describe('selectBannerTest', () => {
         };
 
         const baseTest: Omit<BannerTest, 'name'> = {
+            channel: 'Banner1',
             bannerChannel: 'signIn',
             priority: 1,
             isHardcoded: true,
@@ -489,6 +492,7 @@ describe('selectBannerTest', () => {
         };
 
         const test: BannerTest = {
+            channel: 'Banner1',
             name: 'abandonedBasket',
             priority: 1,
             status: 'Live',
@@ -605,6 +609,7 @@ describe('selectBannerTest', () => {
         });
 
         const test: BannerTest = {
+            channel: 'Banner1',
             name: 'test',
             priority: 1,
             status: 'Live',

--- a/src/server/tests/banners/signInPromptTests.ts
+++ b/src/server/tests/banners/signInPromptTests.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../shared/types';
 
 const baseSignInPromptTest: Omit<BannerTest, 'name' | 'variants'> = {
+    channel: 'Banner1',
     bannerChannel: 'signIn',
     isHardcoded: true,
     userCohort: 'Everyone',

--- a/src/server/tests/epics/epicSelection.test.ts
+++ b/src/server/tests/epics/epicSelection.test.ts
@@ -47,6 +47,7 @@ const variantDefault: EpicVariant = {
 };
 
 const testDefault: EpicTest = {
+    channel: 'Epic',
     name: 'example-1',
     priority: 1,
     status: 'Live',

--- a/src/server/tests/epics/epicTests.ts
+++ b/src/server/tests/epics/epicTests.ts
@@ -4,8 +4,9 @@ import {
     EpicTest,
     epicTestFromToolSchema,
     EpicVariant,
+    Channel,
 } from '../../../shared/types';
-import { ChannelTypes, getTests } from '../store';
+import { getTests } from '../store';
 import { buildReloader, ValueReloader } from '../../utils/valueReloader';
 
 export const variantHasArticleCountCopy = (variant: EpicVariant): boolean => {
@@ -17,7 +18,7 @@ export const variantHasArticleCountCopy = (variant: EpicVariant): boolean => {
     );
 };
 
-const fetchConfiguredEpicTests = (channel: ChannelTypes) => (): Promise<EpicTest[]> => {
+const fetchConfiguredEpicTests = (channel: Channel) => (): Promise<EpicTest[]> => {
     return getTests<EpicTestFromTool>(channel, epicTestFromToolSchema).then((tests) => {
         return tests.map((test: EpicTestFromTool) => {
             const hasArticleCountInCopy = test.variants.some(variantHasArticleCountCopy);

--- a/src/server/tests/epics/fallback.ts
+++ b/src/server/tests/epics/fallback.ts
@@ -1,6 +1,7 @@
 import { EpicTest, SecondaryCtaType } from '../../../shared/types';
 
 export const fallbackEpicTest: EpicTest = {
+    channel: 'Epic',
     name: 'FallbackEpicTest',
     priority: 99,
     status: 'Live',

--- a/src/server/tests/epics/momentumTest.test.ts
+++ b/src/server/tests/epics/momentumTest.test.ts
@@ -7,6 +7,7 @@ import {
 } from './momentumTest';
 
 const testDefault: EpicTest = {
+    channel: 'Epic',
     name: '2024-04-29_MOMENTUM_EPIC',
     priority: 1,
     status: 'Live',

--- a/src/server/tests/headers/headerSelection.test.ts
+++ b/src/server/tests/headers/headerSelection.test.ts
@@ -7,6 +7,7 @@ import {
 import { selectBestTest } from './headerSelection';
 
 const remote_nonUK: HeaderTest = {
+    channel: 'Header',
     name: 'RemoteRrHeaderLinksTest__NonUK',
     priority: 1,
     userCohort: 'AllNonSupporters',
@@ -38,6 +39,7 @@ const remote_nonUK: HeaderTest = {
     ],
 };
 const remote_UK: HeaderTest = {
+    channel: 'Header',
     name: 'RemoteRrHeaderLinksTest__UK',
     priority: 1,
     userCohort: 'AllNonSupporters',
@@ -62,6 +64,7 @@ const remote_UK: HeaderTest = {
     ],
 };
 const locationsNotSet: HeaderTest = {
+    channel: 'Header',
     name: 'LocationsArrayEmpty',
     priority: 1,
     userCohort: 'AllNonSupporters',
@@ -86,6 +89,7 @@ const locationsNotSet: HeaderTest = {
     ],
 };
 const header_supporter: HeaderTest = {
+    channel: 'Header',
     name: 'header-supporter',
     priority: 1,
     userCohort: 'AllExistingSupporters',
@@ -111,6 +115,7 @@ const header_supporter: HeaderTest = {
 };
 
 const header_new_supporter: HeaderTest = {
+    channel: 'Header',
     name: 'header-new-supporter',
     priority: 1,
     userCohort: 'Everyone',
@@ -140,6 +145,7 @@ const header_new_supporter: HeaderTest = {
 };
 
 const header_existing_subscriber: HeaderTest = {
+    channel: 'Header',
     name: 'header-existing-subscriber',
     priority: 1,
     userCohort: 'Everyone',

--- a/src/server/tests/headers/headerSelection.ts
+++ b/src/server/tests/headers/headerSelection.ts
@@ -16,6 +16,7 @@ const moduleName = 'Header';
 
 // --- hardcoded tests
 const nonSupportersTestNonUK: HeaderTest = {
+    channel: 'Header',
     name: 'RemoteRrHeaderLinksTest__NonUK',
     priority: 99,
     userCohort: 'AllNonSupporters',
@@ -49,6 +50,7 @@ const nonSupportersTestNonUK: HeaderTest = {
 };
 
 const nonSupportersTestUK: HeaderTest = {
+    channel: 'Header',
     name: 'RemoteRrHeaderLinksTest__UK',
     priority: 99,
     userCohort: 'AllNonSupporters',
@@ -75,6 +77,7 @@ const nonSupportersTestUK: HeaderTest = {
 };
 
 const supportersTest: HeaderTest = {
+    channel: 'Header',
     name: 'header-supporter',
     priority: 99,
     userCohort: 'AllExistingSupporters',
@@ -101,6 +104,7 @@ const supportersTest: HeaderTest = {
 };
 
 const baseSignInPromptTest: Omit<HeaderTest, 'name' | 'variants'> = {
+    channel: 'Header',
     userCohort: 'Everyone',
     priority: 99,
     status: 'Live',

--- a/src/server/tests/store.ts
+++ b/src/server/tests/store.ts
@@ -1,4 +1,4 @@
-import { BannerDesignFromTool } from '../../shared/types';
+import { BannerDesignFromTool, Channel } from '../../shared/types';
 import * as AWS from 'aws-sdk';
 import { isProd } from '../lib/env';
 import { putMetric } from '../utils/cloudwatch';
@@ -9,18 +9,8 @@ import { removeNullValues } from '../utils/removeNullValues';
 
 const stage = isProd ? 'PROD' : 'CODE';
 
-export type ChannelTypes =
-    | 'Epic'
-    | 'EpicAMP'
-    | 'EpicAppleNews'
-    | 'EpicLiveblog'
-    | 'EpicHoldback'
-    | 'Banner1'
-    | 'Banner2'
-    | 'Header';
-
 export const getTests = <T extends { priority: number }>(
-    channel: ChannelTypes,
+    channel: Channel,
     schema: ZodSchema<T>,
 ): Promise<T[]> =>
     queryChannel(channel, stage)
@@ -50,7 +40,7 @@ export const getTests = <T extends { priority: number }>(
             return Promise.reject(error);
         });
 
-function queryChannel(channel: ChannelTypes, stage: string) {
+function queryChannel(channel: Channel, stage: string) {
     const docClient = new AWS.DynamoDB.DocumentClient({ region: 'eu-west-1' });
     return docClient
         .query({

--- a/src/shared/types/abTests/shared.ts
+++ b/src/shared/types/abTests/shared.ts
@@ -7,6 +7,18 @@ import {
 } from '../purchaseInfo';
 import { OphanComponentType, OphanProduct } from '@guardian/libs';
 
+const Channel = [
+    'Epic',
+    'EpicAMP',
+    'EpicAppleNews',
+    'EpicLiveblog',
+    'Banner1',
+    'Banner2',
+    'Header',
+] as const;
+export type Channel = (typeof Channel)[number];
+const channelSchema = z.enum(Channel);
+
 const TestStatus = ['Live', 'Draft', 'Archived'] as const;
 export type TestStatus = (typeof TestStatus)[number];
 
@@ -42,6 +54,7 @@ export interface Variant {
     name: string;
 }
 export interface Test<V extends Variant> {
+    channel: Channel;
     name: string;
     status: TestStatus;
     priority: number;
@@ -54,6 +67,7 @@ export interface Test<V extends Variant> {
 }
 
 export const testSchema = z.object({
+    channel: channelSchema,
     name: z.string(),
     status: testStatusSchema,
     priority: z.number(),

--- a/src/shared/types/props/banner.ts
+++ b/src/shared/types/props/banner.ts
@@ -49,6 +49,7 @@ export const bannerContentSchema = z.object({
 
 export interface BannerProps {
     tracking: Tracking;
+    // bannerChannel is distinct from the channel defined by RRCP
     bannerChannel: BannerChannel;
     content?: BannerContent;
     mobileContent?: BannerContent;


### PR DESCRIPTION
Changes the banner variant selection logic to use the `methodologies` field, which enables bandit testing. This reuses the functionality used for epics.

Also fixes the fetching of data from the bandit table. It needs to [prefix the test name with the channel name](https://github.com/guardian/support-analytics/blob/main/bandit/src/query-lambda/dynamo.ts#L47).
In order to enable this, I've added the `channel` field to the `Test` model. This field is always present in the Dynamodb tests table (it's the partition key), so it's safe to make it mandatory.