### PR TITLE
Handle deleted variants in bandit data

### DIFF
--- a/src/server/selection/banditData.ts
+++ b/src/server/selection/banditData.ts
@@ -77,7 +77,7 @@ async function getBanditSamplesForTest(
     return parsedResults.data;
 }
 
-interface BanditVariantData {
+export interface BanditVariantData {
     variantName: string;
     mean: number;
 }

--- a/src/server/selection/epsilonGreedySelection.test.ts
+++ b/src/server/selection/epsilonGreedySelection.test.ts
@@ -126,4 +126,18 @@ describe('selectVariantWithHighestMean', () => {
         jest.spyOn(global.Math, 'random').mockReturnValue(0.8);
         expect(selectVariantWithHighestMean(banditData, epicTest)?.name).toEqual('v3');
     });
+
+    it('should ignore variants in bandit data that are not in the test configuration', () => {
+        const banditData = {
+            testName: 'example-1',
+            sortedVariants: [
+                { variantName: 'ghost', mean: 2 }, // not in test.variants
+                { variantName: 'v1', mean: 1 },
+                { variantName: 'v2', mean: 0.5 },
+                { variantName: 'v3', mean: 0.3 },
+            ],
+        };
+        const result = selectVariantWithHighestMean(banditData, epicTest);
+        expect(result?.name).toEqual('v1');
+    });
 });

--- a/src/server/selection/epsilonGreedySelection.ts
+++ b/src/server/selection/epsilonGreedySelection.ts
@@ -2,7 +2,7 @@ import type { Test, Variant } from '../../shared/types';
 import { putMetric } from '../utils/cloudwatch';
 import { logError } from '../utils/logging';
 import type { BanditData } from './banditData';
-import { selectRandomVariant } from './helpers';
+import { filterValidVariants, selectRandomVariant } from './helpers';
 
 /**
  * In general we select the best known variant, except with probability 'epsilon' when we select at random.
@@ -13,7 +13,8 @@ export function selectVariantWithHighestMean<V extends Variant, T extends Test<V
     testBanditData: BanditData,
     test: T,
 ): V | undefined {
-    const { sortedVariants } = testBanditData;
+    const sortedVariants = filterValidVariants(testBanditData.sortedVariants, test);
+
     // variants array is sorted by mean, use just the best variants
     const bestMean = sortedVariants[0].mean;
     const bestVariants = sortedVariants.findIndex((variant) => variant.mean < bestMean);

--- a/src/server/selection/helpers.ts
+++ b/src/server/selection/helpers.ts
@@ -2,6 +2,7 @@ import seedrandom from 'seedrandom';
 import type { Test, Variant } from '../../shared/types';
 import { putMetric } from '../utils/cloudwatch';
 import { logError } from '../utils/logging';
+import type { BanditVariantData } from './banditData';
 
 export function selectRandomVariant<V extends Variant, T extends Test<V>>(test: T): V | undefined {
     const randomVariantIndex = Math.floor(Math.random() * test.variants.length);
@@ -19,4 +20,17 @@ export function selectRandomVariant<V extends Variant, T extends Test<V>>(test: 
 export const getRandomNumber = (seed: string, mvtId: number | string = ''): number => {
     const rng = seedrandom(mvtId + seed);
     return Math.abs(rng.int32());
+};
+
+/**
+ * It's possible for the variants in the bandit data to temporarily not match the variants in a test configuration.
+ * This can happen if a variant is deleted in the RRCP, and the cached bandit data still references the deleted variant.
+ * This function filters out any invalid variants.
+ */
+export const filterValidVariants = <V extends Variant, T extends Test<V>>(
+    sortedVariantsData: BanditVariantData[],
+    test: T,
+): BanditVariantData[] => {
+    const validVariantNames = new Set(test.variants.map((v) => v.name));
+    return sortedVariantsData.filter((v) => validVariantNames.has(v.variantName));
 };


### PR DESCRIPTION
We've occasionally seen an SDC alert, "Error selecting variant for bandit test", and the following error log:
`Failed to select best variant for bandit test: <test name>`

The issue occurs in the following situation:

1. SDC fetches bandit variant data and caches it
2. An RRCP user deletes a variant in a bandit test
3. SDC fetches the latest configuration for that test, but still has stale bandit data

In this case, it's possible for a bandit algorithm to pick the now deleted variant using the stale bandit data.
This will only ever be temporary, until SDC next refreshes the bandit data and filters out the deleted variant.

The solution here is to filter out any invalid variants during variant selection.