### PR TITLE
Add contributionsServiceUrl to BannerProps

### DIFF
--- a/.changeset/tiny-bees-draw.md
+++ b/.changeset/tiny-bees-draw.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': patch
+---
+
+Add contributionsServiceUrl field to BannerProps

--- a/src/shared/types/props/banner.ts
+++ b/src/shared/types/props/banner.ts
@@ -63,10 +63,8 @@ export interface BannerProps {
     countryCode?: string;
     isSupporter?: boolean;
     tickerSettings?: TickerSettings;
-    submitComponentEvent?: (componentEvent: ComponentEvent) => Promise<void>;
     articleCounts: ArticleCounts;
     hasOptedOutOfArticleCount?: boolean;
-    fetchEmail?: () => Promise<string | null>;
     separateArticleCount?: boolean;
     separateArticleCountSettings?: SeparateArticleCount;
     choiceCardAmounts?: SelectedAmountsVariant;
@@ -75,6 +73,10 @@ export interface BannerProps {
     abandonedBasket?: AbandonedBasket;
     promoCodes?: string[];
     isCollapsible?: boolean;
+    // provided by the client
+    submitComponentEvent?: (componentEvent: ComponentEvent) => Promise<void>;
+    fetchEmail?: () => Promise<string | null>;
+    contributionsServiceUrl?: string;
 }
 
 export const bannerSchema = z.object({
@@ -94,4 +96,5 @@ export const bannerSchema = z.object({
     choiceCardsSettings: choiceCardsSettings.nullish(),
     promoCodes: z.array(z.string()).nullish(),
     isCollapsible: z.boolean().nullish(),
+    contributionsServiceUrl: z.string().nullish(),
 });


### PR DESCRIPTION
This is to enable the tracking of Auxia treatments in the banner.
We need the client to make a request to SDC to track views/clicks when the banner is part of an Auxia treatment.
This means the banner component needs to know the SDC url, which it currently doesn't.

This PR adds the `contributionsServiceUrl` field to the BannerProps model.
Currently the client enriches the props data from the server with a couple of fields that are only available client-side, here:
https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/components/StickyBottomBanner/ReaderRevenueBanner.tsx#L296
The `contributionsServiceUrl` field will be another field that the client can add to the props.