### PR TITLE
[auxia] use NONDISMISSIBLE_SIGN_IN_GATE for guMandatoryUserTreatment

### DIFF
--- a/src/server/signin-gate/libPure.ts
+++ b/src/server/signin-gate/libPure.ts
@@ -121,7 +121,7 @@ export const guMandatoryUserTreatment = (): UserTreatment => {
         rank: '1',
         contentLanguageCode: 'en-GB',
         treatmentContent: treatmentContentEncoded,
-        treatmentType: 'DISMISSABLE_SIGN_IN_GATE',
+        treatmentType: 'NONDISMISSIBLE_SIGN_IN_GATE',
         surface: 'ARTICLE_PAGE',
     };
 };


### PR DESCRIPTION
This is the companion PR of https://github.com/guardian/dotcom-rendering/pull/14507

Here we move to using userTreatment.treatmentType, which takes the two values
- DISMISSABLE_SIGN_IN_GATE
- NONDISMISSIBLE_SIGN_IN_GATE

To be closer to the way Auxia model its data.