### PR TITLE
Add contributions-only countries targeting to all channel selection

### DIFF
--- a/src/server/api/bannerRouter.ts
+++ b/src/server/api/bannerRouter.ts
@@ -106,6 +106,8 @@ export const buildBannerRouter = (
             forcedTestVariant: params.force,
             previewTestVariant: params.preview,
             checkAuxiaSuppression,
+            contributionsOnlyCountries:
+                contributionsOnlyCountriesConfig.get().contributionsOnlyCountries,
         });
 
         if (selectedTest) {

--- a/src/server/api/epicRouter.ts
+++ b/src/server/api/epicRouter.ts
@@ -134,6 +134,7 @@ export const buildEpicRouter = (
                     enableSuperMode ? superModeArticles.get() : [],
                     banditData.get(),
                     getMParticleProfile,
+                    contributionsOnlyCountriesConfig.get().contributionsOnlyCountries,
                     params.debug,
                 );
 

--- a/src/server/api/gutterRouter.ts
+++ b/src/server/api/gutterRouter.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../shared/types';
 import type { ExclusionSettings } from '../channelExclusions';
 import type { ChannelSwitches } from '../channelSwitches';
+import type { ContributionsOnlyCountriesConfig } from '../contributionsOnly';
 import { getDeviceType } from '../lib/deviceType';
 import { baseUrl } from '../lib/env';
 import { getQueryParams } from '../lib/params';
@@ -34,6 +35,7 @@ export const buildGutterRouter = (
     channelSwitches: ValueProvider<ChannelSwitches>,
     tests: ValueProvider<GutterTest[]>,
     channelExclusions: ValueProvider<ExclusionSettings>,
+    contributionsOnlyCountriesConfig: ValueProvider<ContributionsOnlyCountriesConfig>,
 ): Router => {
     const router = Router();
 
@@ -63,6 +65,7 @@ export const buildGutterRouter = (
             getDeviceType(req),
             params.force,
             params.preview,
+            contributionsOnlyCountriesConfig.get().contributionsOnlyCountries,
         );
         if (testSelection) {
             const { test, variant, moduleName } = testSelection;

--- a/src/server/api/headerRouter.ts
+++ b/src/server/api/headerRouter.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../shared/types';
 import type { ExclusionSettings } from '../channelExclusions';
 import type { ChannelSwitches } from '../channelSwitches';
+import type { ContributionsOnlyCountriesConfig } from '../contributionsOnly';
 import { getDeviceType } from '../lib/deviceType';
 import { baseUrl } from '../lib/env';
 import type { MParticle, MParticleProfile } from '../lib/mParticle';
@@ -36,6 +37,7 @@ export const buildHeaderRouter = (
     mParticle: MParticle,
     okta: Okta,
     channelExclusions: ValueProvider<ExclusionSettings>,
+    contributionsOnlyCountriesConfig: ValueProvider<ContributionsOnlyCountriesConfig>,
 ): Router => {
     const router = Router();
 
@@ -63,6 +65,7 @@ export const buildHeaderRouter = (
             getMParticleProfile,
             params.force,
             params.preview,
+            contributionsOnlyCountriesConfig.get().contributionsOnlyCountries,
         );
         if (testSelection) {
             const { test, variant, moduleName } = testSelection;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -152,11 +152,27 @@ const buildApp = async (): Promise<Express> => {
             contributionsOnlyCountriesConfig,
         ),
     );
-    app.use(buildHeaderRouter(channelSwitches, headerTests, mParticle, okta, channelExclusions));
+    app.use(
+        buildHeaderRouter(
+            channelSwitches,
+            headerTests,
+            mParticle,
+            okta,
+            channelExclusions,
+            contributionsOnlyCountriesConfig,
+        ),
+    );
 
     app.use(buildAuxiaProxyRouter(channelSwitches, auxiaConfig));
 
-    app.use(buildGutterRouter(channelSwitches, gutterLiveblogTests, channelExclusions));
+    app.use(
+        buildGutterRouter(
+            channelSwitches,
+            gutterLiveblogTests,
+            channelExclusions,
+            contributionsOnlyCountriesConfig,
+        ),
+    );
 
     app.use(buildTickerRouter(tickerData));
 

--- a/src/server/tests/banners/bannerSelection.test.ts
+++ b/src/server/tests/banners/bannerSelection.test.ts
@@ -1810,9 +1810,26 @@ describe('contributionsOnlyCountriesTargeting', () => {
         expect(inOtherCountry).toBe(null);
     });
 
-    it('passes when no mode is set (backward compatible)', async () => {
+    it('defaults to Exclude when no mode is set (suppresses in contributions-only countries)', async () => {
         const result = await selectBannerTest({
             targeting: { ...baseTargeting, countryCode: 'VN' },
+            userDeviceType,
+            tests: [buildTest(undefined)],
+            bannerDeployTimes,
+            enableHardcodedBannerTests: true,
+            enableScheduledDeploys: true,
+            banditData,
+            getMParticleProfile,
+            now,
+            checkAuxiaSuppression,
+            contributionsOnlyCountries,
+        });
+        expect(result).toBe(null);
+    });
+
+    it('shows in non-contributions-only countries when no mode is set (default Exclude)', async () => {
+        const result = await selectBannerTest({
+            targeting: { ...baseTargeting, countryCode: 'GB' },
             userDeviceType,
             tests: [buildTest(undefined)],
             bannerDeployTimes,

--- a/src/server/tests/banners/bannerSelection.test.ts
+++ b/src/server/tests/banners/bannerSelection.test.ts
@@ -1683,3 +1683,147 @@ describe('selectBannerTest', () => {
         });
     });
 });
+
+describe('contributionsOnlyCountriesTargeting', () => {
+    const now = new Date('2020-03-31T12:30:00');
+    const bannerDeployTimes = getBannerDeployTimesReloader('Mon Jul 06 2020 19:20:10 GMT+0100');
+    const contributionsOnlyCountries = ['VN', 'TH'];
+    const checkAuxiaSuppression = buildCheckAuxiaSuppressionMock();
+    const getMParticleProfile = () => Promise.resolve(undefined);
+
+    const baseTargeting: BannerTargeting = {
+        shouldHideReaderRevenue: false,
+        isPaidContent: false,
+        showSupportMessaging: true,
+        mvtId: 3,
+        countryCode: 'GB',
+        engagementBannerLastClosedAt: 'Mon Jun 06 2020 19:20:10 GMT+0100',
+        hasOptedOutOfArticleCount: false,
+        contentType: 'Article',
+        isSignedIn: false,
+        hasConsented: true,
+        weeklyArticleHistory: [{ week: 18330, count: 6 }],
+    };
+
+    const buildTest = (
+        contributionsOnlyCountriesTargeting?: 'Include' | 'Exclude',
+    ): BannerTest => ({
+        channel: 'Banner1',
+        name: 'test',
+        priority: 1,
+        status: 'Live',
+        bannerChannel: 'contributions',
+        isHardcoded: false,
+        userCohort: 'Everyone',
+        variants: [
+            {
+                name: 'variant',
+                template: { designName: 'TEST_DESIGN' },
+                bannerContent: {
+                    messageText: 'body',
+                    highlightedText: 'highlighted text',
+                    cta: { text: 'cta', baseUrl: 'https://support.theguardian.com' },
+                },
+                componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            },
+        ],
+        articlesViewedSettings: { minViews: 5, periodInWeeks: 52 },
+        locations: [],
+        regionTargeting: {
+            targetedCountryGroups: [],
+            targetedCountryCodes: [],
+            contributionsOnlyCountriesTargeting,
+        },
+        contextTargeting: {
+            tagIds: [],
+            sectionIds: [],
+            excludedTagIds: [],
+            excludedSectionIds: [],
+        },
+    });
+
+    it('excludes a contributions-only country when mode is Exclude', async () => {
+        const result = await selectBannerTest({
+            targeting: { ...baseTargeting, countryCode: 'VN' },
+            userDeviceType,
+            tests: [buildTest('Exclude')],
+            bannerDeployTimes,
+            enableHardcodedBannerTests: true,
+            enableScheduledDeploys: true,
+            banditData,
+            getMParticleProfile,
+            now,
+            checkAuxiaSuppression,
+            contributionsOnlyCountries,
+        });
+        expect(result).toBe(null);
+    });
+
+    it('shows a non-contributions-only country when mode is Exclude', async () => {
+        const result = await selectBannerTest({
+            targeting: { ...baseTargeting, countryCode: 'GB' },
+            userDeviceType,
+            tests: [buildTest('Exclude')],
+            bannerDeployTimes,
+            enableHardcodedBannerTests: true,
+            enableScheduledDeploys: true,
+            banditData,
+            getMParticleProfile,
+            now,
+            checkAuxiaSuppression,
+            contributionsOnlyCountries,
+        });
+        expect(result?.test.name).toBe('test');
+    });
+
+    it('only shows in contributions-only countries when mode is Include', async () => {
+        const test = buildTest('Include');
+
+        const inContributionsCountry = await selectBannerTest({
+            targeting: { ...baseTargeting, countryCode: 'VN' },
+            userDeviceType,
+            tests: [test],
+            bannerDeployTimes,
+            enableHardcodedBannerTests: true,
+            enableScheduledDeploys: true,
+            banditData,
+            getMParticleProfile,
+            now,
+            checkAuxiaSuppression,
+            contributionsOnlyCountries,
+        });
+        expect(inContributionsCountry?.test.name).toBe('test');
+
+        const inOtherCountry = await selectBannerTest({
+            targeting: { ...baseTargeting, countryCode: 'GB' },
+            userDeviceType,
+            tests: [test],
+            bannerDeployTimes,
+            enableHardcodedBannerTests: true,
+            enableScheduledDeploys: true,
+            banditData,
+            getMParticleProfile,
+            now,
+            checkAuxiaSuppression,
+            contributionsOnlyCountries,
+        });
+        expect(inOtherCountry).toBe(null);
+    });
+
+    it('passes when no mode is set (backward compatible)', async () => {
+        const result = await selectBannerTest({
+            targeting: { ...baseTargeting, countryCode: 'VN' },
+            userDeviceType,
+            tests: [buildTest(undefined)],
+            bannerDeployTimes,
+            enableHardcodedBannerTests: true,
+            enableScheduledDeploys: true,
+            banditData,
+            getMParticleProfile,
+            now,
+            checkAuxiaSuppression,
+            contributionsOnlyCountries,
+        });
+        expect(result?.test.name).toBe('test');
+    });
+});

--- a/src/server/tests/banners/bannerSelection.ts
+++ b/src/server/tests/banners/bannerSelection.ts
@@ -1,6 +1,10 @@
 import { isAfter } from 'date-fns/isAfter';
 import { subDays } from 'date-fns/subDays';
-import { countryCodeToCountryGroupId, inTargetedCountry } from '../../../shared/lib';
+import {
+    countryCodeToCountryGroupId,
+    inTargetedCountry,
+    passesContributionsOnlyTargeting,
+} from '../../../shared/lib';
 import type {
     BannerTargeting,
     BannerTest,
@@ -252,6 +256,7 @@ interface SelectBannerTestData {
         browserId: string,
         attributes: GetTreatmentsAttributes,
     ) => Promise<boolean>;
+    contributionsOnlyCountries?: string[];
 }
 
 export const selectBannerTest = async ({
@@ -267,6 +272,7 @@ export const selectBannerTest = async ({
     forcedTestVariant,
     previewTestVariant,
     checkAuxiaSuppression,
+    contributionsOnlyCountries = [],
 }: SelectBannerTestData): Promise<BannerTestSelection | null> => {
     if (isTaylorReportPage(targeting)) {
         return null;
@@ -301,6 +307,11 @@ export const selectBannerTest = async ({
             !targeting.isPaidContent &&
             audienceMatches(targeting.showSupportMessaging, test.userCohort) &&
             isCountryTargetedForBanner(test, targeting) &&
+            passesContributionsOnlyTargeting(
+                test.regionTargeting,
+                targeting.countryCode,
+                contributionsOnlyCountries,
+            ) &&
             !(test.articlesViewedSettings && targeting.hasOptedOutOfArticleCount) &&
             historyWithinArticlesViewedSettings(
                 test.articlesViewedSettings,

--- a/src/server/tests/epics/epicSelection.test.ts
+++ b/src/server/tests/epics/epicSelection.test.ts
@@ -180,6 +180,106 @@ describe('findTestAndVariant', () => {
     });
 });
 
+describe('contributionsOnlyCountriesTargeting', () => {
+    const contributionsOnlyCountries = ['VN', 'TH'];
+    const history = { weeklyArticleHistory: [{ week: 18330, count: 45 }] };
+    const testNoArticleSettings = { ...testDefault, articlesViewedSettings: undefined };
+
+    it('excludes a contributions-only country when mode is Exclude', async () => {
+        const test = {
+            ...testNoArticleSettings,
+            regionTargeting: {
+                targetedCountryGroups: [],
+                contributionsOnlyCountriesTargeting: 'Exclude' as const,
+            },
+        };
+        const targeting: EpicTargeting = { ...targetingDefault, countryCode: 'VN', ...history };
+
+        const got = await findTestAndVariant(
+            [test],
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+            getMParticleProfile,
+            contributionsOnlyCountries,
+        );
+
+        expect(got.result).toBe(undefined);
+    });
+
+    it('shows a non-contributions-only country when mode is Exclude', async () => {
+        const test = {
+            ...testNoArticleSettings,
+            regionTargeting: {
+                targetedCountryGroups: [],
+                contributionsOnlyCountriesTargeting: 'Exclude' as const,
+            },
+        };
+        const targeting: EpicTargeting = { ...targetingDefault, countryCode: 'GB', ...history };
+
+        const got = await findTestAndVariant(
+            [test],
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+            getMParticleProfile,
+            contributionsOnlyCountries,
+        );
+
+        expect(got.result?.test.name).toBe('example-1');
+    });
+
+    it('only shows in contributions-only countries when mode is Include', async () => {
+        const test = {
+            ...testNoArticleSettings,
+            regionTargeting: {
+                targetedCountryGroups: [],
+                contributionsOnlyCountriesTargeting: 'Include' as const,
+            },
+        };
+
+        const gotInContributionsCountry = await findTestAndVariant(
+            [test],
+            { ...targetingDefault, countryCode: 'VN', ...history },
+            userDeviceType,
+            superModeArticles,
+            banditData,
+            getMParticleProfile,
+            contributionsOnlyCountries,
+        );
+        expect(gotInContributionsCountry.result?.test.name).toBe('example-1');
+
+        const gotInOtherCountry = await findTestAndVariant(
+            [test],
+            { ...targetingDefault, countryCode: 'GB', ...history },
+            userDeviceType,
+            superModeArticles,
+            banditData,
+            getMParticleProfile,
+            contributionsOnlyCountries,
+        );
+        expect(gotInOtherCountry.result).toBe(undefined);
+    });
+
+    it('passes when no mode is set (backward compatible)', async () => {
+        const targeting: EpicTargeting = { ...targetingDefault, countryCode: 'VN', ...history };
+
+        const got = await findTestAndVariant(
+            [testNoArticleSettings],
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+            getMParticleProfile,
+            contributionsOnlyCountries,
+        );
+
+        expect(got.result?.test.name).toBe('example-1');
+    });
+});
+
 describe('getUserCohort', () => {
     it('should return "AllNonSupporters" when users is not contributor', () => {
         const targeting = {

--- a/src/server/tests/epics/epicSelection.test.ts
+++ b/src/server/tests/epics/epicSelection.test.ts
@@ -263,8 +263,24 @@ describe('contributionsOnlyCountriesTargeting', () => {
         expect(gotInOtherCountry.result).toBe(undefined);
     });
 
-    it('passes when no mode is set (backward compatible)', async () => {
+    it('defaults to Exclude when no mode is set (suppresses in contributions-only countries)', async () => {
         const targeting: EpicTargeting = { ...targetingDefault, countryCode: 'VN', ...history };
+
+        const got = await findTestAndVariant(
+            [testNoArticleSettings],
+            targeting,
+            userDeviceType,
+            superModeArticles,
+            banditData,
+            getMParticleProfile,
+            contributionsOnlyCountries,
+        );
+
+        expect(got.result).toBe(undefined);
+    });
+
+    it('shows in non-contributions-only countries when no mode is set (default Exclude)', async () => {
+        const targeting: EpicTargeting = { ...targetingDefault, countryCode: 'GB', ...history };
 
         const got = await findTestAndVariant(
             [testNoArticleSettings],

--- a/src/server/tests/epics/epicSelection.ts
+++ b/src/server/tests/epics/epicSelection.ts
@@ -2,6 +2,7 @@ import {
     countryCodeToCountryGroupId,
     getCountryName,
     inTargetedCountry,
+    passesContributionsOnlyTargeting,
 } from '../../../shared/lib';
 import type {
     EpicTargeting,
@@ -103,6 +104,18 @@ export const isCountryTargetedForEpic: Filter = {
         );
     },
 };
+
+export const contributionsOnlyCountriesTargetingFilter = (
+    contributionsOnlyCountries: string[],
+): Filter => ({
+    id: 'contributionsOnlyCountriesTargeting',
+    test: (test, targeting): boolean =>
+        passesContributionsOnlyTargeting(
+            test.regionTargeting,
+            targeting.countryCode,
+            contributionsOnlyCountries,
+        ),
+});
 
 export const withinMaxViews = (log: EpicViewLog, now: Date = new Date()): Filter => ({
     id: 'shouldThrottle',
@@ -211,6 +224,7 @@ export const findTestAndVariant = async (
     superModeArticles: SuperModeArticle[],
     banditData: BanditData[],
     getMParticleProfile: () => Promise<MParticleProfile | undefined>,
+    contributionsOnlyCountries: string[] = [],
     includeDebug = false,
 ): Promise<Result> => {
     const debug: Debug = {};
@@ -228,6 +242,7 @@ export const findTestAndVariant = async (
             inCorrectCohort(userCohorts, isSuperModePass),
             hasCountryCode,
             isCountryTargetedForEpic,
+            contributionsOnlyCountriesTargetingFilter(contributionsOnlyCountries),
             // For the super mode pass, we treat all tests as "always ask" so disable this filter
             ...(isSuperModePass ? [] : [withinMaxViews(targeting.epicViewLog ?? [])]),
             respectArticleCountOptOut,

--- a/src/server/tests/gutters/gutterSelection.ts
+++ b/src/server/tests/gutters/gutterSelection.ts
@@ -1,4 +1,4 @@
-import { inTargetedCountry } from '../../../shared/lib';
+import { inTargetedCountry, passesContributionsOnlyTargeting } from '../../../shared/lib';
 import type {
     GutterTargeting,
     GutterTest,
@@ -36,6 +36,7 @@ export const selectBestTest = (
     targeting: GutterTargeting,
     userDeviceType: UserDeviceType,
     allTests: GutterTest[],
+    contributionsOnlyCountries: string[] = [],
 ): GutterTestSelection | null => {
     const { showSupportMessaging, isSignedIn } = targeting;
 
@@ -52,6 +53,11 @@ export const selectBestTest = (
             status === 'Live' &&
             audienceMatches(showSupportMessaging, userCohort) &&
             isCountryTargetedForGutterAsks(test, targeting) &&
+            passesContributionsOnlyTargeting(
+                test.regionTargeting,
+                targeting.countryCode,
+                contributionsOnlyCountries,
+            ) &&
             correctSignedInStatus(isSignedIn, signedInStatus) &&
             pageContextMatches(pageContext, contextTargeting) &&
             matchesHoldbackRequirement(test, targeting.inHoldbackGroup) &&
@@ -102,6 +108,7 @@ export const selectGutterTest = (
     userDeviceType: UserDeviceType,
     forcedTestVariant?: TestVariant,
     previewTestVariant?: TestVariant,
+    contributionsOnlyCountries: string[] = [],
 ): GutterTestSelection | null => {
     if (forcedTestVariant) {
         return getForcedVariant(forcedTestVariant, configuredTests);
@@ -109,5 +116,5 @@ export const selectGutterTest = (
     if (previewTestVariant) {
         return getForcedVariant(previewTestVariant, configuredTests, false);
     }
-    return selectBestTest(targeting, userDeviceType, configuredTests);
+    return selectBestTest(targeting, userDeviceType, configuredTests, contributionsOnlyCountries);
 };

--- a/src/server/tests/headers/headerSelection.ts
+++ b/src/server/tests/headers/headerSelection.ts
@@ -1,4 +1,4 @@
-import { inTargetedCountry } from '../../../shared/lib';
+import { inTargetedCountry, passesContributionsOnlyTargeting } from '../../../shared/lib';
 import type {
     HeaderTargeting,
     HeaderTest,
@@ -362,6 +362,7 @@ export const selectBestTest = async (
     userDeviceType: UserDeviceType,
     allTests: HeaderTest[],
     getMParticleProfile: () => Promise<MParticleProfile | undefined>,
+    contributionsOnlyCountries: string[] = [],
 ): Promise<HeaderTestSelection | null> => {
     const { showSupportMessaging, purchaseInfo, isSignedIn } = targeting;
 
@@ -372,6 +373,11 @@ export const selectBestTest = async (
             status === 'Live' &&
             audienceMatches(showSupportMessaging, userCohort) &&
             isCountryTargetedForHeader(test, targeting) &&
+            passesContributionsOnlyTargeting(
+                test.regionTargeting,
+                targeting.countryCode,
+                contributionsOnlyCountries,
+            ) &&
             deviceTypeMatches(test, userDeviceType) &&
             purchaseMatches(test, purchaseInfo, isSignedIn) &&
             correctSignedInStatus(isSignedIn, signedInStatus) &&
@@ -425,6 +431,7 @@ export const selectHeaderTest = async (
     getMParticleProfile: () => Promise<MParticleProfile | undefined>,
     forcedTestVariant?: TestVariant,
     previewTestVariant?: TestVariant,
+    contributionsOnlyCountries: string[] = [],
 ): Promise<HeaderTestSelection | null> => {
     const allTests = [...configuredTests, ...hardcodedTests];
 
@@ -434,5 +441,11 @@ export const selectHeaderTest = async (
     if (previewTestVariant) {
         return getForcedVariant(previewTestVariant, allTests, false);
     }
-    return selectBestTest(targeting, userDeviceType, allTests, getMParticleProfile);
+    return selectBestTest(
+        targeting,
+        userDeviceType,
+        allTests,
+        getMParticleProfile,
+        contributionsOnlyCountries,
+    );
 };

--- a/src/shared/lib/geolocation.ts
+++ b/src/shared/lib/geolocation.ts
@@ -617,10 +617,12 @@ export const inTargetedCountry = (
  * - `Include`: the test only shows in contributions-only countries.
  * - `Exclude`: the test never shows in contributions-only countries (used for epics/banners
  *   that mention products/promos unavailable in these countries).
- * - undefined: no special targeting (always passes).
+ * - undefined: defaults to `Exclude` (so existing tests are suppressed in
+ *   contributions-only countries without needing a config change).
  *
- * When a mode is set but the user's country code is unknown, the test is suppressed
- * (fail-safe: don't show product/promo copy to users we can't geolocate).
+ * When the user's country code is unknown, the test is shown (we can't apply
+ * geo-targeting without geolocation data, and suppressing everything would break
+ * the case where geolocation fails to load).
  */
 export const passesContributionsOnlyTargeting = (
     regionTargeting:
@@ -629,12 +631,9 @@ export const passesContributionsOnlyTargeting = (
     countryCode: string | undefined,
     contributionsOnlyCountries: string[],
 ): boolean => {
-    const mode = regionTargeting?.contributionsOnlyCountriesTargeting;
-    if (!mode) {
-        return true;
-    }
+    const mode = regionTargeting?.contributionsOnlyCountriesTargeting ?? 'Exclude';
     if (!countryCode) {
-        return false;
+        return true;
     }
     const isContributionsOnly = contributionsOnlyCountries.includes(countryCode);
     return mode === 'Include' ? isContributionsOnly : !isContributionsOnly;

--- a/src/shared/lib/geolocation.ts
+++ b/src/shared/lib/geolocation.ts
@@ -14,12 +14,21 @@ export type CountryGroupId = (typeof CountryGroupId)[number];
 
 export const countryGroupIdSchema = z.enum(CountryGroupId);
 
+export const contributionsOnlyCountriesTargetingSchema = z.enum(['Include', 'Exclude']);
+
+export type ContributionsOnlyCountriesTargeting = z.infer<
+    typeof contributionsOnlyCountriesTargetingSchema
+>;
+
 export const targetedRegionsSchema = z
     .object({
         targetedCountryGroups: z.array(countryGroupIdSchema),
         targetedCountryCodes: z.array(z.string()).optional(),
+        contributionsOnlyCountriesTargeting: contributionsOnlyCountriesTargetingSchema.optional(),
     })
     .optional();
+
+export type RegionTargeting = z.infer<typeof targetedRegionsSchema>;
 
 // Used to internationalise 'Support the Guardian' links
 export type SupportRegionId = 'UK' | 'US' | 'AU' | 'EU' | 'INT' | 'NZ' | 'CA';
@@ -600,6 +609,35 @@ export const inTargetedCountry = (
 
     // Check if the country is in the targeted countries by name
     return countryCodes.includes(countryCodeFromPayload.toUpperCase());
+};
+
+/**
+ * Evaluates a test's contributions-only-countries targeting against the user's country.
+ *
+ * - `Include`: the test only shows in contributions-only countries.
+ * - `Exclude`: the test never shows in contributions-only countries (used for epics/banners
+ *   that mention products/promos unavailable in these countries).
+ * - undefined: no special targeting (always passes).
+ *
+ * When a mode is set but the user's country code is unknown, the test is suppressed
+ * (fail-safe: don't show product/promo copy to users we can't geolocate).
+ */
+export const passesContributionsOnlyTargeting = (
+    regionTargeting:
+        | { contributionsOnlyCountriesTargeting?: ContributionsOnlyCountriesTargeting }
+        | undefined,
+    countryCode: string | undefined,
+    contributionsOnlyCountries: string[],
+): boolean => {
+    const mode = regionTargeting?.contributionsOnlyCountriesTargeting;
+    if (!mode) {
+        return true;
+    }
+    if (!countryCode) {
+        return false;
+    }
+    const isContributionsOnly = contributionsOnlyCountries.includes(countryCode);
+    return mode === 'Include' ? isContributionsOnly : !isContributionsOnly;
 };
 
 const defaultCurrencySymbol = '£';


### PR DESCRIPTION
Adds a `contributionsOnlyCountriesTargeting` (`Include` / `Exclude` / none) field to `RegionTargeting` and evaluates it at selection time for epic, banner, header, and gutter tests, using the existing dynamic contributions-only countries list. Suppresses tests whose copy mentions products/promos unavailable in contributions-only countries (fail-safe when geolocation is unknown). Header and gutter routers now also receive the contributions-only config. Backward compatible (optional field, defaults to no targeting). Pair with the support-admin-console PR which adds the UI control. Includes unit tests for all four selection modules.