### PR TITLE
log response time

### DIFF
--- a/src/server/middleware/logging.ts
+++ b/src/server/middleware/logging.ts
@@ -1,14 +1,17 @@
 import express from 'express';
 import { logger } from '../utils/logging';
 
-export const RequestLogName = 'request';
-
 export const logging = (
     req: express.Request,
     res: express.Response,
     next: express.NextFunction,
 ): void => {
-    res.on('finish', () =>
+    const startTime = process.hrtime();
+
+    res.on('finish', () => {
+        const [seconds, nanoseconds] = process.hrtime(startTime);
+        const responseTimeMs = seconds * 1000 + nanoseconds / 1e6;
+
         logger.info({
             status: res.statusCode,
             method: req.method,
@@ -19,8 +22,9 @@ export const logging = (
             epicTargeting: res.locals.epicTargeting,
             userAgent: isServerError(res.statusCode) ? req.headers['user-agent'] : undefined,
             epicSuperMode: res.locals.epicSuperMode,
-        }),
-    );
+            responseTimeMs: responseTimeMs.toFixed(0),
+        });
+    });
     next();
 };
 


### PR DESCRIPTION
Adds a `responseTimeMs` field to the logging (which ends up in kibana):

For non-auxia requests this should be very small because no additional network calls are made. But for the auxia endpoints it will be much longer.
Note that this is the time taken once the server begins handling a request, but does not account for delays either side.

Tested in CODE:

E.g. `/header` request:

```{"stack":"support","app":"dotcom-components","stage":"CODE","@timestamp":"2025-02-27T09:27:02.208Z","level":"INFO","level_value":20000,"status":200,"method":"POST","path":"/header","responseTimeMs":"2"}```

E.g. `/auxia/get-treatments` request:

```{"stack":"support","app":"dotcom-components","stage":"CODE","@timestamp":"2025-02-27T09:25:50.021Z","level":"INFO","level_value":20000,"status":200,"method":"POST","path":"/auxia/get-treatments","responseTimeMs":"1141"}```