### PR TITLE
Reinstate typescript eslint no unnecessary condition

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,7 @@ export default [
 			curly: 2,
 
 			// potentially to fix later see https://trello.com/c/lc8lG7Zj
-			'@typescript-eslint/no-unnecessary-condition': 'off',
+			//'@typescript-eslint/no-unnecessary-condition': 'off',
 			'@typescript-eslint/no-unsafe-assignment': 'off',
 			'@typescript-eslint/prefer-nullish-coalescing': 'off',
 			'@typescript-eslint/no-unsafe-member-access': 'off',

--- a/src/dotcom/requests.ts
+++ b/src/dotcom/requests.ts
@@ -25,6 +25,7 @@ export interface ModuleDataResponse<PROPS> {
 type ModuleType = 'epic' | 'liveblog-epic' | 'banner' | 'header' | 'gutter-liveblog';
 
 const getForcedVariant = (type: ModuleType): string | null => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this is a polyfill as not all browsers recognise URLSearchParams https://caniuse.com/?search=URLSearchParams
     if (URLSearchParams) {
         const params = new URLSearchParams(window.location.search);
         const value = params.get(`force-${type}`);

--- a/src/server/tests/banners/channelBannerTests.test.ts
+++ b/src/server/tests/banners/channelBannerTests.test.ts
@@ -34,7 +34,7 @@ describe('getDesignForVariant', () => {
         expect(design).toBeDefined();
         expect(design?.visual?.kind).toBe('Image');
         if (design?.visual?.kind === 'Image') {
-            expect(design?.visual?.altText).toBe('Bar Alt');
+            expect(design.visual.altText).toBe('Bar Alt');
         }
     });
 


### PR DESCRIPTION
## What does this change?

There are many of these... perhaps this rule needs to remain off... TBC - I know the build will break at this point.

Reinstated after this [PR which](https://github.com/guardian/support-dotcom-components/pull/1316) switched off many of the rules that were not able to be fixed automatically and relates to [this Trello card](https://trello.com/c/lc8lG7Zj) which we added to ensure we followed up on these rules.

## How to test

run `pnpm lint` and you should get no linting errors.
