### PR TITLE
Fix deploy

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1844,13 +1844,12 @@ groupadd support
 useradd -r -m -s /usr/bin/nologin -g support dotcom-components
 cd /home/dotcom-components
 
+mkdir dotcom-components
 aws --region eu-west-1 s3 cp s3://",
                   {
                     "Ref": "DistributionBucketName",
                   },
-                  "/support/TEST/dotcom-components/dotcom-components.tar ./
-mkdir dotcom-components
-tar -xvf dotcom-components.tar --directory dotcom-components
+                  "/support/TEST/dotcom-components/server.js ./dotcom-components/
 
 chown -R dotcom-components:support dotcom-components
 

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -205,11 +205,10 @@ groupadd support
 useradd -r -m -s /usr/bin/nologin -g support dotcom-components
 cd /home/dotcom-components
 
+mkdir ${appName}
 aws --region eu-west-1 s3 cp s3://${
 			GuDistributionBucketParameter.getInstance(this).valueAsString
-		}/support/${this.stage}/${appName}/${appName}.tar ./
-mkdir ${appName}
-tar -xvf ${appName}.tar --directory ${appName}
+		}/support/${this.stage}/${appName}/server.js ./${appName}/
 
 chown -R dotcom-components:support ${appName}
 


### PR DESCRIPTION
A previous PR migrated to using the riffraff action.
In the new riffraff config it specifies that `server.js` should be copied: https://github.com/guardian/support-dotcom-components/pull/1632/changes#diff-3f1526824e5c112657dd35642973572ae981fe0be404a68a1e31faddf57269a3R71

But the cdk script still downloads `dotcom-components.tar` onto the ec2 instance. This tar used to contain the `server.js` file, but we're not longer building the tar.

This means we haven't updated the artefact since that change was released.
The fix here is just to update the cdk script to download server.js instead.