### PR TITLE
Better error logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@types/body-parser": "^1.19.5",
         "@types/compression": "^1.7.0",
         "@types/cors": "^2.8.6",
-        "@types/express": "^4.17.1",
+        "@types/express": "^5.0.0",
         "@types/jest": "^24.0.25",
         "@types/lodash.debounce": "^4.0.6",
         "@types/node": "^18.14.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ devDependencies:
     specifier: ^2.8.6
     version: 2.8.17
   '@types/express':
-    specifier: ^4.17.1
-    version: 4.17.21
+    specifier: ^5.0.0
+    version: 5.0.0
   '@types/jest':
     specifier: ^24.0.25
     version: 24.9.1
@@ -1525,7 +1525,7 @@ packages:
   /@types/compression@1.7.5:
     resolution: {integrity: sha512-AAQvK5pxMpaT+nDvhHrsBhLSYG5yQdtkaJE1WYieSNY2mVFKAgmU4ks65rkZD5oqnGCFLyQpUr1CqI4DmUMyDg==}
     dependencies:
-      '@types/express': 4.17.21
+      '@types/express': 5.0.0
     dev: true
 
   /@types/connect@3.4.38:
@@ -1548,8 +1548,8 @@ packages:
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
     dev: true
 
-  /@types/express-serve-static-core@4.19.6:
-    resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
+  /@types/express-serve-static-core@5.0.5:
+    resolution: {integrity: sha512-GLZPrd9ckqEBFMcVM/qRFAP0Hg3qiVEojgEFsx/N/zKXsBzbGF6z5FBDpZ0+Xhp1xr+qRZYjfGr1cWHB9oFHSA==}
     dependencies:
       '@types/node': 18.19.59
       '@types/qs': 6.9.16
@@ -1557,11 +1557,11 @@ packages:
       '@types/send': 0.17.4
     dev: true
 
-  /@types/express@4.17.21:
-    resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
+  /@types/express@5.0.0:
+    resolution: {integrity: sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==}
     dependencies:
       '@types/body-parser': 1.19.5
-      '@types/express-serve-static-core': 4.19.6
+      '@types/express-serve-static-core': 5.0.5
       '@types/qs': 6.9.16
       '@types/serve-static': 1.15.7
     dev: true

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -169,7 +169,6 @@ export const buildEpicRouter = (
         (req: express.Request, res: express.Response, next: express.NextFunction): void => {
             try {
                 const epicType: EpicType = 'ARTICLE';
-                throw Error('Testing what happens when it fails');
 
                 const { tracking, targeting } = req.body;
                 const params = getQueryParams(req.query);
@@ -196,7 +195,8 @@ export const buildEpicRouter = (
                     );
                 }
 
-                res.send(response);
+                throw Error('Testing what happens when it fails');
+                // res.send(response);
             } catch (error) {
                 next(error);
             }

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -169,6 +169,7 @@ export const buildEpicRouter = (
         (req: express.Request, res: express.Response, next: express.NextFunction): void => {
             try {
                 const epicType: EpicType = 'ARTICLE';
+                throw Error('Testing what happens when it fails');
 
                 const { tracking, targeting } = req.body;
                 const params = getQueryParams(req.query);

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -195,8 +195,7 @@ export const buildEpicRouter = (
                     );
                 }
 
-                throw Error('Testing what happens when it fails');
-                // res.send(response);
+                res.send(response);
             } catch (error) {
                 next(error);
             }

--- a/src/server/middleware/errorHandling.ts
+++ b/src/server/middleware/errorHandling.ts
@@ -18,5 +18,6 @@ export const errorHandling = (
         message,
         stack: error.stack,
         body: req.body,
+        path: req.path,
     });
 };

--- a/src/server/middleware/errorHandling.ts
+++ b/src/server/middleware/errorHandling.ts
@@ -14,5 +14,5 @@ export const errorHandling = (
 
     res.status(500).send({ error: message });
 
-    logInfo('Something went wrong: ' + message);
+    logInfo(`Error handling request to endpoint ${req.path}. Error message: ${message}. Stack trace: ${error.stack}. Payload: ${req.body}`);
 };

--- a/src/server/middleware/errorHandling.ts
+++ b/src/server/middleware/errorHandling.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { logInfo } from '../utils/logging';
+import { logger } from '../utils/logging';
 
 export const errorHandling = (
     error: Error,
@@ -12,7 +12,11 @@ export const errorHandling = (
 ): void => {
     const message = error.message || error.toString();
 
-    res.status(500).send({ error: message });
+    res.status(500).send();
 
-    logInfo(`Error handling request to endpoint ${req.path}. Error message: ${message}. Stack trace: ${error.stack}. Payload: ${req.body}`);
+    logger.error({
+        message,
+        stack: error.stack,
+        body: req.body,
+    });
 };


### PR DESCRIPTION
Currently the error handling middleware just logs the error message.
For example, we had the following error:
`Something went wrong: Cannot read properties of undefined (reading 'mvtId')`
From this we cannot see which endpoint this was, or what the payload was. So it’s hard to investigate further.

This PR changes the `errorHandling` middleware to log an object with:
- the path
- error message
- stack trace
- request body

I've also removed the error message from the response to the client - just a 500 is enough.

E.g. from kibana -
![Screenshot 2025-01-22 at 09 03 07](https://github.com/user-attachments/assets/43555e11-11fc-4b9f-8371-f4e49d365e71)
![Screenshot 2025-01-22 at 09 03 54](https://github.com/user-attachments/assets/05decbbf-76fa-48b4-ba99-d90be8510192)
