### PR TITLE
Add promoCodes field to banner props model

### DIFF
--- a/.changeset/stale-carrots-speak.md
+++ b/.changeset/stale-carrots-speak.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': minor
+---
+
+Add promoCodes field to banner model

--- a/src/shared/types/props/banner.ts
+++ b/src/shared/types/props/banner.ts
@@ -75,6 +75,7 @@ export interface BannerProps {
     choiceCardsSettings?: ChoiceCardsSettings;
     design?: ConfigurableDesign;
     abandonedBasket?: AbandonedBasket;
+    promoCodes?: string[];
 }
 
 export const bannerSchema = z.object({
@@ -92,4 +93,5 @@ export const bannerSchema = z.object({
     separateArticleCount: z.boolean().nullish(),
     design: configurableDesignSchema.nullish(),
     choiceCardsSettings: choiceCardsSettings.nullish(),
+    promoCodes: z.array(z.string()).nullish(),
 });


### PR DESCRIPTION
I missed this in the [previous PR](https://github.com/guardian/support-dotcom-components/pull/1373)
Which is a sign that these models should ideally be consolidated in some way