### PR TITLE
Reinstate typescript eslint no unsafe function type rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,6 @@ export default [
 			curly: 2,
 
 			// potentially to fix later see https://trello.com/c/lc8lG7Zj
-			'@typescript-eslint/no-unsafe-function-type': 'off',
 			'@typescript-eslint/no-unnecessary-condition': 'off',
 			'@typescript-eslint/no-unsafe-assignment': 'off',
 			'@typescript-eslint/prefer-nullish-coalescing': 'off',

--- a/src/shared/types/props/epic.ts
+++ b/src/shared/types/props/epic.ts
@@ -18,7 +18,7 @@ export interface EpicProps {
     tracking: Tracking;
     countryCode?: string;
     articleCounts: ArticleCounts;
-    onReminderOpen?: Function;
+    onReminderOpen?: () => void;
     fetchEmail?: () => Promise<string | null>;
     submitComponentEvent?: (componentEvent: OphanComponentEvent) => void;
     openCmp?: () => void;


### PR DESCRIPTION
## What does this change?

One interface contains Function rather than a function signature. On checking what that is in DCR, it appears to be an empty param returning void.

Reinstated after this [PR which](https://github.com/guardian/support-dotcom-components/pull/1316) switched off many of the rules that were not able to be fixed automatically and relates to [this Trello card](https://trello.com/c/lc8lG7Zj) which we added to ensure we followed up on these rules.

## How to test

run `pnpm lint` and you should get no linting errors.
Deploy to code and ensure you can use the secondary CTA to open/close the reminders section of Epics.
