### PR TITLE
Auxia Integration (Part 4)

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -93,7 +93,7 @@ const callGetTreatments = async (
     return Promise.resolve(responseBody as AuxiaAPIResponseData);
 };
 
-const buildAuxiaProxyResponseData = (auxiaData: AuxiaAPIResponseData): AuxiaProxyResponseData => {
+const buildAuxiaProxyGetTreatmentsResponseData = (auxiaData: AuxiaAPIResponseData): AuxiaProxyResponseData => {
     // Note the small difference between AuxiaAPIResponseData and AuxiaProxyResponseData
     // In the case of AuxiaProxyResponseData, we have an optional userTreatment field, instead of an array of userTreatments.
     // This is to reflect the what the client expect semantically.
@@ -142,7 +142,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                     config.projectId,
                     config.userId,
                 );
-                const response = buildAuxiaProxyResponseData(auxiaData);
+                const response = buildAuxiaProxyGetTreatmentsResponseData(auxiaData);
 
                 res.send(response);
             } catch (error) {

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -66,7 +66,7 @@ const buildAuxiaAPIRequestPayload = (projectId: string, userId: string): AuxiaAP
     };
 };
 
-const fetchAuxiaData = async (
+const callGetTreatments = async (
     apiKey: string,
     projectId: string,
     userId: string,
@@ -137,7 +137,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
 
         async (req: express.Request, res: express.Response, next: express.NextFunction) => {
             try {
-                const auxiaData = await fetchAuxiaData(
+                const auxiaData = await callGetTreatments(
                     config.apiKey,
                     config.projectId,
                     config.userId,

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -176,7 +176,6 @@ const buildLogTreatmentInteractionRequestPayload = (
     interactionTimeMicros: number,
     actionName: string,
 ): AuxiaAPILogTreatmentInteractionRequestPayload => {
-    // For the moment we are hard coding the data provided in contextualAttributes and surfaces.
     return {
         projectId: projectId,
         userId: userId,


### PR DESCRIPTION
Previous steps:
- Part 1: https://github.com/guardian/support-dotcom-components/pull/1265
- Part 2: https://github.com/guardian/support-dotcom-components/pull/1273
- Part 3: https://github.com/guardian/support-dotcom-components/pull/1276

In this part we

1. Refactor the code a little bit to give better names to the types and functions needed for `/auxia/get-treatments`.
2. Implement `/auxia/log-treatment-interaction` 

Test on local:

```
curl "http://127.0.0.1:8082/auxia/log-treatment-interaction" \
    -X POST \
    -H "Content-Type: application/json" \
    -d '{
    "treatmentTrackingId": "105889_336_ad5eb464-68c6-4ca1-805c-294375422b48",
    "treatmentId": "105889",
    "surface": "ARTICLE_PAGE",
    "interactionType": "CLICKED",
    "interactionTimeMicros": 1667829258250000,
    "actionName": "someActionName"
}'
{"status":"ok"}
```




