### PR TITLE
Pin npm 11 for Changesets OIDC publishing

### DIFF
--- a/.github/workflows/dotcom-components.yml
+++ b/.github/workflows/dotcom-components.yml
@@ -98,8 +98,8 @@ jobs:
                   cache: 'pnpm'
                   registry-url: 'https://registry.npmjs.org'
 
-            - name: Install npm@latest for OIDC trusted publishing
-              run: npx -y npm@latest install -g npm@latest
+            - name: Install npm 11 for OIDC trusted publishing
+              run: npx -y npm@11.16.0 install --global npm@11.16.0
 
             - name: Strip _authToken from .npmrc (let OIDC kick in)
               run: |


### PR DESCRIPTION
Pins the release workflow to npm 11.16.0 while retaining OIDC trusted publishing. This avoids an npm 12 compatibility issue where Changesets incorrectly attempts to publish a version that already exists.