### PR TITLE
Auxia Integration (Part 5): gracefully handle incomplete Auxia answers

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -300,9 +300,9 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
 
                 if (auxiaData !== undefined) {
                     const data = buildAuxiaProxyGetTreatmentsResponseData(auxiaData);
-                    res.send({ status: 'ok', data: data });
+                    res.send({ status: true, data: data });
                 } else {
-                    res.send({ status: 'error' });
+                    res.send({ status: false });
                 }
             } catch (error) {
                 next(error);

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -154,7 +154,7 @@ const callGetTreatments = async (
     is_supporter: boolean,
     daily_article_count: number,
     article_identifier: string,
-): Promise<AuxiaAPIGetTreatmentsResponseData> => {
+): Promise<AuxiaAPIGetTreatmentsResponseData | undefined> => {
     const url = 'https://apis.auxia.io/v1/GetTreatments';
 
     const headers = {
@@ -176,19 +176,30 @@ const callGetTreatments = async (
         body: JSON.stringify(payload),
     };
 
-    const response = await fetch(url, params);
+    try {
+        const response = await fetch(url, params);
+        const responseBody = await response.json();
 
-    const responseBody = await response.json();
-
-    return Promise.resolve(responseBody as AuxiaAPIGetTreatmentsResponseData);
+        // nb: In some circumstances, for instance if the payload although having the right
+        // schema, is going to fail Auxia's validation then the response body may not contain
+        // the userTreatments field. In this case we return undefined.
+        if (responseBody['userTreatments'] === undefined) {
+            return Promise.resolve(undefined);
+        }
+        const data = responseBody as AuxiaAPIGetTreatmentsResponseData;
+        return Promise.resolve(data);
+    } catch (error) {
+        return Promise.resolve(undefined);
+    }
 };
 
 const buildAuxiaProxyGetTreatmentsResponseData = (
     auxiaData: AuxiaAPIGetTreatmentsResponseData,
-): AuxiaProxyGetTreatmentsResponseData => {
+): AuxiaProxyGetTreatmentsResponseData | undefined => {
     // Note the small difference between AuxiaAPIResponseData and AuxiaProxyResponseData
     // In the case of AuxiaProxyResponseData, we have an optional userTreatment field, instead of an array of userTreatments.
     // This is to reflect the what the client expect semantically.
+
     return {
         responseId: auxiaData.responseId,
         userTreatment: auxiaData.userTreatments[0],
@@ -286,9 +297,13 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                     req.body.daily_article_count,
                     req.body.article_identifier,
                 );
-                const response = buildAuxiaProxyGetTreatmentsResponseData(auxiaData);
 
-                res.send(response);
+                if (auxiaData !== undefined) {
+                    const data = buildAuxiaProxyGetTreatmentsResponseData(auxiaData);
+                    res.send({ status: 'ok', data: data });
+                } else {
+                    res.send({ status: 'error' });
+                }
             } catch (error) {
                 next(error);
             }


### PR DESCRIPTION
Previously, in Auxia Integration: https://github.com/guardian/support-dotcom-components/pull/1284

As we accidentally discovered here https://github.com/guardian/dotcom-rendering/pull/13335 , Auxia's answers may be incomplete, for instance when the client submitted incorrect data. Here we address that problem.

With this change we now have 

```
curl "http://127.0.0.1:8082/auxia/get-treatments" \
    -X POST \
    -H "Content-Type: application/json" \
    -d '{
    "browserId": "2598326e-7c",
    "is_supporter" : true,
    "daily_article_count": 12,
    "article_identifier": "www.theguardian.com/us-news/2025/feb/06/trump-sanction-icc"
}'
{"status":false}
```  

and 

```
curl "http://127.0.0.1:8082/auxia/get-treatments" \
    -X POST \
    -H "Content-Type: application/json" \
    -d '{
    "browserId": "2598326e7c",
    "is_supporter" : true,
    "daily_article_count": 12,
    "article_identifier": "www.theguardian.com/us-news/2025/feb/06/trump-sanction-icc"
}'
{"status":true,"data":{"responseId":"d76ff9ca-1ec5-416d-8d37-a5615c0fe8f2","userTreatment":{"treatmentId":"105897","treatmentTrackingId":"105897_336_d76ff9ca-1ec5-416d-8d37-a5615c0fe8f2","rank":"1","contentLanguageCode":"en-GB","treatmentContent":"{\"title\":\"Sign in for a personlised Guardian experience\",\"body\":\"\",\"first_cta_name\":\"Sign in\",\"first_cta_link\":\"https://profile.theguardian.com/signin?\",\"second_cta_name\":\"Next time\",\"second_cta_link\":\"https://profile.theguardian.com/signin?\",\"subtitle\":\"Get less asks for support and more personalised recommendations\",\"privacy_button_name\":\"privacy settings\"}","treatmentType":"DISMISSABLE_SIGN_IN_GATE","surface":"ARTICLE_PAGE"}}}
```

Note that the DCR code will have to be updated now to check for the `status` field before consuming the answer.