### PR TITLE
weekly price variant for choice cards

### DIFF
--- a/src/server/api/bannerRouter.ts
+++ b/src/server/api/bannerRouter.ts
@@ -143,6 +143,8 @@ export const buildBannerRouter = (
 
             const forceExpanded = variant.name.includes('_NO_DEFAULT_CHOICE_CARD_');
 
+            const isWeeklyPriceVariant = variant.name.includes('WEEKLY_PRICE');
+
             const choiceCardsSettings =
                 design?.visual?.kind === 'ChoiceCards' && isVatCompliantCountry
                     ? getChoiceCardsSettings(
@@ -154,6 +156,7 @@ export const buildBannerRouter = (
                           variant.choiceCardsSettings ?? undefined,
                           forceNoDefault,
                           forceExpanded,
+                          isWeeklyPriceVariant,
                       )
                     : undefined;
 

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -166,6 +166,8 @@ export const buildEpicRouter = (
 
         const forceExpanded = variant.name.includes('_NO_DEFAULT_CHOICE_CARD_');
 
+        const isWeeklyPriceVariant = variant.name.includes('WEEKLY_PRICE');
+
         const choiceCardsSettings =
             variant.showChoiceCards && isVatCompliantCountry
                 ? getChoiceCardsSettings(
@@ -177,6 +179,7 @@ export const buildEpicRouter = (
                       variant.choiceCardsSettings ?? undefined,
                       forceNoDefault,
                       forceExpanded,
+                      isWeeklyPriceVariant,
                   )
                 : undefined;
 

--- a/src/server/lib/choiceCards/choiceCards.test.ts
+++ b/src/server/lib/choiceCards/choiceCards.test.ts
@@ -347,7 +347,7 @@ describe('getChoiceCardsSettings', () => {
         );
 
         expect(result).toBeDefined();
-        expect(result?.choiceCards[1].label).toEqual('Support $3.45/weekly');
+        expect(result?.choiceCards[1].label).toEqual('Support $3.45/week');
     });
 
     it('returns weekly price for annual rate plan when weekly variant is enabled', () => {
@@ -378,7 +378,7 @@ describe('getChoiceCardsSettings', () => {
         );
 
         expect(result).toBeDefined();
-        expect(result?.choiceCards[1].label).toEqual('Support $2.88/weekly');
+        expect(result?.choiceCards[1].label).toEqual('Support $2.88/week');
     });
 
     it('returns weekly price with monthly discount (PROMO_B) applied when weekly variant is enabled', () => {
@@ -397,7 +397,7 @@ describe('getChoiceCardsSettings', () => {
         );
 
         expect(result).toBeDefined();
-        expect(result?.choiceCards[1].label).toEqual('Support <s>$3.45</s> $2.07/weekly');
+        expect(result?.choiceCards[1].label).toEqual('Support <s>$3.45</s> $2.07/week');
         expect(result?.choiceCards[1].pill?.copy).toBe('40% off');
     });
 
@@ -429,7 +429,7 @@ describe('getChoiceCardsSettings', () => {
         );
 
         expect(result).toBeDefined();
-        expect(result?.choiceCards[1].label).toEqual('Support <s>$2.88</s> $1.87/weekly');
+        expect(result?.choiceCards[1].label).toEqual('Support <s>$2.88</s> $1.87/week');
     });
 
     it('does not apply discount for promo with future start date', () => {

--- a/src/server/lib/choiceCards/choiceCards.test.ts
+++ b/src/server/lib/choiceCards/choiceCards.test.ts
@@ -331,6 +331,107 @@ describe('getChoiceCardsSettings', () => {
         });
     });
 
+    it('returns weekly price for monthly rate plan when weekly variant is enabled', () => {
+        const variantChoiceCardSettings = defaultEpicChoiceCardsSettings('UnitedStates');
+
+        const result = getChoiceCardsSettings(
+            'UnitedStates',
+            'Epic',
+            mockProductCatalog,
+            mockPromotionsCache,
+            [],
+            variantChoiceCardSettings,
+            undefined,
+            undefined,
+            true,
+        );
+
+        expect(result).toBeDefined();
+        expect(result?.choiceCards[1].label).toEqual('Support $3.45/weekly');
+    });
+
+    it('returns weekly price for annual rate plan when weekly variant is enabled', () => {
+        const variantChoiceCardSettings: ChoiceCardsSettings = {
+            choiceCards: [
+                defaultEpicChoiceCardsSettings('UnitedStates').choiceCards[0],
+                {
+                    ...defaultEpicChoiceCardsSettings('UnitedStates').choiceCards[1],
+                    product: {
+                        ratePlan: 'Annual',
+                        supportTier: 'SupporterPlus',
+                    },
+                },
+                defaultEpicChoiceCardsSettings('UnitedStates').choiceCards[2],
+            ],
+        };
+
+        const result = getChoiceCardsSettings(
+            'UnitedStates',
+            'Epic',
+            mockProductCatalog,
+            mockPromotionsCache,
+            [],
+            variantChoiceCardSettings,
+            undefined,
+            undefined,
+            true,
+        );
+
+        expect(result).toBeDefined();
+        expect(result?.choiceCards[1].label).toEqual('Support $2.88/weekly');
+    });
+
+    it('returns weekly price with monthly discount (PROMO_B) applied when weekly variant is enabled', () => {
+        const variantChoiceCardSettings = defaultEpicChoiceCardsSettings('UnitedStates');
+
+        const result = getChoiceCardsSettings(
+            'UnitedStates',
+            'Epic',
+            mockProductCatalog,
+            mockPromotionsCache,
+            ['PROMO_B'],
+            variantChoiceCardSettings,
+            undefined,
+            undefined,
+            true,
+        );
+
+        expect(result).toBeDefined();
+        expect(result?.choiceCards[1].label).toEqual('Support <s>$3.45</s> $2.07/weekly');
+        expect(result?.choiceCards[1].pill?.copy).toBe('40% off');
+    });
+
+    it('returns weekly price and discount for annual rate plan when weekly variant is enabled', () => {
+        const variantChoiceCardSettings: ChoiceCardsSettings = {
+            choiceCards: [
+                defaultEpicChoiceCardsSettings('UnitedStates').choiceCards[0],
+                {
+                    ...defaultEpicChoiceCardsSettings('UnitedStates').choiceCards[1],
+                    product: {
+                        ratePlan: 'Annual',
+                        supportTier: 'SupporterPlus',
+                    },
+                },
+                defaultEpicChoiceCardsSettings('UnitedStates').choiceCards[2],
+            ],
+        };
+
+        const result = getChoiceCardsSettings(
+            'UnitedStates',
+            'Epic',
+            mockProductCatalog,
+            mockPromotionsCache,
+            ['PROMO_A'],
+            variantChoiceCardSettings,
+            undefined,
+            undefined,
+            true,
+        );
+
+        expect(result).toBeDefined();
+        expect(result?.choiceCards[1].label).toEqual('Support <s>$2.88</s> $1.87/weekly');
+    });
+
     it('does not apply discount for promo with future start date', () => {
         const variantChoiceCardSettings = defaultEpicChoiceCardsSettings('UnitedStates');
         const promoCodes: string[] = ['PROMO_FUTURE'];

--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -182,12 +182,24 @@ export const getChoiceCardsSettings = (
         return {
             choiceCards: choiceCardsSettings.choiceCards.map((card) =>
                 maybeForceCardSettings(
-                    enrichChoiceCard(card, isoCurrency, productCatalog, getPromotion(card), isWeeklyVariant),
+                    enrichChoiceCard(
+                        card,
+                        isoCurrency,
+                        productCatalog,
+                        getPromotion(card),
+                        isWeeklyVariant,
+                    ),
                 ),
             ),
             mobileChoiceCards: choiceCardsSettings.mobileChoiceCards?.map((card) =>
                 maybeForceCardSettings(
-                    enrichChoiceCard(card, isoCurrency, productCatalog, getPromotion(card), isWeeklyVariant),
+                    enrichChoiceCard(
+                        card,
+                        isoCurrency,
+                        productCatalog,
+                        getPromotion(card),
+                        isWeeklyVariant,
+                    ),
                 ),
             ),
         };

--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -25,12 +25,29 @@ const ratePlanCopy = (ratePlan: RatePlan): string => {
     }
 };
 
+const getDayPriceForRatePlan = (price: number, ratePlan: string): number => {
+    if (ratePlan === 'Annual') {
+        return price / 365;
+    }
+    if (ratePlan === 'Quarterly') {
+        return (price * 4) / 365;
+    }
+    if (ratePlan === 'Monthly') {
+        return (price * 12) / 365;
+    }
+    return price / 7;
+};
+
+const formatPrice = (price: number): string =>
+    price % 1 === 0 ? price.toString() : price.toFixed(2);
+
 // Add pricing, currency etc
 const enrichChoiceCard = (
     choiceCard: ChoiceCard,
     isoCurrency: IsoCurrency,
     productCatalog: ProductCatalog,
     promotion?: Promotion,
+    isWeeklyVariant?: boolean,
 ): ChoiceCard => {
     const currencySymbol = isoCurrencyToCurrencySymbol[isoCurrency];
 
@@ -38,15 +55,18 @@ const enrichChoiceCard = (
         ratePlan: RatePlan,
         tier: 'Contribution' | 'SupporterPlus' | 'DigitalSubscription',
     ) => {
-        const price = productCatalog[tier].ratePlans[ratePlan].pricing[isoCurrency];
+        const basePrice = productCatalog[tier].ratePlans[ratePlan].pricing[isoCurrency];
+        const price = isWeeklyVariant ? getDayPriceForRatePlan(basePrice, ratePlan) * 7 : basePrice;
+        const ratePlanCopyText = isWeeklyVariant ? 'weekly' : ratePlanCopy(ratePlan);
+        const formattedPrice = formatPrice(price);
+
         if (promotion) {
             const discount = price * (promotion.discountPercent / 100);
             const discountedPrice = price - discount;
-            const formattedPrice =
-                discountedPrice % 1 === 0 ? discountedPrice.toString() : discountedPrice.toFixed(2);
-            return `Support <s>${currencySymbol}${price}</s> ${currencySymbol}${formattedPrice}/${ratePlanCopy(ratePlan)}`;
+            const formattedDiscountedPrice = formatPrice(discountedPrice);
+            return `Support <s>${currencySymbol}${formattedPrice}</s> ${currencySymbol}${formattedDiscountedPrice}/${ratePlanCopyText}`;
         } else {
-            return `Support ${currencySymbol}${price}/${ratePlanCopy(ratePlan)}`;
+            return `Support ${currencySymbol}${formattedPrice}/${ratePlanCopyText}`;
         }
     };
     const buildLabelForOneOffContribution = (label: string) =>
@@ -113,6 +133,7 @@ export const getChoiceCardsSettings = (
     variantChoiceCardSettings?: ChoiceCardsSettings, // defined only if the test variant overrides the default settings
     forceNoDefault?: boolean,
     forceExpanded?: boolean,
+    isWeeklyVariant?: boolean,
 ): ChoiceCardsSettings | undefined => {
     let choiceCardsSettings: ChoiceCardsSettings | undefined;
     const isoCurrency = countryGroups[countryGroupId].currency;
@@ -161,12 +182,12 @@ export const getChoiceCardsSettings = (
         return {
             choiceCards: choiceCardsSettings.choiceCards.map((card) =>
                 maybeForceCardSettings(
-                    enrichChoiceCard(card, isoCurrency, productCatalog, getPromotion(card)),
+                    enrichChoiceCard(card, isoCurrency, productCatalog, getPromotion(card), isWeeklyVariant),
                 ),
             ),
             mobileChoiceCards: choiceCardsSettings.mobileChoiceCards?.map((card) =>
                 maybeForceCardSettings(
-                    enrichChoiceCard(card, isoCurrency, productCatalog, getPromotion(card)),
+                    enrichChoiceCard(card, isoCurrency, productCatalog, getPromotion(card), isWeeklyVariant),
                 ),
             ),
         };

--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -57,7 +57,7 @@ const enrichChoiceCard = (
     ) => {
         const basePrice = productCatalog[tier].ratePlans[ratePlan].pricing[isoCurrency];
         const price = isWeeklyVariant ? getDayPriceForRatePlan(basePrice, ratePlan) * 7 : basePrice;
-        const ratePlanCopyText = isWeeklyVariant ? 'weekly' : ratePlanCopy(ratePlan);
+        const ratePlanCopyText = isWeeklyVariant ? 'week' : ratePlanCopy(ratePlan);
         const formattedPrice = formatPrice(price);
 
         if (promotion) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
[Ticket link](https://app.asana.com/1/1210045093164357/project/1213309681835463/task/1214778057788644)
## What does this change?
This change updates copy in choice cards for "weekly" in specific test variants that contain "WEEKLY_PRICE" in their name.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Deployed to CODE
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="688" height="684" alt="Screenshot 2026-05-15 at 11 51 12" src="https://github.com/user-attachments/assets/7084cac9-096e-4a7b-b577-8314c915c1d2" />
<img width="1464" height="397" alt="Screenshot 2026-05-15 at 11 50 04" src="https://github.com/user-attachments/assets/dfc4e8b3-4631-4d38-9d67-1fec9bc2d50c" />



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
