### PR TITLE
Fix types package build

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
         "@aws-sdk/credential-providers": "^3.835.0",
         "@aws-sdk/client-cloudwatch": "^3.835.0",
         "@aws-sdk/client-ssm": "^3.835.0",
+        "@smithy/property-provider": "^4.0.4",
         "compression": "1.7.4",
         "cors": "^2.8.5",
         "date-fns": "^2.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   '@guardian/ophan-tracker-js':
     specifier: 2.2.10
     version: 2.2.10
+  '@smithy/property-provider':
+    specifier: ^4.0.4
+    version: 4.0.4
   compression:
     specifier: 1.7.4
     version: 1.7.4

--- a/src/server/utils/aws.ts
+++ b/src/server/utils/aws.ts
@@ -1,7 +1,7 @@
 import { fromIni, fromNodeProviderChain } from '@aws-sdk/credential-providers';
-import { isDev } from '../lib/env';
+import { chain as providerChain } from '@smithy/property-provider';
 
 export const region = 'eu-west-1';
 
 export const credentials = () =>
-    isDev ? fromIni({ profile: 'membership' }) : fromNodeProviderChain();
+    providerChain(fromIni({ profile: 'membership' }), fromNodeProviderChain());


### PR DESCRIPTION
The types package build is currently failing with the error:
`Error: src/server/utils/aws.ts(6,14): error TS2742: The inferred type of 'credentials' cannot be named without a reference to '.pnpm/@aws-sdk+types@3.821.0/node_modules/@aws-sdk/types'. This is likely not portable. A type annotation is necessary.`
This has been happening since the [upgrade](https://github.com/guardian/support-dotcom-components/pull/1378) to AWS sdk v3.

Adding the type here is not simple, and it's simpler to use the `chain` function that the aws sdk accepts.

Similar to the approach in DCR here:
https://github.com/guardian/dotcom-rendering/blob/eb91e8e47ee520f58e0dd6899e9fc4ecfc491e5e/apps-rendering/src/server/aws.ts#L6

Tested locally and in CODE, and AWS requests are still working fine.