### PR TITLE
Bump express

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "compression": "1.7.4",
         "cors": "^2.8.5",
         "date-fns": "^2.25.0",
-        "express": "^4.20.0",
+        "express": "^4.21.2",
         "jsonschema": "^1.4.0",
         "lodash.debounce": "^4.0.8",
         "log4js": "^6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^2.25.0
     version: 2.30.0
   express:
-    specifier: ^4.20.0
-    version: 4.21.1
+    specifier: ^4.21.2
+    version: 4.21.2
   jsonschema:
     specifier: ^1.4.0
     version: 1.4.1
@@ -3796,8 +3796,8 @@ packages:
       jest-util: 29.7.0
     dev: true
 
-  /express@4.21.1:
-    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
+  /express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -3819,7 +3819,7 @@ packages:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.13.0
       range-parser: 1.2.1
@@ -6281,8 +6281,8 @@ packages:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
 
-  /path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  /path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
     dev: false
 
   /path-type@4.0.0:


### PR DESCRIPTION
snyk + dependabot have flagged the `path-to-regexp` dependency, which comes via express.
https://security.snyk.io/vuln/SNYK-JS-PATHTOREGEXP-8482416

This update to express resolves this, by pulling in `path-to-regexp` v0.1.12