### PR TITLE
Always use methodology.testName

### DIFF
--- a/src/server/lib/ab.ts
+++ b/src/server/lib/ab.ts
@@ -97,24 +97,16 @@ export const selectVariant = <V extends Variant, T extends Test<V>>(
     mvtId: number,
     banditData: BanditData[],
 ): { test: T; variant: V } | undefined => {
-    if (test.methodologies && test.methodologies.length === 1) {
-        // Only one configured methodology
-        const variant = selectVariantWithMethodology<V, T>(
-            test,
-            mvtId,
-            banditData,
-            test.methodologies[0],
-        );
-        if (variant) {
-            return {
-                test,
-                variant,
-            };
-        }
-    } else if (test.methodologies) {
-        // More than one methodology, pick one of them using the mvt value
-        const methodology =
-            test.methodologies[getRandomNumber(test.name, mvtId) % test.methodologies.length];
+    if (test.methodologies && test.methodologies.length > 0) {
+        const pickMethodology = (methodologies: Methodology[]) => {
+            if (methodologies.length === 1) {
+                return methodologies[0];
+            } else {
+                // More than one methodology, pick one of them using the mvt value
+                return methodologies[getRandomNumber(test.name, mvtId) % methodologies.length];
+            }
+        };
+        const methodology = pickMethodology(test.methodologies);
 
         // if the methodology should be tracked with a different name then use that
         const testWithNameExtension = {


### PR DESCRIPTION
Each methodology may define a `testName`, against which views/acquisitions should be tracked (instead of the main test name). This is so that we can compare different methodologies against each other.

Currently SDC only uses the methodology `testName` if there is more than 1 methodology.
Normally if there's only 1 methodology then it will not have a `testName`.
But we've had an instance of a test in the RRCP that has a single methodology, which does have a `testName`!
This PR changes the logic to always use the `testName` if it's available.