### PR TITLE
Update tickerSettings and remove endType and countType

### DIFF
--- a/.changeset/fluffy-beers-yawn.md
+++ b/.changeset/fluffy-beers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+Update tickerSettings

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -196,17 +196,6 @@
       "count": 2
     }
   },
-  "src/server/tests/amp/ampTicker.ts": {
-    "@typescript-eslint/no-unnecessary-condition": {
-      "count": 1
-    },
-    "@typescript-eslint/no-unsafe-enum-comparison": {
-      "count": 1
-    },
-    "@typescript-eslint/prefer-nullish-coalescing": {
-      "count": 2
-    }
-  },
   "src/server/tests/banners/bannerDeployTimes.ts": {
     "@typescript-eslint/no-unsafe-argument": {
       "count": 5

--- a/src/dotcom/index.ts
+++ b/src/dotcom/index.ts
@@ -6,7 +6,7 @@ export {
 export * from '../shared/lib/geolocation';
 export * from '../shared/lib/viewLog';
 export * from '../shared/lib/reminderFields';
-export { SecondaryCtaType, TickerCountType, TickerEndType } from '../shared/types/props/shared';
+export { SecondaryCtaType } from '../shared/types/props/shared';
 export { hexColourToString } from '../shared/types/props/design';
 export { contributionTabFrequencies } from '../shared/types/abTests/epic';
 export { headerPropsSchema } from '../shared/types/props/header';

--- a/src/server/tests/amp/ampEpicSelection.test.ts
+++ b/src/server/tests/amp/ampEpicSelection.test.ts
@@ -1,5 +1,4 @@
 import type { TickerSettings } from '../../../shared/types';
-import { TickerCountType, TickerEndType } from '../../../shared/types';
 import type { AmpVariantAssignments } from '../../lib/ampVariantAssignments';
 import { TickerDataProvider } from '../../lib/fetchTickerData';
 import type { AMPEpic, AmpEpicTest } from './ampEpicModels';
@@ -9,8 +8,6 @@ const tickerSettings: TickerSettings = {
     currencySymbol: '$',
     copy: {
         countLabel: 'contributions',
-        goalReachedPrimary: "We've hit our goal!",
-        goalReachedSecondary: 'but you can still support us',
     },
     name: 'US',
 };

--- a/src/server/tests/amp/ampEpicSelection.test.ts
+++ b/src/server/tests/amp/ampEpicSelection.test.ts
@@ -6,8 +6,6 @@ import type { AMPEpic, AmpEpicTest } from './ampEpicModels';
 import { selectAmpEpic } from './ampEpicSelection';
 
 const tickerSettings: TickerSettings = {
-    endType: TickerEndType.unlimited,
-    countType: TickerCountType.money,
     currencySymbol: '$',
     copy: {
         countLabel: 'contributions',

--- a/src/server/tests/amp/ampTicker.ts
+++ b/src/server/tests/amp/ampTicker.ts
@@ -20,12 +20,10 @@ export const ampTicker = (tickerSettings: TickerSettings, tickerData: TickerData
         : undefined;
 
     const topLeft = goalReached
-        ? tickerSettings.copy.goalReachedPrimary || `${prefix}${tickerData.total.toLocaleString()}`
+        ? tickerSettings.copy.countLabel || `${prefix}${tickerData.total.toLocaleString()}`
         : `${prefix}${tickerData.total.toLocaleString()}`;
 
-    const bottomLeft = goalReached
-        ? tickerSettings.copy.goalReachedSecondary || tickerSettings.copy.countLabel
-        : tickerSettings.copy.countLabel;
+    const bottomLeft = tickerSettings.copy.countLabel;
 
     const topRight = goalReached
         ? `${prefix}${tickerData.total.toLocaleString()}`

--- a/src/server/tests/amp/ampTicker.ts
+++ b/src/server/tests/amp/ampTicker.ts
@@ -10,7 +10,7 @@ export interface AMPTicker {
 }
 
 export const ampTicker = (tickerSettings: TickerSettings, tickerData: TickerData): AMPTicker => {
-    const prefix = tickerSettings.countType === 'money' ? tickerSettings.currencySymbol : '';
+    const prefix = tickerSettings.currencySymbol;
     const goalReached = tickerData.total >= tickerData.goal;
     const totalPlusFifteen = tickerData.total + tickerData.total * 0.15;
     const percentage =

--- a/src/shared/types/props/shared.ts
+++ b/src/shared/types/props/shared.ts
@@ -45,32 +45,12 @@ export const secondaryCtaSchema = z.discriminatedUnion('type', [
     contributionsReminderSecondaryCtaSchema,
 ]);
 
-export enum TickerEndType {
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- model predates linting rule
-    unlimited = 'unlimited',
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- model predates linting rule
-    hardstop = 'hardstop', // currently unsupported
-}
-
-export const tickerEndTypeSchema = z.nativeEnum(TickerEndType);
-
-export enum TickerCountType {
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- model predates linting rule
-    money = 'money',
-}
-
-export const tickerCountTypeSchema = z.nativeEnum(TickerCountType);
-
 interface TickerCopy {
     countLabel: string;
-    goalReachedPrimary?: string;
-    goalReachedSecondary?: string;
 }
 
 export const tickerCopySchema = z.object({
     countLabel: z.string(),
-    goalReachedPrimary: z.string().optional(),
-    goalReachedSecondary: z.string().optional(),
 });
 
 export interface TickerData {

--- a/src/shared/types/props/shared.ts
+++ b/src/shared/types/props/shared.ts
@@ -89,8 +89,6 @@ export type TickerName = 'US' | 'AU' | 'global';
 const tickerNameSchema = z.enum(['US', 'AU', 'global']);
 
 export interface TickerSettings {
-    endType: TickerEndType;
-    countType: TickerCountType;
     currencySymbol: string;
     copy: TickerCopy;
     name: TickerName;
@@ -98,8 +96,6 @@ export interface TickerSettings {
 }
 
 export const tickerSettingsSchema = z.object({
-    endType: tickerEndTypeSchema,
-    countType: tickerCountTypeSchema,
     currencySymbol: z.string(),
     copy: tickerCopySchema,
     name: tickerNameSchema,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR is to remove endType and countType from TickerSettings as these are no longer used.

This change was made as part of tooling Ticker in landing page tests

This is to support the changes in [SAC PR](https://github.com/guardian/support-admin-console/pull/725)


## How to test

Deployed the SDC and SAC  branches to CODE and checked the changes in RRCP Preview option.Unable to test in Web preview as we haven't updated DCR yet