### PR TITLE
Bump AMIgo bake to match node version in .nvmrc

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
             cloudFormationStackByTags: false
             amiParameter: AMIDotcomcomponents
             amiTags:
-                Recipe: jammy-membership-node18
+                Recipe: jammy-membership-node22
                 AmigoStage: PROD
 
     dotcom-components:


### PR DESCRIPTION
## What does this change?

As we've specified node v22.13.1 in the .nvmrc file, we need to ensure the AMIgo node image matches.

## How to test

Deploy to CODE

## How can we measure success?

Deploys to CODE successfully, banner, epic and gutter-ask appearing as usual
