### PR TITLE
Fix rollup build

### DIFF
--- a/src/dotcom/package.json
+++ b/src/dotcom/package.json
@@ -14,7 +14,7 @@
         "dist/**/*"
     ],
     "scripts": {
-        "build": "pnpm -w exec rollup --config rollup.config.js"
+        "build": "pnpm -w exec rollup --config rollup.config.js --bundleConfigAsCjs"
     },
     "dependencies": {},
     "devDependencies": {


### PR DESCRIPTION
Fixes an issue with the `dotcom-build` step which seems to have been introduced with a rollup upgrade:
https://github.com/guardian/support-dotcom-components/actions/runs/30441778433/job/90542881273

```
> pnpm -w exec rollup --config rollup.config.js

[!] Error: Cannot find package '@rollup/plugin-babel' imported from /home/runner/work/support-dotcom-components/support-dotcom-components/rollup.config.js
Did you mean to import "@rollup/plugin-babel/dist/cjs/index.js"?
...
```

The `--bundleConfigAsCjs` flag tells Rollup to transpile and bundle the config file itself before executing it