### PR TITLE
Handle intro offer promos in choice cards

### DIFF
--- a/src/server/lib/choiceCards/choiceCards.test.ts
+++ b/src/server/lib/choiceCards/choiceCards.test.ts
@@ -537,5 +537,6 @@ describe('getChoiceCardsSettings', () => {
 
         expect(result).toBeDefined();
         expect(result?.choiceCards[1].label).toEqual('Support $9/monthly');
+        expect(result?.choiceCards[1].pill?.copy).toBe('Recommended');
     });
 });

--- a/src/server/lib/choiceCards/choiceCards.test.ts
+++ b/src/server/lib/choiceCards/choiceCards.test.ts
@@ -513,4 +513,29 @@ describe('getChoiceCardsSettings', () => {
         expect(result?.choiceCards[1].label).toEqual('Support <s>$15</s> $9/monthly');
         expect(result?.choiceCards[1].pill?.copy).toBe('40% off');
     });
+
+    it('applies a discount for a an introductory pricing offer promo but does not show the original price', () => {
+        const variantChoiceCardSettings = defaultEpicChoiceCardsSettings('UnitedStates');
+        const promoCodes: string[] = ['PROMO_INTRO_OFFER'];
+        const mockPromotionsCacheIntroOffer: PromotionsCache = {
+            PROMO_INTRO_OFFER: {
+                promoCode: 'PROMO_INTRO_OFFER',
+                productRatePlanIds: [mockProductCatalog.SupporterPlus.ratePlans.Monthly.id],
+                discountPercent: 40,
+                isIntroductoryPricing: true,
+            },
+        };
+
+        const result = getChoiceCardsSettings(
+            'UnitedStates',
+            'Epic',
+            mockProductCatalog,
+            mockPromotionsCacheIntroOffer,
+            promoCodes,
+            variantChoiceCardSettings,
+        );
+
+        expect(result).toBeDefined();
+        expect(result?.choiceCards[1].label).toEqual('Support $9/monthly');
+    });
 });

--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -96,7 +96,7 @@ const enrichChoiceCard = (
         replaceCurrencyTemplate(choiceCard.benefitsLabel, currencySymbol);
 
     const buildPill = (): ChoiceCard['pill'] => {
-        if (promotion) {
+        if (promotion && promotion.isIntroductoryPricing !== true) {
             return {
                 copy: `${Math.floor(promotion.discountPercent)}% off`,
                 backgroundColour: choiceCard.pill?.backgroundColour ?? {

--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -64,11 +64,12 @@ const enrichChoiceCard = (
             const discount = price * (promotion.discountPercent / 100);
             const discountedPrice = price - discount;
             const formattedDiscountedPrice = formatPrice(discountedPrice);
+            const discountedPriceWithCurrencyAndCopy = `${currencySymbol}${formattedDiscountedPrice}/${ratePlanCopyText}`;
 
             if (promotion.isIntroductoryPricing) {
-                return `Support ${currencySymbol}${formattedDiscountedPrice}/${ratePlanCopyText}`;
+                return `Support ${discountedPriceWithCurrencyAndCopy}`;
             } else {
-                return `Support <s>${currencySymbol}${formattedPrice}</s> ${currencySymbol}${formattedDiscountedPrice}/${ratePlanCopyText}`;
+                return `Support <s>${currencySymbol}${formattedPrice}</s> ${discountedPriceWithCurrencyAndCopy}`;
             }
         } else {
             return `Support ${currencySymbol}${formattedPrice}/${ratePlanCopyText}`;

--- a/src/server/lib/choiceCards/choiceCards.ts
+++ b/src/server/lib/choiceCards/choiceCards.ts
@@ -64,7 +64,12 @@ const enrichChoiceCard = (
             const discount = price * (promotion.discountPercent / 100);
             const discountedPrice = price - discount;
             const formattedDiscountedPrice = formatPrice(discountedPrice);
-            return `Support <s>${currencySymbol}${formattedPrice}</s> ${currencySymbol}${formattedDiscountedPrice}/${ratePlanCopyText}`;
+
+            if (promotion.isIntroductoryPricing) {
+                return `Support ${currencySymbol}${formattedDiscountedPrice}/${ratePlanCopyText}`;
+            } else {
+                return `Support <s>${currencySymbol}${formattedPrice}</s> ${currencySymbol}${formattedDiscountedPrice}/${ratePlanCopyText}`;
+            }
         } else {
             return `Support ${currencySymbol}${formattedPrice}/${ratePlanCopyText}`;
         }

--- a/src/server/lib/promotions/promotions.ts
+++ b/src/server/lib/promotions/promotions.ts
@@ -16,6 +16,7 @@ export interface Promotion {
     discountPercent: number;
     startTimestamp?: string;
     endTimestamp?: string;
+    isIntroductoryPricing?: boolean;
 }
 export type PromotionsCache = Record<PromoCode, Promotion>;
 
@@ -30,6 +31,7 @@ interface PromotionTableItem {
     };
     startTimestamp?: string;
     endTimestamp?: string;
+    isIntroductoryPricing?: boolean;
 }
 
 const mapTableItemToPromotion = (item: PromotionTableItem): Promotion => {
@@ -39,6 +41,7 @@ const mapTableItemToPromotion = (item: PromotionTableItem): Promotion => {
         productRatePlanIds: item.appliesTo.productRatePlanIds,
         startTimestamp: item.startTimestamp,
         endTimestamp: item.endTimestamp,
+        isIntroductoryPricing: item.isIntroductoryPricing,
     };
 };
 


### PR DESCRIPTION
## What does this change?

The RRCP now supports a new kind of promo - an intro offer - which should be rendered slightly differently to a regular promo. For example:

* No original price with strikethrough should be shown
* The pill shouldn't show the % discount

## How has this change been tested?

Tested using a locally running SDC and DCR.

Setup a new introductory pricing promo in CODE: `INTRO_OFFER`

Setup a new banner test which specifies the promo setup above: `2026-07-29_INTRO_OFFER_PROMO`

Ran support-dotcom-components and dotcom-rendering locally, pointing local DCR to local SDC by running like this: `SDC_URL=http://localhost:8082 make dev`.

Visit a local DCR page and force the banner test like with this URL: http://localhost:3030/Article/https://www.theguardian.com/environment/2026/jul/29/half-england-officially-drought-environment-agency?preview-banner=2026-07-29_INTRO_OFFER_PROMO:CONTROL

This is how an introductory pricing promo renders after this change:

<img width="410" height="363" alt="Screenshot 2026-07-29 at 16 22 20" src="https://github.com/user-attachments/assets/711eb0ea-681a-49cd-9de6-d656bc5cfdba" />

