### PR TITLE
Point to new super-mode-calculator tables after Super Mode BigQuery migration

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -479,7 +479,7 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":table/super-mode-TEST",
+                      ":table/super-mode-calculator-TEST",
                     ],
                   ],
                 },
@@ -495,7 +495,7 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":table/super-mode-TEST/index/*",
+                      ":table/super-mode-calculator-TEST/index/*",
                     ],
                   ],
                 },
@@ -539,7 +539,7 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":table/super-mode-TEST/index/*",
+                      ":table/super-mode-calculator-TEST/index/*",
                     ],
                   ],
                 },
@@ -555,7 +555,7 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":table/super-mode-TEST/index/*/index/*",
+                      ":table/super-mode-calculator-TEST/index/*/index/*",
                     ],
                   ],
                 },

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -191,11 +191,11 @@ chown -R dotcom-components:support /var/log/dotcom-components
 				},
 			),
 			new GuDynamoDBReadPolicy(this, 'DynamoReadPolicy', {
-				tableName: `super-mode-${this.stage}`,
+				tableName: `super-mode-calculator-${this.stage}`,
 			}),
 			// TODO: remove when secondary indexes are included in GuDynamoDBRead
 			new GuDynamoDBReadPolicy(this, 'DynamoReadPolicySecondaryIndex', {
-				tableName: `super-mode-${this.stage}/index/*`,
+				tableName: `super-mode-calculator-${this.stage}/index/*`,
 			}),
 			new GuPutCloudwatchMetricsPolicy(this),
 			new GuDynamoDBReadPolicy(this, 'DynamoTestsReadPolicy', {

--- a/src/server/lib/superMode.ts
+++ b/src/server/lib/superMode.ts
@@ -100,7 +100,7 @@ function queryDate(
 ) {
     return docClient
         .query({
-            TableName: `super-mode-${stage.toUpperCase()}`,
+            TableName: `super-mode-calculator-${stage.toUpperCase()}`,
             IndexName: 'end',
             KeyConditionExpression: 'endDate = :ed AND endTimestamp > :et ',
             ExpressionAttributeValues: {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR is to use new super-mode-calculator tables after Super Mode BigQuery migration and the modification of the related query.


## How to test
Tested in CODE

## Before Change
<img width="551" alt="image" src="https://github.com/user-attachments/assets/26be18fd-dcf7-40e0-bbc7-bda87f8c038e">

## After Change

<img width="551" alt="image" src="https://github.com/user-attachments/assets/e467e878-9790-4659-91b3-9e33a9429beb">

