### PR TITLE
refactoring: avoid using negatives in sign-in gate's behaviour names

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -51,7 +51,7 @@ const callGetTreatments = async (
     editionId: string,
     countryCode: string,
     hasConsented: boolean,
-    shouldNotServeMandatory: boolean,
+    shouldServeDismissible: boolean,
 ): Promise<AuxiaAPIGetTreatmentsResponseData | undefined> => {
     // We now have clearance to call the Auxia API.
 
@@ -76,7 +76,7 @@ const callGetTreatments = async (
         editionId,
         countryCode,
         hasConsented,
-        shouldNotServeMandatory,
+        shouldServeDismissible,
     );
 
     const params = {
@@ -163,7 +163,7 @@ interface GetTreatmentRequestBody {
     mvtId: number;
     should_show_legacy_gate_tmp: boolean; // [2]
     hasConsented: boolean;
-    shouldNotServeMandatory: boolean; // [3]
+    shouldServeDismissible: boolean; // [3]
     mustShowDefaultGate: boolean; // [4]
 }
 
@@ -179,7 +179,7 @@ interface GetTreatmentRequestBody {
 
 // [3]
 // date: 03rd July 2025
-// If shouldNotServeMandatory, we should not show a mandatory gate.
+// If shouldServeDismissible, we should show a dismissible (not mandatory) gate.
 
 // [4]
 // date: 23rd July 2025
@@ -222,7 +222,7 @@ const getTreatments = async (
             body.editionId,
             body.countryCode,
             body.hasConsented,
-            body.shouldNotServeMandatory,
+            body.shouldServeDismissible,
         );
 
         if (body.hasConsented) {
@@ -309,7 +309,7 @@ const getTreatments = async (
         body.editionId,
         body.countryCode,
         body.hasConsented, // [1]
-        body.shouldNotServeMandatory,
+        body.shouldServeDismissible,
     );
 
     // [1] here the value should be true, because it's only in Ireland that we send non consented
@@ -338,7 +338,7 @@ export const buildAuxiaProxyRouter = (config: AuxiaRouterConfig): Router => {
             'mvtId',
             'should_show_legacy_gate_tmp',
             'hasConsented',
-            'shouldNotServeMandatory',
+            'shouldServeDismissible',
             'mustShowDefaultGate',
         ]),
         async (req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/src/server/signin-gate/lib.test.ts
+++ b/src/server/signin-gate/lib.test.ts
@@ -32,7 +32,7 @@ describe('buildGetTreatmentsRequestPayload', () => {
         const editionId = 'UK';
         const countryCode = 'GB';
         const hasConsented = true;
-        const shouldNotServeMandatory = false;
+        const shouldServeDismissible = false;
 
         const expectedAnswer = {
             projectId,
@@ -64,7 +64,7 @@ describe('buildGetTreatmentsRequestPayload', () => {
                 },
                 {
                     key: 'should_not_serve_mandatory',
-                    boolValue: shouldNotServeMandatory,
+                    boolValue: shouldServeDismissible,
                 },
             ],
             surfaces: [
@@ -85,7 +85,7 @@ describe('buildGetTreatmentsRequestPayload', () => {
             editionId,
             countryCode,
             hasConsented,
-            shouldNotServeMandatory,
+            shouldServeDismissible,
         );
         expect(returnedAnswer).toStrictEqual(expectedAnswer);
     });

--- a/src/server/signin-gate/lib.ts
+++ b/src/server/signin-gate/lib.ts
@@ -78,7 +78,7 @@ export const buildGetTreatmentsRequestPayload = (
     editionId: string,
     countryCode: string,
     hasConsented: boolean,
-    shouldNotServeMandatory: boolean,
+    shouldServeDismissible: boolean,
 ): AuxiaAPIGetTreatmentsRequestPayload => {
     // For the moment we are hard coding the data provided in contextualAttributes and surfaces.
     return {
@@ -111,7 +111,7 @@ export const buildGetTreatmentsRequestPayload = (
             },
             {
                 key: 'should_not_serve_mandatory',
-                boolValue: shouldNotServeMandatory,
+                boolValue: shouldServeDismissible,
             },
         ],
         surfaces: [


### PR DESCRIPTION
This introduces a refactoring to help understanding sign-in gate behaviour, something that is going to become important in a coming change. 

What we do here is moving from the dichotomy ( dismissible / non dismissible ) or the dichotomy ( mandatory / non mandatory ) to the more natural, and which avoid potentially misleading negations ( dismissible / mandatory ).

Companion DCR PR: https://github.com/guardian/dotcom-rendering/pull/14281

Note that here the only bit we cannot change, but that's ok, is the name of the Auxia extended attribute which will remain `should_not_serve_mandatory`.

 