### PR TITLE
build: no need to update npm to the latest version

### DIFF
--- a/.github/workflows/dotcom-components.yml
+++ b/.github/workflows/dotcom-components.yml
@@ -98,9 +98,6 @@ jobs:
                   node-version-file: '.nvmrc'
                   cache: 'pnpm'
 
-            - name: Update npm
-              run: npm install -g npm@latest
-
             - name: Build
               run: |
                   pnpm install


### PR DESCRIPTION
Previously: 
- upgrade eslint-config from 15.0.0 to 16.0.0 https://github.com/guardian/support-dotcom-components/pull/1746
- upgrade required node version to 22.22.2 https://github.com/guardian/support-dotcom-components/pull/1750

Here we are dealing with 

```
Run npm install -g npm@latest
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/index.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/index.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/libnpmfund/lib/index.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/utils/reify-output.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/utils/reify-finish.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/commands/install.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/npm.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/cli/entry.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/cli.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/bin/npm-cli.js
```
 
We remove the [Update npm] step because the bundled npm version that comes with Node.js 22.22.2 should be enough.