### PR TITLE
Enable npm OIDC trusted publishing for releases

### DIFF
--- a/.github/workflows/dotcom-components.yml
+++ b/.github/workflows/dotcom-components.yml
@@ -37,7 +37,6 @@ jobs:
                   node-version-file: '.nvmrc'
                   cache: 'pnpm'
 
-
             - name: Test + build
               run: |
                   pnpm install
@@ -58,17 +57,17 @@ jobs:
             - name: riffraff
               uses: guardian/actions-riff-raff@v4.3.4
               with:
-                projectName: support::dotcom-components
-                roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-                githubToken: ${{ secrets.GITHUB_TOKEN }}
-                configPath: riff-raff.yaml
-                buildNumberOffset: 4000
-                contentDirectories: |
-                  dotcom-components-cloudformation:
-                    - cdk/cdk.out/sdc-CODE.template.json
-                    - cdk/cdk.out/sdc-PROD.template.json
-                  dotcom-components:
-                    - server-dist/server.js
+                  projectName: support::dotcom-components
+                  roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+                  githubToken: ${{ secrets.GITHUB_TOKEN }}
+                  configPath: riff-raff.yaml
+                  buildNumberOffset: 4000
+                  contentDirectories: |
+                      dotcom-components-cloudformation:
+                        - cdk/cdk.out/sdc-CODE.template.json
+                        - cdk/cdk.out/sdc-PROD.template.json
+                      dotcom-components:
+                        - server-dist/server.js
 
     release:
         name: Release
@@ -97,6 +96,15 @@ jobs:
               with:
                   node-version-file: '.nvmrc'
                   cache: 'pnpm'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Install npm@latest for OIDC trusted publishing
+              run: npx -y npm@latest install -g npm@latest
+
+            - name: Strip _authToken from .npmrc (let OIDC kick in)
+              run: |
+                  npmrc="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+                  sed -i '/_authToken/d' "$npmrc"
 
             - name: Build
               run: |


### PR DESCRIPTION
The release workflow was failing with ENEEDAUTH because npm OIDC trusted publishing requires npm 11.5.1+ and a configured registry. 

https://github.com/guardian/support-dotcom-components/actions/runs/29326495777/job/87064190023

This PR:

- Adds `registry-url` to `setup-node`
- Upgrades npm via `npx` (avoids the bundled npm 10.x self-upgrade bug from #1751)
- Strips the empty `_authToken` line from `.npmrc` so OIDC auto-detection kicks in
