### PR TITLE
Add network front IDs to channel exclusion rules

### DIFF
--- a/src/server/channelExclusions.ts
+++ b/src/server/channelExclusions.ts
@@ -13,6 +13,7 @@ export interface ExclusionRule {
     name: string;
     sectionIds?: string[];
     tagIds?: string[];
+    frontIds?: string[];
     dateRange?: DateRange;
     contentTypes?: Array<'Fronts' | 'Articles'>;
 }

--- a/src/server/utils/channelExclusionsMatcher.test.ts
+++ b/src/server/utils/channelExclusionsMatcher.test.ts
@@ -110,4 +110,73 @@ describe('inExclusions', () => {
             }),
         ).toBe(true);
     });
+
+    it('matches front ids against pageId case-insensitively', () => {
+        const targeting: Targeting = {
+            pageId: 'uk',
+        };
+
+        expect(
+            inExclusions(targeting, {
+                rules: [{ name: 'front-rule', frontIds: ['UK'] }],
+            }),
+        ).toBe(true);
+    });
+
+    it('does not match front ids when pageId is absent', () => {
+        expect(
+            inExclusions(baseTargeting, {
+                rules: [{ name: 'front-rule', frontIds: ['uk'] }],
+            }),
+        ).toBe(false);
+    });
+
+    it('matches rule with only frontIds (no sections or tags)', () => {
+        const targeting: Targeting = {
+            pageId: 'us',
+            contentType: 'Network Front',
+        };
+
+        expect(
+            inExclusions(targeting, {
+                rules: [{ name: 'front-only-rule', frontIds: ['us'] }],
+            }),
+        ).toBe(true);
+    });
+
+    it('matches frontIds OR sectionIds (either suffices)', () => {
+        const frontTargeting: Targeting = {
+            pageId: 'au',
+            contentType: 'Network Front',
+        };
+        const sectionTargeting: Targeting = {
+            sectionId: 'sport',
+            contentType: 'Article',
+        };
+
+        const rules = {
+            rules: [{ name: 'front-or-section', frontIds: ['au'], sectionIds: ['sport'] }],
+        };
+
+        expect(inExclusions(frontTargeting, rules)).toBe(true);
+        expect(inExclusions(sectionTargeting, rules)).toBe(true);
+    });
+
+    it('treats Tag contentType as Fronts', () => {
+        const tagPageTargeting: Targeting = {
+            contentType: 'Tag',
+        };
+
+        expect(
+            inExclusions(tagPageTargeting, {
+                rules: [{ name: 'fronts-only', contentTypes: ['Fronts'] }],
+            }),
+        ).toBe(true);
+
+        expect(
+            inExclusions(tagPageTargeting, {
+                rules: [{ name: 'articles-only', contentTypes: ['Articles'] }],
+            }),
+        ).toBe(false);
+    });
 });

--- a/src/server/utils/channelExclusionsMatcher.ts
+++ b/src/server/utils/channelExclusionsMatcher.ts
@@ -26,12 +26,6 @@ const getTagIds = (targeting: Targeting): string[] => {
     return [];
 };
 
-const getPageId = (targeting: Targeting): string | undefined => {
-    if ('pageId' in targeting) {
-        return targeting.pageId;
-    }
-};
-
 const FRONT_CONTENT_TYPES = ['Network Front', 'Section', 'Tag'];
 
 const getContentType = (targeting: Targeting): 'Fronts' | 'Articles' => {
@@ -44,7 +38,7 @@ const matchesRule = (targeting: Targeting, rule: ExclusionRule): boolean => {
     const currentDate = toIsoDate(now);
     const sectionId = getSectionId(targeting)?.toLowerCase();
     const tagIds = getTagIds(targeting).map((tagId) => tagId.toLowerCase());
-    const pageId = getPageId(targeting)?.toLowerCase();
+    const pageId = targeting.pageId?.toLowerCase();
     const contentType = getContentType(targeting);
 
     const ruleHasSectionsOrTags =
@@ -71,9 +65,9 @@ const matchesRule = (targeting: Targeting, rule: ExclusionRule): boolean => {
         !!pageId &&
         (rule.frontIds ?? []).some((id) => id.toLowerCase() === pageId);
 
-    const hasNoTargetingCriteria = !ruleHasSectionsOrTags && !ruleHasFronts;
+    const hasTargetingCriteria = ruleHasSectionsOrTags || ruleHasFronts;
 
-    if (!hasNoTargetingCriteria && !hasMatchingSectionOrTag && !hasMatchingFront) {
+    if (hasTargetingCriteria && !hasMatchingSectionOrTag && !hasMatchingFront) {
         return false;
     }
 

--- a/src/server/utils/channelExclusionsMatcher.ts
+++ b/src/server/utils/channelExclusionsMatcher.ts
@@ -5,6 +5,7 @@ export interface Targeting {
     tagIds?: string[];
     sectionId?: string;
     contentType?: string;
+    pageId?: string;
 }
 
 const toIsoDate = (date: Date): string => date.toISOString().slice(0, 10);
@@ -25,7 +26,13 @@ const getTagIds = (targeting: Targeting): string[] => {
     return [];
 };
 
-const FRONT_CONTENT_TYPES = ['Network Front', 'Section'];
+const getPageId = (targeting: Targeting): string | undefined => {
+    if ('pageId' in targeting) {
+        return targeting.pageId;
+    }
+};
+
+const FRONT_CONTENT_TYPES = ['Network Front', 'Section', 'Tag'];
 
 const getContentType = (targeting: Targeting): 'Fronts' | 'Articles' => {
     const contentType = 'contentType' in targeting ? targeting.contentType : undefined;
@@ -37,22 +44,36 @@ const matchesRule = (targeting: Targeting, rule: ExclusionRule): boolean => {
     const currentDate = toIsoDate(now);
     const sectionId = getSectionId(targeting)?.toLowerCase();
     const tagIds = getTagIds(targeting).map((tagId) => tagId.toLowerCase());
+    const pageId = getPageId(targeting)?.toLowerCase();
     const contentType = getContentType(targeting);
 
-    const hasMatchingSectionOrTag = pageContextMatches(
-        {
-            sectionId,
-            tagIds,
-        },
-        {
-            sectionIds: (rule.sectionIds ?? []).map((id) => id.toLowerCase()),
-            tagIds: (rule.tagIds ?? []).map((id) => id.toLowerCase()),
-            excludedTagIds: [],
-            excludedSectionIds: [],
-        },
-    );
+    const ruleHasSectionsOrTags =
+        (rule.sectionIds?.length ?? 0) > 0 || (rule.tagIds?.length ?? 0) > 0;
+    const ruleHasFronts = (rule.frontIds?.length ?? 0) > 0;
 
-    if (!hasMatchingSectionOrTag) {
+    const hasMatchingSectionOrTag =
+        ruleHasSectionsOrTags &&
+        pageContextMatches(
+            {
+                sectionId,
+                tagIds,
+            },
+            {
+                sectionIds: (rule.sectionIds ?? []).map((id) => id.toLowerCase()),
+                tagIds: (rule.tagIds ?? []).map((id) => id.toLowerCase()),
+                excludedTagIds: [],
+                excludedSectionIds: [],
+            },
+        );
+
+    const hasMatchingFront =
+        ruleHasFronts &&
+        !!pageId &&
+        (rule.frontIds ?? []).some((id) => id.toLowerCase() === pageId);
+
+    const hasNoTargetingCriteria = !ruleHasSectionsOrTags && !ruleHasFronts;
+
+    if (!hasNoTargetingCriteria && !hasMatchingSectionOrTag && !hasMatchingFront) {
         return false;
     }
 

--- a/src/shared/types/targeting/header.ts
+++ b/src/shared/types/targeting/header.ts
@@ -11,6 +11,7 @@ export interface HeaderTargeting {
     tagIds?: string[];
     sectionId?: string;
     contentType?: string;
+    pageId?: string;
 }
 
 export type HeaderPayload = {


### PR DESCRIPTION
Adds `frontIds` field to [ExclusionRule](cci:1://file:///Users/admin.juarez.mota/code/support-admin-console/public/src/components/channelExclusions/ExclusionRule.tsx:66:0-269:2) and matches it against `pageId` in targeting data, enabling exclusions for network front pages (uk, us, au, europe, international). Also adds `'Tag'` to `FRONT_CONTENT_TYPES` so tag pages are correctly classified as 'Fronts'.