### PR TITLE
Add tests for getTreatments

### DIFF
--- a/src/server/api/auxiaProxyRouter.ts
+++ b/src/server/api/auxiaProxyRouter.ts
@@ -308,7 +308,7 @@ export const getTreatments = async (
     // If we reached this point, then we are the Auxia share of the audience
     // ---------------------------------------------------------------------
 
-    // First we check page metada to comply with Guardian policies.
+    // We check page metada to comply with Guardian policies.
     // If the policies are not met, then we do not display a gate
 
     if (

--- a/src/server/signin-gate/lib.test.ts
+++ b/src/server/signin-gate/lib.test.ts
@@ -326,6 +326,8 @@ describe('getTreatments', () => {
     });
 
     // From this point shouldServeDismissible is going to be false.
+
+    // The attribute showDefaultGate overrides any other behavior
     // We pursue with two tests showing that showDefaultGate is correctly listened to.
 
     it('3', async () => {
@@ -388,7 +390,16 @@ describe('getTreatments', () => {
         expect(treatment).toStrictEqual(expectedAnswer);
     });
 
-    it('should return a gate in the case of the Giulia experiment', async () => {
+    // At this point there should be a test of being in Ireland, but we are postponing this test
+    // for a bit and will do w refactoring in the meantime.
+
+    // TODO: Ireland test
+    // ....
+
+    // We check page metada to comply with Guardian policies.
+    // If the policies are not met, then we do not display a gate
+
+    it('invalid attribute: contentType', async () => {
         const config: AuxiaRouterConfig = {
             apiKey: 'sample',
             projectId: 'sample',
@@ -397,6 +408,113 @@ describe('getTreatments', () => {
             browserId: 'sample',
             isSupporter: false,
             dailyArticleCount: 3,
+            articleIdentifier: 'sample: article identifier',
+            editionId: 'UK',
+            contentType: 'Showcase', // <- [tested]
+            sectionId: 'uk-news',
+            tagIds: ['type/article'],
+            gateDismissCount: 0,
+            countryCode: 'GB',
+            mvtId: 200_000, // <- [needs to be in the Auxia Audience share]
+            should_show_legacy_gate_tmp: true,
+            hasConsented: true,
+            shouldServeDismissible: false,
+            showDefaultGate: undefined,
+        };
+        const treatment = await getTreatments(config, body);
+        expect(treatment).toStrictEqual(undefined);
+    });
+
+    it('invalid attribute: sectionId', async () => {
+        const config: AuxiaRouterConfig = {
+            apiKey: 'sample',
+            projectId: 'sample',
+        };
+        const body: GetTreatmentRequestBody = {
+            browserId: 'sample',
+            isSupporter: false,
+            dailyArticleCount: 3,
+            articleIdentifier: 'sample: article identifier',
+            editionId: 'UK',
+            contentType: 'Article',
+            sectionId: 'about', // <- [tested] `about` is an invalid section
+            tagIds: ['type/article'],
+            gateDismissCount: 0,
+            countryCode: 'GB',
+            mvtId: 200_000, // <- [needs to be in the Auxia Audience share]
+            should_show_legacy_gate_tmp: true,
+            hasConsented: true,
+            shouldServeDismissible: false,
+            showDefaultGate: undefined,
+        };
+        const treatment = await getTreatments(config, body);
+        expect(treatment).toStrictEqual(undefined);
+    });
+
+    it('invalid attribute: tagIds', async () => {
+        const config: AuxiaRouterConfig = {
+            apiKey: 'sample',
+            projectId: 'sample',
+        };
+        const body: GetTreatmentRequestBody = {
+            browserId: 'sample',
+            isSupporter: false,
+            dailyArticleCount: 3,
+            articleIdentifier: 'sample: article identifier',
+            editionId: 'UK',
+            contentType: 'Article',
+            sectionId: 'uk-news',
+            tagIds: ['info/newsletter-sign-up', 'another-tag'], // <- [tested] `info/newsletter-sign-up` is forbidden
+            gateDismissCount: 0,
+            countryCode: 'GB',
+            mvtId: 200_000, // <- [needs to be in the Auxia Audience share]
+            should_show_legacy_gate_tmp: true,
+            hasConsented: true,
+            shouldServeDismissible: false,
+            showDefaultGate: undefined,
+        };
+        const treatment = await getTreatments(config, body);
+        expect(treatment).toStrictEqual(undefined);
+    });
+
+    it('invalid attribute: articleIdentifier', async () => {
+        const config: AuxiaRouterConfig = {
+            apiKey: 'sample',
+            projectId: 'sample',
+        };
+        const body: GetTreatmentRequestBody = {
+            browserId: 'sample',
+            isSupporter: false,
+            dailyArticleCount: 3,
+            articleIdentifier: 'www.theguardian.com/tips', // <- [tested] We have a specific interdiction on that
+            editionId: 'UK',
+            contentType: 'Article',
+            sectionId: 'uk-news',
+            tagIds: ['type/article'],
+            gateDismissCount: 0,
+            countryCode: 'GB',
+            mvtId: 200_000, // <- [tested: needs to be in the Auxia Audience share]
+            should_show_legacy_gate_tmp: true,
+            hasConsented: true,
+            shouldServeDismissible: false,
+            showDefaultGate: undefined,
+        };
+        const treatment = await getTreatments(config, body);
+        expect(treatment).toStrictEqual(undefined);
+    });
+
+    // Should return a gate if we are not in the Auxia share and
+    // dailyArticleCount: 3
+
+    it('should return a gate in the case of the Giulia experiment', async () => {
+        const config: AuxiaRouterConfig = {
+            apiKey: 'sample',
+            projectId: 'sample',
+        };
+        const body: GetTreatmentRequestBody = {
+            browserId: 'sample',
+            isSupporter: false,
+            dailyArticleCount: 3, // <- [tested]
             articleIdentifier: 'sample: article identifier',
             editionId: 'UK',
             contentType: 'Article',

--- a/src/server/signin-gate/lib.test.ts
+++ b/src/server/signin-gate/lib.test.ts
@@ -253,7 +253,7 @@ describe('getTreatments', () => {
 
     // This tests is following the logic getTreatments from top to bottom.
 
-    it('1', async () => {
+    it('test shouldServeDismissible and showDefaultGate:mandatory interacting together', async () => {
         // If we receive instruction to serve a default gate (showDefaultGate
         // can be `mandatory`, `dismissible` or `undefined`, and here we mean not
         // undefined), but also the condition to serve a dismissible gate,
@@ -292,7 +292,7 @@ describe('getTreatments', () => {
         expect(treatment).toStrictEqual(expectedAnswer);
     });
 
-    it('2', async () => {
+    it('test shouldServeDismissible and showDefaultGate:dismissible interacting together', async () => {
         // Similar to test 1, but here we have
         // showDefaultGate: 'dismissible'
 
@@ -330,7 +330,7 @@ describe('getTreatments', () => {
     // The attribute showDefaultGate overrides any other behavior
     // We pursue with two tests showing that showDefaultGate is correctly listened to.
 
-    it('3', async () => {
+    it('showDefaultGate:mandatory overrides any other behavior', async () => {
         const config: AuxiaRouterConfig = {
             apiKey: 'sample',
             projectId: 'sample',
@@ -360,7 +360,7 @@ describe('getTreatments', () => {
         expect(treatment).toStrictEqual(expectedAnswer);
     });
 
-    it('4', async () => {
+    it('showDefaultGate:dismissible overrides any other behavior', async () => {
         const config: AuxiaRouterConfig = {
             apiKey: 'sample',
             projectId: 'sample',

--- a/src/server/signin-gate/lib.test.ts
+++ b/src/server/signin-gate/lib.test.ts
@@ -7,6 +7,7 @@ import {
     buildLogTreatmentInteractionRequestPayload,
     guDefaultDismissibleGateAsAnAuxiaAPIUserTreatment,
     guDefaultGateGetTreatmentsResponseData,
+    guDefaultMandatoryGateAsAnAuxiaAPIUserTreatment,
     isValidContentType,
     isValidSection,
     isValidTagIdCollection,
@@ -282,6 +283,102 @@ describe('getTreatments', () => {
             hasConsented: true,
             shouldServeDismissible: true, // <- [tested]
             showDefaultGate: 'mandatory', // <- [tested]
+        };
+        const treatment = await getTreatments(config, body);
+        const expectedAnswer = {
+            responseId: '',
+            userTreatments: [guDefaultDismissibleGateAsAnAuxiaAPIUserTreatment()],
+        };
+        expect(treatment).toStrictEqual(expectedAnswer);
+    });
+
+    it('2', async () => {
+        // Similar to test 1, but here we have
+        // showDefaultGate: 'dismissible'
+
+        const config: AuxiaRouterConfig = {
+            apiKey: 'sample',
+            projectId: 'sample',
+        };
+        const body: GetTreatmentRequestBody = {
+            browserId: 'sample',
+            isSupporter: false,
+            dailyArticleCount: 3,
+            articleIdentifier: 'sample: article identifier',
+            editionId: 'UK',
+            contentType: 'Article',
+            sectionId: 'uk-news',
+            tagIds: ['type/article'],
+            gateDismissCount: 0,
+            countryCode: 'GB',
+            mvtId: 350001,
+            should_show_legacy_gate_tmp: true,
+            hasConsented: true,
+            shouldServeDismissible: true, // <- [tested]
+            showDefaultGate: 'dismissible', // <- [tested]
+        };
+        const treatment = await getTreatments(config, body);
+        const expectedAnswer = {
+            responseId: '',
+            userTreatments: [guDefaultDismissibleGateAsAnAuxiaAPIUserTreatment()],
+        };
+        expect(treatment).toStrictEqual(expectedAnswer);
+    });
+
+    // From this point shouldServeDismissible is going to be false.
+    // We pursue with two tests showing that showDefaultGate is correctly listened to.
+
+    it('3', async () => {
+        const config: AuxiaRouterConfig = {
+            apiKey: 'sample',
+            projectId: 'sample',
+        };
+        const body: GetTreatmentRequestBody = {
+            browserId: 'sample',
+            isSupporter: false,
+            dailyArticleCount: 3,
+            articleIdentifier: 'sample: article identifier',
+            editionId: 'UK',
+            contentType: 'Article',
+            sectionId: 'uk-news',
+            tagIds: ['type/article'],
+            gateDismissCount: 0,
+            countryCode: 'GB',
+            mvtId: 350001,
+            should_show_legacy_gate_tmp: true,
+            hasConsented: true,
+            shouldServeDismissible: false,
+            showDefaultGate: 'mandatory', // <- [tested]
+        };
+        const treatment = await getTreatments(config, body);
+        const expectedAnswer = {
+            responseId: '',
+            userTreatments: [guDefaultMandatoryGateAsAnAuxiaAPIUserTreatment()],
+        };
+        expect(treatment).toStrictEqual(expectedAnswer);
+    });
+
+    it('4', async () => {
+        const config: AuxiaRouterConfig = {
+            apiKey: 'sample',
+            projectId: 'sample',
+        };
+        const body: GetTreatmentRequestBody = {
+            browserId: 'sample',
+            isSupporter: false,
+            dailyArticleCount: 3,
+            articleIdentifier: 'sample: article identifier',
+            editionId: 'UK',
+            contentType: 'Article',
+            sectionId: 'uk-news',
+            tagIds: ['type/article'],
+            gateDismissCount: 0,
+            countryCode: 'GB',
+            mvtId: 350001,
+            should_show_legacy_gate_tmp: true,
+            hasConsented: true,
+            shouldServeDismissible: false,
+            showDefaultGate: 'dismissible', // <- [tested]
         };
         const treatment = await getTreatments(config, body);
         const expectedAnswer = {

--- a/src/server/signin-gate/lib.test.ts
+++ b/src/server/signin-gate/lib.test.ts
@@ -246,6 +246,51 @@ describe('mvtIdIsInTheNaturalAuxiaShareOfAudience', () => {
 });
 
 describe('getTreatments', () => {
+    // Function getTreatments is written as a set of conditions, from higher priority to lower
+    // priority, where the first satisfactory condition determines the type of gate
+    // that is going to be displayed/
+
+    // This tests is following the logic getTreatments from top to bottom.
+
+    it('1', async () => {
+        // If we receive instruction to serve a default gate (showDefaultGate
+        // can be `mandatory`, `dismissible` or `undefined`, and here we mean not
+        // undefined), but also the condition to serve a dismissible gate,
+        // then the latter condition takes priority, and we should serve
+        // a dismissible gate.
+
+        // This condition essentially resolve the semantic conflict between
+        // showDefaultGate:mandatory and shouldServeDismissible:true
+
+        const config: AuxiaRouterConfig = {
+            apiKey: 'sample',
+            projectId: 'sample',
+        };
+        const body: GetTreatmentRequestBody = {
+            browserId: 'sample',
+            isSupporter: false,
+            dailyArticleCount: 3,
+            articleIdentifier: 'sample: article identifier',
+            editionId: 'UK',
+            contentType: 'Article',
+            sectionId: 'uk-news',
+            tagIds: ['type/article'],
+            gateDismissCount: 0,
+            countryCode: 'GB',
+            mvtId: 350001,
+            should_show_legacy_gate_tmp: true,
+            hasConsented: true,
+            shouldServeDismissible: true, // <- [tested]
+            showDefaultGate: 'mandatory', // <- [tested]
+        };
+        const treatment = await getTreatments(config, body);
+        const expectedAnswer = {
+            responseId: '',
+            userTreatments: [guDefaultDismissibleGateAsAnAuxiaAPIUserTreatment()],
+        };
+        expect(treatment).toStrictEqual(expectedAnswer);
+    });
+
     it('should return a gate in the case of the Giulia experiment', async () => {
         const config: AuxiaRouterConfig = {
             apiKey: 'sample',


### PR DESCRIPTION
Add tests for getTreatments ( follow up of: https://github.com/guardian/support-dotcom-components/pull/1404 )