### PR TITLE
Rename response time field

### DIFF
--- a/src/server/middleware/logging.ts
+++ b/src/server/middleware/logging.ts
@@ -22,7 +22,7 @@ export const logging = (
             epicTargeting: res.locals.epicTargeting,
             userAgent: isServerError(res.statusCode) ? req.headers['user-agent'] : undefined,
             epicSuperMode: res.locals.epicSuperMode,
-            responseTimeMs: Math.round(responseTimeMs),
+            responseTimeInMs: Math.round(responseTimeMs),
         });
     });
     next();


### PR DESCRIPTION
I previously sent the `responseTimeMs` field as a string by mistake.
Kibana now insists that this field is a string, even after fixing it in SDC.
Renaming the field will solve this