### PR TITLE
Auxia Integration (Part 3)

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -129,7 +129,7 @@ export const getAuxiaRouterConfig = async (): Promise<AuxiaRouterConfig> => {
 export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
     const router = Router();
     router.post(
-        '/auxia',
+        '/auxia/get-treatments',
 
         // We are disabling that check for now, we will re-enable it later when we have a
         // better understanding of the request payload.

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -55,10 +55,6 @@ const buildAuxiaAPIRequestPayload = (projectId: string, userId: string): AuxiaAP
                 key: 'profile_id',
                 stringValue: 'pr1234',
             },
-            {
-                key: 'last_action',
-                stringValue: 'button_x_clicked',
-            },
         ],
         surfaces: [
             {


### PR DESCRIPTION
Previous steps
- Part 1: https://github.com/guardian/support-dotcom-components/pull/1265
- Part 3: https://github.com/guardian/support-dotcom-components/pull/1273

Here we 
1. Simplify the payload used to query GetTreatments.
2. Update the URL used to query the treatments. (This is in premise of adding the end point to post to log treatment.)

Sister PR: https://github.com/guardian/dotcom-rendering/pull/13267
