### PR TITLE
feat: update benefits copy for SupporterPlus and shorterChoiceCards

### DIFF
--- a/src/server/lib/choiceCards/defaultChoiceCardSettings.ts
+++ b/src/server/lib/choiceCards/defaultChoiceCardSettings.ts
@@ -47,13 +47,13 @@ const fullChoiceCards = (countryGroupId: CountryGroupId): ChoiceCard[] => [
         isDefault: true,
         benefitsLabel: 'Unlock <strong>All-access digital</strong> benefits:',
         benefits: [
-            { copy: 'Unlimited access to the Guardian app' },
-            { copy: 'Unlimited access to our new Feast App' },
+            { copy: 'Far fewer asks for support' },
             { copy: 'Ad-free reading on all your devices' },
+            { copy: 'Unlimited access to the premium Guardian app' },
             {
                 copy: 'Exclusive newsletter for supporters, sent every week from the Guardian newsroom',
             },
-            { copy: 'Far fewer asks for support' },
+            { copy: 'Unlimited access to our new Guardian Feast App' },
         ],
         pill: {
             copy: 'Recommended',
@@ -85,7 +85,7 @@ const shorterChoiceCards = (countryGroupId: CountryGroupId): ChoiceCard[] => [
         label: '', // label is generated for recurring products
         isDefault: true,
         benefits: [
-            { copy: 'Unlimited access to the Guardian app and Feast app' },
+            { copy: 'Far fewer asks for support' },
             { copy: 'Ad-free reading on all your devices' },
         ],
         pill: {


### PR DESCRIPTION
## What does this change?

Update the supporter plus choice card with the following benefits:

<img width="822" height="360" alt="image" src="https://github.com/user-attachments/assets/d84d0f4c-a3b8-4856-87a7-a9b23a35836b" />

Also updated mobile banner get defaulted to the top two bullet points only.