### PR TITLE
Create changeset for #1257

### DIFF
--- a/.changeset/shiny-colts-lie.md
+++ b/.changeset/shiny-colts-lie.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+Remove lastOneOffContributionDate and isRecurringContributor from targeting data


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
#1257 removed two keys from the targeting data expected from dotcom-rendering, however it didn't create a new changeset to publish these changes to npm so that DCR is aware of them. This PR does that.