### PR TITLE
Bump ophan-tracker-js

### DIFF
--- a/.changeset/seven-kiwis-return.md
+++ b/.changeset/seven-kiwis-return.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+bump ophan-tracker-js to be compatible with dotcom-rendering

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     },
     "dependencies": {
         "@guardian/libs": "22.0.1",
-        "@guardian/ophan-tracker-js": "2.4.1",
+        "@guardian/ophan-tracker-js": "2.6.1",
         "@aws-sdk/client-s3": "^3.835.0",
         "@aws-sdk/client-dynamodb": "^3.835.0",
         "@aws-sdk/lib-dynamodb": "^3.835.0",
@@ -98,7 +98,7 @@
     },
     "peerDependencies": {
         "@guardian/libs": "^22.0.0",
-        "@guardian/ophan-tracker-js": "^2.4.1",
+        "@guardian/ophan-tracker-js": "2.6.1",
         "zod": "^3.22.4"
     },
     "packageManager": "pnpm@8.15.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: 22.0.1
     version: 22.0.1(tslib@2.8.0)(typescript@5.5.4)
   '@guardian/ophan-tracker-js':
-    specifier: 2.4.1
-    version: 2.4.1
+    specifier: 2.6.1
+    version: 2.6.1
   compression:
     specifier: 1.7.4
     version: 1.7.4
@@ -1869,8 +1869,8 @@ packages:
       yargs: 15.4.1
     dev: true
 
-  /@guardian/ophan-tracker-js@2.4.1:
-    resolution: {integrity: sha512-2u/1So21U5zxkLKBwLGOJMIeKf4Y5oNqo5xYlFf84PgVMamuxYPZX1x+Gq95x2fy+qGltJW19djRvdJMp2hR9g==}
+  /@guardian/ophan-tracker-js@2.6.1:
+    resolution: {integrity: sha512-YTBL/PDUTs6jGf9nN7EY7l9xM64pHWGKkf+TEYrXYQI/1vHaLO4wVEW5Ss5g6dNOHNDibELJy+MEZBm6zTzgGw==}
     engines: {node: '>=16'}
     dependencies:
       '@guardian/tsconfig': 1.0.0


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps `ophan-tracker-js` to latest version as dotcom-rendering needs this. Sibling dotcom PR here: https://github.com/guardian/dotcom-rendering/pull/14572

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
