### PR TITLE
Enable promos in choice cards for DigitalSubscription product

### DIFF
--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -154,10 +154,14 @@ export const getChoiceCardsSettings = (
     }
 
     const getPromotion = (choiceCard: ChoiceCard): Promotion | undefined => {
-        // We only support promos for SupporterPlus for now
-        if (promotions.length > 0 && choiceCard.product.supportTier === 'SupporterPlus') {
+        if (
+            promotions.length > 0 &&
+            (choiceCard.product.supportTier === 'SupporterPlus' ||
+                choiceCard.product.supportTier === 'DigitalSubscription')
+        ) {
             const { ratePlan } = choiceCard.product;
-            const choiceCardProduct = productCatalog['SupporterPlus'].ratePlans[ratePlan];
+            const choiceCardProduct =
+                productCatalog[choiceCard.product.supportTier].ratePlans[ratePlan];
             // Find a promo with a matching productRatePlanId
             return promotions.find((promo) =>
                 promo.productRatePlanIds.includes(choiceCardProduct.id),


### PR DESCRIPTION
Currently only SupporterPlus promos are used in the choice cards (in the epic/banner).
We now want to show promos for DigitalSubscription (aka Digital Plus).

Tested in CODE by setting a Digital Plus promo on epic choice cards and checking that the correct copy comes through -
<img width="571" height="101" alt="Screenshot 2026-06-04 at 09 43 16" src="https://github.com/user-attachments/assets/acb9afb0-8861-4825-9624-5e9383c438ba" />
<img width="420" height="204" alt="Screenshot 2026-06-04 at 09 43 55" src="https://github.com/user-attachments/assets/afc1d741-2295-4f9b-ad27-0d026bdeaff9" />

Clicking through to the landing page, we can see the promo again -
<img width="299" height="237" alt="Screenshot 2026-06-04 at 09 45 27" src="https://github.com/user-attachments/assets/c4af307d-454d-4306-8fd3-2e9d4cb7de94" />
