### PR TITLE
 Throttle CloudWatch requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "@types/express": "^5.0.0",
         "@types/jest": "^24.0.25",
         "@types/lodash.debounce": "^4.0.6",
+        "@types/lodash.throttle": "^4.1.7",
         "@types/node": "^22.10.7",
         "@types/seedrandom": "^3.0.1",
         "babel-loader": "^9.1.3",
@@ -89,6 +90,7 @@
         "express": "^4.21.2",
         "jsonschema": "^1.4.0",
         "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
         "log4js": "^6.3.0",
         "seedrandom": "^3.0.5",
         "zod": "3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   lodash.debounce:
     specifier: ^4.0.8
     version: 4.0.8
+  lodash.throttle:
+    specifier: ^4.1.1
+    version: 4.1.1
   log4js:
     specifier: ^6.3.0
     version: 6.9.1
@@ -109,6 +112,9 @@ devDependencies:
   '@types/lodash.debounce':
     specifier: ^4.0.6
     version: 4.0.9
+  '@types/lodash.throttle':
+    specifier: ^4.1.7
+    version: 4.1.9
   '@types/node':
     specifier: ^22.10.7
     version: 22.10.7
@@ -1856,7 +1862,7 @@ packages:
       '@mojotech/json-type-validation': 3.1.0
       '@types/temp': 0.8.34
       archiver: 3.1.1
-      aws-sdk: 2.1691.0
+      aws-sdk: 2.1692.0
       ora: 4.1.1
       temp: 0.9.4
       yaml: 1.10.2
@@ -3106,6 +3112,12 @@ packages:
       '@types/lodash': 4.17.12
     dev: true
 
+  /@types/lodash.throttle@4.1.9:
+    resolution: {integrity: sha512-PCPVfpfueguWZQB7pJQK890F2scYKoDUL3iM522AptHWn7d5NQmeS/LTEHIcLr5PaTzl3dK2Z0xSUHHTHwaL5g==}
+    dependencies:
+      '@types/lodash': 4.17.12
+    dev: true
+
   /@types/lodash@4.17.12:
     resolution: {integrity: sha512-sviUmCE8AYdaF/KIHLDJBQgeYzPBI0vf/17NaYehBJfYD1j6/L95Slh07NlyK2iNyBNaEkb3En2jRt+a8y3xZQ==}
     dev: true
@@ -3876,8 +3888,8 @@ packages:
       possible-typed-array-names: 1.0.0
     dev: true
 
-  /aws-sdk@2.1691.0:
-    resolution: {integrity: sha512-/F2YC+DlsY3UBM2Bdnh5RLHOPNibS/+IcjUuhP8XuctyrN+MlL+fWDAiela32LTDk7hMy4rx8MTgvbJ+0blO5g==}
+  /aws-sdk@2.1692.0:
+    resolution: {integrity: sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==}
     engines: {node: '>= 10.0.0'}
     requiresBuild: true
     dependencies:
@@ -4133,7 +4145,7 @@ packages:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
     dependencies:
       base64-js: 1.5.1
-      ieee754: 1.1.13
+      ieee754: 1.2.1
       isarray: 1.0.0
     dev: true
 
@@ -7152,6 +7164,10 @@ packages:
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
     dev: true
+
+  /lodash.throttle@4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+    dev: false
 
   /lodash.union@4.6.0:
     resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -29,7 +29,8 @@ import { selectAmountsTestVariant } from '../selection/ab';
 import type { BanditData } from '../selection/banditData';
 import type { Debug } from '../tests/epics/epicSelection';
 import { findForcedTestAndVariant, findTestAndVariant } from '../tests/epics/epicSelection';
-import { logWarn } from '../utils/logging';
+import { putMetric } from '../utils/cloudwatch';
+import { logger, logWarn } from '../utils/logging';
 import type { ValueProvider } from '../utils/valueReloader';
 
 interface EpicDataResponse {
@@ -87,6 +88,8 @@ export const buildEpicRouter = (
         baseUrl: string,
         req: express.Request,
     ): EpicDataResponse => {
+        putMetric('bandit-selection-error');
+        logger.info('Console log for debugging purposes');
         const { enableEpics, enableSuperMode, enableHardcodedEpicTests } = channelSwitches.get();
         if (!enableEpics) {
             return {};

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -29,8 +29,7 @@ import { selectAmountsTestVariant } from '../selection/ab';
 import type { BanditData } from '../selection/banditData';
 import type { Debug } from '../tests/epics/epicSelection';
 import { findForcedTestAndVariant, findTestAndVariant } from '../tests/epics/epicSelection';
-import { putMetric } from '../utils/cloudwatch';
-import { logger, logWarn } from '../utils/logging';
+import { logWarn } from '../utils/logging';
 import type { ValueProvider } from '../utils/valueReloader';
 
 interface EpicDataResponse {
@@ -88,8 +87,6 @@ export const buildEpicRouter = (
         baseUrl: string,
         req: express.Request,
     ): EpicDataResponse => {
-        putMetric('bandit-selection-error');
-        logger.info('Console log for debugging purposes');
         const { enableEpics, enableSuperMode, enableHardcodedEpicTests } = channelSwitches.get();
         if (!enableEpics) {
             return {};

--- a/src/server/utils/cloudwatch.ts
+++ b/src/server/utils/cloudwatch.ts
@@ -54,14 +54,15 @@ const throttledPutAllMetrics = throttle(
                         Namespace: namespace,
                         MetricData: metricData,
                     }),
-                ).catch((error) => {
-                logError(`Error putting cloudwatch metric: ${String(error)}`);
-                // Assume it failed to send metrics, add them back onto metricCache
-                // @ts-expect-error - Object.keys is untyped
-                Object.keys(metricCacheCopy).forEach((metric: Metric) => {
-                    metricCache[metric] = metricCacheCopy[metric] + metricCache[metric];
+                )
+                .catch((error) => {
+                    logError(`Error putting cloudwatch metric: ${String(error)}`);
+                    // Assume it failed to send metrics, add them back onto metricCache
+                    // @ts-expect-error - Object.keys is untyped
+                    Object.keys(metricCacheCopy).forEach((metric: Metric) => {
+                        metricCache[metric] = metricCacheCopy[metric] + metricCache[metric];
+                    });
                 });
-            });
         }
     },
     THROTTLE_SECONDS * 1000,

--- a/src/server/utils/cloudwatch.ts
+++ b/src/server/utils/cloudwatch.ts
@@ -1,6 +1,6 @@
-import type { Dimension } from '@aws-sdk/client-cloudwatch';
-import { PutMetricDataCommand } from '@aws-sdk/client-cloudwatch';
-import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import { CloudWatchClient, PutMetricDataCommand } from '@aws-sdk/client-cloudwatch';
+import { StandardUnit } from '@aws-sdk/client-cloudwatch';
+import throttle from 'lodash.throttle';
 import { isProd } from '../lib/env';
 import { credentials, region } from './aws';
 import { logError } from './logging';
@@ -10,30 +10,65 @@ const cloudwatch = new CloudWatchClient({ region, credentials: credentials() });
 const stage = isProd ? 'PROD' : 'CODE';
 const namespace = `support-dotcom-components-${stage}`;
 
-type Metric =
-    | 'super-mode-error'
-    | 'channel-tests-error'
-    | 'banner-designs-load-error'
-    | 'bandit-data-load-error'
-    | 'bandit-selection-error'
-    | 'promotions-fetch-error';
+const ALL_METRICS = [
+    'super-mode-error',
+    'channel-tests-error',
+    'banner-designs-load-error',
+    'bandit-data-load-error',
+    'bandit-selection-error',
+    'promotions-fetch-error',
+] as const;
+type Metric = (typeof ALL_METRICS)[number];
+type MetricCache = Record<Metric, number>;
 
-// Sends a single metric to cloudwatch.
-// Avoid doing this per-request, to avoid high costs. This should instead be called from within a ValueReloader
-export const putMetric = (metricName: Metric, dimensions: Dimension[] = []): void => {
-    cloudwatch
-        .send(
-            new PutMetricDataCommand({
-                Namespace: namespace,
-                MetricData: [
-                    {
-                        MetricName: metricName,
-                        Value: 1,
-                        Unit: 'Count',
-                        Dimensions: dimensions,
-                    },
-                ],
-            }),
-        )
-        .catch((error) => logError(`Error putting cloudwatch metric: ${error}`));
+const buildNewCache = (): MetricCache => {
+    const result: Partial<MetricCache> = {};
+    ALL_METRICS.forEach((metric) => {
+        result[metric] = 0;
+    });
+    return result as MetricCache;
+};
+// Throttle cloudwatch requests to avoid high costs
+let metricCache: MetricCache = buildNewCache();
+const THROTTLE_SECONDS = 10;
+
+const throttledPutAllMetrics = throttle(
+    (): void => {
+        const metricCacheCopy = { ...metricCache };
+        // clear the cache
+        metricCache = buildNewCache();
+
+        const metricData = Object.entries(metricCacheCopy)
+            .filter(([, count]) => count > 0) // ignore any with 0 instances
+            .map(([metricName, count]) => ({
+                MetricName: metricName,
+                Value: count,
+                Unit: StandardUnit.Count,
+                Dimensions: [],
+            }));
+
+        if (metricData.length > 0) {
+            cloudwatch
+                .send(
+                    new PutMetricDataCommand({
+                        Namespace: namespace,
+                        MetricData: metricData,
+                    }),
+                ).catch((error) => {
+                logError(`Error putting cloudwatch metric: ${String(error)}`);
+                // Assume it failed to send metrics, add them back onto metricCache
+                // @ts-expect-error - Object.keys is untyped
+                Object.keys(metricCacheCopy).forEach((metric: Metric) => {
+                    metricCache[metric] = metricCacheCopy[metric] + metricCache[metric];
+                });
+            });
+        }
+    },
+    THROTTLE_SECONDS * 1000,
+    { leading: false, trailing: true },
+);
+
+export const putMetric = (metricName: Metric): void => {
+    metricCache[metricName]++;
+    throttledPutAllMetrics();
 };


### PR DESCRIPTION
## What does this change?

This implements a batching mechanism for sending metric data to CloudWatch using putMetric

[Trello card](https://trello.com/c/EgcsqIuX/1165-sdc-do-not-send-cloudwatch-metrics-per-client-request)

This PR adds a [throttled](https://lodash.com/docs/4.17.15#throttle) mechanism for sending metrics, because it could get very expensive if we send a request to cloudwatch for each request from the apps. It caches in memory counts for each type of metric, and sends them all together in a single request.

## How to test

Add console statement and putMetric('bandit-selection-error') at the top of epicRouter .Deployed the branch to CODE and clicked through a few pages with epic.

It triggered the alarm once and didn't get triggered for every event.All the 24 appeared with the same timestamp

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/ea6588c8-f04b-4fe8-99f5-3d1685224199" />


<img width="1291" alt="image" src="https://github.com/user-attachments/assets/baaa33d9-1c1b-4c4f-98d5-805446f7e222" />
