### PR TITLE
Simplify BanditData model

### DIFF
--- a/src/server/selection/banditData.ts
+++ b/src/server/selection/banditData.ts
@@ -84,7 +84,7 @@ interface BanditVariantData {
 
 export interface BanditData {
     testName: string;
-    sortedVariants: BanditVariantData[];  // sorted by mean, highest first
+    sortedVariants: BanditVariantData[]; // sorted by mean, highest first
 }
 
 function getDefaultWeighting(test: BanditTestConfig): BanditData {

--- a/src/server/selection/epsilonGreedySelection.test.ts
+++ b/src/server/selection/epsilonGreedySelection.test.ts
@@ -62,7 +62,6 @@ const epicTest: EpicTest = {
 
 describe('selectVariantWithHighestMean', () => {
     it('should return the only variant', () => {
-        // const banditData = buildBanditData(1);
         const banditData = {
             testName: 'example-1',
             sortedVariants: [
@@ -73,7 +72,6 @@ describe('selectVariantWithHighestMean', () => {
     });
 
     it('should return the only variant with highest mean', () => {
-        // const banditData = buildBanditData(1);
         const banditData = {
             testName: 'example-1',
             sortedVariants: [
@@ -87,7 +85,6 @@ describe('selectVariantWithHighestMean', () => {
 
     it('should return first of tied best variants', () => {
         // v1 and v2 are tied
-        // const banditData = buildBanditData(2);
         const banditData = {
             testName: 'example-1',
             sortedVariants: [
@@ -104,7 +101,6 @@ describe('selectVariantWithHighestMean', () => {
 
     it('should return second of tied best variants', () => {
         // v1 and v2 are tied
-        // const banditData = buildBanditData(2);
         const banditData = {
             testName: 'example-1',
             sortedVariants: [

--- a/src/server/selection/epsilonGreedySelection.test.ts
+++ b/src/server/selection/epsilonGreedySelection.test.ts
@@ -64,10 +64,8 @@ describe('selectVariantWithHighestMean', () => {
     it('should return the only variant', () => {
         const banditData = {
             testName: 'example-1',
-            sortedVariants: [
-                {variantName: 'v1', mean: 1}
-            ]
-        }
+            sortedVariants: [{ variantName: 'v1', mean: 1 }],
+        };
         expect(selectVariantWithHighestMean(banditData, epicTest)?.name).toEqual('v1');
     });
 
@@ -75,11 +73,11 @@ describe('selectVariantWithHighestMean', () => {
         const banditData = {
             testName: 'example-1',
             sortedVariants: [
-                {variantName: 'v1', mean: 1},
-                {variantName: 'v2', mean: 0.5},
-                {variantName: 'v3', mean: 0.5},
-            ]
-        }
+                { variantName: 'v1', mean: 1 },
+                { variantName: 'v2', mean: 0.5 },
+                { variantName: 'v3', mean: 0.5 },
+            ],
+        };
         expect(selectVariantWithHighestMean(banditData, epicTest)?.name).toEqual('v1');
     });
 
@@ -88,11 +86,11 @@ describe('selectVariantWithHighestMean', () => {
         const banditData = {
             testName: 'example-1',
             sortedVariants: [
-                {variantName: 'v1', mean: 1},
-                {variantName: 'v2', mean: 1},
-                {variantName: 'v3', mean: 0.5},
-            ]
-        }
+                { variantName: 'v1', mean: 1 },
+                { variantName: 'v2', mean: 1 },
+                { variantName: 'v3', mean: 0.5 },
+            ],
+        };
         // fix Math.random to always choose v1
         jest.spyOn(global.Math, 'random').mockReturnValue(0.1);
 
@@ -104,11 +102,11 @@ describe('selectVariantWithHighestMean', () => {
         const banditData = {
             testName: 'example-1',
             sortedVariants: [
-                {variantName: 'v1', mean: 1},
-                {variantName: 'v2', mean: 1},
-                {variantName: 'v3', mean: 0.5},
-            ]
-        }
+                { variantName: 'v1', mean: 1 },
+                { variantName: 'v2', mean: 1 },
+                { variantName: 'v3', mean: 0.5 },
+            ],
+        };
         // fix Math.random to always choose v2
         jest.spyOn(global.Math, 'random').mockReturnValue(0.8);
 

--- a/src/server/selection/epsilonGreedySelection.test.ts
+++ b/src/server/selection/epsilonGreedySelection.test.ts
@@ -1,5 +1,4 @@
 import type { EpicTest } from '../../shared/types';
-import type { BanditData } from './banditData';
 import { selectVariantWithHighestMean } from './epsilonGreedySelection';
 
 const epicTest: EpicTest = {
@@ -61,41 +60,59 @@ const epicTest: EpicTest = {
     hasArticleCountInCopy: true,
 };
 
-const buildBanditData = (variants: number): BanditData => {
-    const bestVariants = [];
-    for (let i = 0; i < variants; i++) {
-        const variantName = `v${i + 1}`;
-        const mean = i + 1;
-        bestVariants.push({
-            variantName,
-            mean,
-        });
-    }
-    return {
-        testName: 'example-1',
-        bestVariants,
-        variants: bestVariants,
-    };
-};
-
 describe('selectVariantWithHighestMean', () => {
-    it('should return the only variant with highest mean', () => {
-        const banditData = buildBanditData(1);
+    it('should return the only variant', () => {
+        // const banditData = buildBanditData(1);
+        const banditData = {
+            testName: 'example-1',
+            sortedVariants: [
+                {variantName: 'v1', mean: 1}
+            ]
+        }
         expect(selectVariantWithHighestMean(banditData, epicTest)?.name).toEqual('v1');
     });
 
-    it('should return first of best variants', () => {
+    it('should return the only variant with highest mean', () => {
+        // const banditData = buildBanditData(1);
+        const banditData = {
+            testName: 'example-1',
+            sortedVariants: [
+                {variantName: 'v1', mean: 1},
+                {variantName: 'v2', mean: 0.5},
+                {variantName: 'v3', mean: 0.5},
+            ]
+        }
+        expect(selectVariantWithHighestMean(banditData, epicTest)?.name).toEqual('v1');
+    });
+
+    it('should return first of tied best variants', () => {
         // v1 and v2 are tied
-        const banditData = buildBanditData(2);
+        // const banditData = buildBanditData(2);
+        const banditData = {
+            testName: 'example-1',
+            sortedVariants: [
+                {variantName: 'v1', mean: 1},
+                {variantName: 'v2', mean: 1},
+                {variantName: 'v3', mean: 0.5},
+            ]
+        }
         // fix Math.random to always choose v1
         jest.spyOn(global.Math, 'random').mockReturnValue(0.1);
 
         expect(selectVariantWithHighestMean(banditData, epicTest)?.name).toEqual('v1');
     });
 
-    it('should return second of best variants', () => {
+    it('should return second of tied best variants', () => {
         // v1 and v2 are tied
-        const banditData = buildBanditData(2);
+        // const banditData = buildBanditData(2);
+        const banditData = {
+            testName: 'example-1',
+            sortedVariants: [
+                {variantName: 'v1', mean: 1},
+                {variantName: 'v2', mean: 1},
+                {variantName: 'v3', mean: 0.5},
+            ]
+        }
         // fix Math.random to always choose v2
         jest.spyOn(global.Math, 'random').mockReturnValue(0.8);
 

--- a/src/server/selection/epsilonGreedySelection.ts
+++ b/src/server/selection/epsilonGreedySelection.ts
@@ -16,14 +16,12 @@ export function selectVariantWithHighestMean<V extends Variant, T extends Test<V
     const { sortedVariants } = testBanditData;
     // variants array is sorted by mean, use just the best variants
     const bestMean = sortedVariants[0].mean;
-    const bestVariants = sortedVariants.findIndex(variant => variant.mean < bestMean);
+    const bestVariants = sortedVariants.findIndex((variant) => variant.mean < bestMean);
 
     const variant =
         bestVariants < 2
             ? sortedVariants[0]
-            : sortedVariants[
-                  Math.floor(Math.random() * bestVariants)
-              ];
+            : sortedVariants[Math.floor(Math.random() * bestVariants)];
 
     if (!variant) {
         return undefined;

--- a/src/server/selection/epsilonGreedySelection.ts
+++ b/src/server/selection/epsilonGreedySelection.ts
@@ -13,11 +13,16 @@ export function selectVariantWithHighestMean<V extends Variant, T extends Test<V
     testBanditData: BanditData,
     test: T,
 ): V | undefined {
+    const { sortedVariants } = testBanditData;
+    // variants array is sorted by mean, use just the best variants
+    const bestMean = sortedVariants[0].mean;
+    const bestVariants = sortedVariants.findIndex(variant => variant.mean < bestMean);
+
     const variant =
-        testBanditData.bestVariants.length < 2
-            ? testBanditData.bestVariants[0]
-            : testBanditData.bestVariants[
-                  Math.floor(Math.random() * testBanditData.bestVariants.length)
+        bestVariants < 2
+            ? sortedVariants[0]
+            : sortedVariants[
+                  Math.floor(Math.random() * bestVariants)
               ];
 
     if (!variant) {

--- a/src/server/selection/rouletteSelection.test.ts
+++ b/src/server/selection/rouletteSelection.test.ts
@@ -62,19 +62,18 @@ const epicTest: EpicTest = {
 };
 
 const buildBanditData = (variants: number): BanditData => {
-    const bestVariants = [];
+    const sortedVariants = [];
     for (let i = 0; i < variants; i++) {
         const variantName = `v${i + 1}`;
         const mean = i + 1;
-        bestVariants.push({
+        sortedVariants.push({
             variantName,
             mean,
         });
     }
     return {
         testName: 'example-1',
-        bestVariants,
-        variants: bestVariants,
+        sortedVariants,
     };
 };
 
@@ -134,8 +133,7 @@ describe('roulette', () => {
         }));
         const banditData = {
             testName: 'example-1',
-            bestVariants: variants,
-            variants: variants,
+            sortedVariants: variants,
         };
         const variant = selectVariantUsingRoulette(epicTest, banditData, rand);
         expect(variant).toBeDefined();
@@ -158,8 +156,7 @@ describe('roulette', () => {
         ];
         const banditData = {
             testName: 'example-1',
-            bestVariants: variants,
-            variants: variants,
+            sortedVariants: variants,
         };
 
         /**
@@ -266,13 +263,7 @@ describe('rouletteTest2', () => {
 
     const rouletteBanditData: BanditData = {
         testName: 'example-2',
-        bestVariants: [
-            {
-                variantName: 'v2',
-                mean: 3,
-            },
-        ],
-        variants: [
+        sortedVariants: [
             {
                 variantName: 'v1',
                 mean: 1,

--- a/src/server/selection/rouletteSelection.ts
+++ b/src/server/selection/rouletteSelection.ts
@@ -11,7 +11,7 @@ export function selectVariantUsingRoulette<V extends Variant, T extends Test<V>>
         return selectRandomVariant(test);
     }
 
-    const sumOfMeans = testBanditData.variants.reduce((sum, v) => sum + v.mean, 0);
+    const sumOfMeans = testBanditData.sortedVariants.reduce((sum, v) => sum + v.mean, 0);
 
     if (sumOfMeans <= 0) {
         return selectRandomVariant(test);
@@ -19,7 +19,7 @@ export function selectVariantUsingRoulette<V extends Variant, T extends Test<V>>
 
     const minWeight = 0.1; // Ensure no variant gets less than 10%
     const variantsWithWeights: Array<{ weight: number; variantName: string }> =
-        testBanditData.variants
+        testBanditData.sortedVariants
             .map(({ variantName, mean }) => ({
                 variantName,
                 weight: Math.max(mean / sumOfMeans, minWeight),


### PR DESCRIPTION
The bandit data is fetched and cached regularly.
Originally this data was only used by the epsilon-greedy algorithm, which only requires the best variants (those with the highest mean). And so for efficiency the model just had a `bestVariants` array:
```
export interface BanditData {
    testName: string;
    bestVariants: BanditVariantData[]; // will contain more than 1 variant if there is a tie
}
```

We later added the "roulette" algorithm, which requires the means for all variants, so we added a `variants` field to the model:
```
export interface BanditData {
    testName: string;
    bestVariants: BanditVariantData[]; // will contain more than 1 variant if there is a tie
    variants: BanditVariantData[];
}
```

This PR simplifies the model to:
```
export interface BanditData {
    testName: string;
    sortedVariants: BanditVariantData[];  // sorted by mean, highest first
}
```

I'm doing this ahead of [some work](https://github.com/guardian/support-dotcom-components/pull/1332) on simulation for selection methods.