### PR TITLE
remove duplicate packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     },
     "author": "The Guardian",
     "license": "MIT",
-    "packageManager": "pnpm@9.15.9",
     "main": "dist/index.js",
     "module": "dist/index.esm.js",
     "types": "dist/dotcom/index.d.ts",


### PR DESCRIPTION
the [previous PR](https://github.com/guardian/support-dotcom-components/pull/1644) added pnpm 10, but I missed the existing `packageManager` field further up!