### PR TITLE
4 instances

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -115,7 +115,7 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
             "Granularity": "1Minute",
           },
         ],
-        "MinSize": "3",
+        "MinSize": "4",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -216,7 +216,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
         ];
 
 		const scaling: GuAsgCapacity = {
-			minimumInstances: this.stage === 'CODE' ? 1 : 3,
+			minimumInstances: this.stage === 'CODE' ? 1 : 4,
 			maximumInstances: this.stage === 'CODE' ? 2 : 18,
 		};
 


### PR DESCRIPTION
Since the rollout of the auxia experiment we've seen an increase in cpu use and autoscaling activity. We've also had some 5XX spikes.
This PR adds 1 to the minimum instance count, to help stabilise while we're running the experiment