### PR TITLE
Add promoCodes to banner response

### DIFF
--- a/src/server/api/bannerRouter.ts
+++ b/src/server/api/bannerRouter.ts
@@ -173,6 +173,7 @@ export const buildBannerRouter = (
                 design,
                 abandonedBasket: targeting.abandonedBasket,
                 isCollapsible: variant.isCollapsible ?? undefined,
+                promoCodes: variant.promoCodes ?? [],
             };
 
             return {


### PR DESCRIPTION
Currently we are not returning the `promoCodes` field in the response to the client.
The `promoCodes` field _is_ used for the choice cards copy, but it's not actually being returned. This means that a user sees the promo copy in the choice cards, but the `promoCode=` parameter is not added to the CTA URL. This is a bug.

This PR is a quick fix. We still need to address the fact that it's so easy to miss a field like this, and the lack of tests.