### PR TITLE
Remove lastOneOffContributionDate and isRecurringContributor from targeting data

### DIFF
--- a/src/server/factories/targeting.ts
+++ b/src/server/factories/targeting.ts
@@ -7,7 +7,6 @@ export default Factory.define<EpicTargeting>(() => ({
     shouldHideReaderRevenue: false,
     isMinuteArticle: false,
     isPaidContent: false,
-    isRecurringContributor: false,
     tags: [],
     showSupportMessaging: true,
     hasOptedOutOfArticleCount: false,

--- a/src/server/lib/dates.test.ts
+++ b/src/server/lib/dates.test.ts
@@ -1,28 +1,9 @@
-import { daysSince, isRecentOneOffContributor } from './dates';
+import { daysSince } from './dates';
 
 describe('daysSince', () => {
     const now = new Date('2020-02-18T10:30:00');
     it('should count the days properly', () => {
         const then = new Date('2020-02-14T13:30:00');
         expect(daysSince(then, now)).toBe(3);
-    });
-});
-
-describe('isRecentOneOffContributor', () => {
-    const now = new Date('2020-02-12T10:24:00');
-
-    it('returns true for recent date', () => {
-        const got = isRecentOneOffContributor(new Date('2020-02-10T10:24:00'), now);
-        expect(got).toBe(true);
-    });
-
-    it('returns false for older date', () => {
-        const got = isRecentOneOffContributor(new Date('2019-02-10T10:24:00'), now);
-        expect(got).toBe(false);
-    });
-
-    it('returns false for someone that has never contributed', () => {
-        const got = isRecentOneOffContributor(undefined, now);
-        expect(got).toBe(false);
     });
 });

--- a/src/server/lib/dates.ts
+++ b/src/server/lib/dates.ts
@@ -1,18 +1,5 @@
-const pauseDays = 90;
-
 export const daysSince = (then: Date, now: Date): number => {
     const oneDayMs = 1000 * 60 * 60 * 24;
     const diffMs = now.valueOf() - then.valueOf();
     return Math.floor(diffMs / oneDayMs);
-};
-
-export const isRecentOneOffContributor = (
-    lastOneOffContributionDate?: Date,
-    now: Date = new Date(Date.now()), // to mock out Date.now in tests
-): boolean => {
-    if (!lastOneOffContributionDate) {
-        return false;
-    }
-
-    return daysSince(lastOneOffContributionDate, now) <= pauseDays;
 };

--- a/src/server/tests/epics/epicSelection.ts
+++ b/src/server/tests/epics/epicSelection.ts
@@ -1,20 +1,18 @@
 import { countryCodeToCountryGroupId, getCountryName, inCountryGroups } from '../../../shared/lib';
 import {
     EpicTargeting,
-    EpicVariant,
-    UserCohort,
-    EpicViewLog,
-    WeeklyArticleHistory,
     EpicTest,
+    EpicVariant,
+    EpicViewLog,
+    UserCohort,
     UserDeviceType,
+    WeeklyArticleHistory,
 } from '../../../shared/types';
 import { BanditData } from '../../bandit/banditData';
 import { selectVariant } from '../../lib/ab';
-import { isRecentOneOffContributor } from '../../lib/dates';
 import { historyWithinArticlesViewedSettings } from '../../lib/history';
 import { TestVariant } from '../../lib/params';
-import { SuperModeArticle } from '../../lib/superMode';
-import { isInSuperMode, superModeify } from '../../lib/superMode';
+import { isInSuperMode, SuperModeArticle, superModeify } from '../../lib/superMode';
 import {
     correctSignedInStatus,
     deviceTypeMatches,
@@ -30,33 +28,9 @@ export interface Filter {
 }
 
 export const getUserCohorts = (targeting: EpicTargeting): UserCohort[] => {
-    const { showSupportMessaging, isRecurringContributor } = targeting;
-
-    const lastOneOffContributionDate = targeting.lastOneOffContributionDate
-        ? new Date(targeting.lastOneOffContributionDate)
-        : undefined;
-
-    // User is a current supporter if she has a subscription or a recurring
-    // donation or has made a one-off contribution in the past 3 months.
-    const isSupporter =
-        !showSupportMessaging ||
-        isRecurringContributor ||
-        isRecentOneOffContributor(lastOneOffContributionDate);
-
-    // User is a past-contributor if she doesn't have an active subscription
-    // or recurring donation, but has made a one-off donation longer than 3
-    // months ago.
-    const isPastContributor =
-        !isSupporter &&
-        lastOneOffContributionDate &&
-        !isRecentOneOffContributor(lastOneOffContributionDate);
-
-    if (isPastContributor) {
-        return ['PostAskPauseSingleContributors', 'AllNonSupporters', 'Everyone'];
-    } else if (isSupporter) {
+    if (!targeting.showSupportMessaging) {
         return ['AllExistingSupporters', 'Everyone'];
     }
-
     return ['AllNonSupporters', 'Everyone'];
 };
 

--- a/src/server/tests/epics/momentumTest.test.ts
+++ b/src/server/tests/epics/momentumTest.test.ts
@@ -42,8 +42,6 @@ const targetingDefault: EpicTargeting = {
     isPaidContent: false,
     tags: [{ id: 'environment/series/the-polluters', type: 'tone' }],
     showSupportMessaging: true,
-    isRecurringContributor: false,
-    lastOneOffContributionDate: undefined,
     mvtId: 2,
     hasOptedOutOfArticleCount: false,
 };

--- a/src/shared/types/targeting/banner.ts
+++ b/src/shared/types/targeting/banner.ts
@@ -19,7 +19,6 @@ export type BannerTargeting = {
     browserId?: string; // Only present if the user has consented to browserId-based targeting
     purchaseInfo?: PurchaseInfo;
     isSignedIn: boolean;
-    lastOneOffContributionDate?: string;
     hasConsented: boolean;
     abandonedBasket?: AbandonedBasket;
 };

--- a/src/shared/types/targeting/epic.ts
+++ b/src/shared/types/targeting/epic.ts
@@ -22,8 +22,6 @@ export type EpicTargeting = {
     weeklyArticleHistory?: WeeklyArticleHistory;
     hasOptedOutOfArticleCount: boolean;
     showSupportMessaging: boolean;
-    isRecurringContributor: boolean;
-    lastOneOffContributionDate?: number; // Platform to send undefined or a timestamp date
     url?: string;
     browserId?: string; // Only present if the user has consented to browserId-based targeting
     isSignedIn?: boolean;

--- a/src/shared/types/targeting/header.ts
+++ b/src/shared/types/targeting/header.ts
@@ -4,7 +4,6 @@ export interface HeaderTargeting {
     showSupportMessaging: boolean;
     countryCode: string;
     mvtId: number;
-    lastOneOffContributionDate?: string;
     numArticles?: number;
     purchaseInfo?: PurchaseInfo;
     isSignedIn: boolean;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The `lastOneOffContributionDate` and `isRecurringContributor` are no longer required in the targeting data, we should just use `showSupportMessaging` instead.
 
This PR removes them so that we can stop sending them from DCR.