### PR TITLE
Log epicSuperMode

### DIFF
--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -190,7 +190,9 @@ export const buildEpicRouter = (
                         .map((c: WeeklyArticleLog) => JSON.stringify(c)),
                 };
                 if (!!response.data) {
-                    res.locals.epicSuperMode = response.data?.meta.labels?.includes('SUPER_MODE');
+                    res.locals.epicSuperMode = (response.data.meta.labels ?? []).includes(
+                        'SUPER_MODE',
+                    );
                 }
 
                 res.send(response);
@@ -221,7 +223,9 @@ export const buildEpicRouter = (
                 res.locals.didRenderEpic = !!response.data;
                 res.locals.clientName = tracking.clientName;
                 if (!!response.data) {
-                    res.locals.epicSuperMode = response.data?.meta.labels?.includes('SUPER_MODE');
+                    res.locals.epicSuperMode = (response.data.meta.labels ?? []).includes(
+                        'SUPER_MODE',
+                    );
                 }
 
                 res.send(response);

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -220,6 +220,9 @@ export const buildEpicRouter = (
                 // for response logging
                 res.locals.didRenderEpic = !!response.data;
                 res.locals.clientName = tracking.clientName;
+                if (!!response.data) {
+                    res.locals.epicSuperMode = response.data?.meta.labels?.includes('SUPER_MODE');
+                }
 
                 res.send(response);
             } catch (error) {

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -189,6 +189,9 @@ export const buildEpicRouter = (
                         .slice(0, 3)
                         .map((c: WeeklyArticleLog) => JSON.stringify(c)),
                 };
+                if (!!response.data) {
+                    res.locals.epicSuperMode = response.data?.meta.labels?.includes('SUPER_MODE');
+                }
 
                 res.send(response);
             } catch (error) {

--- a/src/server/middleware/logging.ts
+++ b/src/server/middleware/logging.ts
@@ -19,6 +19,7 @@ export const logging = (
             bannerTargeting: res.locals.bannerTargeting,
             epicTargeting: res.locals.epicTargeting,
             userAgent: isServerError(res.statusCode) ? req.headers['user-agent'] : undefined,
+            epicSuperMode: res.locals.epicSuperMode,
         }),
     );
     next();


### PR DESCRIPTION
To help investigate a drop in super mode epics.
If an epic is being returned to the client then a new boolean field is added to the log, `epicSuperMode`.
We can then compare this data against the pageview table in bigquery to see if there's a discrepency.

From kibana:
![Screenshot 2025-01-15 at 10 40 14](https://github.com/user-attachments/assets/c16168cb-bb66-4f6a-bf5f-5bb8ebdfdb4e)
