### PR TITLE
Skip 2-step banner tests for US mobile article readers

### DIFF
--- a/src/server/tests/banners/bannerSelection.test.ts
+++ b/src/server/tests/banners/bannerSelection.test.ts
@@ -1211,4 +1211,259 @@ describe('selectBannerTest', () => {
             });
         });
     });
+
+    describe('2-step banner hardcoded exclusion', () => {
+        const now = new Date('2020-03-31T12:30:00');
+        const bannerDeployTimes = getBannerDeployTimesReloader(secondDate);
+
+        const twoStepTest: BannerTest = {
+            channel: 'Banner1',
+            name: '2-step-test',
+            priority: 1,
+            status: 'Live',
+            bannerChannel: 'contributions',
+            isHardcoded: false,
+            userCohort: 'Everyone',
+            variants: [
+                {
+                    name: 'variant',
+                    template: {
+                        designName: 'TEST_DESIGN',
+                    },
+                    bannerContent: {
+                        messageText: 'body',
+                        highlightedText: 'highlighted text',
+                        cta: {
+                            text: 'cta',
+                            baseUrl: 'https://support.theguardian.com',
+                        },
+                    },
+                    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+                    isCollapsible: true,
+                },
+            ],
+            articlesViewedSettings: {
+                minViews: 5,
+                periodInWeeks: 52,
+            },
+            locations: [],
+            regionTargeting: {
+                targetedCountryGroups: [],
+                targetedCountryCodes: [],
+            },
+            contextTargeting: {
+                tagIds: [],
+                sectionIds: [],
+                excludedTagIds: [],
+                excludedSectionIds: [],
+            },
+        };
+
+        const baseTargeting: BannerTargeting = {
+            shouldHideReaderRevenue: false,
+            isPaidContent: false,
+            showSupportMessaging: true,
+            mvtId: 3,
+            countryCode: 'US',
+            engagementBannerLastClosedAt: firstDate,
+            hasOptedOutOfArticleCount: false,
+            isSignedIn: false,
+            hasConsented: true,
+            weeklyArticleHistory: [{ week: 18330, count: 6 }],
+        };
+
+        it('skips 2-step test for US mobile on articles', async () => {
+            const result = await selectBannerTest({
+                targeting: { ...baseTargeting, countryCode: 'US', contentType: 'Article' },
+                userDeviceType: 'iOS',
+                tests: [twoStepTest],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledDeploys,
+                banditData,
+                getMParticleProfile,
+                now,
+                forcedTestVariant: undefined,
+                checkAuxiaSuppression,
+            });
+            expect(result).toBeNull();
+        });
+
+        it('skips 2-step test for US Android on articles', async () => {
+            const result = await selectBannerTest({
+                targeting: { ...baseTargeting, countryCode: 'US', contentType: 'Article' },
+                userDeviceType: 'Android',
+                tests: [twoStepTest],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledDeploys,
+                banditData,
+                getMParticleProfile,
+                now,
+                forcedTestVariant: undefined,
+                checkAuxiaSuppression,
+            });
+            expect(result).toBeNull();
+        });
+
+        it('does not skip 2-step test for US desktop on articles', async () => {
+            const result = await selectBannerTest({
+                targeting: { ...baseTargeting, countryCode: 'US', contentType: 'Article' },
+                userDeviceType: 'Desktop',
+                tests: [twoStepTest],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledDeploys,
+                banditData,
+                getMParticleProfile,
+                now,
+                forcedTestVariant: undefined,
+                checkAuxiaSuppression,
+            });
+            expect(result?.test.name).toBe('2-step-test');
+        });
+
+        it('does not skip 2-step test for UK mobile on articles', async () => {
+            const result = await selectBannerTest({
+                targeting: { ...baseTargeting, countryCode: 'GB', contentType: 'Article' },
+                userDeviceType: 'iOS',
+                tests: [twoStepTest],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledDeploys,
+                banditData,
+                getMParticleProfile,
+                now,
+                forcedTestVariant: undefined,
+                checkAuxiaSuppression,
+            });
+            expect(result?.test.name).toBe('2-step-test');
+        });
+
+        it('does not skip 2-step test for US mobile on fronts', async () => {
+            const result = await selectBannerTest({
+                targeting: { ...baseTargeting, countryCode: 'US', contentType: 'Network Front' },
+                userDeviceType: 'iOS',
+                tests: [twoStepTest],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledDeploys,
+                banditData,
+                getMParticleProfile,
+                now,
+                forcedTestVariant: undefined,
+                checkAuxiaSuppression,
+            });
+            expect(result?.test.name).toBe('2-step-test');
+        });
+
+        it('does not skip non-2-step tests for US mobile on articles', async () => {
+            const nonTwoStepTest: BannerTest = {
+                ...twoStepTest,
+                name: 'regular-test',
+                variants: [
+                    {
+                        name: 'CONTROL',
+                        template: { designName: 'TEST_DESIGN' },
+                        bannerContent: {
+                            messageText: 'body',
+                            highlightedText: 'highlighted text',
+                            cta: {
+                                text: 'cta',
+                                baseUrl: 'https://support.theguardian.com',
+                            },
+                        },
+                        componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+                    },
+                ],
+            };
+            const result = await selectBannerTest({
+                targeting: { ...baseTargeting, countryCode: 'US', contentType: 'Article' },
+                userDeviceType: 'iOS',
+                tests: [nonTwoStepTest],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledDeploys,
+                banditData,
+                getMParticleProfile,
+                now,
+                forcedTestVariant: undefined,
+                checkAuxiaSuppression,
+            });
+            expect(result?.test.name).toBe('regular-test');
+        });
+
+        it('skips test when any variant has isCollapsible = true', async () => {
+            const testWithCollapsibleVariant: BannerTest = {
+                ...twoStepTest,
+                variants: [
+                    {
+                        name: 'CONTROL',
+                        template: { designName: 'TEST_DESIGN' },
+                        bannerContent: {
+                            messageText: 'body',
+                            highlightedText: 'highlighted text',
+                            cta: {
+                                text: 'cta',
+                                baseUrl: 'https://support.theguardian.com',
+                            },
+                        },
+                        componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+                        isCollapsible: true,
+                    },
+                ],
+            };
+            const result = await selectBannerTest({
+                targeting: { ...baseTargeting, countryCode: 'US', contentType: 'Article' },
+                userDeviceType: 'iOS',
+                tests: [testWithCollapsibleVariant],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledDeploys,
+                banditData,
+                getMParticleProfile,
+                now,
+                forcedTestVariant: undefined,
+                checkAuxiaSuppression,
+            });
+            expect(result).toBeNull();
+        });
+
+        it('falls back to next test when 2-step test is skipped', async () => {
+            const fallbackTest: BannerTest = {
+                ...twoStepTest,
+                name: 'fallback-test',
+                priority: 2,
+                variants: [
+                    {
+                        name: 'CONTROL',
+                        template: { designName: 'TEST_DESIGN' },
+                        bannerContent: {
+                            messageText: 'body',
+                            highlightedText: 'highlighted text',
+                            cta: {
+                                text: 'cta',
+                                baseUrl: 'https://support.theguardian.com',
+                            },
+                        },
+                        componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+                    },
+                ],
+            };
+            const result = await selectBannerTest({
+                targeting: { ...baseTargeting, countryCode: 'US', contentType: 'Article' },
+                userDeviceType: 'iOS',
+                tests: [twoStepTest, fallbackTest],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledDeploys,
+                banditData,
+                getMParticleProfile,
+                now,
+                forcedTestVariant: undefined,
+                checkAuxiaSuppression,
+            });
+            expect(result?.test.name).toBe('fallback-test');
+        });
+    });
 });

--- a/src/server/tests/banners/bannerSelection.ts
+++ b/src/server/tests/banners/bannerSelection.ts
@@ -283,8 +283,8 @@ export const selectBannerTest = async ({
             : undefined;
 
         if (
-            !shouldSkipTwoStepBannerTest(test, targeting, userDeviceType) &&
             test.status === 'Live' &&
+            !shouldSkipTwoStepBannerTest(test, targeting, userDeviceType) &&
             (!test.canRun || test.canRun(targeting)) &&
             (enableHardcodedBannerTests || !test.isHardcoded) &&
             !targeting.shouldHideReaderRevenue &&

--- a/src/server/tests/banners/bannerSelection.ts
+++ b/src/server/tests/banners/bannerSelection.ts
@@ -278,15 +278,12 @@ export const selectBannerTest = async ({
     let selection: BannerTestSelection | null = null;
 
     for (const test of tests) {
-        if (shouldSkipTwoStepBannerTest(test, targeting, userDeviceType)) {
-            continue;
-        }
-
         const deploySchedule = enableScheduledDeploys
             ? (targetingTest?.deploySchedule ?? defaultDeploySchedule)
             : undefined;
 
         if (
+            !shouldSkipTwoStepBannerTest(test, targeting, userDeviceType) &&
             test.status === 'Live' &&
             (!test.canRun || test.canRun(targeting)) &&
             (enableHardcodedBannerTests || !test.isHardcoded) &&

--- a/src/server/tests/banners/bannerSelection.ts
+++ b/src/server/tests/banners/bannerSelection.ts
@@ -202,6 +202,36 @@ const matchesFrontsOnlyRequirement = (test: BannerTest, targeting: BannerTargeti
     return true;
 };
 
+/**
+ * Hardcoded exclusion: if a banner test contains a variant with the 2-step
+ * banner (isCollapsible = true), users in the US on mobile devices viewing
+ * articles should never be put in that test.
+ *
+ * This is required due to advertising restrictions in the US that prevent the
+ * 2-step banner from being shown on mobile. CRM can do this manually per test
+ * in the banner tool, but this makes it automatic.
+ */
+const isMobileDevice = (deviceType: UserDeviceType): boolean =>
+    deviceType === 'iOS' || deviceType === 'Android';
+
+const shouldSkipTwoStepBannerTest = (
+    test: BannerTest,
+    targeting: BannerTargeting,
+    userDeviceType: UserDeviceType,
+): boolean => {
+    const hasTwoStepVariant = test.variants.some((variant) => variant.isCollapsible);
+
+    if (!hasTwoStepVariant) {
+        return false;
+    }
+
+    return (
+        targeting.countryCode === 'US' &&
+        isMobileDevice(userDeviceType) &&
+        targeting.contentType === 'Article'
+    );
+};
+
 interface SelectBannerTestData {
     targeting: BannerTargeting;
     userDeviceType: UserDeviceType;
@@ -248,6 +278,10 @@ export const selectBannerTest = async ({
     let selection: BannerTestSelection | null = null;
 
     for (const test of tests) {
+        if (shouldSkipTwoStepBannerTest(test, targeting, userDeviceType)) {
+            continue;
+        }
+
         const deploySchedule = enableScheduledDeploys
             ? (targetingTest?.deploySchedule ?? defaultDeploySchedule)
             : undefined;


### PR DESCRIPTION
- Hardcoded exclusion in `selectBannerTest`: if a banner test has any variant with `isCollapsible: true`, it is now automatically skipped for users in the US on mobile devices (iOS/Android) viewing articles.
- This is required due to US advertising restrictions that prevent the 2-step banner from being shown on mobile. CRM can still do this manually per test in the banner tool, but this makes it automatic as a safety net.
- Skipped tests fall through to the next available test, so US mobile readers can still see non-2-step banners.