### PR TITLE
auxia experiment: prevent 500 errors from bringing down the app

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -123,16 +123,18 @@ const buildApp = async (): Promise<Express> => {
 
     app.use('/amp', buildAmpEpicRouter(choiceCardAmounts, tickerData, ampEpicTests));
 
+    app.use(buildAuxiaProxyRouter(auxiaConfig));
+
+    app.use(buildGutterRouter(channelSwitches, gutterLiveblogTests));
+
+    // The error handling middleware must be the last middleware in the chain
+    // https://stackoverflow.com/questions/72227296/does-the-position-of-error-handling-middleware-matter-in-express
     app.use(errorHandlingMiddleware);
 
     app.get('/healthcheck', (req: express.Request, res: express.Response) => {
         res.header('Content-Type', 'text/plain');
         res.send('OK');
     });
-
-    app.use(buildAuxiaProxyRouter(auxiaConfig));
-
-    app.use(buildGutterRouter(channelSwitches, gutterLiveblogTests));
 
     return Promise.resolve(app);
 };


### PR DESCRIPTION
This corrects a problem that has existed for a while but only became apparent last couple of days as we experienced 500 errors: the position of error handling middleware matter in Express 🙃

https://stackoverflow.com/questions/72227296/does-the-position-of-error-handling-middleware-matter-in-express

Note that this also correct any problems with might have had with `GutterRouter`