### PR TITLE
Update auxia alarm config

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -263,10 +263,10 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
         "AlarmDescription": "Error fetching or parsing treatments from Auxia",
         "AlarmName": "support-dotcom-components: Auxia error - TEST",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 2,
         "MetricName": "auxia-error",
         "Namespace": "support-dotcom-components-TEST",
-        "Period": 3600,
+        "Period": 300,
         "Statistic": "Sum",
         "Tags": [
           {
@@ -286,7 +286,7 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
             "Value": "TEST",
           },
         ],
-        "Threshold": 3,
+        "Threshold": 5,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -197,11 +197,11 @@ export class DotcomComponents extends GuStack {
 			metric: new Metric({
 				metricName: 'auxia-error',
 				namespace,
-				period: Duration.minutes(60),
+				period: Duration.minutes(5),
 				statistic: 'sum',
 			}),
-			threshold: 3,
-			evaluationPeriods: 1,
+			threshold: 5,
+			evaluationPeriods: 2,
 			comparisonOperator:
 				ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 			treatMissingData: TreatMissingData.NOT_BREACHING,


### PR DESCRIPTION
We occasionally get a small number of 500 responses from Auxia. In general we'd only want to know if there's a sustained number of errors.

This PR updates the alarm to fire if there are at least 5 errors in a 5-minute period, sustained across 2 consecutive 5-minute periods