### PR TITLE
minimum weight for roulette sampling

### DIFF
--- a/src/server/roulette/rouletteSelection.test.ts
+++ b/src/server/roulette/rouletteSelection.test.ts
@@ -140,6 +140,48 @@ describe('roulette', () => {
         const variant = selectVariantUsingRoulette([banditData], epicTest, rand);
         expect(variant).toBeDefined();
     });
+
+    it('should ensure a minimum of 10% for variants with mean of 0', () => {
+        const variants = [
+            {
+                variantName: 'v1',
+                mean: 2,
+            },
+            {
+                variantName: 'v2',
+                mean: 0,
+            },
+            {
+                variantName: 'v3',
+                mean: 0,
+            },
+        ];
+        const banditData = {
+            testName: 'example-1',
+            bestVariants: variants,
+            variants: variants,
+        };
+
+        /**
+         * variantsWithWeights: [
+         *     { variantName: 'v2', weight: 0.1 },
+         *     { variantName: 'v3', weight: 0.1 },
+         *     { variantName: 'v1', weight: 1 }
+         * ]
+         *
+         * normalisedWeights: [
+         *     { variantName: 'v2', weight: 0.08333333333333334 },
+         *     { variantName: 'v3', weight: 0.08333333333333334 },
+         *     { variantName: 'v1', weight: 0.8333333333333334 }
+         * ]
+         */
+        const variantSelection1 = selectVariantUsingRoulette([banditData], epicTest, 0.08);
+        const variantSelection2 = selectVariantUsingRoulette([banditData], epicTest, 0.16);
+        const variantSelection3 = selectVariantUsingRoulette([banditData], epicTest, 0.2);
+        expect(variantSelection1).toBe(epicTest.variants[1]);
+        expect(variantSelection2).toBe(epicTest.variants[2]);
+        expect(variantSelection3).toBe(epicTest.variants[0]);
+    });
 });
 
 describe('rouletteTest2', () => {

--- a/src/server/roulette/rouletteSelection.ts
+++ b/src/server/roulette/rouletteSelection.ts
@@ -18,13 +18,23 @@ export function selectVariantUsingRoulette<V extends Variant, T extends Test<V>>
         return selectRandomVariant(test);
     }
 
-    // sorted variant weights, which will add up to 1
+    const minWeight = 0.1; // Ensure no variant gets less than 10%
     const variantsWithWeights: { weight: number; variantName: string }[] = testBanditData.variants
-        .map(({ variantName, mean }) => ({ variantName, weight: mean / sumOfMeans }))
+        .map(({ variantName, mean }) => ({
+            variantName,
+            weight: Math.max(mean / sumOfMeans, minWeight),
+        }))
         .sort((a, b) => a.weight - b.weight);
 
-    for (let i = 0, acc = 0; i < variantsWithWeights.length; i++) {
-        const variant = variantsWithWeights[i];
+    // The sum of the weights may be greater than 1, so we now need to normalise them
+    const sumOfWeights = variantsWithWeights.reduce((sum, v) => sum + v.weight, 0);
+    const normalisedWeights = variantsWithWeights.map(({ variantName, weight }) => ({
+        variantName,
+        weight: weight / sumOfWeights,
+    }));
+
+    for (let i = 0, acc = 0; i < normalisedWeights.length; i++) {
+        const variant = normalisedWeights[i];
         if (rand < variant.weight + acc) {
             return test.variants.find((v) => v.name === variant.variantName);
         }


### PR DESCRIPTION
Currently if a variant doesn’t get any acquisitions during the initial 6 hour discovery period then its weighting gets stuck at 0 forever.

Instead we can hardcoded a minimum weighting per variant to ensure we always explore all variants, even if their score is very low.
For now we're setting this to a minimum of 10% per variant.