### PR TITLE
Remove conflicting gate control condition

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -152,7 +152,7 @@ const callLogTreatmentInteration = async (
 
 type ShowGateValues = 'true' | 'mandatory' | 'dismissible' | undefined;
 
-interface GetTreatmentRequestBody {
+export interface GetTreatmentRequestBody {
     browserId: string | undefined; // optional field, will not be sent by the client is user has not consented to personal data use.
     isSupporter: boolean;
     dailyArticleCount: number; // [1]
@@ -196,7 +196,7 @@ interface GetTreatmentRequestBody {
 
 // Note that this attributes override the value of should_show_legacy_gate_tmp.
 
-const getTreatments = async (
+export const getTreatments = async (
     config: AuxiaRouterConfig,
     body: GetTreatmentRequestBody,
 ): Promise<AuxiaAPIGetTreatmentsResponseData | undefined> => {

--- a/src/server/signin-gate/lib.ts
+++ b/src/server/signin-gate/lib.ts
@@ -62,13 +62,6 @@ export interface AuxiaAPIGetTreatmentsResponseData {
     userTreatments: AuxiaAPIUserTreatment[];
 }
 
-export const guDefaultShouldShowTheGate = (daily_article_count: number): boolean => {
-    // We show the GU gate every 10 pageviews
-    // Note: this behavior was arbitrarily decided by Pascal at the beginning of the Auxia project.
-    // Note that the value of gateDismissCount (see guDefaultGateGetTreatmentsResponseData) overrides it.
-    return daily_article_count % 10 == 0;
-};
-
 export const buildGetTreatmentsRequestPayload = (
     projectId: string,
     browserId: string,
@@ -193,15 +186,6 @@ export const guDefaultGateGetTreatmentsResponseData = (
     // (We do not want users to have to dismiss the gate 6 times)
 
     if (gateDismissCount > 5) {
-        return {
-            responseId,
-            userTreatments: [],
-        };
-    }
-
-    // Then to prevent showing the gate too many times, we only show the gate every 10 pages views
-
-    if (!guDefaultShouldShowTheGate(daily_article_count)) {
         return {
             responseId,
             userTreatments: [],


### PR DESCRIPTION
The following GetTreatments payload should return a gate, but doesn't

.

<img width="1643" height="980" alt="Screenshot 2025-07-31 at 16 51 31" src="https://github.com/user-attachments/assets/cfe8c961-86d5-4120-a99c-f5385ec4aa43" />

.

Here we fix that problem by removing an old and incorrect gate control condition. Also this is an opportunity to test `getTreatments` which has never actually been tested 😬