### PR TITLE
Add promoCodes field to variant models

### DIFF
--- a/.changeset/small-spies-provide.md
+++ b/.changeset/small-spies-provide.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+Add promoCodes field to epic + banner variants

--- a/.changeset/small-spies-provide.md
+++ b/.changeset/small-spies-provide.md
@@ -2,4 +2,4 @@
 '@guardian/support-dotcom-components': minor
 ---
 
-Add promoCodes field to epic + banner variants
+Add promoCodes field to test variant models

--- a/src/server/api/bannerRouter.ts
+++ b/src/server/api/bannerRouter.ts
@@ -122,8 +122,8 @@ export const buildBannerRouter = (
                           channelFromBannerChannel(test.bannerChannel),
                           productCatalog.get(),
                           promotions.get(),
+                          variant.promoCodes ?? [],
                           variant.choiceCardsSettings ?? undefined,
-                          variant.bannerContent?.cta,
                       )
                     : undefined;
 

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -149,8 +149,8 @@ export const buildEpicRouter = (
                       'Epic',
                       productCatalog.get(),
                       promotions.get(),
+                      variant.promoCodes ?? [],
                       variant.choiceCardsSettings ?? undefined,
-                      variant.cta,
                   )
                 : undefined;
 

--- a/src/server/lib/choiceCards/choiceCards.test.ts
+++ b/src/server/lib/choiceCards/choiceCards.test.ts
@@ -1,4 +1,3 @@
-import type { Cta } from '../../../shared/types';
 import type { ChoiceCardsSettings } from '../../../shared/types/props/choiceCards';
 import type { ProductCatalog } from '../../productCatalog';
 import type { PromotionsCache } from '../promotions/promotions';
@@ -75,20 +74,16 @@ describe('getChoiceCardsSettings', () => {
     };
 
     it('returns default settings without promotion applied', () => {
-        const cta: Cta = {
-            baseUrl: `https://support.theguardian.com/contribute`,
-            text: 'Support',
-        };
-
         const variantChoiceCardSettings = undefined;
+        const promoCodes: string[] = [];
 
         const result = getChoiceCardsSettings(
             'UnitedStates',
             'Epic',
             mockProductCatalog,
             mockPromotionsCache,
+            promoCodes,
             variantChoiceCardSettings,
-            cta,
         );
 
         expect(result).toBeDefined();
@@ -101,20 +96,16 @@ describe('getChoiceCardsSettings', () => {
     });
 
     it('returns choice cards with monthly discount (PROMO_B) applied', () => {
-        const cta: Cta = {
-            baseUrl: `https://support.theguardian.com/contribute?promoCode=PROMO_B`,
-            text: 'Support',
-        };
-
         const variantChoiceCardSettings = defaultEpicChoiceCardsSettings('UnitedStates');
+        const promoCodes: string[] = ['PROMO_B'];
 
         const result = getChoiceCardsSettings(
             'UnitedStates',
             'Epic',
             mockProductCatalog,
             mockPromotionsCache,
+            promoCodes,
             variantChoiceCardSettings,
-            cta,
         );
 
         expect(result).toBeDefined();
@@ -127,11 +118,6 @@ describe('getChoiceCardsSettings', () => {
     });
 
     it('returns choice cards with annual discount (PROMO_A) applied', () => {
-        const cta: Cta = {
-            baseUrl: `https://support.theguardian.com/contribute?promoCode=PROMO_A`,
-            text: 'Support',
-        };
-
         // Make the SupporterPlus choice card ratePlan Annual
         const variantChoiceCardSettings: ChoiceCardsSettings = {
             choiceCards: [
@@ -146,14 +132,15 @@ describe('getChoiceCardsSettings', () => {
                 defaultEpicChoiceCardsSettings('UnitedStates').choiceCards[2],
             ],
         };
+        const promoCodes: string[] = ['PROMO_A'];
 
         const result = getChoiceCardsSettings(
             'UnitedStates',
             'Epic',
             mockProductCatalog,
             mockPromotionsCache,
+            promoCodes,
             variantChoiceCardSettings,
-            cta,
         );
 
         expect(result).toBeDefined();

--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -96,7 +96,7 @@ export const getChoiceCardsSettings = (
 ): ChoiceCardsSettings | undefined => {
     let choiceCardsSettings: ChoiceCardsSettings | undefined;
     const isoCurrency = countryGroups[countryGroupId].currency;
-    const promotions = promoCodes.map(code => promotionsCache[code]).filter(Boolean);
+    const promotions = promoCodes.map((code) => promotionsCache[code]).filter(Boolean);
 
     if (variantChoiceCardSettings) {
         // Use the overridden settings from the test variant
@@ -116,8 +116,9 @@ export const getChoiceCardsSettings = (
             const { ratePlan } = choiceCard.product;
             const choiceCardProduct = productCatalog['SupporterPlus'].ratePlans[ratePlan];
             // Find a promo with a matching productRatePlanId
-            return promotions
-                .find(promo => promo.productRatePlanIds.includes(choiceCardProduct.id));
+            return promotions.find((promo) =>
+                promo.productRatePlanIds.includes(choiceCardProduct.id),
+            );
         }
         return undefined;
     };

--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -1,6 +1,6 @@
 import type { CountryGroupId, IsoCurrency } from '../../../shared/lib';
 import { countryGroups, isoCurrencyToCurrencySymbol } from '../../../shared/lib';
-import type { Channel, Cta } from '../../../shared/types';
+import type { Channel } from '../../../shared/types';
 import type {
     ChoiceCard,
     ChoiceCardsSettings,
@@ -86,26 +86,17 @@ const enrichChoiceCard = (
     };
 };
 
-const getPromoCodeFromUrl = (url: string): string | undefined => {
-    try {
-        const parsedUrl = new URL(url);
-        return parsedUrl.searchParams.get('promoCode') ?? undefined;
-    } catch {
-        return undefined;
-    }
-};
-
 export const getChoiceCardsSettings = (
     countryGroupId: CountryGroupId,
     channel: Channel,
     productCatalog: ProductCatalog,
-    promotions: PromotionsCache,
+    promotionsCache: PromotionsCache,
+    promoCodes: string[],
     variantChoiceCardSettings?: ChoiceCardsSettings, // defined only if the test variant overrides the default settings
-    cta?: Cta,
 ): ChoiceCardsSettings | undefined => {
     let choiceCardsSettings: ChoiceCardsSettings | undefined;
     const isoCurrency = countryGroups[countryGroupId].currency;
-    const promoCode = cta ? getPromoCodeFromUrl(cta.baseUrl) : undefined;
+    const promotions = promoCodes.map(code => promotionsCache[code]).filter(Boolean);
 
     if (variantChoiceCardSettings) {
         // Use the overridden settings from the test variant
@@ -121,18 +112,12 @@ export const getChoiceCardsSettings = (
 
     const getPromotion = (choiceCard: ChoiceCard): Promotion | undefined => {
         // We only support promos for SupporterPlus for now
-        if (promoCode && choiceCard.product.supportTier === 'SupporterPlus') {
-            const promo = promotions[promoCode];
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- in case the promo code isn't in the table
-            if (promo) {
-                // Does the productRatePlanId match?
-                const choiceCardProduct =
-                    productCatalog['SupporterPlus'].ratePlans[choiceCard.product.ratePlan];
-                const matches = promo.productRatePlanIds.includes(choiceCardProduct.id);
-                if (matches) {
-                    return promo;
-                }
-            }
+        if (promotions.length > 0 && choiceCard.product.supportTier === 'SupporterPlus') {
+            const { ratePlan } = choiceCard.product;
+            const choiceCardProduct = productCatalog['SupporterPlus'].ratePlans[ratePlan];
+            // Find a promo with a matching productRatePlanId
+            return promotions
+                .find(promo => promo.productRatePlanIds.includes(choiceCardProduct.id));
         }
         return undefined;
     };

--- a/src/shared/types/abTests/banner.ts
+++ b/src/shared/types/abTests/banner.ts
@@ -48,6 +48,7 @@ export const bannerVariantFromToolSchema = z.object({
     separateArticleCount: z.boolean().optional(),
     separateArticleCountSettings: separateArticleCountSchema.optional(),
     choiceCardsSettings: choiceCardsSettings.nullish(),
+    promoCodes: z.array(z.string()).nullish(),
 });
 
 export type BannerVariantFromTool = z.infer<typeof bannerVariantFromToolSchema>;

--- a/src/shared/types/abTests/gutter.ts
+++ b/src/shared/types/abTests/gutter.ts
@@ -9,6 +9,7 @@ import { pageContextTargetingSchema, testSchema, userCohortSchema } from './shar
 const gutterVariantFromToolSchema = z.object({
     name: z.string(),
     content: gutterContentSchema,
+    promoCodes: z.array(z.string()).nullish(),
 });
 export type GutterVariantFromTool = z.infer<typeof gutterVariantFromToolSchema>;
 

--- a/src/shared/types/abTests/header.ts
+++ b/src/shared/types/abTests/header.ts
@@ -10,6 +10,7 @@ const headerVariantFromToolSchema = z.object({
     name: z.string(),
     content: headerContentSchema,
     mobileContent: headerContentSchema.optional(),
+    promoCodes: z.array(z.string()).nullish(),
 });
 export type HeaderVariantFromTool = z.infer<typeof headerVariantFromToolSchema>;
 

--- a/src/shared/types/props/epic.ts
+++ b/src/shared/types/props/epic.ts
@@ -86,6 +86,7 @@ export const variantSchema = z.object({
     image: imageSchema.optional(),
     showReminderFields: reminderFieldsSchema.optional(),
     separateArticleCount: separateArticleCountSchema.optional(),
+    promoCodes: z.array(z.string()).nullish(),
     maxViews: maxViewsSchema.optional(),
     showSignInLink: z.boolean().optional(),
     bylineWithImage: bylineWithImageSchema.optional(),

--- a/src/shared/types/props/gutter.ts
+++ b/src/shared/types/props/gutter.ts
@@ -20,6 +20,7 @@ export interface GutterProps {
     tracking: Tracking;
     countryCode?: string;
     submitComponentEvent?: (componentEvent: ComponentEvent) => Promise<void>;
+    promoCodes?: string[];
 }
 
 export const gutterPropsSchema = z.object({
@@ -27,4 +28,5 @@ export const gutterPropsSchema = z.object({
     tracking: trackingSchema,
     countryCode: z.string().optional(),
     submitComponentEvent: z.any(),
+    promoCodes: z.array(z.string()).nullish(),
 });

--- a/src/shared/types/props/header.ts
+++ b/src/shared/types/props/header.ts
@@ -26,6 +26,7 @@ export interface HeaderProps {
     countryCode?: string;
     submitComponentEvent?: (componentEvent: ComponentEvent) => Promise<void>;
     numArticles?: number;
+    promoCodes?: string[];
 }
 
 export const headerPropsSchema = z.object({
@@ -35,4 +36,5 @@ export const headerPropsSchema = z.object({
     countryCode: z.string().optional(),
     submitComponentEvent: z.any(),
     numArticles: z.number().optional(),
+    promoCodes: z.array(z.string()).nullish(),
 });


### PR DESCRIPTION
Currently if Marketing want to add a promo to a test variant they must add the `promoCode` parameter to the CTA url. This is then used to modify the choice cards to show the promo (if applicable). This is not great UX for Marketing and the choice cards integration feels a bit hacky.

Instead, here we add a `promoCodes` field to the variant models. This field will be used in 2 ways:
- it will be added to the CTA url, as `promoCode` querystring params,
- in the choice cards, to display the discount

This will require a DCR change to add the `promoCode` parameter to the CTA url, client-side.
It will be used on the header + gutter channels, which do not have choice cards.

Note - while the migration to using the new `promoCodes` field is underway, Marketing will not be able to use promos in the channels. I'll make sure none are running.

support-admin-console PR: https://github.com/guardian/support-admin-console/pull/739