### PR TITLE
Fix dependabot updates in /cdk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,6 @@ version: 2
 updates:
     - package-ecosystem: 'npm'
       directory: '/'
-      schedule:
-          interval: 'weekly'
-      cooldown:
-          default-days: 7
-
-    - package-ecosystem: 'npm'
-      directory: '/cdk'
       # The version of aws-cdk-lib libraries must match those from @guardian/cdk.
       # We'd never be able to update them here independently, so just ignore them.
       ignore:


### PR DESCRIPTION
Currently when dependabot updates a dependency in cdk/package.json, it does not also update the pnpm-lock.yaml.
This is because the config in dependabot.yaml defines cdk separately, and causes it to look for the lock file under cdk/.

This PR consolidates the dependabot config. This is correct now that this repo uses pnpm workspaces with a single pnpm-lock.yaml.