### PR TITLE
Fix pill and rate plan copy in choice cards

### DIFF
--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -16,6 +16,14 @@ import {
 const replaceCurrencyTemplate = (s: string, currencySymbol: string) =>
     s.replace(currencySymbolTemplate, currencySymbol);
 
+const ratePlanCopy = (ratePlan: RatePlan): string => {
+    if (ratePlan === 'Monthly') {
+        return 'monthly';
+    } else {
+        return 'annually';
+    }
+};
+
 // Add pricing, currency etc
 const enrichChoiceCard = (
     choiceCard: ChoiceCard,
@@ -29,7 +37,7 @@ const enrichChoiceCard = (
         tier: 'Contribution' | 'SupporterPlus',
     ) => {
         const price = productCatalog[tier].ratePlans.Monthly.pricing[isoCurrency];
-        return `Support ${currencySymbol}${price}/${ratePlan.toLowerCase()}`;
+        return `Support ${currencySymbol}${price}/${ratePlanCopy(ratePlan)}`;
     };
     const buildLabelForOneOffContribution = (label: string) =>
         replaceCurrencyTemplate(label, currencySymbol);

--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -53,6 +53,7 @@ const enrichChoiceCard = (
         isDefault: choiceCard.isDefault,
         benefitsLabel: choiceCard.benefitsLabel,
         benefits,
+        pill: choiceCard.pill,
     };
 };
 


### PR DESCRIPTION
Currently the pill copy is not being sent to the client (e.g. "Recommended").

Also, for annual rate plans it should say e.g. "Support £12/annually", but currently it would say "Support £12/annual". We're not currently showing annual choices so it's not a bug yet.

Tested both fixes in CODE -
<img width="566" alt="Screenshot 2025-05-21 at 11 41 28" src="https://github.com/user-attachments/assets/3e0541b0-7e31-47d1-81ba-d8b6c3425531" />
