### PR TITLE
fetch profile by browserId and log source

### DIFF
--- a/src/server/api/bannerRouter.ts
+++ b/src/server/api/bannerRouter.ts
@@ -205,7 +205,7 @@ export const buildBannerRouter = (
                 const { targeting } = req.body;
                 const params = getQueryParams(req.query);
                 const authHeader = req.headers.authorization;
-                const { fetchProfile, forLogging: mParticleStatus } = mParticle.getProfileFetcher(
+                const { fetchProfile, forLogging: mParticleLogging } = mParticle.getProfileFetcher(
                     channelSwitches.get(),
                     okta,
                     authHeader,
@@ -234,10 +234,12 @@ export const buildBannerRouter = (
                 }
 
                 // for response logging
+                const { mParticleProfileStatus, mParticleProfileSource } = mParticleLogging();
                 res.locals.didRenderBanner = !!response.data;
                 res.locals.hasAuthorization = !!authHeader;
-                res.locals.gotMParticleProfile = mParticleStatus() === 'found';
-                res.locals.mParticleProfileStatus = mParticleStatus();
+                res.locals.gotMParticleProfile = mParticleProfileStatus === 'found';
+                res.locals.mParticleProfileStatus = mParticleProfileStatus;
+                res.locals.mParticleProfileSource = mParticleProfileSource;
                 res.locals.auxiaBannerSuppressionStatus = auxiaStatus();
                 // be specific about which fields to log, to avoid accidentally logging inappropriate things in future
                 res.locals.bannerTargeting = {

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -235,10 +235,11 @@ export const buildEpicRouter = (
                 const { targeting } = req.body;
                 const params = getQueryParams(req.query);
                 const authHeader = req.headers.authorization;
-                const { fetchProfile, forLogging } = mParticle.getProfileFetcher(
+                const { fetchProfile, forLogging: mParticleLogging } = mParticle.getProfileFetcher(
                     channelSwitches.get(),
                     okta,
                     authHeader,
+                    targeting.isSignedIn ? undefined : targeting.browserId,
                 );
 
                 const response = await buildEpicData(
@@ -262,9 +263,11 @@ export const buildEpicRouter = (
                         'SUPER_MODE',
                     );
                 }
+                const { mParticleProfileStatus, mParticleProfileSource } = mParticleLogging();
                 res.locals.hasAuthorization = !!authHeader;
-                res.locals.gotMParticleProfile = forLogging() === 'found';
-                res.locals.mParticleProfileStatus = forLogging();
+                res.locals.gotMParticleProfile = mParticleProfileStatus === 'found';
+                res.locals.mParticleProfileStatus = mParticleProfileStatus;
+                res.locals.mParticleProfileSource = mParticleProfileSource;
 
                 res.send(response);
             } catch (error) {
@@ -286,10 +289,11 @@ export const buildEpicRouter = (
                 const { targeting } = req.body;
                 const params = getQueryParams(req.query);
                 const authHeader = req.headers.authorization;
-                const { fetchProfile, forLogging } = mParticle.getProfileFetcher(
+                const { fetchProfile, forLogging: mParticleLogging } = mParticle.getProfileFetcher(
                     channelSwitches.get(),
                     okta,
                     authHeader,
+                    targeting.isSignedIn ? undefined : targeting.browserId,
                 );
                 const response = await buildEpicData(
                     targeting,
@@ -307,9 +311,11 @@ export const buildEpicRouter = (
                         'SUPER_MODE',
                     );
                 }
+                const { mParticleProfileStatus, mParticleProfileSource } = mParticleLogging();
                 res.locals.hasAuthorization = !!authHeader;
-                res.locals.gotMParticleProfile = forLogging() === 'found';
-                res.locals.mParticleProfileStatus = forLogging();
+                res.locals.gotMParticleProfile = mParticleProfileStatus === 'found';
+                res.locals.mParticleProfileStatus = mParticleProfileStatus;
+                res.locals.mParticleProfileSource = mParticleProfileSource;
 
                 res.send(response);
             } catch (error) {

--- a/src/server/api/headerRouter.ts
+++ b/src/server/api/headerRouter.ts
@@ -104,7 +104,7 @@ export const buildHeaderRouter = (
                 const params = getQueryParams(req.query);
 
                 const authHeader = req.headers.authorization;
-                const { fetchProfile, forLogging } = mParticle.getProfileFetcher(
+                const { fetchProfile, forLogging: mParticleLogging } = mParticle.getProfileFetcher(
                     channelSwitches.get(),
                     okta,
                     authHeader,
@@ -119,10 +119,12 @@ export const buildHeaderRouter = (
                 );
 
                 // for response logging
+                const { mParticleProfileStatus, mParticleProfileSource } = mParticleLogging();
                 res.locals.didRenderHeader = !!response.data;
                 res.locals.hasAuthorization = !!authHeader;
-                res.locals.gotMParticleProfile = forLogging() === 'found';
-                res.locals.mParticleProfileStatus = forLogging();
+                res.locals.gotMParticleProfile = mParticleProfileStatus === 'found';
+                res.locals.mParticleProfileStatus = mParticleProfileStatus;
+                res.locals.mParticleProfileSource = mParticleProfileSource;
 
                 res.send(response);
             } catch (error) {

--- a/src/server/lib/mParticle.test.ts
+++ b/src/server/lib/mParticle.test.ts
@@ -426,10 +426,11 @@ describe('MParticle.getProfileFetcher', () => {
         const result = forLogging();
 
         expect((global.fetch as jest.Mock).mock.calls.length).toBe(callCountBefore);
-        expect(result).toBe('not-fetched');
+        expect(result.mParticleProfileStatus).toBe('not-fetched');
+        expect(result.mParticleProfileSource).toBe('none');
     });
 
-    it('should return "found" when profile is fetched from API', async () => {
+    it('should return "found" when profile is fetched from API with authHeader', async () => {
         const mp = new MParticle(mockConfig);
         await jest.advanceTimersByTimeAsync(0);
 
@@ -445,7 +446,28 @@ describe('MParticle.getProfileFetcher', () => {
         const loggingResult = forLogging();
 
         expect((global.fetch as jest.Mock).mock.calls.length).toBe(callCountAfterFetch);
-        expect(loggingResult).toEqual('found');
+        expect(loggingResult.mParticleProfileStatus).toEqual('found');
+        expect(loggingResult.mParticleProfileSource).toBe('identityId');
+    });
+    it('should return "found" when profile is fetched from API with browserId and no authHeader', async () => {
+        const mp = new MParticle(mockConfig);
+        await jest.advanceTimersByTimeAsync(0);
+
+        const { fetchProfile, forLogging } = mp.getProfileFetcher(
+            channelSwitches,
+            mockOkta,
+            undefined,
+            'BrowserId',
+        );
+
+        await fetchProfile();
+        const callCountAfterFetch = (global.fetch as jest.Mock).mock.calls.length;
+
+        const loggingResult = forLogging();
+
+        expect((global.fetch as jest.Mock).mock.calls.length).toBe(callCountAfterFetch);
+        expect(loggingResult.mParticleProfileStatus).toEqual('found');
+        expect(loggingResult.mParticleProfileSource).toBe('browserId');
     });
 
     it('should return "found-cached" when profile is served from cache', async () => {
@@ -468,7 +490,7 @@ describe('MParticle.getProfileFetcher', () => {
         );
         await fetchProfile();
 
-        expect(forLogging()).toBe('found-cached');
+        expect(forLogging().mParticleProfileStatus).toBe('found-cached');
     });
 
     it('should return "not-found" when profile fetch returns 404', async () => {
@@ -489,7 +511,7 @@ describe('MParticle.getProfileFetcher', () => {
         expect(profile).toBeUndefined();
 
         const loggingResult = forLogging();
-        expect(loggingResult).toBe('not-found');
+        expect(loggingResult.mParticleProfileStatus).toBe('not-found');
     });
 
     it('should return "not-found-cached" when a cached 404 is served', async () => {
@@ -516,14 +538,19 @@ describe('MParticle.getProfileFetcher', () => {
         );
         const profile = await fetchProfile();
         expect(profile).toBeUndefined();
-        expect(forLogging()).toBe('not-found-cached');
+        expect(forLogging().mParticleProfileStatus).toBe('not-found-cached');
     });
 
-    it('should return undefined when authHeader is missing', async () => {
+    it('should return undefined when authHeader and browserId are missing', async () => {
         const mp = new MParticle(mockConfig);
         await jest.advanceTimersByTimeAsync(0);
 
-        const { fetchProfile } = mp.getProfileFetcher(channelSwitches, mockOkta, undefined);
+        const { fetchProfile } = mp.getProfileFetcher(
+            channelSwitches,
+            mockOkta,
+            undefined,
+            undefined,
+        );
 
         const result = await fetchProfile();
 
@@ -539,6 +566,7 @@ describe('MParticle.getProfileFetcher', () => {
             { ...channelSwitches, enableMParticle: false },
             mockOkta,
             'Bearer token',
+            'BrowserId',
         );
 
         const result = await fetchProfile();
@@ -557,6 +585,27 @@ describe('MParticle.getProfileFetcher', () => {
         } as jest.Mocked<Okta>;
 
         const { fetchProfile } = mp.getProfileFetcher(channelSwitches, mockOkta, 'Bearer token');
+
+        const result = await fetchProfile();
+
+        expect(result).toBeUndefined();
+        expect((global.fetch as jest.Mock).mock.calls.length).toBe(0);
+    });
+    it('should return undefined when browserId and authHeader are provided but identityId cannot be retrieved', async () => {
+        const mp = new MParticle(mockConfig);
+        await jest.advanceTimersByTimeAsync(0);
+
+        // @ts-expect-error -- no need to implement private members
+        mockOkta = {
+            getIdentityIdFromOktaToken: jest.fn().mockResolvedValue(undefined),
+        } as jest.Mocked<Okta>;
+
+        const { fetchProfile } = mp.getProfileFetcher(
+            channelSwitches,
+            mockOkta,
+            'Bearer token',
+            'BrowserId',
+        );
 
         const result = await fetchProfile();
 

--- a/src/server/lib/mParticle.ts
+++ b/src/server/lib/mParticle.ts
@@ -272,18 +272,18 @@ export class MParticle {
                 if ((!authHeader && !browserId) || !channelSwitches.enableMParticle) {
                     return undefined;
                 }
-                if (!authHeader && browserId) {
-                    cachedSource = 'browserId';
-                    customerId = browserId;
-                } else {
-                    if (!authHeader) {
-                        return undefined;
-                    }
+                if (authHeader) {
                     cachedSource = 'identityId';
                     customerId = await okta.getIdentityIdFromOktaToken(authHeader);
                     if (!customerId) {
                         return undefined;
                     }
+                } else if (browserId) {
+                    cachedSource = 'browserId';
+                    customerId = browserId;
+                }
+                if (!customerId) {
+                    return undefined;
                 }
                 const { profile, fromCache } = await this.getUserProfile(customerId);
                 if (profile) {

--- a/src/server/lib/mParticle.ts
+++ b/src/server/lib/mParticle.ts
@@ -49,6 +49,12 @@ export type MParticleProfileStatus =
     | 'not-found'
     | 'not-found-cached'
     | 'not-fetched';
+
+export type MParticleProfileSource = 'identityId' | 'browserId' | 'none';
+export type MParticleProfileLogState = {
+    mParticleProfileStatus: MParticleProfileStatus;
+    mParticleProfileSource: MParticleProfileSource;
+};
 const CACHE_TTL_SECONDS = 3600; // 1 hour
 
 type CacheEntry = {
@@ -242,6 +248,7 @@ export class MParticle {
 
     /**
      * If an Authorization header was supplied then attempt to verify it and extract the identityId. Then fetch the profile from mParticle.
+     * If no Authorization header was supplied, try to lookup the profile with browserId, if presented
      * Returns 2 functions:
      * - fetchProfile, which is memoized and lazy. We do not want to make the request to mparticle unless we need to, and should only do it once.
      * - forLogging, which returns the cached status but will not make a request to mparticle. This is used for request logging.
@@ -250,24 +257,35 @@ export class MParticle {
         channelSwitches: ChannelSwitches,
         okta: Okta,
         authHeader?: string,
+        browserId?: string,
     ): {
         fetchProfile: () => Promise<MParticleProfile | undefined>;
-        forLogging: () => MParticleProfileStatus;
+        forLogging: () => MParticleProfileLogState;
     } {
         let cachedPromise: Promise<MParticleProfile | undefined> | undefined;
         let cachedStatus: MParticleProfileStatus = 'not-fetched';
+        let cachedSource: MParticleProfileSource = 'none';
 
         const fetchProfile = async (): Promise<MParticleProfile | undefined> => {
+            let customerId: string | undefined;
             cachedPromise ??= (async () => {
-                if (!authHeader || !channelSwitches.enableMParticle) {
+                if ((!authHeader && !browserId) || !channelSwitches.enableMParticle) {
                     return undefined;
                 }
-
-                const identityId = await okta.getIdentityIdFromOktaToken(authHeader);
-                if (!identityId) {
-                    return undefined;
+                if (!authHeader && browserId) {
+                    cachedSource = 'browserId';
+                    customerId = browserId;
+                } else {
+                    if (!authHeader) {
+                        return undefined;
+                    }
+                    cachedSource = 'identityId';
+                    customerId = await okta.getIdentityIdFromOktaToken(authHeader);
+                    if (!customerId) {
+                        return undefined;
+                    }
                 }
-                const { profile, fromCache } = await this.getUserProfile(identityId);
+                const { profile, fromCache } = await this.getUserProfile(customerId);
                 if (profile) {
                     cachedStatus = fromCache ? 'found-cached' : 'found';
                 } else {
@@ -278,8 +296,11 @@ export class MParticle {
             return cachedPromise;
         };
 
-        const forLogging = (): MParticleProfileStatus => {
-            return cachedStatus;
+        const forLogging = (): MParticleProfileLogState => {
+            return {
+                mParticleProfileStatus: cachedStatus,
+                mParticleProfileSource: cachedSource,
+            };
         };
 
         return { fetchProfile, forLogging };

--- a/src/server/lib/mParticle.ts
+++ b/src/server/lib/mParticle.ts
@@ -275,9 +275,6 @@ export class MParticle {
                 if (authHeader) {
                     cachedSource = 'identityId';
                     customerId = await okta.getIdentityIdFromOktaToken(authHeader);
-                    if (!customerId) {
-                        return undefined;
-                    }
                 } else if (browserId) {
                     cachedSource = 'browserId';
                     customerId = browserId;

--- a/src/server/middleware/logging.ts
+++ b/src/server/middleware/logging.ts
@@ -13,6 +13,7 @@ type LoggingLocals = {
     hasAuthorization?: boolean;
     gotMParticleProfile?: boolean;
     mParticleProfileStatus?: string;
+    mParticleProfileSource?: string;
     auxiaBannerSuppressionStatus?: string;
 };
 
@@ -44,6 +45,7 @@ export const logging = (
             hasAuthorization: res.locals.hasAuthorization,
             gotMParticleProfile: res.locals.gotMParticleProfile,
             mParticleProfileStatus: res.locals.mParticleProfileStatus,
+            mParticleProfileSource: res.locals.mParticleProfileSource,
             auxiaBannerSuppressionStatus: res.locals.auxiaBannerSuppressionStatus,
         });
     });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1214348418702844)
## What does this change?
Changes in this PR add ability to search profile from mParticle by browserId. Previously profile could be searched only for logged in users if request contained authHeader and identityId could be retrieved. With this change it will be possible to also search profile in mParticle for logged out users, who have consent by browserId. Also mParticleProfileSource was added to res.locals in order to be used in kibana dashboard
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed on CODE environment, checked kibana logs -> mParticleProfileSource field is visible in the board
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="1447" height="630" alt="Screenshot 2026-05-06 at 17 00 20" src="https://github.com/user-attachments/assets/4d28398c-372d-4e1e-bc57-7aeef0bac2fc" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
