### PR TITLE
Move to using new Ophan Component Type for Gutters

### DIFF
--- a/src/server/api/gutterRouter.ts
+++ b/src/server/api/gutterRouter.ts
@@ -62,7 +62,7 @@ export const buildGutterRouter = (
                 abTestName: test.name,
                 abTestVariant: variant.name,
                 campaignCode: buildGutterCampaignCode(test, variant),
-                componentType: 'ACQUISITIONS_OTHER', // TODO: TBC - ACQUISITIONS_GUTTER? Changes will need to be made to the Ophan pipeline.
+                componentType: 'ACQUISITIONS_GUTTER',
             };
 
             return {


### PR DESCRIPTION
## What does this change?

Separating out the gutter component into its own Ophan Component Type (ACQUISITIONS_GUTTER) will allow us to more easily separate the data for the new Gutter component, add it to Grafana charts and add alerts to notify us if acquisitions from the component drop below a baseline.

This change only affects the server.

### Related PRs:
- [ophan-data-lake PR8229](https://github.com/guardian/ophan-data-lake/pull/8229)
- [ophan PR6849](https://github.com/guardian/ophan/pull/6849)
- [csnx PR2003](https://github.com/guardian/csnx/pull/2003)
- [SDC PR1316](https://github.com/guardian/support-dotcom-components/pull/1316)

## How to test

Deploy to CODE and test against CODE DCR - open the network tab in dev tools and check if the new component type is being passed in the Ophan Component Event Payload.

Click on the CTA and check that the Component Event is being passed with the click event parameters.

Once live, we can test that the data is feeding through to the datalake with the Ophan Testing Tool (unfortunately it needs to be in prod first).

## How can we measure success?

When we can use SQL to select records against ACQUISITIONS_GUTTER from the datalake.

## Have we considered potential risks?

MRR are aware that this change is underway and we will notify them when it has been merged as it will have an impact on their reporting.

