### PR TITLE
Bulk suppress existing eslint rule failures

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,0 +1,349 @@
+{
+  "src/dotcom/requests.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "src/server/api/ampEpicRouter.ts": {
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 3
+    },
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 2
+    },
+    "@typescript-eslint/no-base-to-string": {
+      "count": 4
+    },
+    "@typescript-eslint/restrict-template-expressions": {
+      "count": 4
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/server/api/auxiaProxyRouter.ts": {
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 4
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 21
+    },
+    "@typescript-eslint/no-unsafe-argument": {
+      "count": 17
+    }
+  },
+  "src/server/api/bannerRouter.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 7
+    },
+    "@typescript-eslint/no-unsafe-argument": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 6
+    }
+  },
+  "src/server/api/epicRouter.ts": {
+    "@typescript-eslint/restrict-template-expressions": {
+      "count": 1
+    },
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-argument": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 3
+    }
+  },
+  "src/server/api/gutterRouter.ts": {
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-argument": {
+      "count": 1
+    }
+  },
+  "src/server/api/headerRouter.ts": {
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-argument": {
+      "count": 1
+    }
+  },
+  "src/server/channelSwitches.ts": {
+    "@typescript-eslint/no-unsafe-return": {
+      "count": 1
+    }
+  },
+  "src/server/factories/test.ts": {
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/server/lib/ampVariantAssignments.ts": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1
+    }
+  },
+  "src/server/lib/fetchTickerData.ts": {
+    "@typescript-eslint/prefer-promise-reject-errors": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-argument": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "src/server/lib/targeting.ts": {
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 1
+    }
+  },
+  "src/server/lib/tracking.ts": {
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 1
+    }
+  },
+  "src/server/middleware/errorHandling.ts": {
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 1
+    }
+  },
+  "src/server/middleware/logging.ts": {
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 8
+    }
+  },
+  "src/server/productPrices.ts": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/server/selection/ab.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    },
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 1
+    }
+  },
+  "src/server/selection/banditData.ts": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    },
+    "@typescript-eslint/prefer-promise-reject-errors": {
+      "count": 1
+    }
+  },
+  "src/server/selection/epsilonGreedySelection.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "src/server/selection/helpers.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "src/server/selection/selectVariant.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "src/server/server.ts": {
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 1
+    }
+  },
+  "src/server/tests/amp/ampEpic.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 1
+    },
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 1
+    }
+  },
+  "src/server/tests/amp/ampEpicSelection.test.ts": {
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 1
+    }
+  },
+  "src/server/tests/amp/ampEpicSelection.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 2
+    }
+  },
+  "src/server/tests/amp/ampTicker.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-enum-comparison": {
+      "count": 1
+    },
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 2
+    }
+  },
+  "src/server/tests/banners/bannerDeployTimes.ts": {
+    "@typescript-eslint/no-unsafe-argument": {
+      "count": 5
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 5
+    }
+  },
+  "src/server/tests/banners/bannerSelection.test.ts": {
+    "@typescript-eslint/prefer-optional-chain": {
+      "count": 8
+    },
+    "@typescript-eslint/await-thenable": {
+      "count": 4
+    }
+  },
+  "src/server/tests/banners/bannerSelection.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3
+    }
+  },
+  "src/server/tests/epics/epicSelection.ts": {
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 4
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "src/server/tests/gutters/gutterSelection.ts": {
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 2
+    }
+  },
+  "src/server/tests/headers/headerSelection.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2
+    },
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 2
+    }
+  },
+  "src/server/tests/store.ts": {
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 2
+    },
+    "@typescript-eslint/prefer-promise-reject-errors": {
+      "count": 1
+    },
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-return": {
+      "count": 1
+    }
+  },
+  "src/server/utils/S3.ts": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1
+    },
+    "@typescript-eslint/prefer-promise-reject-errors": {
+      "count": 1
+    }
+  },
+  "src/server/utils/logging.ts": {
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-return": {
+      "count": 1
+    }
+  },
+  "src/server/utils/removeNullValues.ts": {
+    "@typescript-eslint/no-unsafe-argument": {
+      "count": 2
+    },
+    "@typescript-eslint/no-unsafe-return": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 1
+    }
+  },
+  "src/server/utils/supportFrontend.ts": {
+    "@typescript-eslint/prefer-promise-reject-errors": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/server/utils/valueReloader.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1
+    }
+  },
+  "src/shared/lib/geolocation.ts": {
+    "@typescript-eslint/prefer-nullish-coalescing": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "src/shared/lib/history.ts": {
+    "@typescript-eslint/no-unsafe-return": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 8
+    },
+    "@typescript-eslint/no-unsafe-argument": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 2
+    }
+  },
+  "src/shared/lib/placeholders.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2
+    }
+  },
+  "src/shared/lib/viewLog.ts": {
+    "@typescript-eslint/no-unsafe-return": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1
+    }
+  },
+  "src/shared/types/abTests/banner.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,28 +27,28 @@ export default [
             // e.g. "@typescript-eslint/explicit-function-return-type": "off",
             curly: 2,
 
-			// Since we moved to using the @guardian/eslint-config we are getting many failures on existing code.
-			// These are all rules that we should be using but we are not ready to fix all the existing code yet.
-			// We are using bulk suppressions so we can apply the rules now and fix existing failures later
+            // Since we moved to using the @guardian/eslint-config we are getting many failures on existing code.
+            // These are all rules that we should be using but we are not ready to fix all the existing code yet.
+            // We are using bulk suppressions so we can apply the rules now and fix existing failures later
             // https://eslint.org/blog/2025/04/introducing-bulk-suppressions/
-			
-            // These are the rules that we may need to fix later see https://trello.com/c/lc8lG7Zj
-            // '@typescript-eslint/no-unnecessary-condition': 'off',
-            // '@typescript-eslint/no-unsafe-assignment': 'off',
-            // '@typescript-eslint/prefer-nullish-coalescing': 'off',
-            // '@typescript-eslint/no-unsafe-member-access': 'off',
-            // '@typescript-eslint/require-await': 'off',
-            // '@typescript-eslint/no-unsafe-enum-comparison': 'off',
-            // '@typescript-eslint/no-unsafe-argument': 'off',
-            // '@typescript-eslint/no-unsafe-return': 'off',
-            // '@typescript-eslint/no-base-to-string': 'off',
-            // '@typescript-eslint/prefer-promise-reject-errors': 'off',
-            // '@typescript-eslint/no-unsafe-call': 'off',
-            // '@typescript-eslint/no-floating-promise': 'off',
-            // '@typescript-eslint/restrict-template-expressions': 'off',
-            // '@typescript-eslint/no-floating-promises': 'off',
-            // '@typescript-eslint/prefer-optional-chain': 'off',
+
+            // These are the rules that we may need to fix later see https://trello.com/c/lc8lG7Zj and https://typescript-eslint.io/rules/ 
             // '@typescript-eslint/await-thenable': 'off',
+            // '@typescript-eslint/no-base-to-string': 'off',
+            // '@typescript-eslint/no-floating-promise': 'off',
+            // '@typescript-eslint/no-floating-promises': 'off',
+            // '@typescript-eslint/no-unnecessary-condition': 'off',
+            // '@typescript-eslint/no-unsafe-argument': 'off',
+            // '@typescript-eslint/no-unsafe-assignment': 'off',
+            // '@typescript-eslint/no-unsafe-call': 'off',
+            // '@typescript-eslint/no-unsafe-enum-comparison': 'off',
+            // '@typescript-eslint/no-unsafe-member-access': 'off',
+            // '@typescript-eslint/no-unsafe-return': 'off',
+            // '@typescript-eslint/prefer-nullish-coalescing': 'off',
+            // '@typescript-eslint/prefer-optional-chain': 'off',
+            // '@typescript-eslint/prefer-promise-reject-errors': 'off',
+            // '@typescript-eslint/require-await': 'off',
+            // '@typescript-eslint/restrict-template-expressions': 'off',
         },
     },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,20 +2,12 @@ import guardian from '@guardian/eslint-config';
 import globals from 'globals';
 
 export default [
-	{
-		ignores: [
-			'node_modules',
-			'dist',
-            'server-dist',
-
-			'rollup.config.js',
-			'webpack.*js',
-            'cdk',
-		],
-	},
-	...guardian.configs.recommended,
-	...guardian.configs.jest,
-	{
+    {
+        ignores: ['node_modules', 'dist', 'server-dist', 'rollup.config.js', 'webpack.*js', 'cdk'],
+    },
+    ...guardian.configs.recommended,
+    ...guardian.configs.jest,
+    {
         ignores: ['eslint.config.mjs'],
         languageOptions: {
             globals: {
@@ -30,28 +22,33 @@ export default [
                 tsconfigRootDir: './',
             },
         },
-		rules: {
-			// Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
-			// e.g. "@typescript-eslint/explicit-function-return-type": "off",
-			curly: 2,
+        rules: {
+            // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
+            // e.g. "@typescript-eslint/explicit-function-return-type": "off",
+            curly: 2,
 
-			// potentially to fix later see https://trello.com/c/lc8lG7Zj
-			'@typescript-eslint/no-unnecessary-condition': 'off',
-			'@typescript-eslint/no-unsafe-assignment': 'off',
-			'@typescript-eslint/prefer-nullish-coalescing': 'off',
-			'@typescript-eslint/no-unsafe-member-access': 'off',
-			'@typescript-eslint/require-await': 'off',
-			'@typescript-eslint/no-unsafe-enum-comparison': 'off',
-			'@typescript-eslint/no-unsafe-argument': 'off',
-			'@typescript-eslint/no-unsafe-return': 'off',
-			'@typescript-eslint/no-base-to-string': 'off',
-			'@typescript-eslint/prefer-promise-reject-errors': 'off',
-			'@typescript-eslint/no-unsafe-call': 'off',
-			'@typescript-eslint/no-floating-promise': 'off',
-			'@typescript-eslint/restrict-template-expressions': 'off',
-			'@typescript-eslint/no-floating-promises': 'off',
-            '@typescript-eslint/prefer-optional-chain': 'off',
-            '@typescript-eslint/await-thenable': 'off',
-		},
-	},
+			// Since we moved to using the @guardian/eslint-config we are getting many failures on existing code.
+			// These are all rules that we should be using but we are not ready to fix all the existing code yet.
+			// We are using bulk suppressions so we can apply the rules now and fix existing failures later
+            // https://eslint.org/blog/2025/04/introducing-bulk-suppressions/
+			
+            // These are the rules that we may need to fix later see https://trello.com/c/lc8lG7Zj
+            // '@typescript-eslint/no-unnecessary-condition': 'off',
+            // '@typescript-eslint/no-unsafe-assignment': 'off',
+            // '@typescript-eslint/prefer-nullish-coalescing': 'off',
+            // '@typescript-eslint/no-unsafe-member-access': 'off',
+            // '@typescript-eslint/require-await': 'off',
+            // '@typescript-eslint/no-unsafe-enum-comparison': 'off',
+            // '@typescript-eslint/no-unsafe-argument': 'off',
+            // '@typescript-eslint/no-unsafe-return': 'off',
+            // '@typescript-eslint/no-base-to-string': 'off',
+            // '@typescript-eslint/prefer-promise-reject-errors': 'off',
+            // '@typescript-eslint/no-unsafe-call': 'off',
+            // '@typescript-eslint/no-floating-promise': 'off',
+            // '@typescript-eslint/restrict-template-expressions': 'off',
+            // '@typescript-eslint/no-floating-promises': 'off',
+            // '@typescript-eslint/prefer-optional-chain': 'off',
+            // '@typescript-eslint/await-thenable': 'off',
+        },
+    },
 ];

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "babel-loader": "^9.1.3",
         "body-parser": "^1.20.3",
         "concurrently": "^6.2.0",
-        "eslint": "^9.19.0",
+        "eslint": "^9.24.0",
         "eslint-plugin-react": "^7.33.2",
         "fishery": "^0.3.0",
         "globals": "15.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ devDependencies:
     version: 2.27.9
   '@guardian/eslint-config':
     specifier: ^11.0.0
-    version: 11.0.0(eslint@9.23.0)(typescript@5.5.4)
+    version: 11.0.0(eslint@9.24.0)(typescript@5.5.4)
   '@guardian/node-riffraff-artifact':
     specifier: ^0.3.2
     version: 0.3.2
@@ -107,11 +107,11 @@ devDependencies:
     specifier: ^6.2.0
     version: 6.5.1
   eslint:
-    specifier: ^9.19.0
-    version: 9.23.0
+    specifier: ^9.24.0
+    version: 9.24.0
   eslint-plugin-react:
     specifier: ^7.33.2
-    version: 7.37.2(eslint@9.23.0)
+    version: 7.37.2(eslint@9.24.0)
   fishery:
     specifier: ^0.3.0
     version: 0.3.0
@@ -834,24 +834,24 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@eslint-community/eslint-plugin-eslint-comments@4.4.1(eslint@9.23.0):
+  /@eslint-community/eslint-plugin-eslint-comments@4.4.1(eslint@9.24.0):
     resolution: {integrity: sha512-lb/Z/MzbTf7CaVYM9WCFNQZ4L1yi3ev2fsFPF99h31ljhSEyUoyEsKsNWiU+qD1glbYTDJdqgyaLKtyTkkqtuQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
     dependencies:
       escape-string-regexp: 4.0.0
-      eslint: 9.23.0
+      eslint: 9.24.0
       ignore: 5.3.2
     dev: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@9.23.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@9.24.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 9.23.0
+      eslint: 9.24.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -865,8 +865,8 @@ packages:
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
-  /@eslint/config-array@0.19.2:
-    resolution: {integrity: sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==}
+  /@eslint/config-array@0.20.0:
+    resolution: {integrity: sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       '@eslint/object-schema': 2.1.6
@@ -910,8 +910,8 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
-  /@eslint/js@9.23.0:
-    resolution: {integrity: sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==}
+  /@eslint/js@9.24.0:
+    resolution: {integrity: sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
@@ -932,25 +932,25 @@ packages:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
 
-  /@guardian/eslint-config@11.0.0(eslint@9.23.0)(typescript@5.5.4):
+  /@guardian/eslint-config@11.0.0(eslint@9.24.0)(typescript@5.5.4):
     resolution: {integrity: sha512-+3wY4kWT+y1ghH2hmsXqNBfp7UOjafKzRWQoTabHxaqwMcpdiAdxAMJhpx27lk4BRdjiMOglir9oE07u4mDYtQ==}
     peerDependencies:
       eslint: ^9.19.0
     dependencies:
-      '@eslint-community/eslint-plugin-eslint-comments': 4.4.1(eslint@9.23.0)
+      '@eslint-community/eslint-plugin-eslint-comments': 4.4.1(eslint@9.24.0)
       '@eslint/js': 9.19.0
-      '@stylistic/eslint-plugin': 2.11.0(eslint@9.23.0)(typescript@5.5.4)
-      eslint: 9.23.0
-      eslint-config-prettier: 9.1.0(eslint@9.23.0)
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import-x@4.6.1)(eslint@9.23.0)
-      eslint-plugin-import-x: 4.6.1(eslint@9.23.0)(typescript@5.5.4)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.23.0)
-      eslint-plugin-react: 7.37.2(eslint@9.23.0)
-      eslint-plugin-react-hooks: 5.1.0(eslint@9.23.0)
-      eslint-plugin-storybook: 0.11.1(eslint@9.23.0)(typescript@5.5.4)
+      '@stylistic/eslint-plugin': 2.11.0(eslint@9.24.0)(typescript@5.5.4)
+      eslint: 9.24.0
+      eslint-config-prettier: 9.1.0(eslint@9.24.0)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import-x@4.6.1)(eslint@9.24.0)
+      eslint-plugin-import-x: 4.6.1(eslint@9.24.0)(typescript@5.5.4)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.24.0)
+      eslint-plugin-react: 7.37.2(eslint@9.24.0)
+      eslint-plugin-react-hooks: 5.1.0(eslint@9.24.0)
+      eslint-plugin-storybook: 0.11.1(eslint@9.24.0)(typescript@5.5.4)
       globals: 15.14.0
       read-package-up: 11.0.0
-      typescript-eslint: 8.22.0(eslint@9.23.0)(typescript@5.5.4)
+      typescript-eslint: 8.22.0(eslint@9.24.0)(typescript@5.5.4)
     transitivePeerDependencies:
       - eslint-plugin-import
       - supports-color
@@ -1538,14 +1538,14 @@ packages:
       type-fest: 2.19.0
     dev: true
 
-  /@stylistic/eslint-plugin@2.11.0(eslint@9.23.0)(typescript@5.5.4):
+  /@stylistic/eslint-plugin@2.11.0(eslint@9.24.0)(typescript@5.5.4):
     resolution: {integrity: sha512-PNRHbydNG5EH8NK4c+izdJlxajIR6GxcUhzsYNRsn6Myep4dsZt0qFCz3rCPnkvgO5FYibDcMqgNHUT+zvjYZw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.40.0'
     dependencies:
-      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.5.4)
-      eslint: 9.23.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.24.0)(typescript@5.5.4)
+      eslint: 9.24.0
       eslint-visitor-keys: 4.2.0
       espree: 10.3.0
       estraverse: 5.3.0
@@ -1798,7 +1798,7 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: true
 
-  /@typescript-eslint/eslint-plugin@8.22.0(@typescript-eslint/parser@8.22.0)(eslint@9.23.0)(typescript@5.5.4):
+  /@typescript-eslint/eslint-plugin@8.22.0(@typescript-eslint/parser@8.22.0)(eslint@9.24.0)(typescript@5.5.4):
     resolution: {integrity: sha512-4Uta6REnz/xEJMvwf72wdUnC3rr4jAQf5jnTkeRQ9b6soxLxhDEbS/pfMPoJLDfFPNVRdryqWUIV/2GZzDJFZw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -1807,12 +1807,12 @@ packages:
       typescript: '>=4.8.4 <5.8.0'
     dependencies:
       '@eslint-community/regexpp': 4.11.1
-      '@typescript-eslint/parser': 8.22.0(eslint@9.23.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.22.0(eslint@9.24.0)(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/type-utils': 8.22.0(eslint@9.23.0)(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.23.0)(typescript@5.5.4)
+      '@typescript-eslint/type-utils': 8.22.0(eslint@9.24.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.22.0(eslint@9.24.0)(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 8.22.0
-      eslint: 9.23.0
+      eslint: 9.24.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -1822,7 +1822,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@8.22.0(eslint@9.23.0)(typescript@5.5.4):
+  /@typescript-eslint/parser@8.22.0(eslint@9.24.0)(typescript@5.5.4):
     resolution: {integrity: sha512-MqtmbdNEdoNxTPzpWiWnqNac54h8JDAmkWtJExBVVnSrSmi9z+sZUt0LfKqk9rjqmKOIeRhO4fHHJ1nQIjduIQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -1834,7 +1834,7 @@ packages:
       '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 8.22.0
       debug: 4.3.7(supports-color@5.5.0)
-      eslint: 9.23.0
+      eslint: 9.24.0
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
@@ -1856,7 +1856,7 @@ packages:
       '@typescript-eslint/visitor-keys': 8.28.0
     dev: true
 
-  /@typescript-eslint/type-utils@8.22.0(eslint@9.23.0)(typescript@5.5.4):
+  /@typescript-eslint/type-utils@8.22.0(eslint@9.24.0)(typescript@5.5.4):
     resolution: {integrity: sha512-NzE3aB62fDEaGjaAYZE4LH7I1MUwHooQ98Byq0G0y3kkibPJQIXVUspzlFOmOfHhiDLwKzMlWxaNv+/qcZurJA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -1864,9 +1864,9 @@ packages:
       typescript: '>=4.8.4 <5.8.0'
     dependencies:
       '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.23.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.22.0(eslint@9.24.0)(typescript@5.5.4)
       debug: 4.3.7(supports-color@5.5.0)
-      eslint: 9.23.0
+      eslint: 9.24.0
       ts-api-utils: 2.1.0(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -1921,35 +1921,35 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@8.22.0(eslint@9.23.0)(typescript@5.5.4):
+  /@typescript-eslint/utils@8.22.0(eslint@9.24.0)(typescript@5.5.4):
     resolution: {integrity: sha512-T8oc1MbF8L+Bk2msAvCUzjxVB2Z2f+vXYfcucE2wOmYs7ZUwco5Ep0fYZw8quNwOiw9K8GYVL+Kgc2pETNTLOg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.23.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.24.0)
       '@typescript-eslint/scope-manager': 8.22.0
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.5.4)
-      eslint: 9.23.0
+      eslint: 9.24.0
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@8.28.0(eslint@9.23.0)(typescript@5.5.4):
+  /@typescript-eslint/utils@8.28.0(eslint@9.24.0)(typescript@5.5.4):
     resolution: {integrity: sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.23.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.24.0)
       '@typescript-eslint/scope-manager': 8.28.0
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.5.4)
-      eslint: 9.23.0
+      eslint: 9.24.0
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
@@ -3630,13 +3630,13 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-prettier@9.1.0(eslint@9.23.0):
+  /eslint-config-prettier@9.1.0(eslint@9.24.0):
     resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 9.23.0
+      eslint: 9.24.0
     dev: true
 
   /eslint-import-resolver-node@0.3.9:
@@ -3649,7 +3649,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript@3.7.0(eslint-plugin-import-x@4.6.1)(eslint@9.23.0):
+  /eslint-import-resolver-typescript@3.7.0(eslint-plugin-import-x@4.6.1)(eslint@9.24.0):
     resolution: {integrity: sha512-Vrwyi8HHxY97K5ebydMtffsWAn1SCR9eol49eCd5fJS4O1WV7PaAjbcjmbfJJSMz/t4Mal212Uz/fQZrOB8mow==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -3665,8 +3665,8 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7(supports-color@5.5.0)
       enhanced-resolve: 5.17.1
-      eslint: 9.23.0
-      eslint-plugin-import-x: 4.6.1(eslint@9.23.0)(typescript@5.5.4)
+      eslint: 9.24.0
+      eslint-plugin-import-x: 4.6.1(eslint@9.24.0)(typescript@5.5.4)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.3.0
@@ -3676,7 +3676,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import-x@4.6.1(eslint@9.23.0)(typescript@5.5.4):
+  /eslint-plugin-import-x@4.6.1(eslint@9.24.0)(typescript@5.5.4):
     resolution: {integrity: sha512-wluSUifMIb7UfwWXqx7Yx0lE/SGCcGXECLx/9bCmbY2nneLwvAZ4vkd1IXDjPKFvdcdUgr1BaRnaRpx3k2+Pfw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -3684,11 +3684,11 @@ packages:
     dependencies:
       '@types/doctrine': 0.0.9
       '@typescript-eslint/scope-manager': 8.28.0
-      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.24.0)(typescript@5.5.4)
       debug: 4.3.7(supports-color@5.5.0)
       doctrine: 3.0.0
       enhanced-resolve: 5.17.1
-      eslint: 9.23.0
+      eslint: 9.24.0
       eslint-import-resolver-node: 0.3.9
       get-tsconfig: 4.8.1
       is-glob: 4.0.3
@@ -3701,7 +3701,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-jsx-a11y@6.10.2(eslint@9.23.0):
+  /eslint-plugin-jsx-a11y@6.10.2(eslint@9.24.0):
     resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -3715,7 +3715,7 @@ packages:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.23.0
+      eslint: 9.24.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -3725,16 +3725,16 @@ packages:
       string.prototype.includes: 2.0.1
     dev: true
 
-  /eslint-plugin-react-hooks@5.1.0(eslint@9.23.0):
+  /eslint-plugin-react-hooks@5.1.0(eslint@9.24.0):
     resolution: {integrity: sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
     dependencies:
-      eslint: 9.23.0
+      eslint: 9.24.0
     dev: true
 
-  /eslint-plugin-react@7.37.2(eslint@9.23.0):
+  /eslint-plugin-react@7.37.2(eslint@9.24.0):
     resolution: {integrity: sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3746,7 +3746,7 @@ packages:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.1.0
-      eslint: 9.23.0
+      eslint: 9.24.0
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -3761,15 +3761,15 @@ packages:
       string.prototype.repeat: 1.0.0
     dev: true
 
-  /eslint-plugin-storybook@0.11.1(eslint@9.23.0)(typescript@5.5.4):
+  /eslint-plugin-storybook@0.11.1(eslint@9.24.0)(typescript@5.5.4):
     resolution: {integrity: sha512-yGKpAYkBm/Q2hZg476vRUAvd9lAccjjSvzU5nYy3BSQbKTPy7uopx7JEpwk2vSuw4weTMZzWF64z9/gp/K5RCg==}
     engines: {node: '>= 18'}
     peerDependencies:
       eslint: '>=6'
     dependencies:
       '@storybook/csf': 0.1.13
-      '@typescript-eslint/utils': 8.28.0(eslint@9.23.0)(typescript@5.5.4)
-      eslint: 9.23.0
+      '@typescript-eslint/utils': 8.28.0(eslint@9.24.0)(typescript@5.5.4)
+      eslint: 9.24.0
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -3802,8 +3802,8 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
-  /eslint@9.23.0:
-    resolution: {integrity: sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==}
+  /eslint@9.24.0:
+    resolution: {integrity: sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -3812,13 +3812,13 @@ packages:
       jiti:
         optional: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.23.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.24.0)
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.19.2
+      '@eslint/config-array': 0.20.0
       '@eslint/config-helpers': 0.2.0
       '@eslint/core': 0.12.0
       '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.23.0
+      '@eslint/js': 9.24.0
       '@eslint/plugin-kit': 0.2.7
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
@@ -7854,17 +7854,17 @@ packages:
       possible-typed-array-names: 1.0.0
     dev: true
 
-  /typescript-eslint@8.22.0(eslint@9.23.0)(typescript@5.5.4):
+  /typescript-eslint@8.22.0(eslint@9.24.0)(typescript@5.5.4):
     resolution: {integrity: sha512-Y2rj210FW1Wb6TWXzQc5+P+EWI9/zdS57hLEc0gnyuvdzWo8+Y8brKlbj0muejonhMI/xAZCnZZwjbIfv1CkOw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.22.0(@typescript-eslint/parser@8.22.0)(eslint@9.23.0)(typescript@5.5.4)
-      '@typescript-eslint/parser': 8.22.0(eslint@9.23.0)(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.23.0)(typescript@5.5.4)
-      eslint: 9.23.0
+      '@typescript-eslint/eslint-plugin': 8.22.0(@typescript-eslint/parser@8.22.0)(eslint@9.24.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.22.0(eslint@9.24.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.22.0(eslint@9.24.0)(typescript@5.5.4)
+      eslint: 9.24.0
       typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color

--- a/src/server/tests/banners/channelBannerTests.test.ts
+++ b/src/server/tests/banners/channelBannerTests.test.ts
@@ -34,7 +34,7 @@ describe('getDesignForVariant', () => {
         expect(design).toBeDefined();
         expect(design?.visual?.kind).toBe('Image');
         if (design?.visual?.kind === 'Image') {
-            expect(design?.visual?.altText).toBe('Bar Alt');
+            expect(design.visual.altText).toBe('Bar Alt');
         }
     });
 


### PR DESCRIPTION
## What does this change?

This is a new way to suppress existing rule failures until they can be fixed while applying the rules to any new code. It means that we don't need to disable rules until we fix failures in existing code. 

This new feature is described in this blog post [https://eslint.org/blog/2025/04/introducing-bulk-suppressions](https://eslint.org/blog/2025/04/introducing-bulk-suppressions). 

It creates a new file called eslint-suppressions.json in the project root which holds the list of existing failures.  This can be pruned over time as they get fixed or the rules change.

It requires the latest version of eslint 9.24.0 so this has also been bumped.

If any rules need to be updated or altered as the team makes decision on them, this can be done in the eslint.config.mjs file and the suppressions file pruned (see the blog post above for command).

## How to test

Pull down locally and run pnpm lint - you should get no failures on the older code mentioned in the suppression file (also this PR should not fail with a linting error).
