### PR TITLE
auxia experiment: prepare for the distinction between stages

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -333,7 +333,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                     req.body.interactionTimeMicros,
                     req.body.actionName,
                 );
-                res.send({ status: 'ok' }); // this is the proxy's response, slightly more user's friendly than the api's response.
+                res.send({ status: true }); // this is the proxy's response, slightly more user's friendly than the api's response.
             } catch (error) {
                 next(error);
             }

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -124,10 +124,6 @@ const buildGetTreatmentsRequestPayload = (
         userId: browserId, // In our case the userId is the browserId.
         contextualAttributes: [
             {
-                key: 'profile_id',
-                stringValue: 'pr1234',
-            },
-            {
                 key: 'is_supporter',
                 boolValue: is_supporter,
             },

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -1,4 +1,5 @@
 import express, { Router } from 'express';
+import { isProd } from '../lib/env';
 import { getSsmValue } from '../utils/ssm';
 import { bodyContainsAllFields } from '../middleware';
 
@@ -88,12 +89,14 @@ interface AuxiaProxyGetTreatmentsResponseData {
 // --------------------------------
 
 export const getAuxiaRouterConfig = async (): Promise<AuxiaRouterConfig> => {
-    const apiKey = await getSsmValue('PROD', 'auxia-api-key');
+    const stage = isProd ? 'PROD' : 'CODE';
+
+    const apiKey = await getSsmValue(stage, 'auxia-api-key');
     if (apiKey === undefined) {
         throw new Error('auxia-api-key is undefined');
     }
 
-    const projectId = await getSsmValue('PROD', 'auxia-projectId');
+    const projectId = await getSsmValue(stage, 'auxia-projectId');
     if (projectId === undefined) {
         throw new Error('auxia-projectId is undefined');
     }


### PR DESCRIPTION
Here:

1. Prepare for the distinction between Auxia PROD and Auxia CODE while talking to the Auxia API. 

2. Also we never needed `profile_id`. 

3. To mirror the case of /auxia/get-treatments, we use a boolean for status in /auxia/log-treatment-interaction. (No change needed in DCR, we don't actually consume that answer)