### PR TITLE
Reinstate typescript eslint naming convention rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,6 @@ export default [
 			curly: 2,
 
 			// potentially to fix later see https://trello.com/c/lc8lG7Zj
-			'@typescript-eslint/naming-convention': 'off',
 			'@typescript-eslint/no-unsafe-function-type': 'off',
 			'@typescript-eslint/no-unnecessary-condition': 'off',
 			'@typescript-eslint/no-unsafe-assignment': 'off',

--- a/src/shared/types/props/shared.ts
+++ b/src/shared/types/props/shared.ts
@@ -46,13 +46,16 @@ export const secondaryCtaSchema = z.discriminatedUnion('type', [
 ]);
 
 export enum TickerEndType {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- interaction with scala via zio which has different naming conventions
     unlimited = 'unlimited',
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- interaction with scala via zio which has different naming conventions
     hardstop = 'hardstop', // currently unsupported
 }
 
 export const tickerEndTypeSchema = z.nativeEnum(TickerEndType);
 
 export enum TickerCountType {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- interaction with scala via zio which has different naming conventions
     money = 'money',
 }
 

--- a/src/shared/types/purchaseInfo.ts
+++ b/src/shared/types/purchaseInfo.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 
 const purchaseInfoProduct = ['Contribution', 'SupporterPlus', 'GuardianWeekly', 'Paper'] as const;
+// eslint-disable-next-line @typescript-eslint/naming-convention -- interaction with scala via zio which has different naming conventions
 export type purchaseInfoProduct = (typeof purchaseInfoProduct)[number];
 export const purchaseInfoProductSchema = z.enum(purchaseInfoProduct);
 
 const purchaseInfoUser = ['new', 'guest', 'current'] as const;
+// eslint-disable-next-line @typescript-eslint/naming-convention -- interaction with scala via zio which has different naming conventions
 export type purchaseInfoUser = (typeof purchaseInfoUser)[number];
 export const purchaseInfoUserSchema = z.enum(purchaseInfoUser);


### PR DESCRIPTION
## What does this change?

The only failures of this linting rule relate to fields which are being decoded from JSON which was originally created via Scala which has a different naming convention.  Added comments to disable this rule for each of those.

Reinstated after this [PR which](https://github.com/guardian/support-dotcom-components/pull/1316) switched off many of the rules that were not able to be fixed automatically and relates to [this Trello card](https://trello.com/c/lc8lG7Zj) which we added to ensure we followed up on these rules.

## How to test

run `pnpm lint` and you should get no linting errors.
