### PR TITLE
Remove temporary WazuhSecurityGroup

### DIFF
--- a/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/dotcom-components.test.ts.snap
@@ -1563,40 +1563,6 @@ exports[`The DotcomComponents stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
-    "WazuhSecurityGroup": {
-      "Properties": {
-        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/support-dotcom-components",
-          },
-          {
-            "Key": "Stack",
-            "Value": "support",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
     "supportTESTdotcomcomponentsE4D10170": {
       "DependsOn": [
         "InstanceRoleDotcomcomponents2E8FDE7D",

--- a/cdk/lib/dotcom-components.ts
+++ b/cdk/lib/dotcom-components.ts
@@ -27,7 +27,6 @@ import {
 	InstanceClass,
 	InstanceSize,
 	InstanceType,
-	SecurityGroup,
 	UserData,
 } from 'aws-cdk-lib/aws-ec2';
 import type { Policy } from 'aws-cdk-lib/aws-iam';
@@ -363,25 +362,5 @@ sudo amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-
 				targetRequestsPerMinute: 20000,
 			},
 		);
-
-		const { vpc } = ec2App;
-
-		// Temporary security group to preserve WazuhSecurityGroup during @guardian/cdk upgrade.
-		// Prevents CloudFormation from trying to delete it while dependent objects exist.
-		// Remove in a follow-up PR after cleaning up dependencies in AWS.
-		// See: https://github.com/guardian/support-admin-console/pull/975
-		const wazuhSecurityGroup = new SecurityGroup(
-			this,
-			'WazuhSecurityGroup',
-			{
-				vpc,
-				description:
-					'Allow outbound traffic from wazuh agent to manager',
-			},
-		);
-		this.overrideLogicalId(wazuhSecurityGroup, {
-			logicalId: 'WazuhSecurityGroup',
-			reason: 'Preserve WazuhSecurityGroup during GuCDK upgrade to avoid DELETE_FAILED',
-		});
 	}
 }


### PR DESCRIPTION
Follow-up to the `@guardian/cdk` upgrade PRs

https://github.com/guardian/support-dotcom-components/pull/1717

https://github.com/guardian/support-dotcom-components/pull/1719

Removes the temporary `WazuhSecurityGroup` that was added to prevent CloudFormation `DELETE_FAILED` during the `@guardian/cdk` 61.5.0+ migration. Now that the stack has been successfully deployed and the security group dependencies have been resolved, this temporary construct can be safely removed.