### PR TITLE
Support 'global' ticker campaign

### DIFF
--- a/src/server/lib/fetchTickerData.ts
+++ b/src/server/lib/fetchTickerData.ts
@@ -81,9 +81,11 @@ export const buildTickerDataReloader = async (stage: Stage): Promise<TickerDataP
     const reloaders: TickerDataProviders = await Promise.all([
         buildReloader(getTickerDataForTickerTypeFetcher(stage, 'US'), 60),
         buildReloader(getTickerDataForTickerTypeFetcher(stage, 'AU'), 60),
-    ]).then(([US, AU]) => ({
+        buildReloader(getTickerDataForTickerTypeFetcher(stage, 'global'), 60),
+    ]).then(([US, AU, global]) => ({
         US,
         AU,
+        global,
     }));
     return new TickerDataProvider(reloaders);
 };

--- a/src/server/tests/amp/ampEpicSelection.test.ts
+++ b/src/server/tests/amp/ampEpicSelection.test.ts
@@ -86,6 +86,7 @@ const expectedAmpEpic: AMPEpic = {
 const tickerDataReloader = new TickerDataProvider({
     US: { get: () => ({ total: 999, goal: 1000 }) },
     AU: { get: () => ({ total: 999, goal: 1000 }) },
+    global: { get: () => ({ total: 999, goal: 1000 }) },
 });
 
 describe('ampEpicTests', () => {

--- a/src/shared/types/props/shared.ts
+++ b/src/shared/types/props/shared.ts
@@ -84,9 +84,9 @@ export const tickerDataSchema = z.object({
 });
 
 // Corresponds to .json file names in S3
-export type TickerName = 'US' | 'AU';
+export type TickerName = 'US' | 'AU' | 'global';
 
-const ticketNameSchema = z.enum(['US', 'AU']);
+const tickerNameSchema = z.enum(['US', 'AU', 'global']);
 
 export interface TickerSettings {
     endType: TickerEndType;
@@ -102,7 +102,7 @@ export const tickerSettingsSchema = z.object({
     countType: tickerCountTypeSchema,
     currencySymbol: z.string(),
     copy: tickerCopySchema,
-    name: ticketNameSchema,
+    name: tickerNameSchema,
     tickerData: tickerDataSchema.optional(),
 });
 


### PR DESCRIPTION
The ticker-calculator [now produces](https://github.com/guardian/contributions-ticker-calculator/pull/86) a `global` ticker value, which we'll be using in an upcoming campaign.
This PR adds this new ticker campaign name so that we can poll the value and serve it to the client.

There will also be a change to support-admin-console to make `global` a valid ticker option.