### PR TITLE
Add 27 Europe countries to 100% Auxia roll out

### DIFF
--- a/src/server/signin-gate/libPure.ts
+++ b/src/server/signin-gate/libPure.ts
@@ -389,7 +389,37 @@ export const getTreatmentsRequestPayloadToGateType = (
     }
 
     const isMandatoryRollout = payload.countryCode === 'IE' || payload.countryCode === 'NZ';
-    const isDismissibleRollout = payload.countryCode === 'AU';
+    const euCountries = [
+        'AT',
+        'BE',
+        'BG',
+        'CY',
+        'CZ',
+        'DE',
+        'DK',
+        'EE',
+        'ES',
+        'FI',
+        'FR',
+        'GR',
+        'HR',
+        'HU',
+        'IE',
+        'IT',
+        'LT',
+        'LU',
+        'LV',
+        'MT',
+        'NL',
+        'PL',
+        'PT',
+        'RO',
+        'SE',
+        'SI',
+        'SK',
+    ];
+    const isDismissibleRollout =
+        payload.countryCode === 'AU' || euCountries.includes(payload.countryCode);
 
     // --------------------------------------------------------------
     // We now move to the normal behavior of the gate

--- a/src/server/signin-gate/libPureTests/getTreatmentsRequestPayloadToGateType/world-without-ireland.test.ts
+++ b/src/server/signin-gate/libPureTests/getTreatmentsRequestPayloadToGateType/world-without-ireland.test.ts
@@ -27,7 +27,7 @@ describe('getTreatmentsRequestPayloadToGateType', () => {
             sectionId: 'uk-news',
             tagIds: ['type/article'],
             gateDismissCount: 0,
-            countryCode: 'FR', // <- [outside ireland]
+            countryCode: 'US', // <- [outside Auxia roll out]
             mvtId: 450_000, // <- [Guardian]
             should_show_legacy_gate_tmp: true,
             hasConsented: true, // <- [consented]
@@ -66,7 +66,7 @@ describe('getTreatmentsRequestPayloadToGateType', () => {
             sectionId: 'uk-news',
             tagIds: ['type/article'],
             gateDismissCount: 0,
-            countryCode: 'FR', // <- [outside ireland]
+            countryCode: 'US', // <- [outside Auxia roll out]
             mvtId: 450_000, // <- [Guardian]
             should_show_legacy_gate_tmp: true,
             hasConsented: true, // <- [consented]
@@ -105,7 +105,7 @@ describe('getTreatmentsRequestPayloadToGateType', () => {
             sectionId: 'uk-news',
             tagIds: ['type/article'],
             gateDismissCount: 6,
-            countryCode: 'FR', // <- [outside ireland]
+            countryCode: 'US', // <- [outside Auxia roll out]
             mvtId: 450_000, // <- [Guardian]
             should_show_legacy_gate_tmp: true,
             hasConsented: true, // <- [consented]
@@ -145,7 +145,7 @@ describe('getTreatmentsRequestPayloadToGateType', () => {
             sectionId: 'uk-news',
             tagIds: ['type/article'],
             gateDismissCount: 6,
-            countryCode: 'FR', // <- [outside ireland]
+            countryCode: 'US', // <- [outside Auxia roll out]
             mvtId: 150_000, // <- [Auxia]
             should_show_legacy_gate_tmp: true,
             hasConsented: true, // <- [consented]

--- a/src/server/signin-gate/libPureTests/hideSupportMessagingHasOverride.test.ts
+++ b/src/server/signin-gate/libPureTests/hideSupportMessagingHasOverride.test.ts
@@ -26,7 +26,7 @@ it('hideSupportMessagingHasOverride, undefined', () => {
         sectionId: 'uk-news',
         tagIds: ['type/article'],
         gateDismissCount: 0,
-        countryCode: 'FR', // <- [outside ireland]
+        countryCode: 'US', // <- [outside Auxia roll out]
         mvtId: 450_000, // <- [Guardian]
         should_show_legacy_gate_tmp: true,
         hasConsented: true, // <- [consented]
@@ -66,7 +66,7 @@ it('hideSupportMessagingHasOverride, defined, more than 30 days ago', () => {
         sectionId: 'uk-news',
         tagIds: ['type/article'],
         gateDismissCount: 0,
-        countryCode: 'FR', // <- [outside ireland]
+        countryCode: 'US', // <- [outside Auxia roll out]
         mvtId: 450_000, // <- [Guardian]
         should_show_legacy_gate_tmp: true,
         hasConsented: true, // <- [consented]
@@ -106,7 +106,7 @@ it('hideSupportMessagingHasOverride, defined, less than 30 days ago', () => {
         sectionId: 'uk-news',
         tagIds: ['type/article'],
         gateDismissCount: 0,
-        countryCode: 'FR', // <- [outside ireland]
+        countryCode: 'US', // <- [outside Auxia roll out]
         mvtId: 450_000, // <- [Guardian]
         should_show_legacy_gate_tmp: true,
         hasConsented: true, // <- [consented]
@@ -132,7 +132,7 @@ it('hideSupportMessagingHasOverride, defined, value in the future', () => {
         sectionId: 'uk-news',
         tagIds: ['type/article'],
         gateDismissCount: 0,
-        countryCode: 'FR', // <- [outside ireland]
+        countryCode: 'US', // <- [outside Auxia roll out]
         mvtId: 450_000, // <- [Guardian]
         should_show_legacy_gate_tmp: true,
         hasConsented: true, // <- [consented]
@@ -174,7 +174,7 @@ it('getTreatmentsRequestPayloadToGateType, without override', () => {
         sectionId: 'uk-news',
         tagIds: ['type/article'],
         gateDismissCount: 0,
-        countryCode: 'FR', // <- [outside ireland]
+        countryCode: 'US', // <- [outside Auxia roll out]
         mvtId: 450_000, // <- [Guardian]
         should_show_legacy_gate_tmp: true,
         hasConsented: true, // <- [consented]
@@ -214,7 +214,7 @@ it('getTreatmentsRequestPayloadToGateType, with override', () => {
         sectionId: 'uk-news',
         tagIds: ['type/article'],
         gateDismissCount: 0,
-        countryCode: 'FR', // <- [outside ireland]
+        countryCode: 'US', // <- [outside Auxia roll out]
         mvtId: 450_000, // <- [Guardian]
         should_show_legacy_gate_tmp: true,
         hasConsented: true, // <- [consented]

--- a/src/server/signin-gate/logic.md
+++ b/src/server/signin-gate/logic.md
@@ -9,7 +9,7 @@ This file contains the source of truth of the signin gate behavior. These are th
 - payload.shouldServeDismissible overrides everything else
 - Staff testing gate feature
 
-### Global, excluding Ireland + New Zealand and Australia
+### Global, excluding Ireland + New Zealand and Australia + Europe
 
 No gate display the first 3 page views
 
@@ -85,7 +85,7 @@ not in control |                                              |
 [02] use gu_hide_support_messaging cookie
 ```
 
-### Australia
+### Australia + Europe
 
 ```
                 ----------------------------------------------


### PR DESCRIPTION
## What does this change?

We want to roll out the Auxia sign in gate to Europe (27 countries). This PR changes the sign in gate logic to include these countries in the same group as Australia.

## How has this change been tested?

Unit tests were updated.