### PR TITLE
Log auxiaTreatmentId

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -199,6 +199,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
 
                 if (auxiaData !== undefined) {
                     const data = buildAuxiaProxyGetTreatmentsResponseData(auxiaData);
+                    res.locals.auxiaTreatmentId = data?.userTreatment?.treatmentId;
                     res.send({ status: true, data: data });
                 } else {
                     res.send({ status: false });
@@ -232,6 +233,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                     req.body.interactionTimeMicros,
                     req.body.actionName,
                 );
+                res.locals.auxiaTreatmentId = req.body.treatmentId;
                 res.send({ status: true }); // this is the proxy's response, slightly more user's friendly than the api's response.
             } catch (error) {
                 next(error);

--- a/src/server/middleware/logging.ts
+++ b/src/server/middleware/logging.ts
@@ -23,6 +23,7 @@ export const logging = (
             userAgent: isServerError(res.statusCode) ? req.headers['user-agent'] : undefined,
             epicSuperMode: res.locals.epicSuperMode,
             responseTimeInMs: Math.round(responseTimeMs),
+            auxiaTreatmentId: res.locals.auxiaTreatmentId,
         });
     });
     next();


### PR DESCRIPTION
We're investigating a discrepency with view counts in Auxia. Views are much higher in our own datalake than on Auxia's side.
This PR adds an `auxiaTreatmentId` field to the logging for both Auxia endpoints, so that we can see counts for:
1. each treatment that is returned by Auxia
2. each treatment view that we report to Auxia

This will show in the logs in Kibana