### PR TITLE
Update @guardian/cdk

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -12,13 +12,13 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "61.1.3",
+    "@guardian/cdk": "61.3.2",
     "@guardian/eslint-config-typescript": "8.0.0",
     "@guardian/prettier": "1.0.0",
     "@types/jest": "^29.5.13",
     "@types/node": "18.0.3",
-    "aws-cdk": "2.178.2",
-    "aws-cdk-lib": "2.177.0",
+    "aws-cdk": "2.1005.0",
+    "aws-cdk-lib": "2.185.0",
     "constructs": "10.4.2",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",

--- a/cdk/pnpm-lock.yaml
+++ b/cdk/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 devDependencies:
   '@guardian/cdk':
-    specifier: 61.1.3
-    version: 61.1.3(aws-cdk-lib@2.177.0)(aws-cdk@2.178.2)(constructs@10.4.2)
+    specifier: 61.3.2
+    version: 61.3.2(aws-cdk-lib@2.185.0)(aws-cdk@2.1005.0)(constructs@10.4.2)
   '@guardian/eslint-config-typescript':
     specifier: 8.0.0
     version: 8.0.0(eslint@8.57.1)(tslib@2.8.1)(typescript@5.1.6)
@@ -21,11 +21,11 @@ devDependencies:
     specifier: 18.0.3
     version: 18.0.3
   aws-cdk:
-    specifier: 2.178.2
-    version: 2.178.2
+    specifier: 2.1005.0
+    version: 2.1005.0
   aws-cdk-lib:
-    specifier: 2.177.0
-    version: 2.177.0(constructs@10.4.2)
+    specifier: 2.185.0
+    version: 2.185.0(constructs@10.4.2)
   constructs:
     specifier: 10.4.2
     version: 10.4.2
@@ -61,20 +61,17 @@ packages:
       '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
-  /@aws-cdk/asset-awscli-v1@2.2.221:
-    resolution: {integrity: sha512-+Vu2cMvgtkaHwNezrTVng4+FAMAWKJTkC/2ZQlgkbY05k0lHHK/2eWKqBhTeA7EpxVrx9uFN7GdBFz3mcThpxg==}
-    dev: true
-
-  /@aws-cdk/asset-kubectl-v20@2.1.3:
-    resolution: {integrity: sha512-cDG1w3ieM6eOT9mTefRuTypk95+oyD7P5X/wRltwmYxU7nZc3+076YEVS6vrjDKr3ADYbfn0lDKpfB1FBtO9CQ==}
+  /@aws-cdk/asset-awscli-v1@2.2.230:
+    resolution: {integrity: sha512-kUnhKIYu42hqBa6a8x2/7o29ObpJgjYGQy28lZDq9awXyvpR62I2bRxrNKNR3uFUQz3ySuT9JXhGHhuZPdbnFw==}
     dev: true
 
   /@aws-cdk/asset-node-proxy-agent-v6@2.1.0:
     resolution: {integrity: sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==}
     dev: true
 
-  /@aws-cdk/cloud-assembly-schema@39.2.8:
-    resolution: {integrity: sha512-VkppFgLbm5M1/K8S+BimI/0COq+E9fCDcdDyAe4gFizHNZTALZA4sMds2kug1rtPFKCcWAexrycs2D4iQHcRCw==}
+  /@aws-cdk/cloud-assembly-schema@40.7.0:
+    resolution: {integrity: sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==}
+    engines: {node: '>= 14.15.0'}
     dev: true
     bundledDependencies:
       - jsonschema
@@ -438,22 +435,22 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@guardian/cdk@61.1.3(aws-cdk-lib@2.177.0)(aws-cdk@2.178.2)(constructs@10.4.2):
-    resolution: {integrity: sha512-1n6TBIe6hwmHF2jemXzKtVcEh4wazXJmTiqplkIgAIUkGwhWKEV7qsWv96N6HzThqrI68NPc5M9uX6wZ28kTKA==}
+  /@guardian/cdk@61.3.2(aws-cdk-lib@2.185.0)(aws-cdk@2.1005.0)(constructs@10.4.2):
+    resolution: {integrity: sha512-cK4zzISvDGRqF083WCDlWNXiV1lDehEt3tzl5Sbj1lKRMO7mMrTB1+4E9YKur7uoFiOxVQCxYnNzRkeb9qS9FA==}
     hasBin: true
     peerDependencies:
-      aws-cdk: 2.177.0
-      aws-cdk-lib: 2.177.0
+      aws-cdk: 2.1005.0
+      aws-cdk-lib: 2.185.0
       constructs: 10.4.2
     dependencies:
       '@oclif/core': 3.26.6
-      aws-cdk: 2.178.2
-      aws-cdk-lib: 2.177.0(constructs@10.4.2)
+      aws-cdk: 2.1005.0
+      aws-cdk-lib: 2.185.0(constructs@10.4.2)
       aws-sdk: 2.1692.0
       chalk: 4.1.2
-      codemaker: 1.106.0
+      codemaker: 1.110.0
       constructs: 10.4.2
-      git-url-parse: 16.0.0
+      git-url-parse: 16.0.1
       js-yaml: 4.1.0
       lodash.camelcase: 4.3.0
       lodash.kebabcase: 4.1.1
@@ -1289,16 +1286,15 @@ packages:
       possible-typed-array-names: 1.0.0
     dev: true
 
-  /aws-cdk-lib@2.177.0(constructs@10.4.2):
-    resolution: {integrity: sha512-nTnHAwjZaPJ5gfJjtzE/MyK6q0a66nWthoJl7l8srucRb+I30dczhbbXor6QCdVpJaTRAEliMOMq23aglsAQbg==}
+  /aws-cdk-lib@2.185.0(constructs@10.4.2):
+    resolution: {integrity: sha512-RNcQeNnInumDF1hq3gAf+/A6jhvYDof5a7418gEs/y6359gTYZpTCQkgItC50iV3MmkgerrBAdOE7CDEtQNDWw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
     dependencies:
-      '@aws-cdk/asset-awscli-v1': 2.2.221
-      '@aws-cdk/asset-kubectl-v20': 2.1.3
+      '@aws-cdk/asset-awscli-v1': 2.2.230
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0
-      '@aws-cdk/cloud-assembly-schema': 39.2.8
+      '@aws-cdk/cloud-assembly-schema': 40.7.0
       constructs: 10.4.2
     dev: true
     bundledDependencies:
@@ -1314,8 +1310,8 @@ packages:
       - yaml
       - mime-types
 
-  /aws-cdk@2.178.2:
-    resolution: {integrity: sha512-ojMCMnBGinvDUD6+BOOlUOB9pjsYXoQdFVbf4bvi3dy3nwn557r0j6qDUcJMeikzPJ6YWzfAdL0fYxBZg4xcOg==}
+  /aws-cdk@2.1005.0:
+    resolution: {integrity: sha512-4ejfGGrGCEl0pg1xcqkxK0lpBEZqNI48wtrXhk6dYOFYPYMZtqn1kdla29ONN+eO2unewkNF4nLP1lPYhlf9Pg==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
     optionalDependencies:
@@ -1566,8 +1562,8 @@ packages:
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
 
-  /codemaker@1.106.0:
-    resolution: {integrity: sha512-1aLNQCF/3DVxXol6eRqoLZnYulAwWPGq8BMF8pMZu+CaNkR7c0T5otMcbAXcskRLChiFt+BjVWS3JPVeBOHD4w==}
+  /codemaker@1.110.0:
+    resolution: {integrity: sha512-+aIsH91DjT+c0fDG0CqELCpeZJZyj6Lw266B3iLivBOZvJabdP+myoNLdIqCwcUkp0q17MFL27tilWIhy1DuuQ==}
     engines: {node: '>= 14.17.0'}
     dependencies:
       camelcase: 6.3.0
@@ -2371,8 +2367,8 @@ packages:
       parse-url: 9.2.0
     dev: true
 
-  /git-url-parse@16.0.0:
-    resolution: {integrity: sha512-Y8iAF0AmCaqXc6a5GYgPQW9ESbncNLOL+CeQAJRhmWUOmnPkKpBYeWYp4mFd3LA5j53CdGDdslzX12yEBVHQQg==}
+  /git-url-parse@16.0.1:
+    resolution: {integrity: sha512-mcD36GrhAzX5JVOsIO52qNpgRyFzYWRbU1VSRFCvJt1IJvqfvH427wWw/CFqkWvjVPtdG5VTx4MKUeC5GeFPDQ==}
     dependencies:
       git-up: 8.0.0
     dev: true


### PR DESCRIPTION
Alternative to the [failing dependabot branch](https://github.com/guardian/support-dotcom-components/pull/1318)