### PR TITLE
Log response time as number

### DIFF
--- a/src/server/middleware/logging.ts
+++ b/src/server/middleware/logging.ts
@@ -22,7 +22,7 @@ export const logging = (
             epicTargeting: res.locals.epicTargeting,
             userAgent: isServerError(res.statusCode) ? req.headers['user-agent'] : undefined,
             epicSuperMode: res.locals.epicSuperMode,
-            responseTimeMs: responseTimeMs.toFixed(0),
+            responseTimeMs: Math.round(responseTimeMs),
         });
     });
     next();


### PR DESCRIPTION
Currently this is being logged as a string (because `toFixed` returns a string!).
In order to do aggregations in kibana it needs to be a number