### PR TITLE
Aggregate memory metrics by ASG

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1637,6 +1637,7 @@ cat > /opt/aws/amazon-cloudwatch-agent/bin/config.json <<'EOF'
         "metrics_collection_interval": 60
       }
     },
+    "aggregation_dimensions" : [["AutoScalingGroupName"]],
     "append_dimensions": {
       "App": "dotcom-components",
       "Stack": "support",

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -180,6 +180,7 @@ cat > /opt/aws/amazon-cloudwatch-agent/bin/config.json <<'EOF'
         "metrics_collection_interval": 60
       }
     },
+    "aggregation_dimensions" : [["AutoScalingGroupName"]],
     "append_dimensions": {
       "App": "${appName}",
       "Stack": "${this.stack}",


### PR DESCRIPTION
A [previous PR](https://github.com/guardian/support-dotcom-components/pull/1338) added memory usage metrics using the cloudwatch agent.

We want to view these memory metrics across the whole autoscaling group over time, as well as per instance.
I've done this using cloudwatch queries:
<img width="289" alt="Screenshot 2025-04-25 at 08 43 05" src="https://github.com/user-attachments/assets/0fe6e366-d239-4602-ade7-50447c0a5ce3" />

The current solution is not quite good enough because cloudwatch limits us to 3 hours of data when using queries:
<img width="731" alt="Screenshot 2025-04-25 at 08 37 47" src="https://github.com/user-attachments/assets/862cefe0-f360-462c-9dc2-d0b865b24d02" />

And we cannot break it down further without using cloudwatch queries because the metrics are being grouped by autoscaling group _and_ instance ID:
<img width="313" alt="Screenshot 2025-04-25 at 08 39 10" src="https://github.com/user-attachments/assets/9a2fb731-9eae-4020-9763-7549d65cc30a" />
and instance IDs change all the time with autoscaling/redeploys.

This PR solves this by adding an `aggregation_dimensions` field to aggregate by autoscaling group.
See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-common-scenarios.html

And in CODE we now have it aggregated just by autoscaling group:
<img width="294" alt="Screenshot 2025-04-25 at 08 49 13" src="https://github.com/user-attachments/assets/38055e13-0c73-436f-9f6c-dbcf4827f88f" />
