### PR TITLE
Fix  eslint-comments/require-description rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,8 +37,6 @@ export default [
 
 			// potentially to fix later see https://trello.com/c/lc8lG7Zj
 			'@typescript-eslint/naming-convention': 'off',
-			'@eslint-community/eslint-comments/require-description': 'off',
-			'@typescript-eslint/ban-types': 'off',
 			'@typescript-eslint/no-unsafe-function-type': 'off',
 			'@typescript-eslint/no-unnecessary-condition': 'off',
 			'@typescript-eslint/no-unsafe-assignment': 'off',

--- a/src/server/lib/fetchTickerData.ts
+++ b/src/server/lib/fetchTickerData.ts
@@ -22,7 +22,7 @@ const checkForErrors = (response: Response): Promise<Response> => {
     return Promise.resolve(response);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- JSON not yet parsed to a type.
 const parse = (json: any): Promise<TickerData> => {
     const total = parseInt(json.total);
     const goal = parseInt(json.goal);

--- a/src/server/middleware/errorHandling.ts
+++ b/src/server/middleware/errorHandling.ts
@@ -9,7 +9,7 @@ export const errorHandling = (
     // for it to run when `next()` function is called in the route handler
 
     // next is required here but incompatible with the linting rule.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- next is required for express middleware
     next: express.NextFunction,
 ): void => {
     const message = error.message || error.toString();

--- a/src/server/tests/banners/bannerDeployTimes.ts
+++ b/src/server/tests/banners/bannerDeployTimes.ts
@@ -25,7 +25,7 @@ const fetchBannerDeployTimes = (bannerChannel: BannerChannel) => (): Promise<Ban
     return (
         fetchS3Data(AdminConsoleBucket, `${isProd ? 'PROD' : 'CODE'}/banner-deploy/${channel}.json`)
             .then(JSON.parse)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- not fully parsed at this point to know the type
             .then((data: any) => {
                 const times: BannerDeployTimes = {
                     UnitedKingdom: new Date(data.UnitedKingdom.timestamp),

--- a/src/shared/types/targeting/shared.ts
+++ b/src/shared/types/targeting/shared.ts
@@ -17,10 +17,11 @@ export type WeeklyArticleHistory = WeeklyArticleLog[];
 /**
  * This interface is duplicated from the @guardian/libs definition of StorageFactory. This is to avoid adding the
  * whole library as a dependency.
+ * TODO: @guardian/libs is now a dependency anyway - we should consider using the library directly as it may provide some consent checking in future. 
  */
 export interface LocalStorage {
     set(key: string, value: unknown): void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- the type checking is done where it is used
     get(key: string): any;
 }
 

--- a/src/shared/types/targeting/shared.ts
+++ b/src/shared/types/targeting/shared.ts
@@ -17,7 +17,7 @@ export type WeeklyArticleHistory = WeeklyArticleLog[];
 /**
  * This interface is duplicated from the @guardian/libs definition of StorageFactory. This is to avoid adding the
  * whole library as a dependency.
- * TODO: @guardian/libs is now a dependency anyway - we should consider using the library directly as it may provide some consent checking in future. 
+ * TODO: @guardian/libs is now a dependency anyway - we should consider using the library directly as it may provide some consent checking in future.
  */
 export interface LocalStorage {
     set(key: string, value: unknown): void;


### PR DESCRIPTION
## What does this change?

This re-enables the eslint rule `@eslint-community/eslint-comments/require-description` to the default option recommended in @guardian/eslint-config and adds a comment to the 4 instances of rule override comments where 'any' is used.

Also @typescript-eslint/ban-types was removed without changes required - thought to be deprecated.

Reinstated after this [PR](https://github.com/guardian/support-dotcom-components/pull/1316) which switched off many of the rules that were not able to be fixed automatically and relates to [this Trello card](https://trello.com/c/aqo99v2Y) which we added to ensure we followed up on these rules.

## How to test

run `pnpm lint` and you should get no linting errors.
