### PR TITLE
Reduce UK Auxia sign-in gate audience share to 20%

### DIFF
--- a/src/server/signin-gate/libPure.ts
+++ b/src/server/signin-gate/libPure.ts
@@ -235,6 +235,9 @@ export const mvtIdIsAuxiaAudienceShare = (mvtId: number): boolean => {
 
         This is the function that needs to be modified when we want to increase the share of the
         audience given to the Auxia experiment in the future.
+
+        Note: since July 2026, the Auxia share for the UK (countryCode 'GB') is reduced to 20%.
+        That exception is implemented in isAuxiaAudienceShare below (see logic.md).
     */
 
     // The MVT calculator is very useful: https://ab-tests.netlify.app
@@ -250,6 +253,10 @@ export const mvtIdIsAuxiaAudienceShare = (mvtId: number): boolean => {
 };
 
 export const isAuxiaAudienceShare = (payload: GetTreatmentsRequestPayload): boolean => {
+    // The Auxia audience share for the UK is reduced to 20% (see logic.md)
+    if (payload.countryCode === 'GB') {
+        return payload.mvtId > 0 && payload.mvtId <= 200_000;
+    }
     return mvtIdIsAuxiaAudienceShare(payload.mvtId);
 };
 

--- a/src/server/signin-gate/libPure.ts
+++ b/src/server/signin-gate/libPure.ts
@@ -236,7 +236,7 @@ export const mvtIdIsAuxiaAudienceShare = (mvtId: number): boolean => {
         This is the function that needs to be modified when we want to increase the share of the
         audience given to the Auxia experiment in the future.
 
-        Note: since July 2026, the Auxia share for the UK (countryCode 'GB') is reduced to 20%.
+        Note: since August 2026, the Auxia share for the UK (countryCode 'GB') is reduced to 20%.
         That exception is implemented in isAuxiaAudienceShare below (see logic.md).
     */
 

--- a/src/server/signin-gate/libPureTests/isAuxiaAudienceShare.test.ts
+++ b/src/server/signin-gate/libPureTests/isAuxiaAudienceShare.test.ts
@@ -1,46 +1,38 @@
 import { isAuxiaAudienceShare } from '../libPure';
 import type { GetTreatmentsRequestPayload } from '../types';
 
-it('isAuxiaAudienceShare', () => {
-    const payload1: GetTreatmentsRequestPayload = {
-        browserId: 'sample',
-        isSupporter: false,
-        dailyArticleCount: 3,
-        articleIdentifier: 'sample: article identifier',
-        editionId: 'UK',
-        contentType: 'Article',
-        sectionId: 'uk-news',
-        tagIds: ['type/article'],
-        gateDismissCount: 0,
-        countryCode: 'GB',
-        mvtId: 250001,
-        should_show_legacy_gate_tmp: true,
-        hasConsented: true,
-        shouldServeDismissible: false,
-        showDefaultGate: undefined,
-        gateDisplayCount: 0,
-        hideSupportMessagingTimestamp: undefined,
-    };
-    const payload2: GetTreatmentsRequestPayload = {
-        browserId: 'sample',
-        isSupporter: false,
-        dailyArticleCount: 3,
-        articleIdentifier: 'sample: article identifier',
-        editionId: 'UK',
-        contentType: 'Article',
-        sectionId: 'uk-news',
-        tagIds: ['type/article'],
-        gateDismissCount: 0,
-        countryCode: 'GB',
-        mvtId: 450001,
-        should_show_legacy_gate_tmp: true,
-        hasConsented: true,
-        shouldServeDismissible: false,
-        showDefaultGate: undefined,
-        gateDisplayCount: 0,
-        hideSupportMessagingTimestamp: undefined,
-    };
+const buildPayload = (countryCode: string, mvtId: number): GetTreatmentsRequestPayload => ({
+    browserId: 'sample',
+    isSupporter: false,
+    dailyArticleCount: 3,
+    articleIdentifier: 'sample: article identifier',
+    editionId: 'UK',
+    contentType: 'Article',
+    sectionId: 'uk-news',
+    tagIds: ['type/article'],
+    gateDismissCount: 0,
+    countryCode,
+    mvtId,
+    should_show_legacy_gate_tmp: true,
+    hasConsented: true,
+    shouldServeDismissible: false,
+    showDefaultGate: undefined,
+    gateDisplayCount: 0,
+    hideSupportMessagingTimestamp: undefined,
+});
 
-    expect(isAuxiaAudienceShare(payload1)).toBe(true);
-    expect(isAuxiaAudienceShare(payload2)).toBe(false);
+describe('isAuxiaAudienceShare', () => {
+    it('non-UK countries use the 35% share', () => {
+        expect(isAuxiaAudienceShare(buildPayload('US', 250001))).toBe(true);
+        expect(isAuxiaAudienceShare(buildPayload('US', 350000))).toBe(true);
+        expect(isAuxiaAudienceShare(buildPayload('US', 350001))).toBe(false);
+        expect(isAuxiaAudienceShare(buildPayload('US', 450001))).toBe(false);
+    });
+
+    it('UK uses the reduced 20% share', () => {
+        expect(isAuxiaAudienceShare(buildPayload('GB', 1))).toBe(true);
+        expect(isAuxiaAudienceShare(buildPayload('GB', 200000))).toBe(true);
+        expect(isAuxiaAudienceShare(buildPayload('GB', 200001))).toBe(false);
+        expect(isAuxiaAudienceShare(buildPayload('GB', 250001))).toBe(false);
+    });
 });

--- a/src/server/signin-gate/libPureTests/isGuardianAudienceShare.test.ts
+++ b/src/server/signin-gate/libPureTests/isGuardianAudienceShare.test.ts
@@ -1,46 +1,35 @@
 import { isGuardianAudienceShare } from '../libPure';
 import type { GetTreatmentsRequestPayload } from '../types';
 
-it('isGuardianAudienceShare', () => {
-    const payload1: GetTreatmentsRequestPayload = {
-        browserId: 'sample',
-        isSupporter: false,
-        dailyArticleCount: 3,
-        articleIdentifier: 'sample: article identifier',
-        editionId: 'UK',
-        contentType: 'Article',
-        sectionId: 'uk-news',
-        tagIds: ['type/article'],
-        gateDismissCount: 0,
-        countryCode: 'GB',
-        mvtId: 250001,
-        should_show_legacy_gate_tmp: true,
-        hasConsented: true,
-        shouldServeDismissible: false,
-        showDefaultGate: undefined,
-        gateDisplayCount: 0,
-        hideSupportMessagingTimestamp: undefined,
-    };
-    const payload2: GetTreatmentsRequestPayload = {
-        browserId: 'sample',
-        isSupporter: false,
-        dailyArticleCount: 3,
-        articleIdentifier: 'sample: article identifier',
-        editionId: 'UK',
-        contentType: 'Article',
-        sectionId: 'uk-news',
-        tagIds: ['type/article'],
-        gateDismissCount: 0,
-        countryCode: 'GB',
-        mvtId: 450001,
-        should_show_legacy_gate_tmp: true,
-        hasConsented: true,
-        shouldServeDismissible: false,
-        showDefaultGate: undefined,
-        gateDisplayCount: 0,
-        hideSupportMessagingTimestamp: undefined,
-    };
+const buildPayload = (countryCode: string, mvtId: number): GetTreatmentsRequestPayload => ({
+    browserId: 'sample',
+    isSupporter: false,
+    dailyArticleCount: 3,
+    articleIdentifier: 'sample: article identifier',
+    editionId: 'UK',
+    contentType: 'Article',
+    sectionId: 'uk-news',
+    tagIds: ['type/article'],
+    gateDismissCount: 0,
+    countryCode,
+    mvtId,
+    should_show_legacy_gate_tmp: true,
+    hasConsented: true,
+    shouldServeDismissible: false,
+    showDefaultGate: undefined,
+    gateDisplayCount: 0,
+    hideSupportMessagingTimestamp: undefined,
+});
 
-    expect(isGuardianAudienceShare(payload1)).toBe(false);
-    expect(isGuardianAudienceShare(payload2)).toBe(true);
+describe('isGuardianAudienceShare', () => {
+    it('non-UK countries use the 35% share', () => {
+        expect(isGuardianAudienceShare(buildPayload('US', 250001))).toBe(false);
+        expect(isGuardianAudienceShare(buildPayload('US', 450001))).toBe(true);
+    });
+
+    it('UK uses the reduced 20% share', () => {
+        expect(isGuardianAudienceShare(buildPayload('GB', 200000))).toBe(false);
+        expect(isGuardianAudienceShare(buildPayload('GB', 200001))).toBe(true);
+        expect(isGuardianAudienceShare(buildPayload('GB', 250001))).toBe(true);
+    });
 });

--- a/src/server/signin-gate/logic.md
+++ b/src/server/signin-gate/logic.md
@@ -32,7 +32,9 @@ nb: the numbers, for instance, [01], uniquely identify the experience for the co
                |                                              |
                |  - Auxia drives the gate                     |
   consented +  |                                              |
-  auxia 35% +  |                                              |
+  auxia 35%    |                                              |
+  (20% for     |                                              |
+  the UK)      |                                              |
                |                                              |
                |                                              |
                |                                              |
@@ -43,9 +45,9 @@ nb: the numbers, for instance, [01], uniquely identify the experience for the co
                |                                              |
                |  - No Auxia notification                     |
   consented +  |  - Guardian drives the gate:                 |
- non-auxia 65% |    - No gate for 30 days after a single      |
-               |      contribution event [01]                 |
-               |    - No gate the first 3 page views          |
+ non-auxia    |    - No gate for 30 days after a single      |
+ 65% (80%     |      contribution event [01]                 |
+ for the UK)  |    - No gate the first 3 page views          |
                |    - Dismissible gates,                      |
                |      then no gate after 5 dismisses          |
                |                                              |
@@ -54,6 +56,9 @@ nb: the numbers, for instance, [01], uniquely identify the experience for the co
 
 [01] use gu_hide_support_messaging cookie
 ```
+
+nb: the Auxia share of the audience is the first 35% of mvtIds (1 to 350_000),
+except for the UK (countryCode 'GB') where it is reduced to the first 20% (1 to 200_000).
 
 ### Ireland + New Zealand
 


### PR DESCRIPTION
Reduces the Auxia audience share for consented readers in the UK (`countryCode: 'GB'`) from 35% to 20% (mvtId 1–200_000). All other countries remain at 35%. `logic.md` and the audience share tests are updated accordingly.
