### PR TITLE
Introduce should_not_serve_mandatory

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -50,6 +50,7 @@ const callGetTreatments = async (
     editionId: string,
     countryCode: string,
     hasConsented: boolean,
+    shouldNotServeMandatory: boolean,
 ): Promise<AuxiaAPIGetTreatmentsResponseData | undefined> => {
     // We now have clearance to call the Auxia API.
 
@@ -74,6 +75,7 @@ const callGetTreatments = async (
         editionId,
         countryCode,
         hasConsented,
+        shouldNotServeMandatory,
     );
 
     const params = {
@@ -160,6 +162,7 @@ interface GetTreatmentRequestBody {
     mvtId: number;
     should_show_legacy_gate_tmp: boolean; // [2]
     hasConsented: boolean;
+    shouldNotServeMandatory: boolean; // [2]
 }
 
 // [1] articleIdentifier examples:
@@ -171,6 +174,10 @@ interface GetTreatmentRequestBody {
 // full duplication of the client side logic into SDC.
 // See https://github.com/guardian/dotcom-rendering/pull/13944
 // for details.
+
+// [2]
+// date: 03rd July 2025
+// If shouldNotServeMandatory, we should not show a mandatory gate.
 
 const getTreatments = async (
     config: AuxiaRouterConfig,
@@ -195,6 +202,7 @@ const getTreatments = async (
             body.editionId,
             body.countryCode,
             body.hasConsented,
+            body.shouldNotServeMandatory,
         );
 
         if (body.hasConsented) {
@@ -281,6 +289,7 @@ const getTreatments = async (
         body.editionId,
         body.countryCode,
         body.hasConsented, // [1]
+        body.shouldNotServeMandatory,
     );
 
     // [1] here the value should be true, because it's only in Ireland that we send non consented
@@ -309,6 +318,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
             'mvtId',
             'should_show_legacy_gate_tmp',
             'hasConsented',
+            'shouldNotServeMandatory',
         ]),
         async (req: express.Request, res: express.Response, next: express.NextFunction) => {
             try {

--- a/src/server/signin-gate/lib.test.ts
+++ b/src/server/signin-gate/lib.test.ts
@@ -32,6 +32,7 @@ describe('buildGetTreatmentsRequestPayload', () => {
         const editionId = 'UK';
         const countryCode = 'GB';
         const hasConsented = true;
+        const shouldNotServeMandatory = false;
 
         const expectedAnswer = {
             projectId,
@@ -61,6 +62,10 @@ describe('buildGetTreatmentsRequestPayload', () => {
                     key: 'has_consented',
                     boolValue: hasConsented,
                 },
+                {
+                    key: 'should_not_serve_mandatory',
+                    boolValue: shouldNotServeMandatory,
+                },
             ],
             surfaces: [
                 {
@@ -80,6 +85,7 @@ describe('buildGetTreatmentsRequestPayload', () => {
             editionId,
             countryCode,
             hasConsented,
+            shouldNotServeMandatory,
         );
         expect(returnedAnswer).toStrictEqual(expectedAnswer);
     });

--- a/src/server/signin-gate/lib.ts
+++ b/src/server/signin-gate/lib.ts
@@ -78,6 +78,7 @@ export const buildGetTreatmentsRequestPayload = (
     editionId: string,
     countryCode: string,
     hasConsented: boolean,
+    shouldNotServeMandatory: boolean,
 ): AuxiaAPIGetTreatmentsRequestPayload => {
     // For the moment we are hard coding the data provided in contextualAttributes and surfaces.
     return {
@@ -107,6 +108,10 @@ export const buildGetTreatmentsRequestPayload = (
             {
                 key: 'has_consented',
                 boolValue: hasConsented,
+            },
+            {
+                key: 'should_not_serve_mandatory',
+                boolValue: shouldNotServeMandatory,
             },
         ],
         surfaces: [


### PR DESCRIPTION
`should_not_serve_mandatory` is introduced to indicate to Auxia when we enforce the condition that any gate they return should not be mandatory (aka: non dismissible). This is the companion PR of: https://github.com/guardian/dotcom-rendering/pull/14177