### PR TITLE
Hide epic and banners for info pages

### DIFF
--- a/.changeset/gorgeous-days-give.md
+++ b/.changeset/gorgeous-days-give.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+Add pageId to targeting

--- a/src/server/api/bannerRouter.ts
+++ b/src/server/api/bannerRouter.ts
@@ -9,6 +9,7 @@ import {
     TestTracking,
     BannerDesignFromTool,
     Tracking,
+    pageIdsOfInterest,
 } from '../../shared/types';
 import { selectAmountsTestVariant } from '../lib/ab';
 import { ChannelSwitches } from '../channelSwitches';
@@ -57,6 +58,10 @@ export const buildBannerRouter = (
             channelSwitches.get();
 
         if (!enableBanners) {
+            return {};
+        }
+
+        if (targeting.pageId && pageIdsOfInterest.has(targeting.pageId)) {
             return {};
         }
 

--- a/src/server/api/bannerRouter.ts
+++ b/src/server/api/bannerRouter.ts
@@ -9,7 +9,7 @@ import {
     TestTracking,
     BannerDesignFromTool,
     Tracking,
-    pageIdsOfInterest,
+    hideSRMessagingForInfoPageIds,
 } from '../../shared/types';
 import { selectAmountsTestVariant } from '../lib/ab';
 import { ChannelSwitches } from '../channelSwitches';
@@ -61,7 +61,7 @@ export const buildBannerRouter = (
             return {};
         }
 
-        if (targeting.pageId && pageIdsOfInterest.has(targeting.pageId)) {
+        if (hideSRMessagingForInfoPageIds(targeting)) {
             return {};
         }
 

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -6,7 +6,7 @@ import {
     EpicTest,
     EpicType,
     EpicVariant,
-    pageIdsOfInterest,
+    hideSRMessagingForInfoPageIds,
     TestTracking,
     Tracking,
     WeeklyArticleLog,
@@ -84,7 +84,7 @@ export const buildEpicRouter = (
             return {};
         }
 
-        if (targeting.pageId && pageIdsOfInterest.has(targeting.pageId)) {
+        if (hideSRMessagingForInfoPageIds(targeting)) {
             return {};
         }
 

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -83,6 +83,14 @@ export const buildEpicRouter = (
             return {};
         }
 
+        if (
+            targeting.pageId === 'info/privacy' ||
+            targeting.pageId === 'info/complaints-and-corrections' ||
+            targeting.pageId === 'about'
+        ) {
+            return {};
+        }
+
         const targetingMvtId = targeting.mvtId || 1;
 
         const tests =

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -6,6 +6,7 @@ import {
     EpicTest,
     EpicType,
     EpicVariant,
+    pageIdsOfInterest,
     TestTracking,
     Tracking,
     WeeklyArticleLog,
@@ -83,11 +84,7 @@ export const buildEpicRouter = (
             return {};
         }
 
-        if (
-            targeting.pageId === 'info/privacy' ||
-            targeting.pageId === 'info/complaints-and-corrections' ||
-            targeting.pageId === 'about'
-        ) {
+        if (targeting.pageId && pageIdsOfInterest.has(targeting.pageId)) {
             return {};
         }
 

--- a/src/server/api/gutterRouter.ts
+++ b/src/server/api/gutterRouter.ts
@@ -8,7 +8,7 @@ import {
     TestTracking,
     GutterTargeting,
     Tracking,
-    pageIdsOfInterest,
+    hideSRMessagingForInfoPageIds,
 } from '../../shared/types';
 import { ChannelSwitches } from '../channelSwitches';
 import { getDeviceType } from '../lib/deviceType';
@@ -42,7 +42,8 @@ export const buildGutterRouter = (
         if (!enableGutterLiveblogs) {
             return {};
         }
-        if (targeting.pageId && pageIdsOfInterest.has(targeting.pageId)) {
+
+        if (hideSRMessagingForInfoPageIds(targeting)) {
             return {};
         }
 

--- a/src/server/api/gutterRouter.ts
+++ b/src/server/api/gutterRouter.ts
@@ -8,6 +8,7 @@ import {
     TestTracking,
     GutterTargeting,
     Tracking,
+    pageIdsOfInterest,
 } from '../../shared/types';
 import { ChannelSwitches } from '../channelSwitches';
 import { getDeviceType } from '../lib/deviceType';
@@ -41,6 +42,10 @@ export const buildGutterRouter = (
         if (!enableGutterLiveblogs) {
             return {};
         }
+        if (targeting.pageId && pageIdsOfInterest.has(targeting.pageId)) {
+            return {};
+        }
+
         const testSelection = selectGutterTest(
             targeting,
             tests.get(),

--- a/src/server/tests/banners/bannerSelection.ts
+++ b/src/server/tests/banners/bannerSelection.ts
@@ -205,14 +205,6 @@ export const selectBannerTest = (
         return null;
     }
 
-    if (
-        targeting.pageId === 'info/privacy' ||
-        targeting.pageId === 'info/complaints-and-corrections' ||
-        targeting.pageId === 'about'
-    ) {
-        return null;
-    }
-
     if (forcedTestVariant) {
         return getForcedVariant(forcedTestVariant, tests);
     }

--- a/src/server/tests/banners/bannerSelection.ts
+++ b/src/server/tests/banners/bannerSelection.ts
@@ -205,6 +205,14 @@ export const selectBannerTest = (
         return null;
     }
 
+    if (
+        targeting.pageId === 'info/privacy' ||
+        targeting.pageId === 'info/complaints-and-corrections' ||
+        targeting.pageId === 'about'
+    ) {
+        return null;
+    }
+
     if (forcedTestVariant) {
         return getForcedVariant(forcedTestVariant, tests);
     }

--- a/src/shared/types/targeting/banner.ts
+++ b/src/shared/types/targeting/banner.ts
@@ -21,6 +21,7 @@ export type BannerTargeting = {
     isSignedIn: boolean;
     hasConsented: boolean;
     abandonedBasket?: AbandonedBasket;
+    pageId?: string;
 };
 
 export type BannerPayload = {

--- a/src/shared/types/targeting/epic.ts
+++ b/src/shared/types/targeting/epic.ts
@@ -25,6 +25,7 @@ export type EpicTargeting = {
     url?: string;
     browserId?: string; // Only present if the user has consented to browserId-based targeting
     isSignedIn?: boolean;
+    pageId?: string;
 };
 
 export type EpicPayload = {

--- a/src/shared/types/targeting/gutter.ts
+++ b/src/shared/types/targeting/gutter.ts
@@ -5,6 +5,7 @@ export interface GutterTargeting {
     isSignedIn: boolean;
     tagIds?: string[];
     sectionId?: string;
+    pageId?: string;
 }
 
 export type GutterPayload = {

--- a/src/shared/types/targeting/shared.ts
+++ b/src/shared/types/targeting/shared.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 import { purchaseInfoProduct, purchaseInfoUser } from '../purchaseInfo';
+import { BannerTargeting } from './banner';
+import { EpicTargeting } from './epic';
+import { GutterTargeting } from './gutter';
 
 export type TagCounts = {
     [tag: string]: number;
@@ -34,6 +37,12 @@ export const pageIdsOfInterest = new Set<string>([
     'info/complaints-and-corrections',
     'about',
 ]);
+
+export const hideSRMessagingForInfoPageIds = (
+    targeting: BannerTargeting | EpicTargeting | GutterTargeting,
+): boolean => {
+    return targeting.pageId ? pageIdsOfInterest.has(targeting.pageId) : false;
+};
 
 export const abandonedBasketSchema = z.object({
     amount: z.union([z.number(), z.literal('other')]),

--- a/src/shared/types/targeting/shared.ts
+++ b/src/shared/types/targeting/shared.ts
@@ -28,6 +28,13 @@ export interface PurchaseInfo {
     product: purchaseInfoProduct;
 }
 
+//The pageIdsOfInterest has the pageIds in which we want to hide the SR messages
+export const pageIdsOfInterest = new Set<string>([
+    'info/privacy',
+    'info/complaints-and-corrections',
+    'about',
+]);
+
 export const abandonedBasketSchema = z.object({
     amount: z.union([z.number(), z.literal('other')]),
     billingPeriod: z.union([z.literal('ONE_OFF'), z.literal('MONTHLY'), z.literal('ANNUAL')]),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We need to disable RRCP support messages on pages like [Privacy | The Guardian](https://www.theguardian.com/info/privacy)  like [Privacy | The Guardian](https://www.theguardian.com/info/privacy)

See green section here for full list: https://docs.google.com/spreadsheets/d/1KdwxnOecrV-2j3X-mX_kkvLgupPH8DvBgvEH-D-cRWg/edit?gid=0#gid=0Connect your Google account

[Trello card](https://trello.com/c/xeqIF1aP/944-do-not-show-epic-banner-on-info-pages)

Out of the list we are making this change for the below pageIds
1.  'info/privacy' 
2. 'info/complaints-and-corrections' 
3. 'about'


## how to test

Tested using Postman

## Before change 

<img width="698" alt="image" src="https://github.com/user-attachments/assets/103407c5-c035-4f02-8952-de37a6cc490c" />


## After change 
<img width="698" alt="image" src="https://github.com/user-attachments/assets/1022134b-df04-48a3-b88a-190556cea46b" />
