### PR TITLE
Set keepAliveTimeout

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -143,7 +143,9 @@ buildApp()
     .then((app) => {
         const PORT = process.env.PORT || 3030;
 
-        app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
+        const server = app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
+        // keep-alive timeout should match LB idle timeout value, see https://repost.aws/knowledge-center/elb-alb-troubleshoot-502-errors
+        server.keepAliveTimeout = 60000;
     })
     .catch((err) => {
         logError(`Failed to start server: ${String(err)}`);


### PR DESCRIPTION
Since rolling out the auxia experiment we've seen spikes in 502s from the LB. This indicates connection problems with the server.

This is a small change to see if it relates to the connection keep-alive timeout.

https://repost.aws/knowledge-center/elb-alb-troubleshoot-502-errors

> The load balancer receives a request and forwards it to the target. The target receives the request and starts to process it, but closes the connection to the load balancer too early. This usually occurs when the duration of the keep-alive timeout for the target is shorter than the idle timeout value of the load balancer. Make sure that the duration of the keep-alive timeout is greater than the idle timeout value.

The LB default idle timeout is 60 seconds, and the node.js default keep-alive is 5 seconds.