### PR TITLE
fix: use global URLSearchParams

### DIFF
--- a/.changeset/nine-colts-compare.md
+++ b/.changeset/nine-colts-compare.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+use global URLSearchParams

--- a/src/dotcom/requests.ts
+++ b/src/dotcom/requests.ts
@@ -1,4 +1,3 @@
-import { URLSearchParams } from 'url';
 import type {
     BannerPayload,
     BannerProps,


### PR DESCRIPTION
## What does this change?

Removes an incorrect import of `URLSearchParams` from the `'url'` module.

## Why?

While bundling the client bundles with Webpack, a warning was being thrown:

```
export 'URLSearchParams' (imported as 'n') was not found in 'url'
```

This happened because `URLSearchParams` is not a named export from `'url'` in environments like the browser. It is available globally in modern JavaScript runtimes, so the import is unnecessary and potentially harmful when bundling for the web.

Removing the import resolves the warning without changing the runtime behavior.

## How to test

* Run `make dev` and confirm the warning no longer appears during the build.
* Navigate through the affected functionality and confirm there are no regressions.

## How can we measure success?

The Webpack build completes without module resolution warnings and the functionality relying on `URLSearchParams` continues to work as expected.

## Have we considered potential risks?

This change relies on the global availability of `URLSearchParams`, which is supported in all modern browsers and Node.js 10+. If support for very old environments is needed, a fallback polyfill may be necessary — but for our supported targets, this change is safe.
