### PR TITLE
Auxia Integration (Part 2)

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -26,7 +26,7 @@ interface AuxiaAPIRequestPayload {
     languageCode: string;
 }
 
-interface AuxiaAPIAnswerDataUserTreatment {
+interface AuxiaAPIResponseDataUserTreatment {
     treatmentId: string;
     treatmentTrackingId: string;
     rank: string;
@@ -36,9 +36,9 @@ interface AuxiaAPIAnswerDataUserTreatment {
     surface: string;
 }
 
-interface AuxiaAPIAnswerData {
+interface AuxiaAPIResponseData {
     responseId: string;
-    userTreatments: AuxiaAPIAnswerDataUserTreatment[];
+    userTreatments: AuxiaAPIResponseDataUserTreatment[];
 }
 
 interface AuxiaProxyResponseData {
@@ -75,7 +75,7 @@ const fetchAuxiaData = async (
     apiKey: string,
     projectId: string,
     userId: string,
-): Promise<AuxiaAPIAnswerData> => {
+): Promise<AuxiaAPIResponseData> => {
     const url = 'https://apis.auxia.io/v1/GetTreatments';
 
     const headers = {
@@ -95,10 +95,10 @@ const fetchAuxiaData = async (
 
     const responseBody = await response.json();
 
-    return Promise.resolve(responseBody as AuxiaAPIAnswerData);
+    return Promise.resolve(responseBody as AuxiaAPIResponseData);
 };
 
-const buildAuxiaProxyResponseData = (auxiaData: AuxiaAPIAnswerData): AuxiaProxyResponseData => {
+const buildAuxiaProxyResponseData = (auxiaData: AuxiaAPIResponseData): AuxiaProxyResponseData => {
     // This is the most important function of this router, it takes the answer from auxia and
     // and decides if the sign in gate should be shown or not.
 

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -41,7 +41,8 @@ interface AuxiaAPIResponseData {
 }
 
 interface AuxiaProxyResponseData {
-    shouldShowSignInGate: boolean;
+    responseId: string;
+    userTreatment?: AuxiaAPIResponseDataUserTreatment;
 }
 
 const buildAuxiaAPIRequestPayload = (projectId: string, userId: string): AuxiaAPIRequestPayload => {
@@ -97,15 +98,13 @@ const fetchAuxiaData = async (
 };
 
 const buildAuxiaProxyResponseData = (auxiaData: AuxiaAPIResponseData): AuxiaProxyResponseData => {
-    // This is the most important function of this router, it takes the answer from auxia and
-    // and decides if the sign in gate should be shown or not.
-
-    // In the current interpretation we are saying that a non empty userTreatments array means
-    // that the sign in gate should be shown.
-
-    const shouldShowSignInGate = auxiaData.userTreatments.length > 0;
-
-    return { shouldShowSignInGate };
+    // Note the small difference between AuxiaAPIResponseData and AuxiaProxyResponseData
+    // In the case of AuxiaProxyResponseData, we have an optional userTreatment field, instead of an array of userTreatments.
+    // This is to reflect the what the client expect semantically.
+    return {
+        responseId: auxiaData.responseId,
+        userTreatment: auxiaData.userTreatments[0],
+    };
 };
 
 export const getAuxiaRouterConfig = async (): Promise<AuxiaRouterConfig> => {

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -14,7 +14,6 @@ interface AuxiaApiRequestPayloadContextualAttributes {
 
 interface AuxiaApiRequestPayloadSurface {
     surface: string;
-    minimumTreatmentCount: number;
     maximumTreatmentCount: number;
 }
 
@@ -63,8 +62,7 @@ const buildAuxiaAPIRequestPayload = (projectId: string, userId: string): AuxiaAP
         surfaces: [
             {
                 surface: 'ARTICLE_PAGE',
-                minimumTreatmentCount: 1,
-                maximumTreatmentCount: 5,
+                maximumTreatmentCount: 1,
             },
         ],
         languageCode: 'en-GB',


### PR DESCRIPTION
Previous steps
- https://github.com/guardian/support-dotcom-components/pull/1265

Here we simply upgrade the interface of the Auxia end point, returning a different object, now that we will be expecting the client to process the optional user treatment. 

