### PR TITLE
Process mustShowDefaultGate (v2)

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -9,6 +9,7 @@ import {
     buildGetTreatmentsRequestPayload,
     buildLogTreatmentInteractionRequestPayload,
     guDefaultGateGetTreatmentsResponseData,
+    guGateAsAnAuxiaAPIUserTreatment,
     isValidContentType,
     isValidSection,
     isValidTagIdCollection,
@@ -198,11 +199,11 @@ const getTreatments = async (
     // The attribute mustShowDefaultGate overrides any other behavior, we check it first
 
     if (body.mustShowDefaultGate) {
-        const auxiaData = guDefaultGateGetTreatmentsResponseData(
-            body.dailyArticleCount,
-            body.gateDismissCount,
-        );
-        return Promise.resolve(auxiaData);
+        const data: AuxiaAPIGetTreatmentsResponseData = {
+            responseId: '',
+            userTreatments: [guGateAsAnAuxiaAPIUserTreatment()],
+        };
+        return data;
     }
 
     // Then, we need to check whether we are in Ireland ot not. If we are in Ireland


### PR DESCRIPTION
Follow up of https://github.com/guardian/support-dotcom-components/pull/1397 , to avoid the exclusion logic inside `guDefaultGateGetTreatmentsResponseData`.

