### PR TITLE
Exclude server code from types build

### DIFF
--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -10,6 +10,6 @@
         "allowJs": false,
         "emitDeclarationOnly": true
     },
-    "exclude": ["**/*.test.ts", "dist/**/*"],
+    "exclude": ["**/*.test.ts", "dist/**/*", "src/server/**/*"],
     "files": ["./src/dotcom/index.ts","./src/dotcom/types.ts"]
 }


### PR DESCRIPTION
The types package build is currently failing with the error:
`Error: src/server/utils/aws.ts(6,14): error TS2742: The inferred type of 'credentials' cannot be named without a reference to '.pnpm/@aws-sdk+types@3.821.0/node_modules/@aws-sdk/types'. This is likely not portable. A type annotation is necessary.`
This has been happening since the [upgrade](https://github.com/guardian/support-dotcom-components/pull/1378) to AWS sdk v3.

Adding the type here is not simple.
However, the `aws.ts` file is only relevant to the server-side code. The solution in this PR is to exclude all server code from the types build.