### PR TITLE
deny /tips from being gated

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -21,17 +21,6 @@
       "count": 1
     }
   },
-  "src/server/api/auxiaProxyRouter.ts": {
-    "@typescript-eslint/no-unsafe-assignment": {
-      "count": 4
-    },
-    "@typescript-eslint/no-unsafe-member-access": {
-      "count": 21
-    },
-    "@typescript-eslint/no-unsafe-argument": {
-      "count": 17
-    }
-  },
   "src/server/api/bannerRouter.ts": {
     "@typescript-eslint/no-unnecessary-condition": {
       "count": 1

--- a/src/server/signin-gate/lib.test.ts
+++ b/src/server/signin-gate/lib.test.ts
@@ -1,4 +1,5 @@
 import {
+    articleIdentifierIsAllowed,
     buildAuxiaProxyGetTreatmentsResponseData,
     buildGetTreatmentsRequestPayload,
     buildLogTreatmentInteractionRequestPayload,
@@ -229,4 +230,15 @@ describe('buildLogTreatmentInteractionRequestPayload', () => {
             ),
         ).toStrictEqual(expectedAnswer);
     });
+});
+
+describe('articleIdentifierIsAllowed', () => {
+    expect(
+        articleIdentifierIsAllowed(
+            'www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software',
+        ),
+    ).toBe(true);
+    expect(articleIdentifierIsAllowed('www.theguardian.com/tips')).toBe(false);
+    expect(articleIdentifierIsAllowed('www.theguardian.com/tips#test')).toBe(false);
+    expect(articleIdentifierIsAllowed('www.theguardian.com/tips/test')).toBe(false);
 });

--- a/src/server/signin-gate/lib.ts
+++ b/src/server/signin-gate/lib.ts
@@ -245,7 +245,10 @@ export const articleIdentifierIsAllowed = (articleIdentifier: string): boolean =
     // For the moment we are only going to check for that one string, we will refactor
     // if more come in in the future
 
-    const denyPrefixes = ['www.theguardian.com/tips'];
+    const denyPrefixes = [
+        'www.theguardian.com/tips',
+        'www.theguardian.com/help/ng-interactive/2017/mar/17/contact-the-guardian-securely',
+    ];
 
     return !denyPrefixes.some((denyIdentifer) => articleIdentifier.startsWith(denyIdentifer));
 };

--- a/src/server/signin-gate/lib.ts
+++ b/src/server/signin-gate/lib.ts
@@ -234,3 +234,18 @@ export const buildLogTreatmentInteractionRequestPayload = (
         actionName,
     };
 };
+
+export const articleIdentifierIsAllowed = (articleIdentifier: string): boolean => {
+    // This function was introduced to handle the specific request of not showing a gate for
+    // this url: https://www.theguardian.com/tips
+    // articleIdentifier are given to the end point under the following format:
+    // - 'www.theguardian.com/money/2017/mar/10/ministers-to-criminalise-use-of-ticket-tout-harvesting-software'
+    // - 'www.theguardian.com/tips'
+
+    // For the moment we are only going to check for that one string, we will refactor
+    // if more come in in the future
+
+    const denyPrefixes = ['www.theguardian.com/tips'];
+
+    return !denyPrefixes.some((denyIdentifer) => articleIdentifier.startsWith(denyIdentifer));
+};


### PR DESCRIPTION
This implement the deny of gate for the specific article identifier `www.theguardian.com/tips`.

Also, today is the day prettier decided to be really pedantic with me about types (see below pictures), so we do a bit of clarification (which is a good thing)

BEFORE:

![Screenshot 2025-04-29 at 08 22 40](https://github.com/user-attachments/assets/60bb09c2-3c47-4a5c-9a91-82867885a068)

![Screenshot 2025-04-29 at 08 22 43](https://github.com/user-attachments/assets/11603c1e-3ab5-42e5-b334-b919a1ec39e2)

AFTER:

![Screenshot 2025-04-29 at 08 26 08](https://github.com/user-attachments/assets/c4f2dbeb-beae-4061-8852-859372d57b9b)
