### PR TITLE
minimum 6 instances

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -115,7 +115,7 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
             "Granularity": "1Minute",
           },
         ],
-        "MinSize": "4",
+        "MinSize": "6",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -216,7 +216,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
         ];
 
 		const scaling: GuAsgCapacity = {
-			minimumInstances: this.stage === 'CODE' ? 1 : 4,
+			minimumInstances: this.stage === 'CODE' ? 1 : 6,
 			maximumInstances: this.stage === 'CODE' ? 2 : 18,
 		};
 


### PR DESCRIPTION
We've had some short + shart ELB 502 spikes during heavy traffic. Autoscaling has been going up and down.
While we're running the auxia experiment let's maintain 6 instances
![Screenshot 2025-03-03 at 08 20 44](https://github.com/user-attachments/assets/370f3c02-863a-422b-a1d0-68e8443c6566)

