### PR TITLE
add getting started to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ Consists of:
 
 1. A Node.js server for serving marketing messages to theguardian.com ([dotcom-rendering](https://github.com/guardian/dotcom-rendering/)). Documentation can be found in the [./docs](./docs/) directory.
 2. An npm package with types and logic for use by dotcom-rendering.
+
+## Getting started
+
+1. clone the repo locally
+1. Follow the steps in [docs/server.md](docs/server.md)

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,26 +1,18 @@
 Configuration of the marketing messages is primarily done from the [RRCP](https://github.com/guardian/support-admin-console).
 
-See [architecture](docs/architecture.md) for details.
+See [architecture](architecture.md) for details.
 
-## Development
+## Getting started
 
-This project uses [nvm](https://github.com/nvm-sh/nvm). You should run `nvm use` in your terminal before running any of the following commands. To set up, first run
+This project uses [nvm](https://github.com/nvm-sh/nvm). You should run `nvm use` in your terminal before running any of the following commands.
+
+To set up, install the project dependencies:
 
 ```bash
 $ pnpm install
 ```
 
-This will install all the project dependencies.
-
-If you have a linting problem, try
-
-```bash
-$ pnpm prettier:fix
-```
-
-### Server
-
-To start the server run
+To start the server first get AWS credentials for membership, then run
 
 ```bash
 $ pnpm start
@@ -28,7 +20,17 @@ $ pnpm start
 
 This will start `webpack` in `watch` mode to recompile on file changes and `nodemon` to run the resulting javascript and restart after recompilation.
 
-The server runs on port 8082 locally.
+Now visit the server on: http://localhost:8082/healthcheck
+
+You should see an "OK" on the screen.
+
+### Troubleshooting CI failures
+
+If you have a linting problem, try
+
+```bash
+$ pnpm prettier:fix
+```
 
 #### DCR
 


### PR DESCRIPTION
it took me a while to work out where to look.

I feel like the getting started is important enough to go directly in the readme, but I'm happy to keep the diff small.

Also some updates to the content of the main server.ts, see the diff for details