### PR TITLE
Adds heading size to design model

### DIFF
--- a/.changeset/cool-jeans-raise.md
+++ b/.changeset/cool-jeans-raise.md
@@ -1,0 +1,5 @@
+---
+'support-dotcom-components': minor
+---
+
+Adds a new optional field for fonts to the model for Configurable Design banners

--- a/.changeset/proud-ties-learn.md
+++ b/.changeset/proud-ties-learn.md
@@ -1,5 +1,5 @@
 ---
-'support-dotcom-components': minor
+'@guardian/support-dotcom-components': minor
 ---
 
 Adds a new optional field for fonts to the model for Configurable Design banners

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [architecture](docs/architecture.md) for details.
 This project uses [nvm](https://github.com/nvm-sh/nvm). You should run `nvm use` in your terminal before running any of the following commands. To set up, first run
 
 ```bash
-pnpm
+pnpm install
 ```
 
 This will install all the project dependencies.
@@ -77,7 +77,7 @@ The `/src` directory contains 3 subdirectories:
 
 Releasing to NPM is handled with [changesets] and is performed by CI.
 
-On your feature branch, before merging, run `pnpm dotcom changeset` from the root of the project. This will
+On your feature branch, before merging, run `pnpm changeset` from the root of the project. This will
 interactively ask you what kind of change this is (major, minor, patch) and
 allow you to describe the change. Commit the generated changeset file to git and
 push to your branch.

--- a/src/server/factories/bannerDesign.ts
+++ b/src/server/factories/bannerDesign.ts
@@ -28,6 +28,11 @@ export default Factory.define<BannerDesignFromTool>(() => ({
             'https://i.guim.co.uk/img/media/6c933a058d1ce37a5ad17f79895906150812dfee/0_0_1768_1420/500.png?width=500&quality=75&s=9277532ddf184a308e14218e3576543b',
         altText: 'Example alt text',
     },
+    fonts: {
+        heading: {
+            size: 'medium',
+        },
+    },
     colours: {
         basic: {
             background: stringToHexColour('F1F8FC'),

--- a/src/shared/types/props/design.ts
+++ b/src/shared/types/props/design.ts
@@ -120,9 +120,18 @@ interface ChoiceCardsDesign {
 }
 type Visual = BannerDesignImage | ChoiceCardsDesign;
 
+type FontSize = 'small' | 'medium' | 'large';
+
+interface Font {
+    size: FontSize;
+}
+
 export interface ConfigurableDesign {
     visual?: Visual;
     headerImage?: BannerDesignHeaderImage;
+    fonts?: {
+        heading: Font;
+    };
     colours: {
         basic: {
             background: HexColour;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds an optional font size to the design model which can be picked up by DCR. This allows us to create a tiny banner headline size for banners with no copy.
[Trello ticket](https://trello.com/c/RKgNkcgw)

## How to test

?TBC

## How can we measure success?

The ability to add a tiny banner with a headline size of 17px and medium font-weight.

## Have we considered potential risks?

Added as optional at this point so that we have time to re-save all banners to pick up the default heading size before potentially making it a compulsory field later.

