### PR TITLE
Choice cards formatting

### DIFF
--- a/src/server/lib/choiceCards/defaultChoiceCardSettings.ts
+++ b/src/server/lib/choiceCards/defaultChoiceCardSettings.ts
@@ -43,7 +43,7 @@ const fullChoiceCards = (countryGroupId: CountryGroupId): ChoiceCard[] => [
         },
         label: '', // label is generated for recurring products
         isDefault: true,
-        benefitsLabel: 'Unlock All-access digital benefits:',
+        benefitsLabel: 'Unlock <strong>All-access digital<strong> benefits:',
         benefits: [
             { copy: 'Unlimited access to the Guardian app' },
             { copy: 'Unlimited access to our new Feast App' },

--- a/src/server/lib/choiceCards/defaultChoiceCardSettings.ts
+++ b/src/server/lib/choiceCards/defaultChoiceCardSettings.ts
@@ -43,7 +43,7 @@ const fullChoiceCards = (countryGroupId: CountryGroupId): ChoiceCard[] => [
         },
         label: '', // label is generated for recurring products
         isDefault: true,
-        benefitsLabel: 'Unlock <strong>All-access digital<strong> benefits:',
+        benefitsLabel: 'Unlock <strong>All-access digital</strong> benefits:',
         benefits: [
             { copy: 'Unlimited access to the Guardian app' },
             { copy: 'Unlimited access to our new Feast App' },


### PR DESCRIPTION
This is to match the existing formatting in DCR where this copy is currently hardcoded:
https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/components/marketing/epics/ThreeTierChoiceCards.tsx#L157

An upcoming PR will render this field as html:
https://github.com/guardian/dotcom-rendering/pull/13935/files#diff-781399bcbe277a36529151badd5c2b6ed23db29cdecd1fe96c25f5f87b50ca07R116