### PR TITLE
Remove old designable banner template to force all banners to new 3-tier choice cards

### DIFF
--- a/src/server/tests/banners/bannerSelection.ts
+++ b/src/server/tests/banners/bannerSelection.ts
@@ -135,14 +135,11 @@ export const canShowBannerAgain = (
     );
 };
 
-const DESIGNABLE_BANNER_TEMPLATE_NAME = 'DesignableBanner';
 const DESIGNABLE_BANNER_V2_TEMPLATE_NAME = 'DesignableBannerV2';
 
 const getModuleNameForVariant = (variant: BannerVariant): string => {
     if (uiIsDesign(variant.template)) {
-        return variant.name.includes('BANNER_V2')
-            ? DESIGNABLE_BANNER_V2_TEMPLATE_NAME
-            : DESIGNABLE_BANNER_TEMPLATE_NAME;
+        return DESIGNABLE_BANNER_V2_TEMPLATE_NAME;
     } else {
         return variant.template;
     }


### PR DESCRIPTION
## What does this change?

This is the first step in removing old choice cards.  It ensures all designable banners follow the new V2 Designable Banner design.

## How to test

Deploy to code and test against DCR.
Test against existing banners with the old choice cards - they will appear with the new design.

## Have we considered potential risks?

This removes reminders on banners as they are not supported in the new design.
This has been tested and works for all tested (live) designable banner variants in CODE.

## Example Images

| V1      | V2      | 
| ----------- | ---------- | 
| <img width="1904" alt="Screenshot 2025-06-04 at 16 36 52" src="https://github.com/user-attachments/assets/3b8518b0-9f60-4e44-b4b4-2a0dad7a7aca" /> | <img width="1887" alt="Screenshot 2025-06-04 at 16 36 41" src="https://github.com/user-attachments/assets/918c4f24-489a-4b86-9426-16541eea4d98" /> | 
| <img width="1898" alt="Screenshot 2025-06-04 at 16 40 38" src="https://github.com/user-attachments/assets/5b7deee7-e932-4efa-9e7b-96bffec42c5e" /> | <img width="1901" alt="Screenshot 2025-06-04 at 16 40 51" src="https://github.com/user-attachments/assets/f625b956-e9f0-4f5f-a3b5-ce459c6a883d" /> |
| <img width="1902" alt="Screenshot 2025-06-04 at 16 43 19" src="https://github.com/user-attachments/assets/67647bc2-7192-402f-85d6-8b02ed742f4d" /> | <img width="1904" alt="Screenshot 2025-06-04 at 16 44 44" src="https://github.com/user-attachments/assets/5485c068-cd04-4bfd-a2e9-755052999a30" /> |










