### PR TITLE
[sign-in gate] add helper functions

### DIFF
--- a/src/server/signin-gate/libPure.ts
+++ b/src/server/signin-gate/libPure.ts
@@ -354,6 +354,66 @@ export const decideGuGateTypeNonConsentedIreland = (
     return 'AuxiaAnalyticThenGuDismissible';
 };
 
+// The prefix `gtrp`, carried by some functions, means "GetTreatmentsRequestPayload", and
+// is used for those with signature: GetTreatmentsRequestPayload -> Type
+
+export const gtrpIsAuxiaAudienceShare = (payload: GetTreatmentsRequestPayload): boolean => {
+    return mvtIdIsAuxiaAudienceShare(payload.mvtId);
+};
+
+export const gtrpIsGuardianAudienceShare = (payload: GetTreatmentsRequestPayload): boolean => {
+    return !gtrpIsAuxiaAudienceShare(payload);
+};
+
+//export const gtrpIsConsentedUser = (payload: GetTreatmentsRequestPayload): boolean => {
+//    return true;
+//};
+
+export const pageMetaDataIsEligibleForGateDisplay = (
+    contentType: string,
+    sectionId: string,
+    tagIds: string[],
+): boolean => {
+    return isValidContentType(contentType) && isValidSection(sectionId) && isValidTagIds(tagIds);
+};
+
+export const gtrpPageMetadataIsEligibleForGateDisplay = (
+    payload: GetTreatmentsRequestPayload,
+): boolean => {
+    return pageMetaDataIsEligibleForGateDisplay(
+        payload.contentType,
+        payload.sectionId,
+        payload.tagIds,
+    );
+};
+
+export const gtrpIsOverridingConditionShowDismissibleGate = (
+    payload: GetTreatmentsRequestPayload,
+): boolean => {
+    return payload.shouldServeDismissible;
+};
+
+export const gtrpIsStaffTestConditionShowDefaultGate = (
+    payload: GetTreatmentsRequestPayload,
+): boolean => {
+    return payload.showDefaultGate !== undefined;
+};
+
+export const staffTestConditionToDefaultGate = (payload: GetTreatmentsRequestPayload): GateType => {
+    if (payload.showDefaultGate === undefined) {
+        return 'None';
+    }
+    if (payload.showDefaultGate == 'mandatory') {
+        return 'GuMandatory';
+    }
+    // values 'true' or 'dismissible'
+    return 'GuDismissible';
+};
+
+export const gtrpUserHasConsented = (payload: GetTreatmentsRequestPayload): boolean => {
+    return payload.hasConsented;
+};
+
 export const getTreatmentsRequestPayloadToGateType = (
     payload: GetTreatmentsRequestPayload,
 ): GateType => {

--- a/src/server/signin-gate/libPureTests/gtrpIsAuxiaAudienceShare.test.ts
+++ b/src/server/signin-gate/libPureTests/gtrpIsAuxiaAudienceShare.test.ts
@@ -1,0 +1,44 @@
+import { gtrpIsAuxiaAudienceShare } from '../libPure';
+import type { GetTreatmentsRequestPayload } from '../types';
+
+it('gtrpIsAuxiaAudienceShare', () => {
+    const payload1: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 250001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: false,
+        showDefaultGate: undefined,
+        gateDisplayCount: 0,
+    };
+    const payload2: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 450001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: false,
+        showDefaultGate: undefined,
+        gateDisplayCount: 0,
+    };
+
+    expect(gtrpIsAuxiaAudienceShare(payload1)).toBe(true);
+    expect(gtrpIsAuxiaAudienceShare(payload2)).toBe(false);
+});

--- a/src/server/signin-gate/libPureTests/gtrpIsGuardianAudienceShare.test.ts
+++ b/src/server/signin-gate/libPureTests/gtrpIsGuardianAudienceShare.test.ts
@@ -1,0 +1,44 @@
+import { gtrpIsGuardianAudienceShare } from '../libPure';
+import type { GetTreatmentsRequestPayload } from '../types';
+
+it('gtrpIsGuardianAudienceShare', () => {
+    const payload1: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 250001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: false,
+        showDefaultGate: undefined,
+        gateDisplayCount: 0,
+    };
+    const payload2: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 450001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: false,
+        showDefaultGate: undefined,
+        gateDisplayCount: 0,
+    };
+
+    expect(gtrpIsGuardianAudienceShare(payload1)).toBe(false);
+    expect(gtrpIsGuardianAudienceShare(payload2)).toBe(true);
+});

--- a/src/server/signin-gate/libPureTests/gtrpIsStaffTestConditionShowDefaultGate.test.ts
+++ b/src/server/signin-gate/libPureTests/gtrpIsStaffTestConditionShowDefaultGate.test.ts
@@ -1,0 +1,64 @@
+import { gtrpIsStaffTestConditionShowDefaultGate } from '../libPure';
+import type { GetTreatmentsRequestPayload } from '../types';
+
+it('gtrpIsStaffTestConditionShowDefaultGate', () => {
+    const payload1: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 250001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: false,
+        showDefaultGate: undefined,
+        gateDisplayCount: 0,
+    };
+    expect(gtrpIsStaffTestConditionShowDefaultGate(payload1)).toBe(false);
+
+    const payload2: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 450001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: true,
+        showDefaultGate: 'true',
+        gateDisplayCount: 0,
+    };
+    expect(gtrpIsStaffTestConditionShowDefaultGate(payload2)).toBe(true);
+
+    const payload3: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 450001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: true,
+        showDefaultGate: 'dismissible',
+        gateDisplayCount: 0,
+    };
+    expect(gtrpIsStaffTestConditionShowDefaultGate(payload3)).toBe(true);
+});

--- a/src/server/signin-gate/libPureTests/gtrpUserHasConsented.test.ts
+++ b/src/server/signin-gate/libPureTests/gtrpUserHasConsented.test.ts
@@ -1,0 +1,44 @@
+import { gtrpUserHasConsented } from '../libPure';
+import type { GetTreatmentsRequestPayload } from '../types';
+
+it('gtrpUserHasConsented', () => {
+    const payload1: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 250001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: false,
+        showDefaultGate: undefined,
+        gateDisplayCount: 0,
+    };
+    expect(gtrpUserHasConsented(payload1)).toBe(true);
+
+    const payload2: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 450001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: false,
+        shouldServeDismissible: true,
+        showDefaultGate: 'true',
+        gateDisplayCount: 0,
+    };
+    expect(gtrpUserHasConsented(payload2)).toBe(false);
+});

--- a/src/server/signin-gate/libPureTests/staffTestConditionToDefaultGate.test.ts
+++ b/src/server/signin-gate/libPureTests/staffTestConditionToDefaultGate.test.ts
@@ -1,0 +1,84 @@
+import { staffTestConditionToDefaultGate } from '../libPure';
+import type { GetTreatmentsRequestPayload } from '../types';
+
+it('staffTestConditionToDefaultGate', () => {
+    const payload1: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 250001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: false,
+        showDefaultGate: undefined,
+        gateDisplayCount: 0,
+    };
+    expect(staffTestConditionToDefaultGate(payload1)).toBe('None');
+
+    const payload2: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 450001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: true,
+        showDefaultGate: 'true',
+        gateDisplayCount: 0,
+    };
+    expect(staffTestConditionToDefaultGate(payload2)).toBe('GuDismissible');
+
+    const payload3: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 450001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: true,
+        showDefaultGate: 'dismissible',
+        gateDisplayCount: 0,
+    };
+    expect(staffTestConditionToDefaultGate(payload3)).toBe('GuDismissible');
+
+    const payload4: GetTreatmentsRequestPayload = {
+        browserId: 'sample',
+        isSupporter: false,
+        dailyArticleCount: 3,
+        articleIdentifier: 'sample: article identifier',
+        editionId: 'UK',
+        contentType: 'Article',
+        sectionId: 'uk-news',
+        tagIds: ['type/article'],
+        gateDismissCount: 0,
+        countryCode: 'GB',
+        mvtId: 450001,
+        should_show_legacy_gate_tmp: true,
+        hasConsented: true,
+        shouldServeDismissible: true,
+        showDefaultGate: 'mandatory',
+        gateDisplayCount: 0,
+    };
+    expect(staffTestConditionToDefaultGate(payload4)).toBe('GuMandatory');
+});


### PR DESCRIPTION
This is another prelude for https://github.com/guardian/support-dotcom-components/pull/1414

Here we introduce pure functions as well as their tests, to help with better expression the formal/clarified specs that we introduced here: https://github.com/guardian/support-dotcom-components/pull/1419

There is is a transparent change with no effects on the existing behavior of the gate.