### PR TITLE
Preserve WazuhSecurityGroup during @guardian/cdk upgrade

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1563,6 +1563,40 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
+    "WazuhSecurityGroup": {
+      "Properties": {
+        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-dotcom-components",
+          },
+          {
+            "Key": "Stack",
+            "Value": "support",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
     "supportTESTdotcomcomponentsE4D10170": {
       "DependsOn": [
         "InstanceRoleDotcomcomponents2E8FDE7D",

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -27,6 +27,7 @@ import {
 	InstanceClass,
 	InstanceSize,
 	InstanceType,
+	SecurityGroup,
 	UserData,
 } from 'aws-cdk-lib/aws-ec2';
 import type { Policy } from 'aws-cdk-lib/aws-iam';
@@ -362,5 +363,25 @@ sudo amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-
 				targetRequestsPerMinute: 20000,
 			},
 		);
+
+		const { vpc } = ec2App;
+
+		// Temporary security group to preserve WazuhSecurityGroup during @guardian/cdk upgrade.
+		// Prevents CloudFormation from trying to delete it while dependent objects exist.
+		// Remove in a follow-up PR after cleaning up dependencies in AWS.
+		// See: https://github.com/guardian/support-admin-console/pull/975
+		const wazuhSecurityGroup = new SecurityGroup(
+			this,
+			'WazuhSecurityGroup',
+			{
+				vpc,
+				description:
+					'Allow outbound traffic from wazuh agent to manager',
+			},
+		);
+		this.overrideLogicalId(wazuhSecurityGroup, {
+			logicalId: 'WazuhSecurityGroup',
+			reason: 'Preserve WazuhSecurityGroup during GuCDK upgrade to avoid DELETE_FAILED',
+		});
 	}
 }


### PR DESCRIPTION
Add temporary `WazuhSecurityGroup` to prevent CloudFormation `DELETE_FAILED` during the upgrade (removed from `@guardian/cdk` 61.5.0+). 

See [support-admin-console#975](https://github.com/guardian/support-admin-console/pull/975) for context.