### PR TITLE
refactor GateType

### DIFF
--- a/src/server/signin-gate/lib.test.ts
+++ b/src/server/signin-gate/lib.test.ts
@@ -13,7 +13,6 @@ import {
     userTreatmentsEnvelopToProxyGetTreatmentsAnswerData,
 } from './libPure';
 import type { GetTreatmentsRequestPayload } from './types';
-import { GateType } from './types';
 
 describe('buildGetTreatmentsRequestPayload', () => {
     it('should return return the right payload', () => {
@@ -341,7 +340,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 0,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.GuDismissible);
+        expect(gateType).toStrictEqual('GuDismissible');
     });
 
     it('test shouldServeDismissible and showDefaultGate:dismissible interacting together', () => {
@@ -364,7 +363,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 0,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.GuDismissible);
+        expect(gateType).toStrictEqual('GuDismissible');
     });
 
     it('showDefaultGate:mandatory overrides any other behavior', () => {
@@ -387,7 +386,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 0,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.GuMandatory);
+        expect(gateType).toStrictEqual('GuMandatory');
     });
 
     it('showDefaultGate:dismissible overrides any other behavior', () => {
@@ -410,7 +409,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 0,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.GuDismissible);
+        expect(gateType).toStrictEqual('GuDismissible');
     });
 
     it('non consenting users in Ireland, low dailyArticleCount', () => {
@@ -433,7 +432,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 0,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.AuxiaAnalyticThenNone);
+        expect(gateType).toStrictEqual('AuxiaAnalyticThenNone');
     });
 
     it('non consenting users in Ireland, low dailyArticleCount=3 (start of gate showing)', () => {
@@ -456,7 +455,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 0,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.GuDismissible);
+        expect(gateType).toStrictEqual('GuDismissible');
     });
 
     it('non consenting users in Ireland, low gateDisplayCount: 1 (still dismissible)', () => {
@@ -479,7 +478,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 1,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.AuxiaAnalyticThenGuDismissible);
+        expect(gateType).toStrictEqual('AuxiaAnalyticThenGuDismissible');
     });
 
     it('non consenting users in Ireland, low gateDisplayCount: 3 (mandatory from now on)', () => {
@@ -502,7 +501,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 3,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.AuxiaAnalyticThenGuMandatory);
+        expect(gateType).toStrictEqual('AuxiaAnalyticThenGuMandatory');
     });
 
     it('non consenting users in Ireland, low gateDisplayCount: 4 (mandatory from now on)', () => {
@@ -525,7 +524,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 4,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.AuxiaAnalyticThenGuMandatory);
+        expect(gateType).toStrictEqual('AuxiaAnalyticThenGuMandatory');
     });
 
     it('invalid attribute: contentType', () => {
@@ -548,7 +547,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 0,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.None);
+        expect(gateType).toStrictEqual('None');
     });
 
     it('invalid attribute: sectionId', () => {
@@ -571,7 +570,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 0,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.None);
+        expect(gateType).toStrictEqual('None');
     });
 
     it('invalid attribute: tagIds', () => {
@@ -594,7 +593,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 0,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.None);
+        expect(gateType).toStrictEqual('None');
     });
 
     it('invalid attribute: articleIdentifier', () => {
@@ -617,7 +616,7 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 0,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.None);
+        expect(gateType).toStrictEqual('None');
     });
 
     it('should return a gate in the case of the Giulia experiment', () => {
@@ -640,6 +639,6 @@ describe('decideGateTypeFromGetTreatmentsRequestPayload', () => {
             gateDisplayCount: 0,
         };
         const gateType = getTreatmentsRequestPayloadToGateType(body);
-        expect(gateType).toStrictEqual(GateType.GuDismissible);
+        expect(gateType).toStrictEqual('GuDismissible');
     });
 });

--- a/src/server/signin-gate/libEffect.ts
+++ b/src/server/signin-gate/libEffect.ts
@@ -9,8 +9,12 @@ import {
     guDismissibleUserTreatment,
     guMandatoryUserTreatment,
 } from './libPure';
-import type { GetTreatmentsRequestPayload, UserTreatment, UserTreatmentsEnvelop } from './types';
-import { GateType } from './types';
+import type {
+    GateType,
+    GetTreatmentsRequestPayload,
+    UserTreatment,
+    UserTreatmentsEnvelop,
+} from './types';
 
 export const callAuxiaGetTreatments = async (
     apiKey: string,
@@ -81,19 +85,19 @@ export const gateTypeToUserTreatmentsEnvelop = async (
     getTreatmentsRequestPayload: GetTreatmentsRequestPayload,
 ): Promise<UserTreatmentsEnvelop | undefined> => {
     switch (gateType) {
-        case GateType.None:
+        case 'None':
             return Promise.resolve(undefined);
-        case GateType.GuDismissible:
+        case 'GuDismissible':
             return {
                 responseId: '',
                 userTreatments: [guDismissibleUserTreatment()],
             };
-        case GateType.GuMandatory:
+        case 'GuMandatory':
             return {
                 responseId: '',
                 userTreatments: [guDismissibleUserTreatment()],
             };
-        case GateType.Auxia:
+        case 'AuxiaAPI':
             return await callAuxiaGetTreatments(
                 config.apiKey,
                 config.projectId,
@@ -106,7 +110,7 @@ export const gateTypeToUserTreatmentsEnvelop = async (
                 getTreatmentsRequestPayload.hasConsented,
                 getTreatmentsRequestPayload.shouldServeDismissible,
             );
-        case GateType.AuxiaAnalyticThenNone:
+        case 'AuxiaAnalyticThenNone':
             await callAuxiaGetTreatments(
                 config.apiKey,
                 config.projectId,
@@ -120,7 +124,7 @@ export const gateTypeToUserTreatmentsEnvelop = async (
                 getTreatmentsRequestPayload.shouldServeDismissible,
             );
             return Promise.resolve(undefined);
-        case GateType.AuxiaAnalyticThenGuDismissible:
+        case 'AuxiaAnalyticThenGuDismissible':
             await callAuxiaGetTreatments(
                 config.apiKey,
                 config.projectId,
@@ -137,7 +141,7 @@ export const gateTypeToUserTreatmentsEnvelop = async (
                 responseId: '',
                 userTreatments: [guDismissibleUserTreatment()],
             };
-        case GateType.AuxiaAnalyticThenGuMandatory:
+        case 'AuxiaAnalyticThenGuMandatory':
             await callAuxiaGetTreatments(
                 config.apiKey,
                 config.projectId,

--- a/src/server/signin-gate/libPure.ts
+++ b/src/server/signin-gate/libPure.ts
@@ -5,12 +5,12 @@
 import type {
     AuxiaAPIGetTreatmentsRequestPayload,
     AuxiaAPILogTreatmentInteractionRequestPayload,
+    GateType,
     GetTreatmentsRequestPayload,
     ProxyGetTreatmentsAnswerData,
     UserTreatment,
     UserTreatmentsEnvelop,
 } from './types';
-import { GateType } from './types';
 
 export const buildGetTreatmentsRequestPayload = (
     projectId: string,
@@ -315,13 +315,13 @@ export const decideGateTypeNoneOrDismissible = (gateDismissCount: number): GateT
     // (We do not want users to have to dismiss the gate 6 times)
 
     if (gateDismissCount > 5) {
-        return GateType.None;
+        return 'None';
     }
 
     // -----------------------------------------------------------------------
     // We are now clear to show the default (dismissible) gu gate.
 
-    return GateType.GuDismissible;
+    return 'GuDismissible';
 };
 
 export const decideGuGateTypeNonConsentedIreland = (
@@ -332,7 +332,7 @@ export const decideGuGateTypeNonConsentedIreland = (
     // If we reach this point, we are in Ireland
 
     if (dailyArticleCount < 3) {
-        return GateType.AuxiaAnalyticThenNone;
+        return 'AuxiaAnalyticThenNone';
     }
 
     // gateDisplayCount was introduced to enrich the behavior of the default gate.
@@ -348,10 +348,10 @@ export const decideGuGateTypeNonConsentedIreland = (
     //  -------------------------------------------------------------------------
 
     if (gateDisplayCount >= 3) {
-        return GateType.AuxiaAnalyticThenGuMandatory;
+        return 'AuxiaAnalyticThenGuMandatory';
     }
 
-    return GateType.AuxiaAnalyticThenGuDismissible;
+    return 'AuxiaAnalyticThenGuDismissible';
 };
 
 export const getTreatmentsRequestPayloadToGateType = (
@@ -382,7 +382,7 @@ export const getTreatmentsRequestPayloadToGateType = (
         getTreatmentsRequestPayload.showDefaultGate !== undefined &&
         getTreatmentsRequestPayload.shouldServeDismissible
     ) {
-        return GateType.GuDismissible;
+        return 'GuDismissible';
     }
 
     // --------------------------------------------------------------
@@ -390,9 +390,9 @@ export const getTreatmentsRequestPayloadToGateType = (
 
     if (getTreatmentsRequestPayload.showDefaultGate) {
         if (getTreatmentsRequestPayload.showDefaultGate == 'mandatory') {
-            return GateType.GuMandatory;
+            return 'GuMandatory';
         } else {
-            return GateType.GuDismissible;
+            return 'GuDismissible';
         }
     }
 
@@ -408,7 +408,7 @@ export const getTreatmentsRequestPayloadToGateType = (
         !isValidTagIdCollection(getTreatmentsRequestPayload.tagIds) ||
         !articleIdentifierIsAllowed(getTreatmentsRequestPayload.articleIdentifier)
     ) {
-        return GateType.None;
+        return 'None';
     }
 
     // --------------------------------------------------------------
@@ -419,7 +419,7 @@ export const getTreatmentsRequestPayloadToGateType = (
 
     if (getTreatmentsRequestPayload.countryCode === 'IE') {
         if (mvtIdIsAuxiaAudienceShare(getTreatmentsRequestPayload.mvtId)) {
-            return GateType.Auxia;
+            return 'AuxiaAPI';
         } else {
             return decideGuGateTypeNonConsentedIreland(
                 getTreatmentsRequestPayload.dailyArticleCount,
@@ -444,12 +444,12 @@ export const getTreatmentsRequestPayloadToGateType = (
         if (getTreatmentsRequestPayload.should_show_legacy_gate_tmp) {
             return decideGateTypeNoneOrDismissible(getTreatmentsRequestPayload.gateDismissCount);
         } else {
-            return GateType.None;
+            return 'None';
         }
     }
 
     // --------------------------------------------------------------
     // Auxia share of the audience (outside Ireland)
 
-    return GateType.Auxia;
+    return 'AuxiaAPI';
 };

--- a/src/server/signin-gate/types.ts
+++ b/src/server/signin-gate/types.ts
@@ -66,15 +66,14 @@ export interface UserTreatmentsEnvelop {
     userTreatments: UserTreatment[];
 }
 
-export enum GateType {
-    None, // [1]
-    GuDismissible, // [2]
-    GuMandatory, // [3]
-    Auxia, // [4]
-    AuxiaAnalyticThenNone, // [5]
-    AuxiaAnalyticThenGuDismissible, // [6]
-    AuxiaAnalyticThenGuMandatory, // [7]
-}
+export type GateType =
+    | 'None' // [1]
+    | 'GuDismissible' // [2]
+    | 'GuMandatory' // [3]
+    | 'AuxiaAPI' // [4]
+    | 'AuxiaAnalyticThenNone' // [5]
+    | 'AuxiaAnalyticThenGuDismissible' // [6]
+    | 'AuxiaAnalyticThenGuMandatory'; // [7]
 
 // [1] Signals no gate to display
 // [2] Signals the Gu Dismissible gate


### PR DESCRIPTION
Here we move the `GateType` from an enum to a different, isomorphic, type of enum.

This is a bit sad, because I really like the purity of `GateType` as it was defined, but the linter keeps confusing itself about whether GateType is a type or something else and make the developer experience awful. This solves it. 

This is another preliminary PR for https://github.com/guardian/support-dotcom-components/pull/1414


