### PR TITLE
Ab/reuse page context matches to fix exclusion selection

### DIFF
--- a/.changeset/some-shrimps-carry.md
+++ b/.changeset/some-shrimps-carry.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+Optional contentType property is added to headerTargeting

--- a/src/server/utils/channelExclusionsMatcher.ts
+++ b/src/server/utils/channelExclusionsMatcher.ts
@@ -1,4 +1,5 @@
 import type { ChannelExclusions, DateRange, ExclusionRule } from '../channelExclusions';
+import { pageContextMatches } from '../lib/targeting';
 
 export interface Targeting {
     tagIds?: string[];
@@ -35,24 +36,24 @@ const matchesRule = (targeting: Targeting, rule: ExclusionRule): boolean => {
     const now = new Date();
     const currentDate = toIsoDate(now);
     const sectionId = getSectionId(targeting)?.toLowerCase();
-    const tagIds = new Set(getTagIds(targeting).map((tagId) => tagId.toLowerCase()));
+    const tagIds = getTagIds(targeting).map((tagId) => tagId.toLowerCase());
     const contentType = getContentType(targeting);
 
-    if (rule.sectionIds?.length) {
-        if (!sectionId) {
-            return false;
-        }
-        const hasSection = rule.sectionIds.some((id) => id.toLowerCase() === sectionId);
-        if (!hasSection) {
-            return false;
-        }
-    }
+    const hasMatchingSectionOrTag = pageContextMatches(
+        {
+            sectionId,
+            tagIds,
+        },
+        {
+            sectionIds: (rule.sectionIds ?? []).map((id) => id.toLowerCase()),
+            tagIds: (rule.tagIds ?? []).map((id) => id.toLowerCase()),
+            excludedTagIds: [],
+            excludedSectionIds: [],
+        },
+    );
 
-    if (rule.tagIds?.length) {
-        const hasTag = rule.tagIds.some((id) => tagIds.has(id.toLowerCase()));
-        if (!hasTag) {
-            return false;
-        }
+    if (!hasMatchingSectionOrTag) {
+        return false;
     }
 
     if (rule.dateRange && !inDateRange(currentDate, rule.dateRange)) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1213735979039323)
## What does this change?
This change refactors channel exclusion section/tag matching to reuse shared page context logic from targeting. Previous implementation introduced the bug in the logic of how component is excluded, so this change:
- Removes duplicated matching logic.
- Keeps behaviour aligned with existing page-context matching semantics.
- Reduces maintenance risk by centralizing section/tag matching behaviour in one place.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE and verified that epic/header/gutterAsk/banner components are correctly excluded based on tagIds and sectionIds
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
