### PR TITLE
correct history tests

### DIFF
--- a/src/shared/lib/history.test.ts
+++ b/src/shared/lib/history.test.ts
@@ -4,16 +4,16 @@ const oneDay = 86400000;
 
 describe('getMondayFromDate', () => {
     it('should return Monday midnight if today is Monday', () => {
-        const mondayMidnight = new Date('2020-03-02T00:00:00');
-        const mondayEvening = new Date('2020-03-02T19:25:00');
+        const mondayMidnight = new Date('2020-03-02T00:00:00Z');
+        const mondayEvening = new Date('2020-03-02T19:25:00Z');
 
         const got = getMondayFromDate(mondayEvening);
         expect(got).toBe(mondayMidnight.getTime() / oneDay);
     });
 
     it('should return Monday midnight if today is some other day', () => {
-        const mondayMidnight = new Date('2020-03-02T00:00:00');
-        const fridayAfternoon = new Date('2020-03-06T16:35:00');
+        const mondayMidnight = new Date('2020-03-02T00:00:00Z');
+        const fridayAfternoon = new Date('2020-03-06T16:35:00Z');
 
         const got = getMondayFromDate(fridayAfternoon);
         expect(got).toBe(mondayMidnight.getTime() / oneDay);


### PR DESCRIPTION
This add timezone information to the fixtures in history.test.ts. This prevent failing tests when the local system is not on UK timezone. 

Co-discovered with @tomrf1 🥇