### PR TITLE
Filter inactive promos from choice cards based on start/end dates

### DIFF
--- a/src/server/lib/choiceCards/choiceCards.test.ts
+++ b/src/server/lib/choiceCards/choiceCards.test.ts
@@ -4,6 +4,10 @@ import type { PromotionsCache } from '../promotions/promotions';
 import { getChoiceCardsSettings } from './choiceCards';
 import { defaultEpicChoiceCardsSettings } from './defaultChoiceCardSettings';
 
+const now = new Date();
+const futureDate = new Date(now.getTime() + 24 * 60 * 60 * 1000 * 30).toISOString(); // 30 days from now
+const pastDate = new Date(now.getTime() - 24 * 60 * 60 * 1000 * 30).toISOString(); // 30 days ago
+
 describe('getChoiceCardsSettings', () => {
     const mockProductCatalog: ProductCatalog = {
         Contribution: {
@@ -325,5 +329,87 @@ describe('getChoiceCardsSettings', () => {
             supportTier: 'DigitalSubscription',
             ratePlan: 'Annual',
         });
+    });
+
+    it('does not apply discount for promo with future start date', () => {
+        const variantChoiceCardSettings = defaultEpicChoiceCardsSettings('UnitedStates');
+        const promoCodes: string[] = ['PROMO_FUTURE'];
+        const mockPromotionsCacheWithFuturePromo: PromotionsCache = {
+            PROMO_FUTURE: {
+                promoCode: 'PROMO_FUTURE',
+                productRatePlanIds: [mockProductCatalog.SupporterPlus.ratePlans.Monthly.id],
+                discountPercent: 40,
+                startTimestamp: futureDate,
+            },
+        };
+
+        const result = getChoiceCardsSettings(
+            'UnitedStates',
+            'Epic',
+            mockProductCatalog,
+            mockPromotionsCacheWithFuturePromo,
+            promoCodes,
+            variantChoiceCardSettings,
+        );
+
+        expect(result).toBeDefined();
+        // Should show full price without discount since promo hasn't started yet
+        expect(result?.choiceCards[1].label).toEqual('Support $15/monthly');
+        // Should not show the discount pill (e.g., "40% off")
+        expect(result?.choiceCards[1].pill?.copy).not.toBe('40% off');
+    });
+
+    it('does not apply discount for promo with past end date', () => {
+        const variantChoiceCardSettings = defaultEpicChoiceCardsSettings('UnitedStates');
+        const promoCodes: string[] = ['PROMO_EXPIRED'];
+        const mockPromotionsCacheWithExpiredPromo: PromotionsCache = {
+            PROMO_EXPIRED: {
+                promoCode: 'PROMO_EXPIRED',
+                productRatePlanIds: [mockProductCatalog.SupporterPlus.ratePlans.Monthly.id],
+                discountPercent: 40,
+                endTimestamp: pastDate,
+            },
+        };
+
+        const result = getChoiceCardsSettings(
+            'UnitedStates',
+            'Epic',
+            mockProductCatalog,
+            mockPromotionsCacheWithExpiredPromo,
+            promoCodes,
+            variantChoiceCardSettings,
+        );
+
+        expect(result).toBeDefined();
+        // Should show full price without discount since promo has expired
+        expect(result?.choiceCards[1].label).toEqual('Support $15/monthly');
+        // Should not show the discount pill (e.g., "40% off")
+        expect(result?.choiceCards[1].pill?.copy).not.toBe('40% off');
+    });
+
+    it('applies discount for promo with no dates (always live)', () => {
+        const variantChoiceCardSettings = defaultEpicChoiceCardsSettings('UnitedStates');
+        const promoCodes: string[] = ['PROMO_NO_DATES'];
+        const mockPromotionsCacheNoDates: PromotionsCache = {
+            PROMO_NO_DATES: {
+                promoCode: 'PROMO_NO_DATES',
+                productRatePlanIds: [mockProductCatalog.SupporterPlus.ratePlans.Monthly.id],
+                discountPercent: 40,
+            },
+        };
+
+        const result = getChoiceCardsSettings(
+            'UnitedStates',
+            'Epic',
+            mockProductCatalog,
+            mockPromotionsCacheNoDates,
+            promoCodes,
+            variantChoiceCardSettings,
+        );
+
+        expect(result).toBeDefined();
+        // Should show discounted price since promo has no date restrictions
+        expect(result?.choiceCards[1].label).toEqual('Support <s>$15</s> $9/monthly');
+        expect(result?.choiceCards[1].pill?.copy).toBe('40% off');
     });
 });

--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -7,7 +7,7 @@ import type {
     RatePlan,
 } from '../../../shared/types/props/choiceCards';
 import type { ProductCatalog } from '../../productCatalog';
-import type { Promotion, PromotionsCache } from '../promotions/promotions';
+import { isPromotionLive, type Promotion, type PromotionsCache } from '../promotions/promotions';
 import {
     currencySymbolTemplate,
     defaultBannerChoiceCardsSettings,
@@ -116,7 +116,9 @@ export const getChoiceCardsSettings = (
 ): ChoiceCardsSettings | undefined => {
     let choiceCardsSettings: ChoiceCardsSettings | undefined;
     const isoCurrency = countryGroups[countryGroupId].currency;
-    const promotions = promoCodes.map((code) => promotionsCache[code]).filter(Boolean);
+    const promotions = promoCodes
+        .map((code) => promotionsCache[code])
+        .filter((promo): promo is Promotion => Boolean(promo) && isPromotionLive(promo));
 
     if (variantChoiceCardSettings) {
         // Use the overridden settings from the test variant

--- a/src/server/lib/promotions/promotions.ts
+++ b/src/server/lib/promotions/promotions.ts
@@ -14,6 +14,8 @@ export interface Promotion {
     promoCode: PromoCode;
     productRatePlanIds: string[]; // the product rate plans that this promo applies to
     discountPercent: number;
+    startTimestamp?: string;
+    endTimestamp?: string;
 }
 export type PromotionsCache = Record<PromoCode, Promotion>;
 
@@ -26,6 +28,8 @@ interface PromotionTableItem {
     discount?: {
         amount: number;
     };
+    startTimestamp?: string;
+    endTimestamp?: string;
 }
 
 const mapTableItemToPromotion = (item: PromotionTableItem): Promotion => {
@@ -33,7 +37,29 @@ const mapTableItemToPromotion = (item: PromotionTableItem): Promotion => {
         promoCode: item.promoCode,
         discountPercent: item.discount?.amount ?? 0,
         productRatePlanIds: item.appliesTo.productRatePlanIds,
+        startTimestamp: item.startTimestamp,
+        endTimestamp: item.endTimestamp,
     };
+};
+
+export const isPromotionLive = (promotion: Promotion): boolean => {
+    const now = new Date();
+
+    if (promotion.startTimestamp) {
+        const startDate = new Date(promotion.startTimestamp);
+        if (now < startDate) {
+            return false;
+        }
+    }
+
+    if (promotion.endTimestamp) {
+        const endDate = new Date(promotion.endTimestamp);
+        if (now > endDate) {
+            return false;
+        }
+    }
+
+    return true;
 };
 
 // Does a full scan of the Promotions table - there isn't a smarter way to do this with the existing schema.


### PR DESCRIPTION
Choice cards were displaying discounts for promos that weren't live yet (future start date) or had expired (past end date). This change filters out inactive promos so choice cards show full price without the discount when the promo isn't active.

**Changes:**
- Added `startTimestamp` and `endTimestamp` fields to [Promotion](cci:2://file:///Users/admin.juarez.mota/code/support-dotcom-components/src/server/lib/promotions/promotions.ts:12:0-18:1) type (matching DynamoDB schema)
- Added [isPromotionLive()](cci:1://file:///Users/admin.juarez.mota/code/support-dotcom-components/src/server/lib/promotions/promotions.ts:44:0-62:2) helper to check if promo is within its valid date range
- Updated [getChoiceCardsSettings()](cci:1://file:///Users/admin.juarez.mota/code/support-dotcom-components/src/server/lib/choiceCards/choiceCards.ts:106:0-174:2) to filter promotions using [isPromotionLive()](cci:1://file:///Users/admin.juarez.mota/code/support-dotcom-components/src/server/lib/promotions/promotions.ts:44:0-62:2) before applying discounts

**Behavior:**
- Promo with future `startTimestamp` → choice card shows full price (no discount)
- Promo with past `endTimestamp` → choice card shows full price (no discount)
- Promo with no dates or within range → choice card shows discounted price