### PR TITLE
Fix lint no unnecessary conditions in requests.ts

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,9 +1,4 @@
 {
-  "src/dotcom/requests.ts": {
-    "@typescript-eslint/no-unnecessary-condition": {
-      "count": 1
-    }
-  },
   "src/server/api/ampEpicRouter.ts": {
     "@typescript-eslint/no-unsafe-assignment": {
       "count": 3

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "publish-dry-run": "pnpm publish --dry-run",
         "publish": "pnpm publish",
         "lint": "eslint .",
+        "prune-lint-suppressions": "pnpm lint --prune-suppressions",
         "prettier:check": "prettier --check ./src",
         "prettier:fix": "prettier --write ./src",
         "test": "export stage=DEV; jest",

--- a/src/dotcom/requests.ts
+++ b/src/dotcom/requests.ts
@@ -1,3 +1,4 @@
+import { URLSearchParams } from 'url';
 import type {
     BannerPayload,
     BannerProps,
@@ -25,15 +26,8 @@ export interface ModuleDataResponse<PROPS> {
 type ModuleType = 'epic' | 'liveblog-epic' | 'banner' | 'header' | 'gutter-liveblog';
 
 const getForcedVariant = (type: ModuleType): string | null => {
-    if (URLSearchParams) {
-        const params = new URLSearchParams(window.location.search);
-        const value = params.get(`force-${type}`);
-        if (value) {
-            return value;
-        }
-    }
-
-    return null;
+    const params = new URLSearchParams(window.location.search);
+    return params.get(`force-${type}`);
 };
 
 type Payload = EpicPayload | BannerPayload | HeaderPayload | GutterPayload;


### PR DESCRIPTION
## What does this change?

This removes the check for the existence of URLSearchParam before calling the constructor.  [URLSearchParams](https://nodejs.org/docs/latest-v22.x/api/url.html#class-urlsearchparams) is a class on the Node global object now therefore this condition was creating a lint error '@typescript-eslint/no-unnecessary-condition'.  It also simplifies the code

This PR also adds a prune-lint-suppressions script to the package JSON file - making it easier to find

## How to test

Run into CODE and check if web-preview in CODE RRCP for banners, epics, gutters still displays as expected