### PR TITLE
Only show 2-step banner for GB mobile article readers

### DIFF
--- a/src/server/tests/banners/bannerSelection.test.ts
+++ b/src/server/tests/banners/bannerSelection.test.ts
@@ -1306,7 +1306,41 @@ describe('selectBannerTest', () => {
             expect(result).toBeNull();
         });
 
-        it('does not skip 2-step test for US desktop on articles', async () => {
+        it('skips 2-step test for AU mobile on articles', async () => {
+            const result = await selectBannerTest({
+                targeting: { ...baseTargeting, countryCode: 'AU', contentType: 'Article' },
+                userDeviceType: 'iOS',
+                tests: [twoStepTest],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledDeploys,
+                banditData,
+                getMParticleProfile,
+                now,
+                forcedTestVariant: undefined,
+                checkAuxiaSuppression,
+            });
+            expect(result).toBeNull();
+        });
+
+        it('skips 2-step test for ROW mobile on articles', async () => {
+            const result = await selectBannerTest({
+                targeting: { ...baseTargeting, countryCode: 'BR', contentType: 'Article' },
+                userDeviceType: 'iOS',
+                tests: [twoStepTest],
+                bannerDeployTimes,
+                enableHardcodedBannerTests,
+                enableScheduledDeploys,
+                banditData,
+                getMParticleProfile,
+                now,
+                forcedTestVariant: undefined,
+                checkAuxiaSuppression,
+            });
+            expect(result).toBeNull();
+        });
+
+        it('does not skip 2-step test for non-GB desktop on articles', async () => {
             const result = await selectBannerTest({
                 targeting: { ...baseTargeting, countryCode: 'US', contentType: 'Article' },
                 userDeviceType: 'Desktop',
@@ -1323,7 +1357,7 @@ describe('selectBannerTest', () => {
             expect(result?.test.name).toBe('2-step-test');
         });
 
-        it('does not skip 2-step test for UK mobile on articles', async () => {
+        it('does not skip 2-step test for GB mobile on articles', async () => {
             const result = await selectBannerTest({
                 targeting: { ...baseTargeting, countryCode: 'GB', contentType: 'Article' },
                 userDeviceType: 'iOS',
@@ -1340,7 +1374,7 @@ describe('selectBannerTest', () => {
             expect(result?.test.name).toBe('2-step-test');
         });
 
-        it('does not skip 2-step test for US mobile on fronts', async () => {
+        it('does not skip 2-step test for non-GB mobile on fronts', async () => {
             const result = await selectBannerTest({
                 targeting: { ...baseTargeting, countryCode: 'US', contentType: 'Network Front' },
                 userDeviceType: 'iOS',
@@ -1357,7 +1391,7 @@ describe('selectBannerTest', () => {
             expect(result?.test.name).toBe('2-step-test');
         });
 
-        it('does not skip non-2-step tests for US mobile on articles', async () => {
+        it('does not skip non-2-step tests for non-GB mobile on articles', async () => {
             const nonTwoStepTest: BannerTest = {
                 ...twoStepTest,
                 name: 'regular-test',

--- a/src/server/tests/banners/bannerSelection.ts
+++ b/src/server/tests/banners/bannerSelection.ts
@@ -204,12 +204,13 @@ const matchesFrontsOnlyRequirement = (test: BannerTest, targeting: BannerTargeti
 
 /**
  * Hardcoded exclusion: if a banner test contains a variant with the 2-step
- * banner (isCollapsible = true), users in the US on mobile devices viewing
- * articles should never be put in that test.
+ * banner (isCollapsible = true), users outside the UK on mobile devices viewing
+ * articles should never be put in that test. The 2-step banner should only
+ * appear for GB users.
  *
- * This is required due to advertising restrictions in the US that prevent the
- * 2-step banner from being shown on mobile. CRM can do this manually per test
- * in the banner tool, but this makes it automatic.
+ * This is required due to advertising restrictions outside the UK that prevent
+ * the 2-step banner from being shown on mobile. CRM can do this manually per
+ * test in the banner tool, but this makes it automatic.
  */
 const isMobileDevice = (deviceType: UserDeviceType): boolean =>
     deviceType === 'iOS' || deviceType === 'Android';
@@ -226,7 +227,7 @@ const shouldSkipTwoStepBannerTest = (
     }
 
     return (
-        targeting.countryCode === 'US' &&
+        targeting.countryCode !== 'GB' &&
         isMobileDevice(userDeviceType) &&
         targeting.contentType === 'Article'
     );


### PR DESCRIPTION
## Summary
- Hardcoded exclusion in `selectBannerTest`: if a banner test has any variant with `isCollapsible: true`, it is now automatically skipped for users outside the UK on mobile devices viewing articles.
- The 2-step banner should only appear for GB users due to advertising restrictions outside the UK.
- Skipped tests fall through to the next available test, so non-GB mobile readers still see non-2-step banners.