### PR TITLE
Fix S3 AccessDenied error when fetching exclusions.json from support-admin-console bucket

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -16,6 +16,7 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuDistributionBucketParameter",
       "GuGetS3ObjectsPolicy",
+      "GuAllowPolicy",
       "GuGetS3ObjectsPolicy",
       "GuGetS3ObjectsPolicy",
       "GuDynamoDBReadPolicy",
@@ -1440,6 +1441,27 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "S3ListBucketSupportAdminConsole09DA14FD": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::support-admin-console",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "S3ListBucketSupportAdminConsole09DA14FD",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleDotcomcomponents2E8FDE7D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "S3ReadPolicyContributionsTicker451E0B8F": {
       "Properties": {

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -268,6 +268,10 @@ sudo amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-
 					`PROD/auxia-credentials.json`,
 				],
 			}),
+			new GuAllowPolicy(this, 'S3ListBucketSupportAdminConsole', {
+				actions: ['s3:ListBucket'],
+				resources: ['arn:aws:s3:::support-admin-console'],
+			}),
 			new GuGetS3ObjectsPolicy(
 				this,
 				'S3ReadPolicyGuContributionsPublic',


### PR DESCRIPTION
The SDC service was experiencing continuous AccessDenied errors when attempting to fetch `exclusions.json` from the `support-admin-console` S3 bucket in production. The error indicated that the IAM role lacked the `s3:ListBucket` permission, which is required by the AWS SDK as part of the GetObject operation.

This fix adds a `GuAllowPolicy` to grant the `s3:ListBucket` permission on the `support-admin-console` bucket to the SDC IAM role, allowing the service to successfully retrieve the exclusions configuration.