### PR TITLE
auxia experiment: Use default GU data in case of non consenting reader

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -153,7 +153,17 @@ const guDefaultGetTreatmentsResponseData = (): AuxiaAPIGetTreatmentsResponseData
         'We’re committed to keeping our quality reporting open. By registering and providing us with insight into your preferences, you’re helping us to engage with you more deeply, and that allows us to keep our journalism free for all. You’ll always be able to control your own';
     const second_cta_name = 'I’ll do it later';
     const privacy_button_name = 'privacy settings';
-    const treatmentContentEncoded = `{"title":"${title}","body":"${body}","first_cta_name":"Sign in","first_cta_link":"https://profile.theguardian.com/signin?","second_cta_name":"${second_cta_name}","second_cta_link":"https://profile.theguardian.com/signin?","subtitle":"${subtitle}","privacy_button_name":"${privacy_button_name}"}`;
+    const treatmentContent = {
+        title,
+        subtitle,
+        body,
+        first_cta_name: 'Sign in',
+        first_cta_link: 'https://profile.theguardian.com/signin?',
+        second_cta_name,
+        second_cta_link: 'https://profile.theguardian.com/signin?',
+        privacy_button_name,
+    };
+    const treatmentContentEncoded = JSON.stringify(treatmentContent);
     const userTreatment: AuxiaAPIUserTreatment = {
         treatmentId: 'default-treatment-id',
         treatmentTrackingId: 'default-treatment-tracking-id',

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -146,7 +146,19 @@ const buildGetTreatmentsRequestPayload = (
     };
 };
 
-const guDefaultGetTreatmentsResponseData = (): AuxiaAPIGetTreatmentsResponseData => {
+const guDefaultGetTreatmentsResponseData = (
+    daily_article_count: number,
+): AuxiaAPIGetTreatmentsResponseData => {
+    const responseId = ''; // This value is not important, it is not used by the client.
+
+    if (daily_article_count % 10 != 0) {
+        // We show the GU gate every 10 pageviews
+        return {
+            responseId,
+            userTreatments: [],
+        };
+    }
+
     const title = 'Register: it’s quick and easy';
     const subtitle = 'It’s still free to read – this is not a paywall';
     const body =
@@ -174,7 +186,7 @@ const guDefaultGetTreatmentsResponseData = (): AuxiaAPIGetTreatmentsResponseData
         surface: 'ARTICLE_PAGE',
     };
     const data: AuxiaAPIGetTreatmentsResponseData = {
-        responseId: '', // This value is not important, it is not used by the client.
+        responseId,
         userTreatments: [userTreatment],
     };
     return data;
@@ -194,7 +206,7 @@ const callGetTreatments = async (
     // If false, we return a default answer (controlled by GU).
 
     if (!user_has_consented_to_personal_data_use) {
-        const data = guDefaultGetTreatmentsResponseData();
+        const data = guDefaultGetTreatmentsResponseData(daily_article_count);
         return Promise.resolve(data);
     }
 

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -235,6 +235,7 @@ const buildLogTreatmentInteractionRequestPayload = (
 const callLogTreatmentInteration = async (
     apiKey: string,
     projectId: string,
+    user_has_consented_to_personal_data_use: boolean,
     browserId: string,
     treatmentTrackingId: string,
     treatmentId: string,
@@ -315,6 +316,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
     router.post(
         '/auxia/log-treatment-interaction',
         bodyContainsAllFields([
+            'user_has_consented_to_personal_data_use',
             'browserId',
             'treatmentTrackingId',
             'treatmentId',
@@ -328,6 +330,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                 await callLogTreatmentInteration(
                     config.apiKey,
                     config.projectId,
+                    req.body.user_has_consented_to_personal_data_use,
                     req.body.browserId,
                     req.body.treatmentTrackingId,
                     req.body.treatmentId,

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -114,9 +114,9 @@ export const getAuxiaRouterConfig = async (): Promise<AuxiaRouterConfig> => {
 const buildGetTreatmentsRequestPayload = (
     projectId: string,
     browserId: string,
-    is_supporter: boolean,
-    daily_article_count: number,
-    article_identifier: string,
+    isSupporter: boolean,
+    dailyArticleCount: number,
+    articleIdentifier: string,
 ): AuxiaAPIGetTreatmentsRequestPayload => {
     // For the moment we are hard coding the data provided in contextualAttributes and surfaces.
     return {
@@ -125,15 +125,15 @@ const buildGetTreatmentsRequestPayload = (
         contextualAttributes: [
             {
                 key: 'is_supporter',
-                boolValue: is_supporter,
+                boolValue: isSupporter,
             },
             {
                 key: 'daily_article_count',
-                integerValue: daily_article_count,
+                integerValue: dailyArticleCount,
             },
             {
                 key: 'article_identifier',
-                stringValue: article_identifier,
+                stringValue: articleIdentifier,
             },
         ],
         surfaces: [
@@ -168,17 +168,17 @@ const guDefaultGateGetTreatmentsResponseData = (
     const subtitle = 'It’s still free to read – this is not a paywall';
     const body =
         'We’re committed to keeping our quality reporting open. By registering and providing us with insight into your preferences, you’re helping us to engage with you more deeply, and that allows us to keep our journalism free for all. You’ll always be able to control your own';
-    const second_cta_name = 'I’ll do it later';
-    const privacy_button_name = 'privacy settings';
+    const secondCtaName = 'I’ll do it later';
+    const privacyButtonName = 'privacy settings';
     const treatmentContent = {
         title,
         subtitle,
         body,
         first_cta_name: 'Sign in',
         first_cta_link: 'https://profile.theguardian.com/signin?',
-        second_cta_name,
+        second_cta_name: secondCtaName,
         second_cta_link: 'https://profile.theguardian.com/signin?',
-        privacy_button_name,
+        privacy_button_name: privacyButtonName,
     };
     const treatmentContentEncoded = JSON.stringify(treatmentContent);
     const userTreatment: AuxiaAPIUserTreatment = {
@@ -201,16 +201,16 @@ const callGetTreatments = async (
     apiKey: string,
     projectId: string,
     browserId: string | undefined,
-    is_supporter: boolean,
-    daily_article_count: number,
-    article_identifier: string,
+    isSupporter: boolean,
+    dailyArticleCount: number,
+    articleIdentifier: string,
 ): Promise<AuxiaAPIGetTreatmentsResponseData | undefined> => {
     // Here the behavior depends on the value of `user_has_consented_to_personal_data_use`
     // If defined, we perform the normal API call to Auxia.
     // If undefined, we return a default answer (controlled by GU).
 
     if (browserId === undefined) {
-        const data = guDefaultGateGetTreatmentsResponseData(daily_article_count);
+        const data = guDefaultGateGetTreatmentsResponseData(dailyArticleCount);
         return Promise.resolve(data);
     }
 
@@ -224,9 +224,9 @@ const callGetTreatments = async (
     const payload = buildGetTreatmentsRequestPayload(
         projectId,
         browserId,
-        is_supporter,
-        daily_article_count,
-        article_identifier,
+        isSupporter,
+        dailyArticleCount,
+        articleIdentifier,
     );
 
     const params = {
@@ -348,16 +348,16 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
 
     router.post(
         '/auxia/get-treatments',
-        bodyContainsAllFields(['is_supporter', 'daily_article_count', 'article_identifier']),
+        bodyContainsAllFields(['isSupporter', 'dailyArticleCount', 'articleIdentifier']),
         async (req: express.Request, res: express.Response, next: express.NextFunction) => {
             try {
                 const auxiaData = await callGetTreatments(
                     config.apiKey,
                     config.projectId,
                     req.body.browserId, // optional field, will not be sent by the client is user has not consented to personal data use.
-                    req.body.is_supporter,
-                    req.body.daily_article_count,
-                    req.body.article_identifier,
+                    req.body.isSupporter,
+                    req.body.dailyArticleCount,
+                    req.body.articleIdentifier,
                 );
 
                 if (auxiaData !== undefined) {

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -147,8 +147,13 @@ const buildGetTreatmentsRequestPayload = (
 };
 
 const guDefaultGetTreatmentsResponseData = (): AuxiaAPIGetTreatmentsResponseData => {
-    const treatmentContentEncoded =
-        '{"title":"Sign in for a personlised Guardian experience","body":"","first_cta_name":"Sign in","first_cta_link":"https://profile.theguardian.com/signin?","second_cta_name":"Next time","second_cta_link":"https://profile.theguardian.com/signin?","subtitle":"Get less asks for support and more personalised recommendations","privacy_button_name":"privacy settings"}';
+    const title = 'Register: it’s quick and easy';
+    const subtitle = 'It’s still free to read – this is not a paywall';
+    const body =
+        'We’re committed to keeping our quality reporting open. By registering and providing us with insight into your preferences, you’re helping us to engage with you more deeply, and that allows us to keep our journalism free for all. You’ll always be able to control your own';
+    const second_cta_name = 'I’ll do it later';
+    const privacy_button_name = 'privacy settings';
+    const treatmentContentEncoded = `{"title":"${title}","body":"${body}","first_cta_name":"Sign in","first_cta_link":"https://profile.theguardian.com/signin?","second_cta_name":"${second_cta_name}","second_cta_link":"https://profile.theguardian.com/signin?","subtitle":"${subtitle}","privacy_button_name":"${privacy_button_name}"}`;
     const userTreatment: AuxiaAPIUserTreatment = {
         treatmentId: 'default-treatment-id',
         treatmentTrackingId: 'default-treatment-tracking-id',
@@ -163,7 +168,7 @@ const guDefaultGetTreatmentsResponseData = (): AuxiaAPIGetTreatmentsResponseData
         userTreatments: [userTreatment],
     };
     return data;
-}
+};
 
 const callGetTreatments = async (
     apiKey: string,

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -149,6 +149,7 @@ const buildGetTreatmentsRequestPayload = (
 const callGetTreatments = async (
     apiKey: string,
     projectId: string,
+    user_has_consented_to_personal_data_use: boolean,
     browserId: string,
     is_supporter: boolean,
     daily_article_count: number,
@@ -281,6 +282,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
     router.post(
         '/auxia/get-treatments',
         bodyContainsAllFields([
+            'user_has_consented_to_personal_data_use',
             'browserId',
             'is_supporter',
             'daily_article_count',
@@ -291,6 +293,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                 const auxiaData = await callGetTreatments(
                     config.apiKey,
                     config.projectId,
+                    req.body.user_has_consented_to_personal_data_use,
                     req.body.browserId,
                     req.body.is_supporter,
                     req.body.daily_article_count,


### PR DESCRIPTION
Here we require an additional attribute in the payload of the auxia queries and perform special handling in case the reader had non consented to their personal data being used. In this latter case, re do not connect to the Auxia API and return the GU template. 