### PR TITLE
Prevent sign-in gate for Filter articles

### DIFF
--- a/src/server/signin-gate/lib.ts
+++ b/src/server/signin-gate/lib.ts
@@ -344,6 +344,7 @@ export const isValidSection = (sectionId: string): boolean => {
         'help',
         'guardian-live-australia',
         'gnm-archive',
+        'thefilter',
     ];
     return !invalidSections.includes(sectionId);
 };


### PR DESCRIPTION
Prevent sign-in gate for Filter articles. This is the companion PR of DCR's https://github.com/guardian/dotcom-rendering/pull/14422/files

Note that we have a temporary duplication of logic on both system because we are in the middle of a refactoring. The client side code will be decommissioned soon.
