### PR TITLE
Remove hover from CTADesign for banners

### DIFF
--- a/.changeset/swift-oranges-travel.md
+++ b/.changeset/swift-oranges-travel.md
@@ -2,4 +2,4 @@
 '@guardian/support-dotcom-components': minor
 ---
 
-Remove hover from CTA banner design
+Remove hover from CtaDesign type as now automated

--- a/.changeset/swift-oranges-travel.md
+++ b/.changeset/swift-oranges-travel.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+Remove hover from CTA banner design

--- a/src/server/factories/bannerDesign.ts
+++ b/src/server/factories/bannerDesign.ts
@@ -50,10 +50,6 @@ export default Factory.define<BannerDesignFromTool>(() => ({
                 text: stringToHexColour('FFFFFF'),
                 background: stringToHexColour('0077B6'),
             },
-            hover: {
-                text: stringToHexColour('FFFFFF'),
-                background: stringToHexColour('004E7C'),
-            },
         },
         secondaryCta: {
             default: {
@@ -61,21 +57,12 @@ export default Factory.define<BannerDesignFromTool>(() => ({
                 background: stringToHexColour('F1F8FC'),
                 border: stringToHexColour('FFFFFF'),
             },
-            hover: {
-                text: stringToHexColour('004E7C'),
-                background: stringToHexColour('E5E5E5'),
-                border: stringToHexColour('222527'),
-            },
         },
         closeButton: {
             default: {
                 text: stringToHexColour('052962'),
                 background: stringToHexColour('F1F8FC'),
                 border: stringToHexColour('052962'),
-            },
-            hover: {
-                text: stringToHexColour('052962'),
-                background: stringToHexColour('E5E5E5'),
             },
         },
         ticker: {

--- a/src/shared/types/props/design.ts
+++ b/src/shared/types/props/design.ts
@@ -85,7 +85,6 @@ interface CtaStateDesign {
 }
 export interface CtaDesign {
     default: CtaStateDesign;
-    hover: CtaStateDesign;
 }
 
 interface TickerDesign {


### PR DESCRIPTION
## What does this change?
Use automatic cta hover colours

[Trello card](https://trello.com/c/rrkYaudf/1089-banner-design-use-automatic-cta-hover-colours)


Currently in the RRCP banner design tool users have to configure the cta hover colours.
The latest version of source now has automatic hover colours on ctas, based on the main colour. If we use this instead then we can simplify the configuration of banner designs.
## How to test
