### PR TITLE
auxia: add country information

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -51,6 +51,7 @@ const callGetTreatments = async (
     sectionId: string,
     tagIds: string[],
     gateDismissCount: number,
+    countryCode: string,
 ): Promise<AuxiaAPIGetTreatmentsResponseData | undefined> => {
     // The logic here is to perform a certain number of checks, each resulting with a different behavior.
 
@@ -91,6 +92,7 @@ const callGetTreatments = async (
         dailyArticleCount,
         articleIdentifier,
         editionId,
+        countryCode
     );
 
     const params = {
@@ -182,6 +184,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
             'sectionId',
             'tagIds',
             'gateDismissCount',
+            'countryCode',
         ]),
         async (req: express.Request, res: express.Response, next: express.NextFunction) => {
             try {
@@ -197,6 +200,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                     req.body.sectionId,
                     req.body.tagIds,
                     req.body.gateDismissCount,
+                    req.body.countryCode,
                 );
 
                 if (auxiaData !== undefined) {

--- a/src/server/signin-gate/lib.test.ts
+++ b/src/server/signin-gate/lib.test.ts
@@ -28,6 +28,7 @@ describe('buildGetTreatmentsRequestPayload', () => {
         const dailyArticleCount = 21;
         const articleIdentifier = 'articleIdentifier';
         const editionId = 'UK';
+        const countryCode = 'GB';
 
         const expectedAnswer = {
             projectId,
@@ -49,6 +50,10 @@ describe('buildGetTreatmentsRequestPayload', () => {
                     key: 'edition',
                     stringValue: editionId,
                 },
+                {
+                    key: 'country_key',
+                    stringValue: countryCode,
+                },
             ],
             surfaces: [
                 {
@@ -66,6 +71,7 @@ describe('buildGetTreatmentsRequestPayload', () => {
             dailyArticleCount,
             articleIdentifier,
             editionId,
+            countryCode,
         );
         expect(returnedAnswer).toStrictEqual(expectedAnswer);
     });

--- a/src/server/signin-gate/lib.ts
+++ b/src/server/signin-gate/lib.ts
@@ -76,6 +76,7 @@ export const buildGetTreatmentsRequestPayload = (
     dailyArticleCount: number,
     articleIdentifier: string,
     editionId: string,
+    countryCode: string,
 ): AuxiaAPIGetTreatmentsRequestPayload => {
     // For the moment we are hard coding the data provided in contextualAttributes and surfaces.
     return {
@@ -97,6 +98,10 @@ export const buildGetTreatmentsRequestPayload = (
             {
                 key: 'edition',
                 stringValue: editionId,
+            },
+            {
+                key: 'country_key',
+                stringValue: countryCode,
             },
         ],
         surfaces: [


### PR DESCRIPTION
This is the follow up the DCR change ( https://github.com/guardian/dotcom-rendering/pull/13715 ), to add `country_key` as a new contextual attribute of the auxia GetTreatments payload.