### PR TITLE
mvtIdIsAuxiaAudienceShare

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -7,41 +7,47 @@ See [architecture](docs/architecture.md) for details.
 This project uses [nvm](https://github.com/nvm-sh/nvm). You should run `nvm use` in your terminal before running any of the following commands. To set up, first run
 
 ```bash
-pnpm install
+$ pnpm install
 ```
 
 This will install all the project dependencies.
 
+If you have a linting problem, try
+
+```bash
+$ pnpm prettier:fix
+```
 
 ### Server
 
 To start the server run
 
 ```bash
-pnpm start
+$ pnpm start
 ```
 
 This will start `webpack` in `watch` mode to recompile on file changes and `nodemon` to run the resulting javascript and restart after recompilation.
 
 The server runs on port 8082 locally.
 
-
 #### DCR
 
 A local instance of DCR will use the `SDC_URL` environment variable to get the url for requests to SDC. To point DCR at a local instance of SDC we can therefore run DCR like
 
 ```bash
-SDC_URL=http://localhost:8082 make dev
+$ SDC_URL=http://localhost:8082 make dev
 ```
 
-
 #### Browserstack Local:
+
 If you need to test against local instances of SDC + DCR through Browserstack Local then it's necessary to use the `thegulocal.com` domain.
 To do this, in SDC:
+
 1. setup nginx with `packages/server/scripts/nginx/setup.sh`
 2. run `base_url=https://contributions.thegulocal.com pnpm server start`
 
 Then in DCR:
+
 1. setup nginx with `scripts/nginx/setup.sh`
 2. run `SDC_URL=https://contributions.thegulocal.com make dev`
 3. use https://r.thegulocal.com, rather than localhost
@@ -51,21 +57,22 @@ Then in DCR:
 To run the tests run
 
 ```bash
-pnpm test
+$ pnpm test
 ```
 
 To run specific tests specify the path, e.g.
+
 ```bash
-pnpm test src/server/tests/banners/bannerDeploySchedule.test.ts
+$ pnpm test src/server/tests/banners/bannerDeploySchedule.test.ts
 ```
 
 ### Project structure
 
 The `/src` directory contains 3 subdirectories:
 
-- `/server` - a Node.js express server.
-- `/dotcom` - exports selected code/types for publishing to an npm package, for use by dotcom-rendering.
-- `/shared` - shared code between `/server` and `/dotcom`.
+-   `/server` - a Node.js express server.
+-   `/dotcom` - exports selected code/types for publishing to an npm package, for use by dotcom-rendering.
+-   `/shared` - shared code between `/server` and `/dotcom`.
 
 ## Publishing to npm
 
@@ -94,15 +101,19 @@ a change to the README.
 
 You can manually bump the version of SDC in `package.json` and run `pnpm i`, or run
 
-`pnpm --filter=@guardian/dotcom-rendering i @guardian/support-dotcom-components@latest`
+```
+$ pnpm --filter=@guardian/dotcom-rendering i @guardian/support-dotcom-components@latest
+```
 
 from the root of the project.
-
 
 ## SSH access
 
 To ssh onto an instance use:
-`ssm ssh --profile <aws profile> -x --ssm-tunnel -i <instance ID>`
+
+```
+$ ssm ssh --profile <aws profile> -x --ssm-tunnel -i <instance ID>
+```
 
 ## Logging
 

--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -188,6 +188,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
             'tagIds',
             'gateDismissCount',
             'countryCode',
+            'mvtId',
         ]),
         async (req: express.Request, res: express.Response, next: express.NextFunction) => {
             try {
@@ -202,6 +203,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
                     tagIds: string[];
                     gateDismissCount: number;
                     countryCode: string;
+                    mvtId: number;
                 };
 
                 // [1] articleIdentifier examples:

--- a/src/server/signin-gate/lib.test.ts
+++ b/src/server/signin-gate/lib.test.ts
@@ -9,6 +9,7 @@ import {
     isValidContentType,
     isValidSection,
     isValidTagIdCollection,
+    mvtIdIsAuxiaAudienceShare,
 } from './lib';
 
 describe('guDefaultShouldShowTheGate', () => {
@@ -241,4 +242,13 @@ describe('articleIdentifierIsAllowed', () => {
     expect(articleIdentifierIsAllowed('www.theguardian.com/tips')).toBe(false);
     expect(articleIdentifierIsAllowed('www.theguardian.com/tips#test')).toBe(false);
     expect(articleIdentifierIsAllowed('www.theguardian.com/tips/test')).toBe(false);
+});
+
+describe('mvtIdIsInTheNaturalAuxiaShareOfAudience', () => {
+    expect(mvtIdIsAuxiaAudienceShare(0)).toBe(false);
+    expect(mvtIdIsAuxiaAudienceShare(1)).toBe(true);
+    expect(mvtIdIsAuxiaAudienceShare(210945)).toBe(true);
+    expect(mvtIdIsAuxiaAudienceShare(210946)).toBe(true);
+    expect(mvtIdIsAuxiaAudienceShare(350000)).toBe(true);
+    expect(mvtIdIsAuxiaAudienceShare(350001)).toBe(false);
 });

--- a/src/server/signin-gate/lib.ts
+++ b/src/server/signin-gate/lib.ts
@@ -252,3 +252,42 @@ export const articleIdentifierIsAllowed = (articleIdentifier: string): boolean =
 
     return !denyPrefixes.some((denyIdentifer) => articleIdentifier.startsWith(denyIdentifer));
 };
+
+export const mvtIdIsAuxiaAudienceShare = (mvtId: number): boolean => {
+    /*
+        In May 2025, we decided that we would decommission the old / previous definition
+        of the Auxia share of the audience, which was done using a client side defined AB test,
+        by which the "first" 35% of the audience is sent to Auxia, and the rest (65%) split between
+        "SignInGateMainVariant" and "SignInGateMainControl"
+        (
+            https://github.com/guardian/dotcom-rendering/blob/d6e44406cffb362c99d5734f6e82f6e664682da8/dotcom-rendering/src/experiments/tests/auxia-sign-in-gate.ts
+        )
+
+        ... and move to those shares being controlled by SDC and in particular SDC's default gate
+        taking over the old gate hard coded into DCR.
+
+        To maintain invariance of how the cohorts are defined, SDC, must be able to convert a
+        mvtId into a share of audience. Passing the mvtId to the GetTreatment call was done in these two PRs:
+
+        https://github.com/guardian/dotcom-rendering/pull/13938
+        https://github.com/guardian/dotcom-rendering/pull/13941
+
+        In particular we must be able to take a mvtId and simply return
+        a boolean indicating whether or not it is in the first 35% of the audience. This is what this function
+        does.
+
+        This is the function that needs to be modified when we want to increase the share of the
+        audience given to the Auxia experiment in the future.
+    */
+
+    // The MVT calculator is very useful: https://ab-tests.netlify.app
+
+    // The Auxia experiment is 35% audience with 0% offset.
+
+    // The value numbers we are interested in are between 1 and 350_000 [1]
+    // (essentially the first 35% of the total of 1_000_000 possible values for mvtId)
+
+    // [1] Interestingly, 0 is not considered a valid mvtId number.
+
+    return mvtId > 0 && mvtId <= 350_000;
+};


### PR DESCRIPTION
We are now sending mvtId to SDC

- https://github.com/guardian/dotcom-rendering/pull/13938
- https://github.com/guardian/dotcom-rendering/pull/13941

Here we are just implementing the function that is going to ensure invariance of the experiments cohorts as we decommission the old experiment(s) from DCR and hand over total air traffic control to SDC in the next PRs. 

