### PR TITLE
[sign-in gate] logic.md

### DIFF
--- a/src/server/signin-gate/logic.md
+++ b/src/server/signin-gate/logic.md
@@ -1,0 +1,68 @@
+## SignIn Gate Logic
+
+This file contains the source of truth of the signin gate behavior. These are the specs that the tests must be written against.
+
+### Special Cases
+
+See code for details
+
+### World without Ireland
+
+No gate display the first 3 page views
+
+nb: the numbers, for instance, [01], uniquely identify the experience for the code and the tests
+
+```
+                                                              |
+                   Auxia share of the Audience                |     Guardian share of the Audience
+                               35%                            |                65%
+                ---------------------------------------------------------------------------------------------
+               | [01]                                         | [02]                                         |
+               |                                              |                                              |
+               |  - No Auxia notification                     | - No Auxia notification                      |
+ un-consented  |  - Guardian drives the gate:                 | - Guardian drives the gate:                  |
+               |    - No gate display the first 3 page views  |   - No gate display the first 3 page views   |
+               |    - Gate: dismissible gates,                |   - Gate: dismissible gates                  |
+               |            then no gate after 5 dismisses    |           then no gate after 5 dismisses     |
+               |                                              |                                              |
+    -----------|-----------------------------------------------------------------------------------------------------
+               | [03]                                         | [04]                                         |
+               |                                              |                                              |
+               |  - Auxia drives the gate                     | - No Auxia notification                      |
+    consented  |                                              | - Guardian drivess the gate:                 |
+               |                                              |   - No gate display the first 3 page views   |
+               |                                              |   - Gate: dismissible gates                  |
+               |                                              |           then no gate after 5 dismisses     |
+               |                                              |                                              |
+                ---------------------------------------------------------------------------------------------
+                                                              |
+                                                              |
+```
+
+### Ireland
+
+```
+                                                              |
+                   Auxia share of the Audience                |     Guardian share of the Audience
+                               35%                            |                65%
+                ---------------------------------------------------------------------------------------------
+               | [05]                                         | [06]                                         |
+               |                                              |                                              |
+               |  - Notify Auxia for analytics                | - Notify Auxia for analytics                 |
+ un-consented  |  - Guardian drives the gate:                 | - Guardian drives the gate:                  |
+               |    - No gate display the first 3 page views  |   - No gate display the first 3 page views   |
+               |    - Gate: 3x dismissal, then mandatory      |   - Gate: 3x dismissal, then mandatory       |
+               |                                              |                                              |
+    -----------|-----------------------------------------------------------------------------------------------------
+               | [07]                                         | [08]                                         |
+               |                                              |                                              |
+               |  - Auxia drives the gate                     | - No Auxia notification                      |
+    consented  |                                              | - Guardian drives the gate:                  |
+               |                                              |   - No gate display the first 3 page views   |
+               |                                              |   - Gate: dismissible gates                  |
+               |                                              |           then no gate after 5 dismisses     |
+               |                                              |                                              |
+                ---------------------------------------------------------------------------------------------
+                                                              |
+                                                              |
+```


### PR DESCRIPTION
In this change we encode the sign-in gate specs as defined by the business (Giulia). The logic file is going to be where the official specs are encoded and any further business modification of the gate should be reported in in this file in the same PR that implement the change.

The file was built from two diagrams that Pascal drew and that Giulia signed off. Given here for reference. 

<img width="1002" height="640" alt="481321700-1d5aea41-3c95-46d2-bcbb-3adc8c246512" src="https://github.com/user-attachments/assets/973f243b-1759-4ff5-8f88-63ec5136d7ed" />

<img width="915" height="623" alt="481328700-5f677be1-838f-4e09-8085-17a57f7a934a" src="https://github.com/user-attachments/assets/b5dc048c-4fa1-4697-babf-bf7c9226b489" />

