### PR TITLE
Auxia Integration (Part 5) 

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -8,7 +8,6 @@ import { getSsmValue } from '../utils/ssm';
 export interface AuxiaRouterConfig {
     apiKey: string;
     projectId: string;
-    userId: string;
 }
 
 interface AuxiaContextualAttributeString {
@@ -98,15 +97,9 @@ export const getAuxiaRouterConfig = async (): Promise<AuxiaRouterConfig> => {
         throw new Error('auxia-projectId is undefined');
     }
 
-    const userId = await getSsmValue('PROD', 'auxia-userId');
-    if (userId === undefined) {
-        throw new Error('auxia-userId is undefined');
-    }
-
     return Promise.resolve({
         apiKey,
         projectId,
-        userId,
     });
 };
 
@@ -207,7 +200,7 @@ const buildAuxiaProxyGetTreatmentsResponseData = (
 
 const buildLogTreatmentInteractionRequestPayload = (
     projectId: string,
-    userId: string,
+    browserId: string,
     treatmentTrackingId: string,
     treatmentId: string,
     surface: string,
@@ -217,7 +210,7 @@ const buildLogTreatmentInteractionRequestPayload = (
 ): AuxiaAPILogTreatmentInteractionRequestPayload => {
     return {
         projectId: projectId,
-        userId: userId,
+        userId: browserId, // In our case the userId is the browserId.
         treatmentTrackingId,
         treatmentId,
         surface,
@@ -230,7 +223,7 @@ const buildLogTreatmentInteractionRequestPayload = (
 const callLogTreatmentInteration = async (
     apiKey: string,
     projectId: string,
-    userId: string,
+    browserId: string,
     treatmentTrackingId: string,
     treatmentId: string,
     surface: string,
@@ -247,7 +240,7 @@ const callLogTreatmentInteration = async (
 
     const payload = buildLogTreatmentInteractionRequestPayload(
         projectId,
-        userId,
+        browserId,
         treatmentTrackingId,
         treatmentId,
         surface,
@@ -308,7 +301,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                 await callLogTreatmentInteration(
                     config.apiKey,
                     config.projectId,
-                    config.userId,
+                    req.body.browserId,
                     req.body.treatmentTrackingId,
                     req.body.treatmentId,
                     req.body.surface,

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -1,5 +1,6 @@
 import express, { Router } from 'express';
 import { getSsmValue } from '../utils/ssm';
+import { bodyContainsAllFields } from '../middleware';
 
 // --------------------------------
 // Basic Types
@@ -269,11 +270,12 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
 
     router.post(
         '/auxia/get-treatments',
-
-        // We are disabling that check for now, we will re-enable it later when we have a
-        // better understanding of the request payload.
-        // bodyContainsAllFields(['tracking', 'targeting']),
-
+        bodyContainsAllFields([
+            'browserId',
+            'is_supporter',
+            'daily_article_count',
+            'article_identifier',
+        ]),
         async (req: express.Request, res: express.Response, next: express.NextFunction) => {
             try {
                 const auxiaData = await callGetTreatments(
@@ -295,7 +297,15 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
 
     router.post(
         '/auxia/log-treatment-interaction',
-
+        bodyContainsAllFields([
+            'browserId',
+            'treatmentTrackingId',
+            'treatmentId',
+            'surface',
+            'interactionType',
+            'interactionTimeMicros',
+            'actionName',
+        ]),
         async (req: express.Request, res: express.Response, next: express.NextFunction) => {
             try {
                 await callLogTreatmentInteration(

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -11,10 +11,19 @@ export interface AuxiaRouterConfig {
     userId: string;
 }
 
-interface AuxiaContextualAttributes {
+interface AuxiaContextualAttributeString {
     key: string;
     stringValue: string;
 }
+
+interface AuxiaContextualAttributeBoolean {
+    key: string;
+    boolValue: boolean;
+}
+
+type AuxiaGenericContexualAttribute =
+    | AuxiaContextualAttributeString
+    | AuxiaContextualAttributeBoolean;
 
 interface AuxiaSurface {
     surface: string;
@@ -38,7 +47,7 @@ interface AuxiaUserTreatment {
 interface AuxiaAPIGetTreatmentsRequestPayload {
     projectId: string;
     userId: string;
-    contextualAttributes: AuxiaContextualAttributes[];
+    contextualAttributes: AuxiaGenericContexualAttribute[];
     surfaces: AuxiaSurface[];
     languageCode: string;
 }
@@ -102,6 +111,7 @@ export const getAuxiaRouterConfig = async (): Promise<AuxiaRouterConfig> => {
 const buildGetTreatmentsRequestPayload = (
     projectId: string,
     browserId: string,
+    is_supporter: boolean,
 ): AuxiaAPIGetTreatmentsRequestPayload => {
     // For the moment we are hard coding the data provided in contextualAttributes and surfaces.
     return {
@@ -111,6 +121,10 @@ const buildGetTreatmentsRequestPayload = (
             {
                 key: 'profile_id',
                 stringValue: 'pr1234',
+            },
+            {
+                key: 'is_supporter',
+                boolValue: is_supporter,
             },
         ],
         surfaces: [
@@ -127,6 +141,7 @@ const callGetTreatments = async (
     apiKey: string,
     projectId: string,
     browserId: string,
+    is_supporter: boolean,
 ): Promise<AuxiaAPIGetTreatmentsResponseData> => {
     const url = 'https://apis.auxia.io/v1/GetTreatments';
 
@@ -135,7 +150,7 @@ const callGetTreatments = async (
         'x-api-key': apiKey,
     };
 
-    const payload = buildGetTreatmentsRequestPayload(projectId, browserId);
+    const payload = buildGetTreatmentsRequestPayload(projectId, browserId, is_supporter);
 
     const params = {
         method: 'POST',
@@ -248,6 +263,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                     config.apiKey,
                     config.projectId,
                     req.body.browserId,
+                    req.body.is_supporter,
                 );
                 const response = buildAuxiaProxyGetTreatmentsResponseData(auxiaData);
 

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -101,12 +101,12 @@ export const getAuxiaRouterConfig = async (): Promise<AuxiaRouterConfig> => {
 
 const buildGetTreatmentsRequestPayload = (
     projectId: string,
-    userId: string,
+    browserId: string,
 ): AuxiaAPIGetTreatmentsRequestPayload => {
     // For the moment we are hard coding the data provided in contextualAttributes and surfaces.
     return {
         projectId: projectId,
-        userId: userId,
+        userId: browserId, // In our case the userId is the browserId.
         contextualAttributes: [
             {
                 key: 'profile_id',
@@ -126,7 +126,7 @@ const buildGetTreatmentsRequestPayload = (
 const callGetTreatments = async (
     apiKey: string,
     projectId: string,
-    userId: string,
+    browserId: string,
 ): Promise<AuxiaAPIGetTreatmentsResponseData> => {
     const url = 'https://apis.auxia.io/v1/GetTreatments';
 
@@ -135,7 +135,7 @@ const callGetTreatments = async (
         'x-api-key': apiKey,
     };
 
-    const payload = buildGetTreatmentsRequestPayload(projectId, userId);
+    const payload = buildGetTreatmentsRequestPayload(projectId, browserId);
 
     const params = {
         method: 'POST',
@@ -247,7 +247,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                 const auxiaData = await callGetTreatments(
                     config.apiKey,
                     config.projectId,
-                    config.userId,
+                    req.body.browserId,
                 );
                 const response = buildAuxiaProxyGetTreatmentsResponseData(auxiaData);
 

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -21,9 +21,15 @@ interface AuxiaContextualAttributeBoolean {
     boolValue: boolean;
 }
 
+interface AuxiaContextualAttributeInteger {
+    key: string;
+    integerValue: number;
+}
+
 type AuxiaGenericContexualAttribute =
     | AuxiaContextualAttributeString
-    | AuxiaContextualAttributeBoolean;
+    | AuxiaContextualAttributeBoolean
+    | AuxiaContextualAttributeInteger;
 
 interface AuxiaSurface {
     surface: string;
@@ -112,6 +118,8 @@ const buildGetTreatmentsRequestPayload = (
     projectId: string,
     browserId: string,
     is_supporter: boolean,
+    daily_article_count: number,
+    article_identifier: string,
 ): AuxiaAPIGetTreatmentsRequestPayload => {
     // For the moment we are hard coding the data provided in contextualAttributes and surfaces.
     return {
@@ -125,6 +133,14 @@ const buildGetTreatmentsRequestPayload = (
             {
                 key: 'is_supporter',
                 boolValue: is_supporter,
+            },
+            {
+                key: 'daily_article_count',
+                integerValue: daily_article_count,
+            },
+            {
+                key: 'article_identifier',
+                stringValue: article_identifier,
             },
         ],
         surfaces: [
@@ -142,6 +158,8 @@ const callGetTreatments = async (
     projectId: string,
     browserId: string,
     is_supporter: boolean,
+    daily_article_count: number,
+    article_identifier: string,
 ): Promise<AuxiaAPIGetTreatmentsResponseData> => {
     const url = 'https://apis.auxia.io/v1/GetTreatments';
 
@@ -150,7 +168,13 @@ const callGetTreatments = async (
         'x-api-key': apiKey,
     };
 
-    const payload = buildGetTreatmentsRequestPayload(projectId, browserId, is_supporter);
+    const payload = buildGetTreatmentsRequestPayload(
+        projectId,
+        browserId,
+        is_supporter,
+        daily_article_count,
+        article_identifier,
+    );
 
     const params = {
         method: 'POST',
@@ -264,6 +288,8 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                     config.projectId,
                     req.body.browserId,
                     req.body.is_supporter,
+                    req.body.daily_article_count,
+                    req.body.article_identifier,
                 );
                 const response = buildAuxiaProxyGetTreatmentsResponseData(auxiaData);
 


### PR DESCRIPTION
Previously, in Auxia Integration: https://github.com/guardian/support-dotcom-components/pull/1277

In this Part, we upgrade the requirements for the /auxia/get-treatments to require the following attributes: `browserId`, `is_supporter`, `daily_article_count`, `article_identifier`, as requested by Auxia. 

We also upgrade the requirements for the /auxia/log-treatment-interaction call, to add `browserId`.
