### PR TITLE
Use request count for autoscaling policy

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -115,7 +115,7 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
             "Granularity": "1Minute",
           },
         ],
-        "MinSize": "6",
+        "MinSize": "3",
         "Tags": [
           {
             "Key": "App",
@@ -161,7 +161,10 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
     },
-    "AutoScalingGroupDotcomcomponentsScalingPolicyCpuScalingPolicy29FF9AE6": {
+    "AutoScalingGroupDotcomcomponentsScalingPolicyRequestCountScalingPolicy2E40F328": {
+      "DependsOn": [
+        "ListenerDotcomcomponentsF68CDC56",
+      ],
       "Properties": {
         "AutoScalingGroupName": {
           "Ref": "AutoScalingGroupDotcomcomponentsASG512C0EA8",
@@ -169,9 +172,64 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
         "PolicyType": "TargetTrackingScaling",
         "TargetTrackingConfiguration": {
           "PredefinedMetricSpecification": {
-            "PredefinedMetricType": "ASGAverageCPUUtilization",
+            "PredefinedMetricType": "ALBRequestCountPerTarget",
+            "ResourceLabel": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "ListenerDotcomcomponentsF68CDC56",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "ListenerDotcomcomponentsF68CDC56",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  {
+                    "Fn::Select": [
+                      3,
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "ListenerDotcomcomponentsF68CDC56",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  {
+                    "Fn::GetAtt": [
+                      "TargetGroupDotcomcomponents54FF73AB",
+                      "TargetGroupFullName",
+                    ],
+                  },
+                ],
+              ],
+            },
           },
-          "TargetValue": 40,
+          "TargetValue": 20000,
         },
       },
       "Type": "AWS::AutoScaling::ScalingPolicy",

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -216,7 +216,7 @@ chown -R dotcom-components:support /var/log/dotcom-components
         ];
 
 		const scaling: GuAsgCapacity = {
-			minimumInstances: this.stage === 'CODE' ? 1 : 6,
+			minimumInstances: this.stage === 'CODE' ? 1 : 3,
 			maximumInstances: this.stage === 'CODE' ? 2 : 18,
 		};
 
@@ -252,8 +252,8 @@ chown -R dotcom-components:support /var/log/dotcom-components
 			scaling,
 		});
 
-		ec2App.autoScalingGroup.scaleOnCpuUtilization('CpuScalingPolicy', {
-			targetUtilizationPercent: 40,
-		});
+        ec2App.autoScalingGroup.scaleOnRequestCount('RequestCountScalingPolicy', {
+            targetRequestsPerMinute: 20000,
+        });
     }
 }


### PR DESCRIPTION
Currently we scale up when average cpu hits 40%. This is bad because:
a) cpu clearly isn't the only relevant factor when considering error spikes
b) it soon scales back down because cpu goes down, even if traffic is still high

Instead we can use the `RequestCountPerTarget` metric ([documented here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html)) to scale up when traffic increases. This is more suitable for e.g. the morning traffic spike.

I've set it to 20,000 requests per target.
This means e.g. at 80k requests per minute the ASG will have 4 instances.