### PR TITLE
Increase auxia banner handling to 10%

### DIFF
--- a/src/server/lib/auxia.test.ts
+++ b/src/server/lib/auxia.test.ts
@@ -13,10 +13,10 @@ const mockChannelSwitches = {
     enableAuxiaForBanners: true,
 } as ChannelSwitches;
 
-// mvtId within the 1% rollout (0–9,999)
+// mvtId within the 10% rollout (0–99,999)
 const inRolloutMvtId = 0;
-// mvtId outside the 1% rollout (10,000+)
-const outOfRolloutMvtId = 10_000;
+// mvtId outside the 10% rollout (100,000+)
+const outOfRolloutMvtId = 100_000;
 
 const mockAttributes: GetTreatmentsAttributes = {
     isSupporter: false,
@@ -464,7 +464,7 @@ describe('Auxia.getBannerSuppressedChecker – mvtId rollout', () => {
         jest.clearAllMocks();
     });
 
-    it('should return false, not call fetch, and leave forLogging as "not-consulted" when mvtId is outside the 1% rollout', async () => {
+    it('should return false, not call fetch, and leave forLogging as "not-consulted" when mvtId is outside the 10% rollout', async () => {
         const auxia = new Auxia(mockConfig);
         const { checkAuxiaSuppression, forLogging } = auxia.getBannerSuppressedChecker(
             mockChannelSwitches,
@@ -478,7 +478,7 @@ describe('Auxia.getBannerSuppressedChecker – mvtId rollout', () => {
         expect(forLogging()).toBe('not-consulted');
     });
 
-    it('should call fetch and apply suppression logic when mvtId is within the 1% rollout', async () => {
+    it('should call fetch and apply suppression logic when mvtId is within the 10% rollout', async () => {
         (global.fetch as jest.Mock).mockResolvedValueOnce(
             successResponse([makeUserTreatment(JSON.stringify({ show_banner: 'false' }))]),
         );

--- a/src/server/lib/auxia.ts
+++ b/src/server/lib/auxia.ts
@@ -52,7 +52,7 @@ export type AuxiaInteractionType = 'VIEWED' | 'CLICKED' | 'SNOOZED' | 'DISMISSED
 export type AuxiaBannerStatus = 'suppressed' | 'not-suppressed' | 'not-consulted';
 
 // Use the mvtId (which has range 0 - 1,000,000) to rollout gradually
-const AUXIA_ROLLOUT_SHARE = 0.1 * 1_000_000;
+const AUXIA_ROLLOUT_SHARE = 0.1 * 1_000_000; // 10%
 const inAuxiaAudience = (mvtId: number): boolean => mvtId < AUXIA_ROLLOUT_SHARE;
 
 export class Auxia {

--- a/src/server/lib/auxia.ts
+++ b/src/server/lib/auxia.ts
@@ -52,7 +52,7 @@ export type AuxiaInteractionType = 'VIEWED' | 'CLICKED' | 'SNOOZED' | 'DISMISSED
 export type AuxiaBannerStatus = 'suppressed' | 'not-suppressed' | 'not-consulted';
 
 // Use the mvtId (which has range 0 - 1,000,000) to rollout gradually
-const AUXIA_ROLLOUT_SHARE = 0.01 * 1_000_000;
+const AUXIA_ROLLOUT_SHARE = 0.1 * 1_000_000;
 const inAuxiaAudience = (mvtId: number): boolean => mvtId < AUXIA_ROLLOUT_SHARE;
 
 export class Auxia {


### PR DESCRIPTION
A [previous PR](https://github.com/guardian/support-dotcom-components/pull/1579) introduced the use of the Auxia API for banner display decision making. This currently applies to 1% of the audience.

We are now increasing this to 10%