### PR TITLE
Fix roulette

### DIFF
--- a/src/server/roulette/rouletteSelection.test.ts
+++ b/src/server/roulette/rouletteSelection.test.ts
@@ -125,6 +125,21 @@ describe('roulette', () => {
         );
         expect(variant).toBe(epicTest.variants[2]);
     });
+
+    it('should randomly select variant if means are 0', () => {
+        const rand = 0.49;
+        const variants = epicTest.variants.map((variant) => ({
+            variantName: variant.name,
+            mean: 0,
+        }));
+        const banditData = {
+            testName: 'example-1',
+            bestVariants: variants,
+            variants: variants,
+        };
+        const variant = selectVariantUsingRoulette([banditData], epicTest, rand);
+        expect(variant).toBeDefined();
+    });
 });
 
 describe('rouletteTest2', () => {

--- a/src/server/roulette/rouletteSelection.ts
+++ b/src/server/roulette/rouletteSelection.ts
@@ -14,6 +14,10 @@ export function selectVariantUsingRoulette<V extends Variant, T extends Test<V>>
 
     const sumOfMeans = testBanditData.variants.reduce((sum, v) => sum + v.mean, 0);
 
+    if (sumOfMeans <= 0) {
+        return selectRandomVariant(test);
+    }
+
     // sorted variant weights, which will add up to 1
     const variantsWithWeights: { weight: number; variantName: string }[] = testBanditData.variants
         .map(({ variantName, mean }) => ({ variantName, weight: mean / sumOfMeans }))


### PR DESCRIPTION
Currently the "roulette" selection method doesn't work if there is not yet any data. This is because the means for the variants will be 0. If this is the case then it should randomly select a variant until there is enough data.

In the current implementation, no variant is ever returned when users are put into the test.