### PR TITLE
Adjustment to allow hard coded 3 tier choice cards in new test variant

### DIFF
--- a/src/server/tests/banners/bannerSelection.ts
+++ b/src/server/tests/banners/bannerSelection.ts
@@ -140,7 +140,7 @@ const DESIGNABLE_BANNER_V2_TEMPLATE_NAME = 'DesignableBannerV2';
 
 const getModuleNameForVariant = (variant: BannerVariant): string => {
     if (uiIsDesign(variant.template)) {
-        return variant.name === 'BANNER_V2'
+        return variant.name.includes('BANNER_V2')
             ? DESIGNABLE_BANNER_V2_TEMPLATE_NAME
             : DESIGNABLE_BANNER_TEMPLATE_NAME;
     } else {


### PR DESCRIPTION
## What does this change?

Enables any variant with the name including the string BANNER_V2 anywhere in the name to pick up the new choice cards.  This is a temporary fix while we build them as default to allow MRR to use them for an up-coming campaign.

## How to test

Deploy to code and create a variant with BANNER_V2 in the name - check web preview.

Co-authored-by @tomrf1 