### PR TITLE
Change package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "support-dotcom-components",
+    "name": "@guardian/support-dotcom-components",
     "version": "3.0.0",
     "description": "Service to serve Reader Revenue components to dotcom",
     "repository": "github:guardian/support-dotcom-components",


### PR DESCRIPTION
this was incorrectly changed during the removal of yarn workspaces here - https://github.com/guardian/support-dotcom-components/pull/1227/files#diff-71db75fec126fab2fe574a02a4edd65df9591e2a832db4345f1600bfc0340f47L2