### PR TITLE
Remove unused fields from models

### DIFF
--- a/.changeset/tough-rocks-build.md
+++ b/.changeset/tough-rocks-build.md
@@ -1,0 +1,5 @@
+---
+'@guardian/support-dotcom-components': major
+---
+
+Remove unused fields from models

--- a/src/server/api/bannerRouter.ts
+++ b/src/server/api/bannerRouter.ts
@@ -157,7 +157,6 @@ export const buildBannerRouter = (
             const props: BannerProps = {
                 tracking: testTracking as Tracking, // PageTracking is added client-side
                 bannerChannel: test.bannerChannel,
-                isSupporter: !targeting.showSupportMessaging,
                 countryCode: targeting.countryCode,
                 content: variant.bannerContent,
                 mobileContent: variant.mobileBannerContent,

--- a/src/server/api/headerRouter.ts
+++ b/src/server/api/headerRouter.ts
@@ -82,7 +82,6 @@ export const buildHeaderRouter = (
                             mobileContent: variant.mobileContent,
                             tracking: testTracking as Tracking, // PageTracking is added client-side
                             countryCode: targeting.countryCode,
-                            numArticles: targeting.numArticles,
                         },
                     },
                     meta: testTracking,

--- a/src/server/factories/targeting.ts
+++ b/src/server/factories/targeting.ts
@@ -1,10 +1,8 @@
 import type { EpicTargeting } from '../../shared/types';
 
 export default (overrides?: Partial<EpicTargeting>): EpicTargeting => ({
-    contentType: 'Article',
     sectionId: 'culture',
     shouldHideReaderRevenue: false,
-    isMinuteArticle: false,
     isPaidContent: false,
     tags: [],
     showSupportMessaging: true,

--- a/src/server/lib/targeting.ts
+++ b/src/server/lib/targeting.ts
@@ -58,7 +58,7 @@ export const shouldThrottle = (
 };
 
 export const shouldNotRenderEpic = (meta: EpicTargeting): boolean => {
-    const section = meta.sectionId ?? meta.sectionName;
+    const section = meta.sectionId;
     const isLowValueSection = !!section && lowValueSections.includes(section);
     const isLowValueTag = lowValueTags.some((id) => meta.tags.some((pageTag) => pageTag.id === id));
 

--- a/src/server/tests/epics/epicSelection.test.ts
+++ b/src/server/tests/epics/epicSelection.test.ts
@@ -76,10 +76,8 @@ const testDefault: EpicTest = {
 };
 
 const targetingDefault: EpicTargeting = {
-    contentType: 'Article',
     sectionId: 'environment',
     shouldHideReaderRevenue: false,
-    isMinuteArticle: false,
     isPaidContent: false,
     tags: [{ id: 'environment/series/the-polluters', type: 'tone' }],
     showSupportMessaging: true,
@@ -916,10 +914,8 @@ describe('holdback group targeting', () => {
     const getMParticleProfile = () => Promise.resolve(undefined);
 
     const baseTargeting: EpicTargeting = {
-        contentType: 'Article',
         sectionId: 'environment',
         shouldHideReaderRevenue: false,
-        isMinuteArticle: false,
         isPaidContent: false,
         tags: [{ id: 'environment/series/the-polluters', type: 'tone' }],
         showSupportMessaging: true,

--- a/src/server/tests/epics/momentumTest.test.ts
+++ b/src/server/tests/epics/momentumTest.test.ts
@@ -35,10 +35,8 @@ const testDefault: EpicTest = {
 };
 
 const targetingDefault: EpicTargeting = {
-    contentType: 'Article',
     sectionId: 'environment',
     shouldHideReaderRevenue: false,
-    isMinuteArticle: false,
     isPaidContent: false,
     tags: [{ id: 'environment/series/the-polluters', type: 'tone' }],
     showSupportMessaging: true,

--- a/src/shared/types/props/banner.ts
+++ b/src/shared/types/props/banner.ts
@@ -61,7 +61,6 @@ export interface BannerProps {
     content?: BannerContent;
     mobileContent?: BannerContent;
     countryCode?: string;
-    isSupporter?: boolean;
     tickerSettings?: TickerSettings;
     articleCounts: ArticleCounts;
     hasOptedOutOfArticleCount?: boolean;
@@ -84,7 +83,6 @@ export const bannerSchema = z.object({
     content: bannerContentSchema.nullish(),
     mobileContent: bannerContentSchema.nullish(),
     countryCode: z.string().nullish(),
-    isSupporter: z.boolean().nullish(),
     tickerSettings: tickerSettingsSchema.nullish(),
     submitComponentEvent: z.any(),
     articleCounts: articleCountsSchema,

--- a/src/shared/types/props/epic.ts
+++ b/src/shared/types/props/epic.ts
@@ -68,7 +68,6 @@ export const variantSchema = z.object({
     bylineWithImage: bylineWithImageSchema.optional(),
     showChoiceCards: z.boolean().optional(),
     choiceCardsSettings: choiceCardsSettings.nullish(),
-    defaultChoiceCardFrequency: contributionFrequencySchema.optional(), // deprecated, use choiceCardsSettings
 });
 
 export const epicPropsSchema = z.object({

--- a/src/shared/types/props/header.ts
+++ b/src/shared/types/props/header.ts
@@ -25,7 +25,6 @@ export interface HeaderProps {
     mobileContent?: HeaderContent;
     countryCode?: string;
     submitComponentEvent?: (componentEvent: ComponentEvent) => Promise<void>;
-    numArticles?: number;
     promoCodes?: string[];
 }
 

--- a/src/shared/types/props/header.ts
+++ b/src/shared/types/props/header.ts
@@ -34,6 +34,5 @@ export const headerPropsSchema = z.object({
     mobileContent: headerContentSchema.optional(),
     countryCode: z.string().optional(),
     submitComponentEvent: z.any(),
-    numArticles: z.number().optional(),
     promoCodes: z.array(z.string()).nullish(),
 });

--- a/src/shared/types/targeting/epic.ts
+++ b/src/shared/types/targeting/epic.ts
@@ -7,14 +7,9 @@ type Tag = {
 };
 
 export type EpicTargeting = {
-    contentType: string;
-    sectionName?: string; // Deprecated - use sectionId
     sectionId?: string;
     shouldHideReaderRevenue: boolean;
-
-    isMinuteArticle: boolean;
     isPaidContent: boolean;
-
     tags: Tag[];
     mvtId?: number;
     epicViewLog?: EpicViewLog;

--- a/src/shared/types/targeting/header.ts
+++ b/src/shared/types/targeting/header.ts
@@ -4,7 +4,6 @@ export interface HeaderTargeting {
     showSupportMessaging: boolean;
     countryCode: string;
     mvtId: number;
-    numArticles?: number;
     purchaseInfo?: PurchaseInfo;
     isSignedIn: boolean;
     inHoldbackGroup?: boolean;


### PR DESCRIPTION
Remove a number of fields from the `targeting` and `props` models because they are no longer used by server or client.
Once this change is published to npm I will update dotcom-rendering.

Tested by deploying SDC to CODE and checking messages still display on the site